### PR TITLE
optimize source chain operator

### DIFF
--- a/interactive_engine/src/executor/runtime/src/dataflow/operator/sourcestep/builder.rs
+++ b/interactive_engine/src/executor/runtime/src/dataflow/operator/sourcestep/builder.rs
@@ -85,7 +85,8 @@ fn build_graph_source_operator<VV, VVI, EE, EEI, F>(source: &query_flow::SourceO
         if op_type == OperatorType::V ||
             op_type == OperatorType::E ||
             op_type == OperatorType::V_COUNT ||
-            op_type == OperatorType::E_COUNT {
+            op_type == OperatorType::E_COUNT ||
+            op_type == OperatorType::SOURCE_CHAIN {
             let primary_key_list = parse_from_bytes::<VertexPrimaryKeyListProto>(source.get_base().get_argument().get_payload()).unwrap();
             for primary_key in primary_key_list.get_primary_keys() {
                 let label_id = primary_key.get_label_id();


### PR DESCRIPTION
Description
-----------

GIE scan all vertices unnecessarily for a simple query like `g.V().has('label','id', xxx).out()`.
It should use primary key to find the exact vertex.

Relational Context
------------------

This bug was found in an experiment of an industrial paper, where some simple query cost too much time to execute.

