### PR TITLE
Print useful information for commonly used objects.

### DIFF
--- a/python/graphscope/experimental/nx/classes/digraph.py
+++ b/python/graphscope/experimental/nx/classes/digraph.py
@@ -272,6 +272,12 @@ class DiGraph(Graph):
         self.graph.update(attr)
         self._saved_signature = self.signature
 
+    def __repr__(self):
+        s = "graphscope.nx.DiGraph\n"
+        s += "type: " + self.template_str.split("<")[0]
+        s += str(self._schema)
+        return s
+
     @property
     def adj(self):
         """Graph adjacency object holding the successors of each node.

--- a/python/graphscope/experimental/nx/classes/graph.py
+++ b/python/graphscope/experimental/nx/classes/graph.py
@@ -376,6 +376,12 @@ class Graph(object):
         """
         return self.name
 
+    def __repr__(self):
+        s = "graphscope.nx.Graph\n"
+        s += "type: " + self.template_str.split("<")[0]
+        s += str(self._schema)
+        return s
+
     def __copy__(self):
         raise NetworkXError("not support shallow copy.")
 

--- a/python/graphscope/framework/app.py
+++ b/python/graphscope/framework/app.py
@@ -126,6 +126,9 @@ class AppAssets(object):
             # built_in apps has no gar resource.
             self._gar = None
 
+    def __repr__(self) -> str:
+        return f"graphscope.AppAssets <type: {self._type}, algorithm: {self._algo}>"
+
     @property
     def algo(self):
         """Algorithm name, e.g. sssp, pagerank.
@@ -268,7 +271,7 @@ class App(object):
         self._saved_signature = self.signature
 
     def __repr__(self):
-        return "<graphscope.App '%s'>" % self.key
+        return f"graphscope.App <type: {self._app_assets.type}, algorithm: {self._app_assets.algo}, bounded_graph: {str(self._graph)}>"
 
     @property
     def key(self):

--- a/python/graphscope/framework/app.py
+++ b/python/graphscope/framework/app.py
@@ -271,7 +271,9 @@ class App(object):
         self._saved_signature = self.signature
 
     def __repr__(self):
-        return f"graphscope.App <type: {self._app_assets.type}, algorithm: {self._app_assets.algo}, bounded_graph: {str(self._graph)}>"
+        s = f"graphscope.App <type: {self._app_assets.type}, algorithm: {self._app_assets.algo}"
+        s += f"bounded_graph: {str(self._graph)}>"
+        return s
 
     @property
     def key(self):

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -66,6 +66,9 @@ class BaseContext(object):
         self._session_id = session_id
         self._saved_signature = self.signature
 
+    def __repr__(self):
+        return f"graphscope.{self.__class__.__name__} from graph {str(self._graph)}"
+
     @property
     def key(self):
         """Unique identifier of a context."""

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -250,8 +250,14 @@ class Graph(object):
     def loaded(self):
         return self._key is not None
 
+    def __str__(self):
+        s = f"graphscope.Graph <{self.template_str}"
+
     def __repr__(self):
-        return "<grape.Graph '%s'>" % self._key
+        s = "graphscope.Graph\n"
+        s += "type: " + self.template_str.split("<")[0]
+        s += str(self._schema)
+        return s
 
     def unload(self):
         """Unload this graph from graphscope engine."""

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -251,11 +251,11 @@ class Graph(object):
         return self._key is not None
 
     def __str__(self):
-        s = f"graphscope.Graph <{self.template_str}"
+        return f"graphscope.Graph   {self.template_str}"
 
     def __repr__(self):
         s = "graphscope.Graph\n"
-        s += "type: " + self.template_str.split("<")[0]
+        s += "type: " + self.template_str.split("<")[0] + "\n\n"
         s += str(self._schema)
         return s
 

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -254,10 +254,7 @@ class Graph(object):
         return f"graphscope.Graph   {self.template_str}"
 
     def __repr__(self):
-        s = "graphscope.Graph\n"
-        s += "type: " + self.template_str.split("<")[0] + "\n\n"
-        s += str(self._schema)
-        return s
+        return f"graphscope.Graph\ntype: {self.template_str.split('<')[0]}\n\n{str(self._schema)}"
 
     def unload(self):
         """Unload this graph from graphscope engine."""

--- a/python/graphscope/framework/graph_schema.py
+++ b/python/graphscope/framework/graph_schema.py
@@ -129,7 +129,8 @@ class GraphSchema:
             self._vdata_type != types_pb2.INVALID
             and self._edata_type != types_pb2.INVALID
         ):
-            s += f"vdata_type: {types_pb2.DataType.Name(self._vdata_type)}\nedata_type: {types_pb2.DataType.Name(self._edata_type)}\n"
+            s += f"vdata_type: {types_pb2.DataType.Name(self._vdata_type)}\n"
+            s += f"edata_type: {types_pb2.DataType.Name(self._edata_type)}\n"
         for index, label in enumerate(self._vertex_labels):
             props = list(self._vertex_properties[index].keys())
             s += f"label: {label}\ntype: VERTEX\nproperties: {props}\n\n"

--- a/python/graphscope/framework/graph_schema.py
+++ b/python/graphscope/framework/graph_schema.py
@@ -124,29 +124,18 @@ class GraphSchema:
             self._edge_relationships.append([("_", "_")])
 
     def __repr__(self):
-        s = "oid_type: {}\nvid_type: {}\n".format(self._oid_type, self._vid_type)
+        s = f"oid_type: {self._oid_type}\nvid_type: {self._vid_type}\n"
         if (
             self._vdata_type != types_pb2.INVALID
             and self._edata_type != types_pb2.INVALID
         ):
-            s += "vdata_type: {}\nedata_type: {}\n".format(
-                types_pb2.DataType.Name(self._vdata_type),
-                types_pb2.DataType.Name(self._edata_type),
-            )
+            s += f"vdata_type: {types_pb2.DataType.Name(self._vdata_type)}\nedata_type: {types_pb2.DataType.Name(self._edata_type)}\n"
         for index, label in enumerate(self._vertex_labels):
-            props = [
-                (prop_name, types_pb2.DataType.Name(prop_type))
-                for prop_name, prop_type in self._vertex_properties[index].items()
-            ]
-            s += "label: {}\ntype: VERTEX\nproperties: {}\n\n".format(label, props)
+            props = list(self._vertex_properties[index].keys())
+            s += f"label: {label}\ntype: VERTEX\nproperties: {props}\n\n"
         for index, label in enumerate(self.edge_labels):
-            props = [
-                (prop_name, types_pb2.DataType.Name(prop_type))
-                for prop_name, prop_type in self._edge_properties[index].items()
-            ]
-            s += """label: {}\ntype: EDGE\nproperties: {}\nrelations: {}\n\n""".format(
-                label, props, self._edge_relationships[index]
-            )
+            props = list(self._edge_properties[index].keys())
+            s += f"""label: {label}\ntype: EDGE\nproperties: {props}\nrelations: {self._edge_relationships[index]}\n\n"""
         return s
 
     def __str__(self):

--- a/python/graphscope/interactive/query.py
+++ b/python/graphscope/interactive/query.py
@@ -52,6 +52,9 @@ class InteractiveQuery(object):
         self._client = Client(self._graph_url, "g")
         self._closed = False
 
+    def __repr__(self):
+        return f"graphscope.InteractiveQuery <{self._graph_url}>"
+
     @property
     def object_id(self):
         """Get the vineyard object id of graph.


### PR DESCRIPTION
Override `__repr__` and `__str__` for commonly used objects such as `Graph`, `App`, `Context`, etc. 
Now it's more easier to inspect informations about those objects.

Fixes #164

