### PR TITLE
Requires vineyard-io, and drop the copy hack.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,11 +388,6 @@ jobs:
         python3 -m pip install pytest-cov --user
         pushd python && sudo -E python3 setup.py develop && popd
 
-        # Copy Vineyard drivers to /usr/local
-        sudo rm -f ./artifacts/opt/graphscope/bin/vineyard-codegen || true
-        sudo cp -rvf ./artifacts/opt/graphscope/bin/* /usr/local/bin/
-        sudo cp -rvf ./artifacts/opt/graphscope/share/vineyard /usr/local/share/
-
     - name: Kubernetes test
       env:
         CHANGE_MINIKUBE_NONE_USER: true
@@ -410,6 +405,7 @@ jobs:
       with:
         file: ./python/coverage.xml
         fail_ci_if_error: true
+
     - name: Clean
       run: |
         sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -11,3 +11,4 @@ protobuf
 PyYAML
 scipy
 vineyard==0.1.8
+vineyard-io==0.1.8


### PR DESCRIPTION
That is introduced in https://github.com/alibaba/GraphScope/pull/103.
