### PR TITLE
Wait etcd ready before launching vineyard container.

### DIFF
--- a/python/graphscope/deploy/kubernetes/resource_builder.py
+++ b/python/graphscope/deploy/kubernetes/resource_builder.py
@@ -557,12 +557,13 @@ class GSEngineBuilder(ReplicaSetBuilder):
         )
         commands = []
         commands.append(
-            "while ! curl --output /dev/null --silent --head %s" % etcd_endpoint
+            "while ! curl --output /dev/null --silent --head --connect-timeout 1 %s"
+            % etcd_endpoint
         )
         commands.append("do sleep 1 && echo -n .")
         commands.append("done")
         commands.append(vineyard_command)
-        cmd = ["bash", "-c", "'%s'" % ("; ".join(commands),)]
+        cmd = ["bash", "-c", "%s" % ("; ".join(commands),)]
 
         resources_dict = {
             "requests": ResourceBuilder(cpu, mem).build(),

--- a/python/graphscope/deploy/kubernetes/resource_builder.py
+++ b/python/graphscope/deploy/kubernetes/resource_builder.py
@@ -546,13 +546,23 @@ class GSEngineBuilder(ReplicaSetBuilder):
     def add_vineyard_container(
         self, name, image, cpu, mem, shared_mem, etcd_endpoint, port, **kwargs
     ):
-        cmd = [
-            "vineyardd",
-            "--size=%s" % str(shared_mem),
-            "--etcd_endpoint=http://%s" % etcd_endpoint,
-            "--socket=%s" % self._ipc_socket_file,
-            "--etcd_prefix=vineyard",
-        ]
+        vineyard_command = " ".join(
+            [
+                "vineyardd",
+                "--size=%s" % str(shared_mem),
+                "--etcd_endpoint=http://%s" % etcd_endpoint,
+                "--socket=%s" % self._ipc_socket_file,
+                "--etcd_prefix=vineyard",
+            ]
+        )
+        commands = []
+        commands.append(
+            "while ! curl --output /dev/null --silent --head %s" % etcd_endpoint
+        )
+        commands.append("do sleep 1 && echo -n .")
+        commands.append("done")
+        commands.append(vineyard_command)
+        cmd = ["bash", "-c", "'%s'" % ("; ".join(commands),)]
 
         resources_dict = {
             "requests": ResourceBuilder(cpu, mem).build(),


### PR DESCRIPTION

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Wait etcd endpoint ready for curl before launching vineyardd, to resolve the "failed to connect to vineyardd" issue.

## Related issue number

None