### PR TITLE
Enable workflow from pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,10 @@ on:
 
 jobs:
   build:
-    # runs-on: ${{ matrix.os }}
     runs-on: self-hosted
     strategy:
       matrix:
         experimental: [ON, OFF]
-        ci: [true]
         profile: [release]
     steps:
     - name: Clean up
@@ -89,7 +87,6 @@ jobs:
         # run cpplint
         python3 ./misc/cpplint.py --recursive ./apps ./benchmarks ./core ./frame ./test
 
-
     - name: Python Format and Lint Check
       run: |
         echo "Checking formatting for $GITHUB_REPOSITORY"
@@ -104,33 +101,15 @@ jobs:
         python3 -m black --check --diff .
         python3 -m flake8 .
 
-    - name: Install dependencies
-      shell: bash
-      run: |
-        sudo pip3 install vineyard==0.1.3 -i https://pypi.org/simple
-
-        # Install pip dependencies, build builtin gar, and generate proto stuffs.
-        pushd python && sudo python3 setup.py develop && popd
-        pushd coordinator && sudo python3 setup.py develop && popd
-
     - name: Get Test Data
       shell: bash
       run: |
         export GS_TEST_DIR=${GITHUB_WORKSPACE}/gstest
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR} || true
-        cd ${GS_TEST_DIR}
 
     - name: Build image
-      env:
-        ALIYUN_TOKEN: ${{ secrets.ALIYUN_TOKEN }}
       shell: bash
       run: |
-        echo "$ALIYUN_TOKEN" | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
-
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:latest
-
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-runtime:latest
-
         sudo docker build --build-arg EXPERIMENTAL_ON=${{ matrix.experimental }} \
                           --build-arg profile=${{ matrix.profile }} \
                           --build-arg ci=${{ matrix.ci }} \
@@ -138,6 +117,9 @@ jobs:
                           --network=host \
                           -f ./k8s/graphscope.Dockerfile .
 
+      - name: Run GAE Tests
+        shell: bash
+        run: |
         sudo docker run --rm --shm-size=4096m \
              -v ${GS_TEST_DIR}:/root/gstest \
              -v `pwd`:/root/gs \
@@ -145,19 +127,23 @@ jobs:
              sh -c "echo Container id $(hostname) && \
                     set pipefail && \
                     export GS_TEST_DIR='/root/gstest' && \
-                    cd /root/gs/analytical_engine && mkdir build && \
+                    cd /root/gs/analytical_engine && \
+                    mkdir build && \
                     cd build && \
-                    cmake -DEXPERIMENTAL_ON=${{ matrix.experimental }} .. && make -j`nproc` && \
+                    cmake -DEXPERIMENTAL_ON=${{ matrix.experimental }} .. && \
+                    make run_app run_vy_app run_pregel_app -j`nproc` && \
                     bash /root/gs/analytical_engine/test/app_tests.sh --test_dir /root/gstest"
 
-    - name: Push
-      env:
-        ALIYUN_TOKEN: ${{ secrets.ALIYUN_TOKEN }}
+    - name: Save Image
+      run: sudo docker save docker.pkg.github.com/siyuan0322/graphscope/graphscope:${{ github.sha }} | gzip > graphscope.tar.gz
+
+    - name: Archive image
       if: matrix.experimental == 'ON'
-      shell: bash
-      run: |
-        echo "$ALIYUN_TOKEN" | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
-        sudo docker push registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: graphscope
+        path: graphscope.tar.gz
+        retention-days: 5
 
     - name: Clean up
       shell: bash
@@ -187,21 +173,25 @@ jobs:
         submodules: true
 
     - name: Build manager
-      env:
-        ALIYUN_TOKEN: ${{ secrets.ALIYUN_TOKEN }}
       shell: bash
       run: |
-        echo "$ALIYUN_TOKEN" | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
-        cd ./k8s && sudo make manager
-        sudo docker tag registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0 \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }}
-        sudo docker push registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }}
+        cd ./k8s
+        sudo make manager REGISTRY='registry.cn-hongkong.aliyuncs.com'
+
+    - name: Save Image
+      run: sudo docker save docker.pkg.github.com/siyuan0322/graphscope/maxgraph_standalone_manager:1.0 | gzip > maxgraph_standalone_manager.tar.gz
+
+    - name: Archive image
+      uses: actions/upload-artifact@v2
+      with:
+        name: maxgraph_standalone_manager
+        path: maxgraph_standalone_manager.tar.gz
+        retention-days: 5
 
     - name: Clean
       shell: bash
       run: |
         sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0 \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} \
                         || true
 
   gae-and-python-tests:
@@ -230,23 +220,34 @@ jobs:
       with:
         submodules: true
 
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Get Test Data
       shell: bash
       run: |
         export GS_TEST_DIR=${GITHUB_WORKSPACE}/gstest
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR} || true
-        cd ${GS_TEST_DIR}
+
+    - name: Download Image
+      uses: actions/download-artifact@v2
+      with:
+        name: graphscope
 
     - name: Prepare environment
       env:
         ALIYUN_TOKEN: ${{ secrets.ALIYUN_TOKEN }}
       shell: bash
       run: |
-        echo "$ALIYUN_TOKEN" | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }}
+        sudo docker load < graphscope.tar.gz
+        sudo python3 -m pip install -r python/requirements.txt
+        sudo python3 -m pip install -r python/requirements-dev.txt
 
-        # generate proto, and builtin gar
-        sudo pip3 install -r python/requirements-dev.txt
         pushd python && sudo -E python3 setup.py build_proto && popd
         pushd coordinator && sudo -E python3 setup.py build_builtin && popd
 
@@ -282,7 +283,7 @@ jobs:
 
     - name: NetworkX algo test
       shell: bash
-      if:  matrix.experimental == 'ON'
+      if: matrix.experimental == 'ON'
       run: |
         info=$(git log -1 --pretty=%B)
         if echo ${info} | grep -iqFw ci-algo; then echo ''run nx-algo-ci''; else exit 0; fi
@@ -300,11 +301,9 @@ jobs:
       run: |
         sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} || true
 
+
   k8s-test:
     runs-on: self-hosted
-    strategy:
-      matrix:
-        ci: [true]
 
     needs: [build, build-manager]
     steps:
@@ -325,25 +324,30 @@ jobs:
       with:
         submodules: true
 
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Get Test Data
       shell: bash
       run: |
         export GS_TEST_DIR=${GITHUB_WORKSPACE}/gstest
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR} || true
 
+    - name: Download Image
+      uses: actions/download-artifact@v2
+
     - name: Prepare environment
-      env:
-        ALIYUN_TOKEN: ${{ secrets.ALIYUN_TOKEN }}
       shell: bash
       run: |
-        echo "$ALIYUN_TOKEN" | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }}
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }}
-        sudo docker tag registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0
-
-        sudo pip3 install kubernetes
-
-        sudo pip3 install vineyard==0.1.3 -i https://pypi.org/simple
+        sudo docker load < graphscope/graphscope.tar.gz
+        sudo docker load < maxgraph_standalone_manager/maxgraph_standalone_manager.tar.gz
+        sudo python3 -m pip install -r python/requirements.txt
+        sudo python3 -m pip install -r python/requirements-dev.txt
 
         pushd python && sudo -E python3 setup.py develop && popd
 
@@ -355,7 +359,6 @@ jobs:
       run: |
         export GS_TEST_DIR=${GITHUB_WORKSPACE}/gstest
         export PYTHONPATH=${GITHUB_WORKSPACE}/python
-        export CI=${{ matrix.ci }}
         python3 -m pytest --exitfirst -s -vvv --log-cli-level=INFO \
                           ./python/graphscope/deploy/tests/
 
@@ -363,7 +366,6 @@ jobs:
       shell: bash
       run: |
         sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0 || true
 
   gie-test:
@@ -388,24 +390,31 @@ jobs:
       with:
         submodules: true
 
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Download Image
+      uses: actions/download-artifact@v2
+
     - name: Prepare environment
-      env:
-        ALIYUN_TOKEN: ${{ secrets.ALIYUN_TOKEN }}
       shell: bash
       run: |
-        echo "$ALIYUN_TOKEN" | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }}
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }}
-        sudo docker tag registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0
+        sudo docker load < graphscope/graphscope.tar.gz
+        sudo docker load < maxgraph_standalone_manager/maxgraph_standalone_manager.tar.gz
 
+        sudo python3 -m pip install -r python/requirements.txt
+        sudo python3 -m pip install -r python/requirements-dev.txt
         pushd python && sudo -E python3 setup.py develop && popd
 
     - name: Run function test
       shell: bash
       run: |
         export PYTHONPATH=${GITHUB_WORKSPACE}/python
-        export CI=true
         cd interactive_engine/tests
         ./function_test.sh 8111 1 registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }}
         ./function_test.sh 8111 2 registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }}
@@ -414,32 +423,27 @@ jobs:
       shell: bash
       run: |
         sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0 || true
 
   release-image:
     runs-on: self-hosted
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: [ gie-test, gae-and-python-tests, k8s-test ]
     steps:
+    - name: Download Image
+      uses: actions/download-artifact@v2
+
+    - name: Prepare environment
+        sudo docker load < graphscope/graphscope.tar.gz
+        sudo docker load < maxgraph_standalone_manager/maxgraph_standalone_manager.tar.gz
+
     - name: Release images
-      env:
-        ALIYUN_TOKEN: ${{ secrets.ALIYUN_TOKEN }}
       shell: bash
       run: |
-        echo "$ALIYUN_TOKEN" | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
+        echo ${{ secrets.ALIYUN_TOKEN }} | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
 
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }}
         sudo docker tag registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:latest
         sudo docker push registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:latest
-
-        sudo docker pull registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }}
-        sudo docker tag registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0
         sudo docker push registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0
-
-        sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:latest \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:1.0 || true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,14 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-20.04]
-        python-version: [3.8]
-        include:
-          - { os: ubuntu-20.04, python-version: 3.8 }
-
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2

--- a/k8s/graphscope.Dockerfile
+++ b/k8s/graphscope.Dockerfile
@@ -69,7 +69,7 @@ RUN export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/graphscope/lib:/opt/graphscope/
 ARG profile=$profile
 
 # rust & cargo registry
-RUN wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz && \
+RUN wget --no-verbose https://golang.org/dl/go1.15.5.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go1.15.5.linux-amd64.tar.gz && \
     curl -sf -L https://static.rust-lang.org/rustup.sh | \
         sh -s -- -y --profile minimal --default-toolchain 1.48.0 && \
@@ -96,10 +96,11 @@ RUN source ~/.bashrc \
 # # # # # # # # # # # # # # # # # # # # # #
 # generate final runtime image
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-runtime:latest
+
 ARG profile=release
 
 COPY --from=builder /opt/graphscope /usr/local/
-RUN cd /usr/local/dist/ &&  pip3 install ./*.whl
+RUN cd /usr/local/dist/ && pip3 install ./*.whl
 
 RUN mkdir -p /home/maxgraph
 ENV VINEYARD_IPC_SOCKET /home/maxgraph/data/vineyard/vineyard.sock

--- a/k8s/manager.Dockerfile
+++ b/k8s/manager.Dockerfile
@@ -8,7 +8,7 @@ ADD . /root/maxgraph/
 # RUN cd /root/maxgraph/ && mvn clean -T 1 install -DskipTests -P java-release
 COPY ./deploy/docker/dockerfile/maven.settings.xml /root/.m2/settings.xml
 RUN cd /root/maxgraph/ && \
-    mvn clean package -DskipTests -Pjava-release
+    mvn clean package -DskipTests -Pjava-release --quiet
 
 # # # # # # # # # # # # # # # # # # # # # #
 # RUNTIME: manager 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Removes the needs of permission push to registry from PR workflow.

<!-- Please give a short brief about these changes. -->
1. Use artifact instead of registry push-and-pull to transfer image between jobs.
2. Remove unused environment variables
3. Reduce the time in Build Image stage by not build unnecessary executables.
4. Reduce logs that are too verbose.
5. Add cache for pip packages.

