### PR TITLE
Show commands when running `prepare_env.sh`, to help users diagnose the errors. 

### DIFF
--- a/scripts/prepare_dev.sh
+++ b/scripts/prepare_dev.sh
@@ -2,6 +2,7 @@
 #
 # A script to install dependencies for GraphScope dev user
 
+set -x
 set -e
 set -o pipefail
 
@@ -40,5 +41,6 @@ function install_dependencies() {
 
 install_dependencies
 
+set +x
 set +e
 set +o pipefail

--- a/scripts/prepare_env.sh
+++ b/scripts/prepare_env.sh
@@ -3,6 +3,7 @@
 # A script to install dependencies for GraphScope user
 
 set -e
+set -x
 set -o pipefail
 
 platform=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
@@ -72,5 +73,6 @@ sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalon
 sudo docker pull zookeeper:3.4.14 || true
 sudo docker pull quay.io/coreos/etcd:v3.4.13 || true
 
+set +x
 set +e
 set +o pipefail


### PR DESCRIPTION
## What do these changes do?

Make `prepare_env.sh` more verbose.

## Related issue number

This pr could help #3, but doesn't fix it.
