### PR TITLE
Fix compile app with graph which use string as original id.

### DIFF
--- a/python/graphscope/framework/dag_utils.py
+++ b/python/graphscope/framework/dag_utils.py
@@ -41,7 +41,9 @@ def create_app(graph, app):
     config = {
         types_pb2.APP_ALGO: utils.s_to_attr(app.algo),
         types_pb2.GRAPH_TYPE: utils.graph_type_to_attr(graph.graph_type),
-        types_pb2.OID_TYPE: utils.s_to_attr(graph.schema.oid_type),
+        types_pb2.OID_TYPE: utils.s_to_attr(
+            utils.normalize_data_type_str(graph.schema.oid_type)
+        ),
         types_pb2.VID_TYPE: utils.s_to_attr(graph.schema.vid_type),
         types_pb2.V_DATA_TYPE: utils.s_to_attr(
             utils.data_type_to_cpp(graph.schema.vdata_type)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -467,6 +467,28 @@ def p2p_property_graph(graphscope_session):
 
 
 @pytest.fixture(scope="module")
+def p2p_property_graph_string(graphscope_session):
+    g = graphscope_session.load_from(
+        edges={
+            "knows": (
+                Loader("{}/p2p-31_property_e_0".format(property_dir), header_row=True),
+                ["src_label_id", "dst_label_id", "dist"],
+                ("src_id", "person"),
+                ("dst_id", "person"),
+            ),
+        },
+        vertices={
+            "person": Loader(
+                "{}/p2p-31_property_v_0".format(property_dir), header_row=True
+            ),
+        },
+        generate_eid=False,
+        oid_type="string",
+    )
+    yield g
+
+
+@pytest.fixture(scope="module")
 def p2p_property_graph_undirected(graphscope_session):
     g = graphscope_session.load_from(
         edges={
@@ -498,6 +520,12 @@ def p2p_project_directed_graph(p2p_property_graph):
 @pytest.fixture(scope="module")
 def p2p_project_undirected_graph(p2p_property_graph_undirected):
     pg = p2p_property_graph_undirected.project_to_simple(0, 0, 0, 2)
+    yield pg
+
+
+@pytest.fixture(scope="module")
+def p2p_project_directed_graph_string(p2p_property_graph_string):
+    pg = p2p_property_graph_string.project_to_simple(0, 0, 0, 2)
     yield pg
 
 

--- a/python/tests/test_app.py
+++ b/python/tests/test_app.py
@@ -341,6 +341,12 @@ def test_app_on_undirected_graph(
     assert np.all(ctx10.to_numpy("r", vertex_range={"begin": 1, "end": 4}) == [0, 0, 0])
 
 
+def test_run_app_on_string_oid_graph(p2p_project_directed_graph_string):
+    ctx = sssp(p2p_project_directed_graph_string, src="6")
+    r1 = ctx.to_dataframe({"node": "v.id", "r": "r"})
+    assert r1[r1["node"] == "6"].r.values[0] == 0.0
+
+
 def test_error_on_parameters_not_correct(arrow_project_graph):
     # Incorrect type of parameters
     with pytest.raises(ValueError, match="could not convert string to float"):


### PR DESCRIPTION
This PR fixed `string` not recognized in some frame files cause the `std` prefix is not there.

But when digging deep in whether all apps could run on graph which use string as original id, it seems that most apps will error out when quering. The reason includes 1. AutoWorkers cannot send string messages. 2. Some apps are not designed with support string in mind, so weird error happens, etc. These require a more careful case by case study.
