### PR TITLE
Generalize k8s_volumes and support mount pvc

### DIFF
--- a/coordinator/gscoordinator/cluster.py
+++ b/coordinator/gscoordinator/cluster.py
@@ -43,12 +43,11 @@ except ImportError:
     K8SApiException = None
     K8SConfigException = None
 
-from graphscope.deploy.kubernetes.resource_builder import EmptyDirVolumeBuilder
 from graphscope.deploy.kubernetes.resource_builder import GSEngineBuilder
 from graphscope.deploy.kubernetes.resource_builder import GSEtcdBuilder
 from graphscope.deploy.kubernetes.resource_builder import GSGraphManagerBuilder
-from graphscope.deploy.kubernetes.resource_builder import HostPathVolumeBuilder
 from graphscope.deploy.kubernetes.resource_builder import ServiceBuilder
+from graphscope.deploy.kubernetes.resource_builder import VolumeBuilder
 from graphscope.deploy.kubernetes.resource_builder import resolve_volume_builder
 from graphscope.deploy.kubernetes.utils import delete_kubernetes_object
 from graphscope.deploy.kubernetes.utils import get_kubernetes_object_info
@@ -251,8 +250,9 @@ class KubernetesClusterLauncher(Launcher):
         # volume1 is for vineyard ipc socket
         # MaxGraph: /home/maxgraph/data/vineyard
         engine_builder.add_volume(
-            EmptyDirVolumeBuilder(
+            VolumeBuilder(
                 name="vineyard-ipc-volume",
+                type="emptyDir",
                 field={},
                 mounts_list=[
                     {"mountPath": "/tmp/vineyard_workspace"},
@@ -262,8 +262,9 @@ class KubernetesClusterLauncher(Launcher):
         )
         # volume2 is for shared memory
         engine_builder.add_volume(
-            EmptyDirVolumeBuilder(
+            VolumeBuilder(
                 name="host-shm",
+                type="emptyDir",
                 field={"medium": "Memory"},
                 mounts_list=[{"mountPath": "/dev/shm"}],
             )

--- a/interactive_engine/tests/function_test.sh
+++ b/interactive_engine/tests/function_test.sh
@@ -51,6 +51,7 @@ function _start {
 }
 
 function _stop {
+    curl -XPOST http://localhost:${_port} -d 'session.close()'
     _port=`cat $tmp_result | awk -F":" '{print $3}'`
     echo "stop port is ${_port}"
     kill -INT `lsof -i:${_port} -t`

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -231,7 +231,7 @@ class Session(object):
                 Minimum number of memory request for graphmanager container. Defaults to '4Gi'.
 
             k8s_volumes (dict, optional): A dict of k8s volume which represents a directory containing data, accessible to the
-                containers in a pod. Defaults to {}. Only 'hostPath' supported yet. For example, we can mount host path with:
+                containers in a pod. Defaults to {}. For example, we can mount host path with:
 
                 k8s_volumes = {
                     "my-data": {

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -231,7 +231,9 @@ class Session(object):
                 Minimum number of memory request for graphmanager container. Defaults to '4Gi'.
 
             k8s_volumes (dict, optional): A dict of k8s volume which represents a directory containing data, accessible to the
-                containers in a pod. Defaults to {}. For example, we can mount host path with:
+                containers in a pod. Defaults to {}.
+
+                For example, you can mount host path with:
 
                 k8s_volumes = {
                     "my-data": {
@@ -246,6 +248,22 @@ class Session(object):
                             },
                             {
                                 "mountPath": "<path2>"
+                            }
+                        ]
+                    }
+                }
+
+                Or you can mount PVC with:
+
+                k8s_volumes = {
+                    "my-data": {
+                        "type": "persistentVolumeClaim",
+                        "field": {
+                            "claimName": "your-pvc-name"
+                        },
+                        "mounts": [
+                            {
+                                "mountPath": "<path1>"
                             }
                         ]
                     }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This pr also addresses problem #136. Now we can mount the same PVC with RWX mode between engine's pod and notebook server's pod

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #154 

