### PR TITLE
Support bytecode-based requests for interactive engine

### DIFF
--- a/python/graphscope/deploy/tests/test_demo_script.py
+++ b/python/graphscope/deploy/tests/test_demo_script.py
@@ -239,8 +239,8 @@ def test_query_modern_graph(modern_graph_data_dir):
 
 
 def test_traversal_modern_graph(modern_graph_data_dir):
-    from gremlin_python.process.traversal import P
     from gremlin_python.process.traversal import Order
+    from gremlin_python.process.traversal import P
 
     image = get_gs_image_on_ci_env()
     sess = graphscope.session(

--- a/python/graphscope/interactive/query.py
+++ b/python/graphscope/interactive/query.py
@@ -42,7 +42,7 @@ class InteractiveQuery(object):
     which lifetime is independent from the origin graph.
 
     Use `execute()` to submit a script,
-    ans use `traversal_source()` to get a `GraphTraversalSource` for further traversal.
+    and use `traversal_source()` to get a `GraphTraversalSource` for further traversal.
     """
 
     def __init__(self, graphscope_session, object_id, front_ip, front_port):

--- a/python/graphscope/interactive/query.py
+++ b/python/graphscope/interactive/query.py
@@ -41,8 +41,8 @@ class InteractiveQuery(object):
     from origin graph, produce a new, smaller but concise graph stored in vineyard,
     which lifetime is independent from the origin graph.
 
-    Use `execute()` to submit a script,
-    and use `traversal_source()` to get a `GraphTraversalSource` for further traversal.
+    User can either use `execute()` to submit a script, or use `traversal_source()`
+    to get a `GraphTraversalSource` for further traversal.
     """
 
     def __init__(self, graphscope_session, object_id, front_ip, front_port):

--- a/python/graphscope/interactive/query.py
+++ b/python/graphscope/interactive/query.py
@@ -149,12 +149,12 @@ class InteractiveQuery(object):
 
     def traversal_source(self):
         """Create a GraphTraversalSource and return.
-        Once "g" has been created using a connection, we can start to write
+        Once `g` has been created using a connection, we can start to write
         Gremlin traversals to query the remote graph.
 
         Examples:
 
-            ..code:: python
+            .. code:: python
 
                 sess = graphscope.session()
                 graph = load_modern_graph(sess, modern_graph_data_dir)

--- a/python/graphscope/interactive/query.py
+++ b/python/graphscope/interactive/query.py
@@ -22,8 +22,8 @@ import random
 from concurrent.futures import ThreadPoolExecutor
 
 from gremlin_python.driver.client import Client
-from gremlin_python.process.anonymous_traversal import traversal
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from gremlin_python.process.anonymous_traversal import traversal
 
 from graphscope.framework.loader import Loader
 

--- a/python/graphscope/interactive/query.py
+++ b/python/graphscope/interactive/query.py
@@ -22,6 +22,8 @@ import random
 from concurrent.futures import ThreadPoolExecutor
 
 from gremlin_python.driver.client import Client
+from gremlin_python.process.anonymous_traversal import traversal
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 
 from graphscope.framework.loader import Loader
 
@@ -32,11 +34,15 @@ class InteractiveQuery(object):
     """`InteractiveQuery` class, is a simple wrapper around
     `Gremlin-Python <https://pypi.org/project/gremlinpython/>`_,
     which implements Gremlin within the Python language.
-    It also can expose gremlin endpoint which can be used by any other standard gremlin console.
+    It also can expose gremlin endpoint which can be used by
+    any other standard gremlin console, with the method `graph_url()`.
 
     It also has a method called `subgraph` which can extract some fragments
     from origin graph, produce a new, smaller but concise graph stored in vineyard,
     which lifetime is independent from the origin graph.
+
+    Use `execute()` to submit a script,
+    ans use `traversal_source()` to get a `GraphTraversalSource` for further traversal.
     """
 
     def __init__(self, graphscope_session, object_id, front_ip, front_port):
@@ -140,6 +146,27 @@ class InteractiveQuery(object):
         if self.closed():
             raise RuntimeError("Interactive query is closed.")
         return self._client.submit(query)
+
+    def traversal_source(self):
+        """Create a GraphTraversalSource and return.
+        Once "g" has been created using a connection, we can start to write
+        Gremlin traversals to query the remote graph.
+
+        Examples:
+
+            ..code:: python
+
+                sess = graphscope.session()
+                graph = load_modern_graph(sess, modern_graph_data_dir)
+                interactive = sess.gremlin(graph)
+                g = interactive.traversal_source()
+                print(g.V().both()[1:3].toList())
+                print(g.V().both().name.toList())
+
+        Returns:
+            `GraphTraversalSource`
+        """
+        return traversal().withRemote(DriverRemoteConnection(self._graph_url, "g"))
 
     def close(self):
         """Close interactive instance and release resources"""


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Support bytecode-based requests for interactive engine.
User can get a `GraphTraversalSource` to traversal a remote graph by using `interactive.traversal_source()` where `interactive` is created by `sess.gremlin(graph)`.

Examples:
```
>>> sess = graphscope.session()
>>> graph = load_modern_graph(sess, modern_graph_data_dir)
>>> interactive = sess.gremlin(graph)
>>> g = interactive.traversal_source()
>>> g.V().both()[1:3].toList()
[v[0.1], v[0.2]]
>>> g.V().both().name.toList()
['vadas', 'peter', 'lop', 'josh', 'marko', 'ripple']
```
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #35 

