### PR TITLE
[WIP] Adapt to the vineyard deployed with kubernetes DaemonSet object

### DIFF
--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -878,6 +878,7 @@ def launch_graphscope():
             image_pull_secrets=args.k8s_image_pull_secrets,
             volumes=args.k8s_volumes,
             num_workers=args.num_workers,
+            vineyard_socket=args.vineyard_socket,
             instance_id=args.instance_id,
             log_level=args.log_level,
             timeout_seconds=args.timeout_seconds,

--- a/python/graphscope/config.py
+++ b/python/graphscope/config.py
@@ -74,6 +74,7 @@ class GSConfig(object):
 
     k8s_waiting_for_delete = False
     num_workers = 2
+    vineyard_socket = None
     show_log = False
     log_level = "INFO"
 

--- a/python/graphscope/deploy/kubernetes/resource_builder.py
+++ b/python/graphscope/deploy/kubernetes/resource_builder.py
@@ -897,6 +897,7 @@ class GSCoordinatorBuilder(DeploymentBuilder):
         name,
         port,
         num_workers,
+        vineyard_socket,
         instance_id,
         log_level,
         namespace,
@@ -929,6 +930,7 @@ class GSCoordinatorBuilder(DeploymentBuilder):
     ):
         self._port = port
         self._num_workers = num_workers
+        self._vineyard_socket = vineyard_socket
         self._instance_id = instance_id
         self._log_level = log_level
         self._namespace = namespace
@@ -1072,4 +1074,6 @@ class GSCoordinatorBuilder(DeploymentBuilder):
             "--k8s_delete_namespace",
             str(self._delete_namespace),
         ]
+        if self._vineyard_socket is not None:
+            cmd.extend(["--vineyard_socket", self._vineyard_socket])
         return cmd


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Make GraphScope run on top of DaemonSet vineyard. 

## Please give a short brief about these changes.

Add a session parameter `vineyard_socket`, which is a path of vineyard socket file.     

In K8s cluster, it will mount this path as a hostPath volume with Socket type. Or GraphScope will launch a vineyard container inside engine pods and a random socket will be created if param missing.

## Notes

This pr cannot be merged yet caused by the following reasons:
- [x] `interactive.subgraph` need a vineyard rpc endpoint.
- [ ] Get vineyard IPC socket from daemonSet's annotation by `namespace` and `name`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #89 

