### PR TITLE
support dangling handle for each session connection

### DIFF
--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -229,24 +229,14 @@ class CoordinatorServiceServicer(
             if self._dangling_detecting_timer:
                 self._dangling_detecting_timer.cancel()
 
-            if self._request.cleanup_instance:
-                self._dangling_detecting_timer = threading.Timer(
-                    interval=self._request.dangling_timeout_seconds,
-                    function=self._cleanup,
-                    args=(
-                        True,
-                        True,
-                    ),
-                )
-            else:
-                self._dangling_detecting_timer = threading.Timer(
-                    interval=self._request.dangling_timeout_seconds,
-                    function=self._cleanup,
-                    args=(
-                        False,
-                        True,
-                    ),
-                )
+            self._dangling_detecting_timer = threading.Timer(
+                interval=self._request.dangling_timeout_seconds,
+                function=self._cleanup,
+                args=(
+                    self._request.cleanup_instance,
+                    True,
+                ),
+            )
             self._dangling_detecting_timer.start()
 
         # analytical engine

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -103,7 +103,7 @@ class CoordinatorServiceServicer(
 
     """
 
-    def __init__(self, launcher, dangling_seconds, log_level="INFO"):
+    def __init__(self, launcher, dangling_timeout_seconds, log_level="INFO"):
         self._launcher = launcher
 
         self._request = None
@@ -149,10 +149,15 @@ class CoordinatorServiceServicer(
         self._streaming_logs = True
 
         # dangling check
-        self._dangling_seconds = dangling_seconds
-        if self._dangling_seconds >= 0:
+        self._dangling_timeout_seconds = dangling_timeout_seconds
+        if self._dangling_timeout_seconds >= 0:
             self._dangling_detecting_timer = threading.Timer(
-                interval=self._dangling_seconds, function=self._cleanup, args=(True,)
+                interval=self._dangling_timeout_seconds,
+                function=self._cleanup,
+                args=(
+                    True,
+                    True,
+                ),
             )
             self._dangling_detecting_timer.start()
 
@@ -219,13 +224,31 @@ class CoordinatorServiceServicer(
         )
 
     def HeartBeat(self, request, context):
-        if self._dangling_seconds >= 0:
+        if self._request and self._request.dangling_timeout_seconds >= 0:
             # Reset dangling detect timer
-            self._dangling_detecting_timer.cancel()
-            self._dangling_detecting_timer = threading.Timer(
-                interval=self._dangling_seconds, function=self._cleanup, args=(True,)
-            )
+            if self._dangling_detecting_timer:
+                self._dangling_detecting_timer.cancel()
+
+            if self._request.cleanup_instance:
+                self._dangling_detecting_timer = threading.Timer(
+                    interval=self._request.dangling_timeout_seconds,
+                    function=self._cleanup,
+                    args=(
+                        True,
+                        True,
+                    ),
+                )
+            else:
+                self._dangling_detecting_timer = threading.Timer(
+                    interval=self._request.dangling_timeout_seconds,
+                    function=self._cleanup,
+                    args=(
+                        False,
+                        True,
+                    ),
+                )
             self._dangling_detecting_timer.start()
+
         # analytical engine
         request = message_pb2.HeartBeatRequest()
         try:
@@ -442,7 +465,9 @@ class CoordinatorServiceServicer(
                 "Session handle does not match",
             )
 
-        self._cleanup(stop_instance=request.stop_instance)
+        self._cleanup(
+            cleanup_instance=self._request.cleanup_instance, is_dangling=False
+        )
         self._request = None
 
         # Session closed, stop streaming logs
@@ -589,7 +614,7 @@ class CoordinatorServiceServicer(
             resp.status.op.CopyFrom(op)
         return resp
 
-    def _cleanup(self, stop_instance=True, is_dangling=False):
+    def _cleanup(self, cleanup_instance=True, is_dangling=False):
         # clean up session resources.
         for key in self._object_manager.keys():
             obj = self._object_manager.get(key)
@@ -625,12 +650,14 @@ class CoordinatorServiceServicer(
 
         self._object_manager.clear()
 
+        self._request = None
+
         # cancel dangling detect timer
         if self._dangling_detecting_timer:
             self._dangling_detecting_timer.cancel()
 
         # close engines
-        if stop_instance:
+        if cleanup_instance:
             self._analytical_engine_stub = None
             self._analytical_engine_endpoint = None
             self._launcher.stop(is_dangling=is_dangling)
@@ -958,7 +985,7 @@ def launch_graphscope():
 
     coordinator_service_servicer = CoordinatorServiceServicer(
         launcher=launcher,
-        dangling_seconds=args.dangling_timeout_seconds,
+        dangling_timeout_seconds=args.dangling_timeout_seconds,
         log_level=args.log_level,
     )
 
@@ -974,7 +1001,8 @@ def launch_graphscope():
 
     # handle SIGTERM signal
     def terminate(signum, frame):
-        del coordinator_service_servicer  # noqa: F821
+        global coordinator_service_servicer
+        del coordinator_service_servicer
 
     signal.signal(signal.SIGTERM, terminate)
 

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -40,6 +40,8 @@ message ResponseStatus {
 ////////////////////////////////////////////////////////////////////////////////
 
 message ConnectSessionRequest {
+  bool cleanup_instance = 1;
+  int32 dangling_timeout_seconds = 2;
 }
 
 message ConnectSessionResponse {
@@ -129,7 +131,6 @@ message CloseSessionRequest {
   // REQUIRED: session_id must be returned by a CreateSession call
   // to the same master service.
   string session_id = 1;
-  bool stop_instance = 2;
 }
 
 message CloseSessionResponse {

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -305,6 +305,7 @@ class Session(object):
 
             dangling_timeout_seconds (int, optional): After seconds of client disconnect,
                 coordinator will kill this graphscope instance. Defaults to 600.
+                Expect this value to be greater than 5 (heartbeat interval).
                 Disable dangling check by setting -1.
 
             k8s_waiting_for_delete (bool, optional): Waiting for service delete or not. Defaults to False.
@@ -777,7 +778,7 @@ class Session(object):
                 self._config_params["num_workers"],
                 self._config_params["k8s_namespace"],
             ) = self._grpc_client.connect(
-                cleanup_instance=False if self._config_params["addr"] else True,
+                cleanup_instance=not bool(self._config_params["addr"]),
                 dangling_timeout_seconds=self._config_params[
                     "dangling_timeout_seconds"
                 ],

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -563,9 +563,7 @@ class Session(object):
         self._learning_instance_dict.clear()
 
         if self._grpc_client:
-            self._grpc_client.close(
-                stop_instance=False if self._config_params["addr"] else True
-            )
+            self._grpc_client.close()
             self._grpc_client = None
             _session_dict.pop(self._session_id, None)
 
@@ -778,7 +776,12 @@ class Session(object):
                 self._pod_name_list,
                 self._config_params["num_workers"],
                 self._config_params["k8s_namespace"],
-            ) = self._grpc_client.connect()
+            ) = self._grpc_client.connect(
+                cleanup_instance=False if self._config_params["addr"] else True,
+                dangling_timeout_seconds=self._config_params[
+                    "dangling_timeout_seconds"
+                ],
+            )
             # fetch logs
             if self._config_params["enable_k8s"]:
                 self._grpc_client.fetch_logs()

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -184,13 +184,6 @@ class Graph(object):
         self._e_labels = self._schema.edge_labels
         self._e_relationships = self._schema.edge_relationships
 
-        # create gremlin server pod asynchronously
-        if gs_config.initializing_interactive_engine:
-            self._interactive_instance_launching_thread = threading.Thread(
-                target=self._launch_interactive_instance_impl, args=()
-            )
-            self._interactive_instance_launching_thread.start()
-
     def _ensure_loaded(self):
         if self._key is not None and self._pending_op is None:
             return
@@ -211,6 +204,12 @@ class Graph(object):
             self._unsealed_edges.clear()
             # init saved_signature (must be after init schema)
             self._saved_signature = self.signature
+            # create gremlin server pod asynchronously
+            if gs_config.initializing_interactive_engine:
+                self._interactive_instance_launching_thread = threading.Thread(
+                    target=self._launch_interactive_instance_impl, args=()
+                )
+                self._interactive_instance_launching_thread.start()
 
     @property
     def key(self):


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Support reconnect to the coordinator service in `addr` mode when session quit accidentally.

```python
# deploy graphscope with HELM
import graphscope
graphscope.set_option(dangling_timeout_seconds=60)
sess = graphscope.session(addr='<ip>:<port>')

# now session quit accidentally.
# after dangling_timeout_seconds=60 s, you can reconnect to the service

# note that resource such as app/graph inside session will not exist.
sess = graphscope.session(addr='<ip>:<port>')
```

This PR also fix problem of creating `interactive_query` pod asynchronously after loading graph.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #195 

