### PR TITLE
Refine project_to_simple method.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,8 +411,8 @@ jobs:
     - name: Clean
       if: always()
       run: |
-        sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} || true
+        sudo docker rmi -f registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
+            registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} || true
 
   gie-test:
     runs-on: self-hosted
@@ -482,8 +482,8 @@ jobs:
     - name: Clean
       if: always()
       run: |
-        sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} || true
+        sudo docker rmi -f registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
+            registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} || true
 
   release-image:
     runs-on: ubuntu-20.04
@@ -526,5 +526,7 @@ jobs:
     - name: Clean
       if: always()
       run: |
-        sudo docker rmi registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
-                        registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} || true
+        sudo docker rmi -f registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:latest \
+            registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:latest \
+            registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:${{ github.sha }} \
+            registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:${{ github.sha }} || true

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -325,27 +325,26 @@ class Graph(object):
                 v_label_id = self._schema.vertex_label_index(v_label)
             else:
                 v_label_id = v_label
-                v_label = self._schema.vertex_labels(v_label_id)
+                check_out_of_range(v_label_id, self._schema.vertex_label_num)
+                v_label = self._schema.vertex_labels[v_label_id]
             if isinstance(e_label, str):
                 e_label_id = self._schema.edge_label_index(e_label)
             else:
                 e_label_id = e_label
-                e_label = self._schema.edge_labels(e_label)
+                check_out_of_range(e_label_id, self._schema.edge_label_num)
+                e_label = self._schema.edge_labels[e_label]
         except ValueError as e:
             raise ValueError("Label does not exists.") from e
 
         def check_out_of_range(id, length):
             if id >= length or id < 0:
-                raise KeyError("id {} is out of range.".format(id))
-
-        check_out_of_range(v_label_id, self._schema.vertex_label_num)
-        check_out_of_range(e_label_id, self._schema.edge_label_num)
+                raise IndexError("id {} is out of range.".format(id))
 
         # Check relation v_label -> e_label <- v_label exists.
         relation = (v_label, v_label)
-        if relation not in self._schema.edge_relations[e_label_id]:
+        if relation not in self._schema.edge_relationships[e_label_id]:
             raise ValueError(
-                f"Graph doesn't contain such relationship {v_label} -> {e_label} <- {v_label}."
+                f"Graph doesn't contain such relationship: {v_label} -> {e_label} <- {v_label}."
             )
 
         try:

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -320,6 +320,10 @@ class Graph(object):
         check_argument(self.graph_type == types_pb2.ARROW_PROPERTY)
         self.check_unmodified()
 
+        def check_out_of_range(id, length):
+            if id >= length or id < 0:
+                raise IndexError("id {} is out of range.".format(id))
+
         try:
             if isinstance(v_label, str):
                 v_label_id = self._schema.vertex_label_index(v_label)
@@ -336,10 +340,6 @@ class Graph(object):
         except ValueError as e:
             raise ValueError("Label does not exists.") from e
 
-        def check_out_of_range(id, length):
-            if id >= length or id < 0:
-                raise IndexError("id {} is out of range.".format(id))
-
         # Check relation v_label -> e_label <- v_label exists.
         relation = (v_label, v_label)
         if relation not in self._schema.edge_relationships[e_label_id]:
@@ -350,7 +350,7 @@ class Graph(object):
         try:
             if v_prop is None:
                 v_prop_id = -1
-                v_data_type = None
+                vdata_type = None
             else:
                 if isinstance(v_prop, str):
                     v_prop_id = self._schema.vertex_property_index(v_label_id, v_prop)
@@ -361,7 +361,7 @@ class Graph(object):
                 vdata_type = list(properties.values())[v_prop_id]
             if e_prop is None:
                 e_prop_id = -1
-                e_properties = [None]
+                edata_type = None
             else:
                 if isinstance(e_prop, str):
                     e_prop_id = self._schema.edge_property_index(e_label_id, e_prop)

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -317,85 +317,65 @@ class Graph(object):
             raise RuntimeError(
                 "The graph is not registered in remote, and can't project to simple"
             )
-        self.check_unmodified()
         check_argument(self.graph_type == types_pb2.ARROW_PROPERTY)
-        check_argument(isinstance(v_label, (int, str)))
-        check_argument(isinstance(e_label, (int, str)))
+        self.check_unmodified()
+
+        try:
+            if isinstance(v_label, str):
+                v_label_id = self._schema.vertex_label_index(v_label)
+            else:
+                v_label_id = v_label
+                v_label = self._schema.vertex_labels(v_label_id)
+            if isinstance(e_label, str):
+                e_label_id = self._schema.edge_label_index(e_label)
+            else:
+                e_label_id = e_label
+                e_label = self._schema.edge_labels(e_label)
+        except ValueError as e:
+            raise ValueError("Label does not exists.") from e
 
         def check_out_of_range(id, length):
-            if id < length and id > -1:
-                return id
-            else:
+            if id >= length or id < 0:
                 raise KeyError("id {} is out of range.".format(id))
 
-        try:
-            v_label_id = (
-                check_out_of_range(v_label, self._schema.vertex_label_num)
-                if isinstance(v_label, int)
-                else self._schema.vertex_label_index(v_label)
-            )
-        except ValueError as e:
+        check_out_of_range(v_label_id, self._schema.vertex_label_num)
+        check_out_of_range(e_label_id, self._schema.edge_label_num)
+
+        # Check relation v_label -> e_label <- v_label exists.
+        relation = (v_label, v_label)
+        if relation not in self._schema.edge_relations[e_label_id]:
             raise ValueError(
-                "graph not contains the vertex label {}.".format(v_label)
-            ) from e
+                f"Graph doesn't contain such relationship {v_label} -> {e_label} <- {v_label}."
+            )
 
         try:
-            e_label_id = (
-                check_out_of_range(e_label, self._schema.edge_label_num)
-                if isinstance(e_label, int)
-                else self._schema.edge_label_index(e_label)
-            )
+            if v_prop is None:
+                v_prop_id = -1
+                v_data_type = None
+            else:
+                if isinstance(v_prop, str):
+                    v_prop_id = self._schema.vertex_property_index(v_label_id, v_prop)
+                else:
+                    v_prop_id = v_prop
+                properties = self._schema.vertex_properties[v_label_id]
+                check_out_of_range(v_prop_id, len(properties))
+                vdata_type = list(properties.values())[v_prop_id]
+            if e_prop is None:
+                e_prop_id = -1
+                e_properties = [None]
+            else:
+                if isinstance(e_prop, str):
+                    e_prop_id = self._schema.edge_property_index(e_label_id, e_prop)
+                else:
+                    e_prop_id = e_prop
+                properties = self._schema.edge_properties[e_label_id]
+                check_out_of_range(e_prop_id, len(properties))
+                edata_type = list(properties.values())[e_prop_id]
         except ValueError as e:
-            raise InvalidArgumentError(
-                "graph not contains the edge label {}.".format(e_label)
-            ) from e
-
-        if v_prop is None:
-            # NB: -1 means vertex property is None
-            v_prop_id = -1
-            v_properties = None
-        else:
-            check_argument(isinstance(v_prop, (int, str)))
-            v_properties = self._schema.vertex_properties[v_label_id]
-            try:
-                v_prop_id = (
-                    check_out_of_range(v_prop, len(v_properties))
-                    if isinstance(v_prop, int)
-                    else self._schema.vertex_property_index(v_label_id, v_prop)
-                )
-            except ValueError as e:
-                raise ValueError(
-                    "vertex label {} not contains the property {}".format(
-                        v_label, v_prop
-                    )
-                ) from e
-
-        if e_prop is None:
-            # NB: -1 means edge property is None
-            e_prop_id = -1
-            e_properties = None
-        else:
-            check_argument(isinstance(e_prop, (int, str)))
-            e_properties = self._schema.edge_properties[e_label_id]
-            try:
-                e_prop_id = (
-                    check_out_of_range(e_prop, len(e_properties))
-                    if isinstance(e_prop, int)
-                    else self._schema.edge_property_index(e_label_id, e_prop)
-                )
-            except ValueError as e:
-                raise ValueError(
-                    "edge label {} not contains the property {}".format(e_label, e_prop)
-                ) from e
+            raise ValueError("Property does not exists.") from e
 
         oid_type = self._schema.oid_type
         vid_type = self._schema.vid_type
-        vdata_type = None
-        if v_properties:
-            vdata_type = list(v_properties.values())[v_prop_id]
-        edata_type = None
-        if e_properties:
-            edata_type = list(e_properties.values())[e_prop_id]
 
         op = dag_utils.project_arrow_property_graph(
             self,
@@ -424,8 +404,8 @@ class Graph(object):
         check_argument(
             isinstance(selector, Mapping), "selector of add column must be a dict"
         )
-        self.check_unmodified()
         check_argument(self.graph_type == types_pb2.ARROW_PROPERTY)
+        self.check_unmodified()
         selector = {
             key: results._transform_selector(value) for key, value in selector.items()
         }
@@ -443,6 +423,7 @@ class Graph(object):
         Returns:
             `numpy.ndarray`
         """
+        check_argument(self.graph_type == types_pb2.ARROW_PROPERTY)
         self.check_unmodified()
         selector = utils.transform_labeled_vertex_property_data_selector(self, selector)
         vertex_range = utils.transform_vertex_range(vertex_range)
@@ -460,6 +441,7 @@ class Graph(object):
         Returns:
             `pandas.DataFrame`
         """
+        check_argument(self.graph_type == types_pb2.ARROW_PROPERTY)
         self.check_unmodified()
         check_argument(
             isinstance(selector, Mapping),

--- a/python/tests/test_graph.py
+++ b/python/tests/test_graph.py
@@ -84,19 +84,19 @@ def test_project_to_simple_with_id(p2p_property_graph, sssp_result):
 def test_error_on_project_to_simple_id_out_of_range(arrow_property_graph):
     g = arrow_property_graph
     # g has 4 vertex labels and 2 edge labels, each label has 1 property
-    with pytest.raises(KeyError, match="id 5 is out of range"):
+    with pytest.raises(IndexError, match="id 5 is out of range"):
         g.project_to_simple(v_label=5, e_label=0)
 
-    with pytest.raises(KeyError, match="id 3 is out of range"):
+    with pytest.raises(IndexError, match="id 3 is out of range"):
         g.project_to_simple(v_label=0, e_label=3)
 
-    with pytest.raises(KeyError, match="id -1 is out of range"):
+    with pytest.raises(IndexError, match="id -1 is out of range"):
         g.project_to_simple(v_label=-1, e_label=3)
 
-    with pytest.raises(KeyError, match="id 2 is out of range"):
+    with pytest.raises(IndexError, match="id 2 is out of range"):
         g.project_to_simple(v_label=0, e_label=0, v_prop=2, e_prop=0)
 
-    with pytest.raises(KeyError, match="id 1 is out of range"):
+    with pytest.raises(IndexError, match="id 1 is out of range"):
         g.project_to_simple(v_label=0, e_label=0, v_prop=0, e_prop=1)
 
 
@@ -115,6 +115,19 @@ def test_error_label_on_project_to_simple(arrow_property_graph):
 
     with pytest.raises(ValueError, match="Property does not exists."):
         g.project_to_simple(v_label="v0", e_label="e0", e_prop="foo")
+
+
+def test_error_relationship_on_project_to_simple(arrow_modern_graph):
+    with pytest.raises(
+        ValueError,
+        match="Graph doesn't contain such relationship: person -> created <- person",
+    ):
+        g.project_to_simple(v_label="person", e_label="created")
+    with pytest.raises(
+        ValueError,
+        match="Graph doesn't contain such relationship: software -> knows <- software",
+    ):
+        g.project_to_simple(v_label="software", e_label="knows")
 
 
 def test_unload(graphscope_session):

--- a/python/tests/test_graph.py
+++ b/python/tests/test_graph.py
@@ -118,6 +118,7 @@ def test_error_label_on_project_to_simple(arrow_property_graph):
 
 
 def test_error_relationship_on_project_to_simple(arrow_modern_graph):
+    g = arrow_modern_graph
     with pytest.raises(
         ValueError,
         match="Graph doesn't contain such relationship: person -> created <- person",

--- a/python/tests/test_graph.py
+++ b/python/tests/test_graph.py
@@ -104,18 +104,16 @@ def test_error_label_on_project_to_simple(arrow_property_graph):
     g = arrow_property_graph
     # g has vertex labels: v0, v1, v2, v3, each label has a property: weight
     # g has edge label: e0, e1, each label has a property: dist
-    with pytest.raises(ValueError, match="graph not contains the vertex label v4"):
+    with pytest.raises(ValueError, match="Label does not exists"):
         g.project_to_simple(v_label="v4", e_label="e0")
 
-    with pytest.raises(ValueError, match="graph not contains the edge label e2"):
+    with pytest.raises(ValueError, match="Label does not exists"):
         g.project_to_simple(v_label="v0", e_label="e2")
 
-    with pytest.raises(
-        ValueError, match="vertex label v0 not contains the property foo"
-    ):
+    with pytest.raises(ValueError, match="Property does not exists."):
         g.project_to_simple(v_label="v0", e_label="e0", v_prop="foo")
 
-    with pytest.raises(ValueError, match="edge label e0 not contains the property foo"):
+    with pytest.raises(ValueError, match="Property does not exists."):
         g.project_to_simple(v_label="v0", e_label="e0", e_prop="foo")
 
 


### PR DESCRIPTION
1. Add relationship check for `project_to_simple`, and some test cases.
2. Make `project_to_simple` more concise.
3. Add graph type check for `graph.to_numpy` and `graph.to_dataframe`.
4. Always clean up temporal image in CI.