### PR TITLE
Use None to select all property, and empty list to deselect all.

### DIFF
--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -745,7 +745,7 @@ class Graph(object):
             graph._base_graph = self._base_graph or self
         return graph
 
-    def add_vertices(self, vertices, label="_", properties=[], vid_field=0):
+    def add_vertices(self, vertices, label="_", properties=None, vid_field=0):
         is_from_existed_graph = len(self._unsealed_vertices) != len(
             self._v_labels
         ) or len(self._unsealed_edges) != len(self._e_labels)
@@ -780,7 +780,7 @@ class Graph(object):
         self,
         edges,
         label="_",
-        properties=[],
+        properties=None,
         src_label=None,
         dst_label=None,
         src_field=0,

--- a/python/graphscope/framework/graph_utils.py
+++ b/python/graphscope/framework/graph_utils.py
@@ -82,7 +82,7 @@ class VertexLabel(object):
         elif self.loader.deduced_properties:
             self.add_properties(self.loader.deduced_properties)
         self.loader.select_columns(
-            self.properties, include_all=bool(not self.raw_properties)
+            self.properties, include_all=bool(self.raw_properties is None)
         )
         self.loader.finish()
         self._finished = True
@@ -163,7 +163,7 @@ class EdgeSubLabel(object):
         elif self.loader.deduced_properties:
             self.add_properties(self.loader.deduced_properties)
         self.loader.select_columns(
-            self.properties, include_all=bool(not self.raw_properties)
+            self.properties, include_all=bool(self.raw_properties is None)
         )
         self.loader.finish()
         self._finished = True

--- a/python/graphscope/framework/loader.py
+++ b/python/graphscope/framework/loader.py
@@ -17,6 +17,7 @@
 #
 
 import logging
+import pathlib
 from typing import Dict
 from typing import Sequence
 from typing import Tuple
@@ -170,6 +171,8 @@ class Loader(object):
         """
         if isinstance(source, str):
             self.process_location(source)
+        elif isinstance(source, pathlib.Path):
+            self.process_location(str(source))
         elif isinstance(source, pd.DataFrame):
             self.process_pandas(source)
         elif vineyard is not None and isinstance(

--- a/python/tests/test_create_graph.py
+++ b/python/tests/test_create_graph.py
@@ -218,7 +218,7 @@ def test_prop_is_empty_loader(graphscope_session, student_group_e, student_v):
     graph = graph.add_vertices(student_v, "student", [], "student_id")
     graph = graph.add_edges(student_group_e, "group", [])
     assert len(graph.schema.get_vertex_properties("student")) == 1
-    assert len(graph.schema.get_edge_properties("group")) == 1
+    assert len(graph.schema.get_edge_properties("group")) == 0
 
 
 def test_properties_omitted_loader_with_generate_eid(

--- a/python/tests/test_create_graph.py
+++ b/python/tests/test_create_graph.py
@@ -205,20 +205,28 @@ def test_complete_form_loader_deprecated(
     assert graph.loaded()
 
 
-def test_properties_omitted_loader(graphscope_session, student_group_e, student_v):
+def test_properties_is_none_loader(graphscope_session, student_group_e, student_v):
+    graph = graphscope_session.g(generate_eid=False)
+    graph = graph.add_vertices(student_v, "student", None, "student_id")
+    graph = graph.add_edges(student_group_e, "group", None)
+    assert len(graph.schema.get_vertex_properties("student")) == 4
+    assert len(graph.schema.get_edge_properties("group")) == 2
+
+
+def test_properties_is_empty_loader(graphscope_session, student_group_e, student_v):
     graph = graphscope_session.g(generate_eid=False)
     graph = graph.add_vertices(student_v, "student", [], "student_id")
     graph = graph.add_edges(student_group_e, "group", [])
-    assert len(graph.schema.get_vertex_properties("student")) == 4
-    assert len(graph.schema.get_edge_properties("group")) == 2
+    assert len(graph.schema.get_vertex_properties("student")) == 1
+    assert len(graph.schema.get_edge_properties("group")) == 1
 
 
 def test_properties_omitted_loader_with_generate_eid(
     graphscope_session, student_group_e, student_v
 ):
     graph = graphscope_session.g(generate_eid=True)
-    graph = graph.add_vertices(student_v, "student", [], "student_id")
-    graph = graph.add_edges(student_group_e, "group", [])
+    graph = graph.add_vertices(student_v, "student", None, "student_id")
+    graph = graph.add_edges(student_group_e, "group", None)
     assert len(graph.schema.get_vertex_properties("student")) == 4
     assert len(graph.schema.get_edge_properties("group")) == 3
 

--- a/python/tests/test_create_graph.py
+++ b/python/tests/test_create_graph.py
@@ -205,15 +205,15 @@ def test_complete_form_loader_deprecated(
     assert graph.loaded()
 
 
-def test_properties_is_none_loader(graphscope_session, student_group_e, student_v):
+def test_default_prop_is_none_loader(graphscope_session, student_group_e, student_v):
     graph = graphscope_session.g(generate_eid=False)
-    graph = graph.add_vertices(student_v, "student", None, "student_id")
-    graph = graph.add_edges(student_group_e, "group", None)
+    graph = graph.add_vertices(student_v, "student")
+    graph = graph.add_edges(student_group_e, "group")
     assert len(graph.schema.get_vertex_properties("student")) == 4
     assert len(graph.schema.get_edge_properties("group")) == 2
 
 
-def test_properties_is_empty_loader(graphscope_session, student_group_e, student_v):
+def test_prop_is_empty_loader(graphscope_session, student_group_e, student_v):
     graph = graphscope_session.g(generate_eid=False)
     graph = graph.add_vertices(student_v, "student", [], "student_id")
     graph = graph.add_edges(student_group_e, "group", [])


### PR DESCRIPTION
* Use None to select all property, and empty list to deselect all.
* Loader now accepts a `pathlib.Path` object.
* Add tests.

Related to #191 