### PR TITLE
Deprecated 'k8s_minikube_vm_driver' parameter in session.

### DIFF
--- a/interactive_engine/tests/function_test.sh
+++ b/interactive_engine/tests/function_test.sh
@@ -32,8 +32,9 @@ function _start {
     cd $curdir/../deploy/testing && python3 maxgraph_test_server.py ${_port} &
     sleep 5s
     curl -XPOST http://localhost:${_port} -d 'import graphscope'
+    curl -XPOST http://localhost:${_port} -d 'graphscope.set_option(show_log=True)'
     curl -XPOST http://localhost:${_port} -d 'from graphscope.framework.loader import Loader'
-    curl_sess="curl -XPOST http://localhost:${_port} -d 'session = graphscope.session(num_workers=${workers}, show_log=True, k8s_volumes={\"data\": {\"type\": \"hostPath\", \"field\": {\"path\": \"${GS_TEST_DIR}\", \"type\": \"Directory\"}, \"mounts\": {\"mountPath\": \"/testingdata\"}}}, k8s_coordinator_cpu=1.0, k8s_coordinator_mem='\''4Gi'\'', k8s_vineyard_cpu=1.0, k8s_vineyard_mem='\''4Gi'\'', k8s_vineyard_shared_mem='\''4Gi'\'', k8s_engine_cpu=1.0, k8s_engine_mem='\''4Gi'\'', k8s_gie_graph_manager_image='\''${gie_manager_image}'\'', k8s_gs_image='\''${gs_image}'\'')' --write-out %{http_code} --silent --output ./curl.tmp"
+    curl_sess="curl -XPOST http://localhost:${_port} -d 'session = graphscope.session(num_workers=${workers}, k8s_volumes={\"data\": {\"type\": \"hostPath\", \"field\": {\"path\": \"${GS_TEST_DIR}\", \"type\": \"Directory\"}, \"mounts\": {\"mountPath\": \"/testingdata\"}}}, k8s_coordinator_cpu=1.0, k8s_coordinator_mem='\''4Gi'\'', k8s_vineyard_cpu=1.0, k8s_vineyard_mem='\''4Gi'\'', k8s_vineyard_shared_mem='\''4Gi'\'', k8s_engine_cpu=1.0, k8s_engine_mem='\''4Gi'\'', k8s_gie_graph_manager_image='\''${gie_manager_image}'\'', k8s_gs_image='\''${gs_image}'\'')' --write-out %{http_code} --silent --output ./curl.tmp"
 
     echo $curl_sess
     code=`sh -c "$curl_sess"`

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -271,10 +271,7 @@ class Session(object):
             k8s_waiting_for_delete (bool, optional): Waiting for service delete or not. Defaults to False.
 
             **kw (dict, optional): Other optional parameters will be put to :code:`**kw`.
-                - k8s_minikube_vm_driver (bool, optional):
-                    If your kubernetes cluster deployed on inner virtual machine
-                    (such as minikube with param --vm-driver is not None), you can specify
-                    :code:`k8s_minikube_vm_driver` is :code:`True`.
+                - k8s_minikube_vm_driver: Deprecated.
 
                 - k8s_client_config (dict, optional):
                     Provide configurable parameters for connecting to remote k8s,
@@ -363,11 +360,6 @@ class Session(object):
                 % kw.pop("show_log", None),
                 category=DeprecationWarning,
             )
-
-        # deploy minikube on virtual machine
-        self._config_params["k8s_minikube_vm_driver"] = kw.pop(
-            "k8s_minikube_vm_driver", False
-        )
 
         # update k8s_client_config params
         self._config_params["k8s_client_config"] = kw.pop("k8s_client_config", {})
@@ -678,7 +670,6 @@ class Session(object):
                 api_client=api_client,
                 namespace=self._config_params["k8s_namespace"],
                 service_type=self._config_params["k8s_service_type"],
-                minikube_vm_driver=self._config_params["k8s_minikube_vm_driver"],
                 num_workers=self._config_params["num_workers"],
                 gs_image=self._config_params["k8s_gs_image"],
                 etcd_image=self._config_params["k8s_etcd_image"],
@@ -741,10 +732,6 @@ class Session(object):
                 except:  # noqa: E722
                     pass
             raise
-
-        if self._config_params["enable_k8s"]:
-            # minikube service
-            self._k8s_cluster.check_and_set_vineyard_rpc_endpoint(self._engine_config)
 
         return proc, endpoint
 

--- a/python/graphscope/deploy/kubernetes/cluster.py
+++ b/python/graphscope/deploy/kubernetes/cluster.py
@@ -44,7 +44,6 @@ from graphscope.deploy.kubernetes.resource_builder import ServiceBuilder
 from graphscope.deploy.kubernetes.utils import KubernetesPodWatcher
 from graphscope.deploy.kubernetes.utils import delete_kubernetes_object
 from graphscope.deploy.kubernetes.utils import get_service_endpoints
-from graphscope.deploy.kubernetes.utils import is_minikube_cluster
 from graphscope.deploy.kubernetes.utils import try_to_read_namespace_from_context
 from graphscope.deploy.kubernetes.utils import wait_for_deployment_complete
 from graphscope.framework.errors import K8sError
@@ -65,9 +64,6 @@ class KubernetesCluster(object):
 
         service_type: str, optional
             Type determines how the GraphScope service is exposed.
-
-        minikube_vm_driver: bool, optional
-            True if minikube cluster :code:`--vm-driver` is not :code:`None`
 
         num_workers: int
             Number of workers to launch graphscope engine.
@@ -161,7 +157,6 @@ class KubernetesCluster(object):
         api_client=None,
         namespace=None,
         service_type=None,
-        minikube_vm_driver=None,
         num_workers=None,
         gs_image=None,
         etcd_image=None,
@@ -194,7 +189,6 @@ class KubernetesCluster(object):
 
         self._namespace = namespace
         self._service_type = service_type
-        self._minikube_vm_driver = minikube_vm_driver
         self._gs_image = gs_image
         self._num_workers = num_workers
         self._etcd_image = etcd_image
@@ -261,12 +255,6 @@ class KubernetesCluster(object):
             str: Kubernetes namespace.
         """
         return self._namespace
-
-    def check_and_set_vineyard_rpc_endpoint(self, engine_config):
-        if is_minikube_cluster() and self._minikube_vm_driver:
-            engine_config["vineyard_rpc_endpoint"] = self._get_minikube_service(
-                self._namespace, engine_config["vineyard_service_name"]
-            )
 
     def _get_free_namespace(self):
         while True:
@@ -557,11 +545,6 @@ class KubernetesCluster(object):
         )
 
     def _get_coordinator_endpoint(self):
-        if is_minikube_cluster() and self._minikube_vm_driver:
-            return self._get_minikube_service(
-                self._namespace, self._coordinator_service_name
-            )
-
         # Always len(endpoints) >= 1
         endpoints = get_service_endpoints(
             api_client=self._api_client,

--- a/python/graphscope/deploy/kubernetes/utils.py
+++ b/python/graphscope/deploy/kubernetes/utils.py
@@ -48,12 +48,6 @@ def parse_readable_memory(value):
     return value
 
 
-def is_minikube_cluster():
-    contexts, active_context = kube_config.list_kube_config_contexts()
-    if contexts:
-        return active_context["context"]["cluster"] == "minikube"
-
-
 def try_to_read_namespace_from_context():
     contexts, active_context = kube_config.list_kube_config_contexts()
     if contexts and "namespace" in active_context["context"]:

--- a/python/graphscope/deploy/tests/test_demo_script.py
+++ b/python/graphscope/deploy/tests/test_demo_script.py
@@ -268,7 +268,6 @@ def test_traversal_modern_graph(modern_graph_data_dir):
 
     gs_image, gie_manager_image = get_gs_image_on_ci_env()
     sess = graphscope.session(
-        show_log=True,
         num_workers=1,
         k8s_gs_image=gs_image,
         k8s_gie_graph_manager_image=gie_manager_image,

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,7 @@ nest_asyncio
 networkx
 numpy
 pandas
-protobuf
+protobuf>=3.12.0
 PyYAML
 scipy
 vineyard==0.1.8

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -33,7 +33,8 @@ from graphscope.framework.loader import Loader
 
 @pytest.fixture(scope="module")
 def graphscope_session():
-    sess = graphscope.session(run_on_local=True, show_log=True)
+    graphscope.set_option(show_log=True)
+    sess = graphscope.session(run_on_local=True)
     yield sess
     sess.close()
 

--- a/python/tests/test_scalability.py
+++ b/python/tests/test_scalability.py
@@ -28,7 +28,8 @@ from graphscope.framework.loader import Loader
 
 def p2p_property_graph(num_workers, directed=True):
     data_dir = os.path.expandvars("${GS_TEST_DIR}/property")
-    sess = graphscope.session(show_log=True, num_workers=num_workers, run_on_local=True)
+    graphscope.set_option(show_log=True)
+    sess = graphscope.session(num_workers=num_workers, run_on_local=True)
 
     g = sess.load_from(
         edges={

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -29,6 +29,8 @@ import pytest
 import graphscope
 from graphscope.client.session import DEFAULT_CONFIG_FILE
 
+graphscope.set_option(show_log=True)
+
 COORDINATOR_HOME = os.path.join(os.path.dirname(__file__), "../", "../coordinator")
 new_data_dir = os.path.expandvars("${GS_TEST_DIR}/new_property/v2_e2")
 
@@ -120,7 +122,7 @@ def load_graph(session):
 
 
 def test_default_session():
-    s = graphscope.session(run_on_local=True, show_log=True)
+    s = graphscope.session(run_on_local=True)
 
     info = s.info
     assert info["status"] == "active"
@@ -128,7 +130,7 @@ def test_default_session():
 
 
 def test_launch_cluster_on_local(local_config_file):
-    s = graphscope.session(run_on_local=True, show_log=True, config=local_config_file)
+    s = graphscope.session(run_on_local=True, config=local_config_file)
     info = s.info
     assert info["status"] == "active"
     s.close()
@@ -138,7 +140,7 @@ def test_launch_session_from_config(local_config_file):
     saved = os.environ.get("GS_CONFIG_PATH", "")
     try:
         os.environ["GS_CONFIG_PATH"] = local_config_file
-        s = graphscope.session(run_on_local=True, show_log=True)
+        s = graphscope.session(run_on_local=True)
 
         info = s.info
         assert info["status"] == "active"
@@ -149,7 +151,7 @@ def test_launch_session_from_config(local_config_file):
 
 def test_launch_session_from_dict():
     conf_dict = {"num_workers": 4}
-    s = graphscope.session(run_on_local=True, show_log=True, config=conf_dict)
+    s = graphscope.session(run_on_local=True, config=conf_dict)
 
     info = s.info
     assert info["status"] == "active"
@@ -157,9 +159,7 @@ def test_launch_session_from_dict():
 
 
 def test_config_dict_has_highest_priority(local_config_file):
-    s = graphscope.session(
-        run_on_local=True, show_log=True, config=local_config_file, num_workers=2
-    )
+    s = graphscope.session(run_on_local=True, config=local_config_file, num_workers=2)
 
     info = s.info
     assert info["status"] == "active"
@@ -168,20 +168,18 @@ def test_config_dict_has_highest_priority(local_config_file):
 
 def test_error_on_config_file_not_exist():
     with pytest.raises(FileNotFoundError, match="No such file or directory"):
-        graphscope.session(
-            run_on_local=True, show_log=True, config="~/non_existing_filename.txt"
-        )
+        graphscope.session(run_on_local=True, config="~/non_existing_filename.txt")
 
 
 def test_error_on_invalid_config_file(invalid_config_file):
     # invalid config file (example json format incorrect)
     with pytest.raises(json.decoder.JSONDecodeError):
-        graphscope.session(run_on_local=True, show_log=True, config=invalid_config_file)
+        graphscope.session(run_on_local=True, config=invalid_config_file)
 
 
 def test_error_on_used_after_close():
     # use after session close
-    s1 = graphscope.session(run_on_local=True, show_log=True)
+    s1 = graphscope.session(run_on_local=True)
 
     s1.close()
     with pytest.raises(RuntimeError, match="Attempted to use a closed Session."):
@@ -204,7 +202,7 @@ def test_error_on_used_after_close():
         )
 
     # close after close
-    s2 = graphscope.session(run_on_local=True, show_log=True)
+    s2 = graphscope.session(run_on_local=True)
 
     s2.close()
     assert s2.info["status"] == "closed"
@@ -214,7 +212,7 @@ def test_error_on_used_after_close():
 
 
 def test_correct_closing_on_hosts():
-    s1 = graphscope.session(run_on_local=True, show_log=True)
+    s1 = graphscope.session(run_on_local=True)
 
     s1.close()
     # check, launched coordinator and graphscope-engines on local are correctly closed.
@@ -223,9 +221,9 @@ def test_correct_closing_on_hosts():
 
 
 def test_border_cases():
-    s1 = graphscope.session(run_on_local=True, show_log=True)
-    s2 = graphscope.session(run_on_local=True, show_log=True)
-    s3 = graphscope.session(run_on_local=True, show_log=True)
+    s1 = graphscope.session(run_on_local=True)
+    s2 = graphscope.session(run_on_local=True)
+    s3 = graphscope.session(run_on_local=True)
 
     with pytest.raises(RuntimeError, match="No default session found."):
         g = graphscope.load_from(

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -29,10 +29,12 @@ import pytest
 import graphscope
 from graphscope.client.session import DEFAULT_CONFIG_FILE
 
-graphscope.set_option(show_log=True)
-
 COORDINATOR_HOME = os.path.join(os.path.dirname(__file__), "../", "../coordinator")
 new_data_dir = os.path.expandvars("${GS_TEST_DIR}/new_property/v2_e2")
+
+
+def setUpModule():
+    graphscope.set_option(show_log=True)
 
 
 @pytest.fixture

--- a/tutorials/6_unsupervised_learning_with_graphsage.ipynb
+++ b/tutorials/6_unsupervised_learning_with_graphsage.ipynb
@@ -54,7 +54,7 @@
     "\n",
     "# create session\n",
     "graphscope.set_option(show_log=True)\n",
-    "sess = graphscope.session(show_log=True, k8s_volumes=k8s_volumes)\n",
+    "sess = graphscope.session(k8s_volumes=k8s_volumes)\n",
     "\n",
     "# loading ppi graph\n",
     "graph = sess.load_from(\n",

--- a/tutorials/7_supervised_learning_with_gcn.ipynb
+++ b/tutorials/7_supervised_learning_with_gcn.ipynb
@@ -55,7 +55,7 @@
     "\n",
     "# create session\n",
     "graphscope.set_option(show_log=True)\n",
-    "sess = graphscope.session(show_log=True, k8s_volumes=k8s_volumes)\n",
+    "sess = graphscope.session(k8s_volumes=k8s_volumes)\n",
     "\n",
     "# loading cora graph\n",
     "graph = sess.load_from(\n",

--- a/tutorials/zh/6_unsupervised_learning_with_graphsage.ipynb
+++ b/tutorials/zh/6_unsupervised_learning_with_graphsage.ipynb
@@ -54,7 +54,7 @@
     "\n",
     "# 建立会话\n",
     "graphscope.set_option(show_log=True)\n",
-    "sess = graphscope.session(show_log=True, k8s_volumes=k8s_volumes)\n",
+    "sess = graphscope.session(k8s_volumes=k8s_volumes)\n",
     "\n",
     "# 加载PPI图数据\n",
     "graph = sess.load_from(\n",

--- a/tutorials/zh/7_supervised_learning_with_gcn.ipynb
+++ b/tutorials/zh/7_supervised_learning_with_gcn.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "# 开启会话\n",
     "graphscope.set_option(show_log=True)\n",
-    "sess = graphscope.session(show_log=True, k8s_volumes=k8s_volumes)\n",
+    "sess = graphscope.session(k8s_volumes=k8s_volumes)\n",
     "\n",
     "# 载入cora图数据\n",
     "graph = sess.load_from(\n",


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Minikube can not be deployed with non-driver in mac OS,  so we deprecate the k8s_minikube_vm_driver in session which is a bit hacky.
This PR also fixes #54 #106 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #54 #106 #114 

