### PR TITLE
[Bugfix]: Stop propgagating signal to coordinator subprocess

### DIFF
--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -944,8 +944,15 @@ def launch_graphscope():
     logger.info("Coordinator server listen at 0.0.0.0:%d", args.port)
 
     server.start()
+
+    # handle SIGTERM signal
+    def terminate(signum, frame):
+        del coordinator_service_servicer  # noqa: F821
+
+    signal.signal(signal.SIGTERM, terminate)
+
     try:
-        # Grpc has handled SIGINT/SIGTERM
+        # Grpc has handled SIGINT
         server.wait_for_termination()
     except KeyboardInterrupt:
         del coordinator_service_servicer

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -1109,8 +1109,11 @@ def _launch_coordinator_on_local(config_params):
 
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "TRUE"
+    # Param `start_new_session=True` is for putting child process to a new process group
+    # so it won't get the signals from parent.
     process = subprocess.Popen(
         cmd,
+        start_new_session=True,
         cwd=COORDINATOR_HOME,
         universal_newlines=True,
         encoding="utf-8",


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
This pr is a fix when `ctrl-c` will kill the analytical engine after session launched in python interpreter with  `run_on_local` mode.

Also, Add `SIGTERM` signal handle In coordinator to stop graceful. 

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #178 

