### PR TITLE
[networkx] implement clear_edges, deepcopy of to_directed and to_undirected api

### DIFF
--- a/analytical_engine/core/fragment/dynamic_fragment.h
+++ b/analytical_engine/core/fragment/dynamic_fragment.h
@@ -792,7 +792,7 @@ class DynamicFragment {
   // generate directed graph from orignal undirected graph.
   void ToDirectedFrom(std::shared_ptr<DynamicFragment> origin) {
     // original graph must be undirected.
-    assert(!origin->directed);
+    assert(!origin->directed());
 
     directed_ = true;
     load_strategy_ = grape::LoadStrategy::kBothOutIn;
@@ -805,7 +805,7 @@ class DynamicFragment {
   // generate undirected graph from original directed graph.
   void ToUnDirectedFrom(std::shared_ptr<DynamicFragment> origin) {
     // original graph must be directed.
-    assert(origin->directed);
+    assert(origin->directed());
 
     directed_ = false;
     load_strategy_ = grape::LoadStrategy::kOnlyOut;
@@ -2275,7 +2275,7 @@ class DynamicFragment {
   void copyEdges(std::shared_ptr<DynamicFragment>& other,
                  const std::string& type) {
     if (type == "reverse") {
-      assert(orig->directed_);
+      assert(other->directed());
       ienum_ = other->oenum_;
       oenum_ = other->ienum_;
       inner_ie_pos_.resize(other->inner_oe_pos_.size());

--- a/analytical_engine/core/fragment/dynamic_fragment.h
+++ b/analytical_engine/core/fragment/dynamic_fragment.h
@@ -523,6 +523,8 @@ class NbrMapSpace {
  public:
   NbrMapSpace() : index_(0) {}
 
+  size_t size() { return buffer_.size(); }
+
   // Create a new linked list
   inline size_t emplace(VID_T vid, const EDATA_T& edata) {
     buffer_.resize(index_ + 1);
@@ -603,6 +605,27 @@ class NbrMapSpace {
     }
   }
 
+  // copy the edge space double size, use for undirected graph to directed
+  // graph.
+  void double_copy(const NbrMapSpace<EDATA_T>& other) {
+    index_ = other.index_ * 2;
+    size_t old_index = other.index_;
+    buffer_.resize(other.buffer_.size() * 2);
+    for (size_t i = 0; i < other.buffer_.size(); ++i) {
+      if (other.buffer_[i] != nullptr) {
+        buffer_[i] = new std::map<VID_T, NbrT>();
+        buffer_[i + old_index] = new std::map<VID_T, NbrT>();
+        for (auto& item : *(other.buffer_[i])) {
+          buffer_[i]->operator[](item.first) = item.second;
+          buffer_[i + old_index]->operator[](item.first) = item.second;
+        }
+      } else {
+        buffer_[i] = nullptr;
+        buffer_[i + old_index] = nullptr;
+      }
+    }
+  }
+
   void Clear() {
     for (size_t i = 0; i < buffer_.size(); ++i) {
       delete buffer_[i];
@@ -668,7 +691,8 @@ class DynamicFragment {
 
   using IsEdgeCut = std::true_type;
   using IsVertexCut = std::false_type;
-  // This member is used by grape::check_load_strategy_compatible()
+  // This member is used by grape::check_load_strategy_compatible(), not use in
+  // DynamicFragment, real strategy is member load_strategy_
   static constexpr grape::LoadStrategy load_strategy =
       grape::LoadStrategy::kBothOutIn;
 
@@ -753,68 +777,61 @@ class DynamicFragment {
     Init(fid, empty_vertices, empty_edges, directed);
   }
 
-  void Copy(std::shared_ptr<DynamicFragment> other,
-            const std::string& copy_type = "identical") {
-    ivnum_ = other->ivnum_;
-    ovnum_ = other->ovnum_;
-    tvnum_ = other->tvnum_;
-    alive_ivnum_ = other->alive_ivnum_;
-    alive_ovnum_ = other->alive_ovnum_;
-    id_mask_ = other->id_mask_;
-    fid_offset_ = other->fid_offset_;
-    fid_ = other->fid_;
-    fnum_ = other->fnum_;
-    message_strategy_ = other->message_strategy_;
+  void CopyFrom(std::shared_ptr<DynamicFragment> other,
+                const std::string& copy_type = "identical") {
     directed_ = other->directed_;
     load_strategy_ = other->load_strategy_;
 
-    ovg2i_ = other->ovg2i_;
-    ovgid_.resize(other->ovgid_.size());
-    memcpy(&ovgid_[0], &(other->ovgid_[0]),
-           other->ovgid_.size() * sizeof(vid_t));
+    copyVertices(other);
+    copyEdges(other, copy_type);
 
-    vdata_.clear();
-    vdata_.resize(other->vdata_.size());
-    for (size_t i = 0; i < ivnum_; ++i) {
-      vdata_[i] = other->vdata_[i];
-    }
+    mirrors_of_frag_.resize(fnum_);
+    InvalidCache();
+  }
 
-    inner_vertex_alive_.resize(other->inner_vertex_alive_.size());
-    memcpy(&inner_vertex_alive_[0], &(other->inner_vertex_alive_[0]),
-           other->inner_vertex_alive_.size() * sizeof(bool));
+  // generate directed graph from orignal undirected graph.
+  void ToDirectedFrom(std::shared_ptr<DynamicFragment> origin) {
+    // original graph must be undirected.
+    assert(!origin->directed);
 
-    outer_vertex_alive_.resize(other->outer_vertex_alive_.size());
-    memcpy(&outer_vertex_alive_[0], &(other->outer_vertex_alive_[0]),
-           other->outer_vertex_alive_.size() * sizeof(bool));
+    directed_ = true;
+    load_strategy_ = grape::LoadStrategy::kBothOutIn;
+    copyVertices(origin);
+    toDirectedEdges(origin);
+    mirrors_of_frag_.resize(fnum_);
+    InvalidCache();
+  }
 
-    if (copy_type == "reverse") {
-      ienum_ = other->oenum_;
-      oenum_ = other->ienum_;
-      inner_ie_pos_.resize(other->inner_oe_pos_.size());
-      memcpy(&inner_ie_pos_[0], &(other->inner_oe_pos_[0]),
-             other->inner_oe_pos_.size() * sizeof(int32_t));
-      inner_oe_pos_.resize(other->inner_ie_pos_.size());
-      memcpy(&inner_oe_pos_[0], &(other->inner_ie_pos_[0]),
-             other->inner_ie_pos_.size() * sizeof(int32_t));
-    } else {
-      ienum_ = other->ienum_;
-      oenum_ = other->oenum_;
-      inner_ie_pos_.resize(other->inner_ie_pos_.size());
-      memcpy(&inner_ie_pos_[0], &(other->inner_ie_pos_[0]),
-             other->inner_ie_pos_.size() * sizeof(int32_t));
+  // generate undirected graph from original directed graph.
+  void ToUnDirectedFrom(std::shared_ptr<DynamicFragment> origin) {
+    // original graph must be directed.
+    assert(origin->directed);
 
-      inner_oe_pos_.resize(other->inner_oe_pos_.size());
-      memcpy(&inner_oe_pos_[0], &(other->inner_oe_pos_[0]),
-             other->inner_oe_pos_.size() * sizeof(int32_t));
-    }
+    directed_ = false;
+    load_strategy_ = grape::LoadStrategy::kOnlyOut;
+    copyVertices(origin);
+    toUnDirectedEdges(origin);
+    mirrors_of_frag_.resize(fnum_);
+    InvalidCache();
+  }
 
-    // inner_edge_space_
-    inner_edge_space_.copy(other->inner_edge_space_);
+  void ClearEdges() {
+    // clear outer vertices.
+    ovgid_.clear();
+    ovg2i_.clear();
+    outer_vertex_alive_.clear();
+    // clear edges.
+    inner_ie_pos_.clear();
+    inner_oe_pos_.clear();
+    inner_ie_pos_.resize(ivnum_, -1);
+    inner_oe_pos_.resize(ivnum_, -1);
+    inner_edge_space_.Clear();
 
-    outer_vertices_of_frag_.resize(fnum_);
-    for (size_t i = 0; i < fnum_; ++i) {
-      outer_vertices_of_frag_[i] = other->outer_vertices_of_frag_[i];
-    }
+    ovnum_ = 0;
+    tvnum_ = ivnum_;
+    alive_ovnum_ = 0;
+    oenum_ = 0;
+    ienum_ = 0;
 
     mirrors_of_frag_.resize(fnum_);
     InvalidCache();
@@ -2215,6 +2232,102 @@ class DynamicFragment {
       inner_oe_pos_[src_lid] =
           inner_edge_space_.emplace(pos, dst_lid, edata, created);
       return created;
+    }
+  }
+
+  void copyVertices(std::shared_ptr<DynamicFragment>& other) {
+    ivnum_ = other->ivnum_;
+    ovnum_ = other->ovnum_;
+    tvnum_ = other->tvnum_;
+    alive_ivnum_ = other->alive_ivnum_;
+    alive_ovnum_ = other->alive_ovnum_;
+    id_mask_ = other->id_mask_;
+    fid_offset_ = other->fid_offset_;
+    fid_ = other->fid_;
+    fnum_ = other->fnum_;
+    message_strategy_ = other->message_strategy_;
+
+    ovg2i_ = other->ovg2i_;
+    ovgid_.resize(other->ovgid_.size());
+    memcpy(&ovgid_[0], &(other->ovgid_[0]),
+           other->ovgid_.size() * sizeof(vid_t));
+
+    vdata_.clear();
+    vdata_.resize(other->vdata_.size());
+    for (size_t i = 0; i < ivnum_; ++i) {
+      vdata_[i] = other->vdata_[i];
+    }
+
+    inner_vertex_alive_.resize(other->inner_vertex_alive_.size());
+    memcpy(&inner_vertex_alive_[0], &(other->inner_vertex_alive_[0]),
+           other->inner_vertex_alive_.size() * sizeof(bool));
+
+    outer_vertex_alive_.resize(other->outer_vertex_alive_.size());
+    memcpy(&outer_vertex_alive_[0], &(other->outer_vertex_alive_[0]),
+           other->outer_vertex_alive_.size() * sizeof(bool));
+
+    outer_vertices_of_frag_.resize(fnum_);
+    for (size_t i = 0; i < fnum_; ++i) {
+      outer_vertices_of_frag_[i] = other->outer_vertices_of_frag_[i];
+    }
+  }
+
+  void copyEdges(std::shared_ptr<DynamicFragment>& other,
+                 const std::string& type) {
+    if (type == "reverse") {
+      assert(orig->directed_);
+      ienum_ = other->oenum_;
+      oenum_ = other->ienum_;
+      inner_ie_pos_.resize(other->inner_oe_pos_.size());
+      memcpy(&inner_ie_pos_[0], &(other->inner_oe_pos_[0]),
+             other->inner_oe_pos_.size() * sizeof(int32_t));
+      inner_oe_pos_.resize(other->inner_ie_pos_.size());
+      memcpy(&inner_oe_pos_[0], &(other->inner_ie_pos_[0]),
+             other->inner_ie_pos_.size() * sizeof(int32_t));
+    } else {
+      ienum_ = other->ienum_;
+      oenum_ = other->oenum_;
+      inner_ie_pos_.resize(other->inner_ie_pos_.size());
+      memcpy(&inner_ie_pos_[0], &(other->inner_ie_pos_[0]),
+             other->inner_ie_pos_.size() * sizeof(int32_t));
+
+      inner_oe_pos_.resize(other->inner_oe_pos_.size());
+      memcpy(&inner_oe_pos_[0], &(other->inner_oe_pos_[0]),
+             other->inner_oe_pos_.size() * sizeof(int32_t));
+    }
+
+    inner_edge_space_.copy(other->inner_edge_space_);
+  }
+  void toDirectedEdges(std::shared_ptr<DynamicFragment>& origin) {
+    ienum_ = origin->oenum_ / 2;
+    oenum_ = origin->oenum_ / 2;
+
+    inner_edge_space_.double_copy(origin->inner_edge_space_);
+    inner_oe_pos_.resize(origin->inner_oe_pos_.size());
+    memcpy(&inner_oe_pos_[0], &(origin->inner_oe_pos_[0]),
+           origin->inner_oe_pos_.size() * sizeof(int32_t));
+    inner_ie_pos_.resize(origin->inner_oe_pos_.size(), -1);
+    size_t old_edge_space_size = origin->inner_edge_space_.size();
+    for (size_t i = 0; i < origin->inner_oe_pos_.size(); ++i) {
+      if (origin->inner_oe_pos_[i] != -1) {
+        inner_ie_pos_[i] = origin->inner_oe_pos_[i] + old_edge_space_size;
+      }
+    }
+  }
+
+  void toUnDirectedEdges(std::shared_ptr<DynamicFragment>& origin) {
+    inner_oe_pos_.resize(origin->inner_oe_pos_.size());
+    memcpy(&inner_oe_pos_[0], &(origin->inner_oe_pos_[0]),
+           origin->inner_oe_pos_.size() * sizeof(int32_t));
+    inner_edge_space_.copy(origin->inner_edge_space_);
+    inner_ie_pos_.resize(ivnum_, -1);
+
+    auto inner_vertices = origin->InnerVertices();
+    for (auto v : inner_vertices) {
+      for (auto& e : origin->GetIncomingAdjList(v)) {
+        vid_t vlid = e.get_neighbor().GetValue();
+        addOutgoingEdge(v.GetValue(), vlid, e.get_data());
+      }
     }
   }
 

--- a/analytical_engine/core/fragment/dynamic_fragment.h
+++ b/analytical_engine/core/fragment/dynamic_fragment.h
@@ -2298,6 +2298,7 @@ class DynamicFragment {
 
     inner_edge_space_.copy(other->inner_edge_space_);
   }
+
   void toDirectedEdges(std::shared_ptr<DynamicFragment>& origin) {
     ienum_ = origin->oenum_ / 2;
     oenum_ = origin->oenum_ / 2;
@@ -2316,6 +2317,8 @@ class DynamicFragment {
   }
 
   void toUnDirectedEdges(std::shared_ptr<DynamicFragment>& origin) {
+    oenum_ = origin->oenum_;
+    ienum_ = 0;
     inner_oe_pos_.resize(origin->inner_oe_pos_.size());
     memcpy(&inner_oe_pos_[0], &(origin->inner_oe_pos_[0]),
            origin->inner_oe_pos_.size() * sizeof(int32_t));
@@ -2326,7 +2329,9 @@ class DynamicFragment {
     for (auto v : inner_vertices) {
       for (auto& e : origin->GetIncomingAdjList(v)) {
         vid_t vlid = e.get_neighbor().GetValue();
-        addOutgoingEdge(v.GetValue(), vlid, e.get_data());
+        if (addOutgoingEdge(v.GetValue(), vlid, e.get_data())) {
+          ++oenum_;
+        }
       }
     }
   }

--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -858,35 +858,35 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
     break;
   }
-#ifdef EXPERIMENTAL_ON
   case rpc::TO_DIRECTED: {
+#ifdef EXPERIMENTAL_ON
     BOOST_LEAF_AUTO(graph_def, toDirected(params));
     r->set_graph_def(graph_def);
-    break;
-  }
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
                     "GS is built with experimental off");
 #endif
-#ifdef EXPERIMENTAL_ON
+    break;
+  }
   case rpc::TO_UNDIRECTED: {
+#ifdef EXPERIMENTAL_ON
     BOOST_LEAF_AUTO(graph_def, toUnDirected(params));
     r->set_graph_def(graph_def);
-    break;
-  }
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
                     "GS is built with experimental off");
 #endif
-#ifdef EXPERIMENTAL_ON
+    break;
+  }
   case rpc::CLEAR_EDGES: {
+#ifdef EXPERIMENTAL_ON
     BOOST_LEAF_CHECK(clearEdges(params));
-    break;
-  }
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
                     "GS is built with experimental off");
 #endif
+    break;
+  }
   case rpc::ADD_LABELS: {
     BOOST_LEAF_AUTO(graph_def, addLabelsToGraph(params));
     r->set_graph_def(graph_def);

--- a/analytical_engine/core/grape_instance.h
+++ b/analytical_engine/core/grape_instance.h
@@ -101,6 +101,8 @@ class GrapeInstance : public Subscriber {
   bl::result<void> modifyEdges(const rpc::GSParams& params,
                                const std::vector<std::string>& edges);
 
+  bl::result<void> clearEdges(const rpc::GSParams& params);
+
   bl::result<std::shared_ptr<grape::InArchive>> contextToNumpy(
       const rpc::GSParams& params);
 
@@ -117,6 +119,10 @@ class GrapeInstance : public Subscriber {
   bl::result<rpc::GraphDef> convertGraph(const rpc::GSParams& params);
 
   bl::result<rpc::GraphDef> copyGraph(const rpc::GSParams& params);
+
+  bl::result<rpc::GraphDef> toDirected(const rpc::GSParams& params);
+
+  bl::result<rpc::GraphDef> toUnDirected(const rpc::GSParams& params);
 
   bl::result<rpc::GraphDef> addLabelsToGraph(const rpc::GSParams& params);
 

--- a/analytical_engine/core/object/i_fragment_wrapper.h
+++ b/analytical_engine/core/object/i_fragment_wrapper.h
@@ -48,6 +48,12 @@ class IFragmentWrapper : public GSObject {
       const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
       const std::string& copy_type) = 0;
 
+  virtual bl::result<std::shared_ptr<IFragmentWrapper>> ToDirected(
+      const grape::CommSpec& comm_spec, const std::string& dst_graph_name) = 0;
+
+  virtual bl::result<std::shared_ptr<IFragmentWrapper>> ToUnDirected(
+      const grape::CommSpec& comm_spec, const std::string& dst_graph_name) = 0;
+
  protected:
   explicit IFragmentWrapper(std::string id, ObjectType type)
       : GSObject(std::move(id), type) {}

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -48,6 +48,7 @@ enum DataType {
   BOOLEAN = 20;
   STRING = 21;
   DATETIME = 22;
+  LIST = 23;
   INVALID = 536870911;
 };
 
@@ -86,6 +87,9 @@ enum OperationType {
   ADD_VERTICES = 14;  // not used, leaves room for future development
   ADD_EDGES = 15;  // not used, leaves room for future development
   ADD_LABELS = 16;  // return graph, add new label of vertices or label of edges to existed graph
+  TO_DIRECTED = 17;  // return graph, generate directed graph from undirected graph
+  TO_UNDIRECTED = 18;  // return graph, generate undirected graph from directed graph
+  CLEAR_EDGES = 19;  // clear edges
 
   // data
   CONTEXT_TO_NUMPY = 50;

--- a/python/graphscope/experimental/nx/classes/dicts.py
+++ b/python/graphscope/experimental/nx/classes/dicts.py
@@ -95,7 +95,7 @@ class NodeAttrDict(MutableMapping):
         return self.mapping
 
     def __repr__(self):
-        return self.mapping
+        return str(self.mapping)
 
 
 # NB: implement the dict structure to reuse the views of networkx. since we

--- a/python/graphscope/experimental/nx/tests/classes/test_graph.py
+++ b/python/graphscope/experimental/nx/tests/classes/test_graph.py
@@ -58,13 +58,17 @@ class TestGraph(_TestGraph):
         G[1][2]["foo"] = "new_foo"
         assert G[1][2]["foo"] == H[1][2]["foo"]
 
-    def add_attributes(self, G):
-        G.graph["foo"] = "foo"
-        G.nodes[0]["foo"] = "foo"
-        G.remove_edge(1, 2)
-        ll = "ll"
-        G.add_edge(1, 2, foo=ll)
-        G.add_edge(2, 1, foo=ll)
+    def deepcopy_node_attr(self, H, G):
+        assert G.nodes[0]["foo"] == H.nodes[0]["foo"]
+        attr = G.nodes[0]["foo"]
+        G.nodes[0]["foo"] = attr.append(1)
+        assert G.nodes[0]["foo"] != H.nodes[0]["foo"]
+
+    def deepcopy_edge_attr(self, H, G):
+        assert G[1][2]["foo"] == H[1][2]["foo"]
+        attr = G[1][2]["foo"]
+        G[1][2]["foo"] = attr.append(1)
+        assert G[1][2]["foo"] != H[1][2]["foo"]
 
     def test_memory_leak(self):
         pass
@@ -72,17 +76,17 @@ class TestGraph(_TestGraph):
     def test_pickle(self):
         pass
 
-    @pytest.mark.skip(reason="not support to_undirected not as view")
     def test_to_undirected(self):
-        pass
+        G = self.K3
+        self.add_attributes(G)
+        H = G.to_undirected()
+        self.is_deepcopy(H, G)
 
-    @pytest.mark.skip(reason="not support to_directed not as view")
     def test_to_directed(self):
-        pass
-
-    @pytest.mark.skip(reason="not support clear_edges in Graph yet.")
-    def test_clear_edges(self):
-        pass
+        G = self.K3
+        self.add_attributes(G)
+        H = G.to_directed()
+        self.is_deepcopy(H, G)
 
     def test_graph_chain(self):
         # subgraph now is fallback with networkx, not view

--- a/python/graphscope/experimental/nx/tests/classes/test_graphviews.py
+++ b/python/graphscope/experimental/nx/tests/classes/test_graphviews.py
@@ -64,9 +64,6 @@ class TestToDirected(test_gvs.TestToDirected):
         pass
 
     def test_already_directed(self):
-        pass
-
-    def test_already_directed(self):
         dd = nx.to_directed(self.dv)
         assert_edges_equal(dd.edges, self.dv.edges)
 
@@ -76,6 +73,7 @@ class TestToUndirected(test_gvs.TestToUndirected):
         self.DG = nx.path_graph(9, create_using=nx.DiGraph())
         self.uv = nx.to_undirected(self.DG)
 
+    @pytest.mark.skip(reason="not support pickle remote graph.")
     def test_pickle(self):
         pass
 
@@ -96,6 +94,7 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
         for G in cls.graphs:
             G.edges, G.nodes, G.degree
 
+    @pytest.mark.skip(reason="not support pickle remote graph.")
     def test_pickle(self):
         pass
 
@@ -179,9 +178,11 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
         assert list(USSG) == [4, 5]
         assert sorted(USSG.edges) == [(4, 5)]
 
+    @pytest.mark.skip(reason="not support multigraph.")
     def test_copy_multidisubgraph(self):
         pass
 
+    @pytest.mark.skip(reason="not support multigraph.")
     def test_copy_multisubgraph(self):
         pass
 
@@ -198,4 +199,8 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
 
     @pytest.mark.skip(reason="subgraph now is fallback with networkx, not view")
     def test_restricted_induced_subgraph_chains(self):
+        pass
+
+    @pytest.mark.skip(reason="subgraph now is view, but to_directted is deepcopy")
+    def test_subgraph_todirected(self):
         pass

--- a/python/graphscope/experimental/nx/tests/test_nx.py
+++ b/python/graphscope/experimental/nx/tests/test_nx.py
@@ -377,12 +377,6 @@ class TestGraphProjectTest(object):
         nx.builtin.degree_centrality(g)
         nx.builtin.single_source_dijkstra_path_length(g, source=6, weight="weight")
 
-    def test_error_on_view_project_to_simple(self):
-        g = self.NXGraph()
-        g._graph = None  # a graph view always has '_graph_' attribute
-        with pytest.raises(TypeError, match="graph view can't project to simple graph"):
-            sg = g.project_to_simple()
-
     def test_error_on_not_exist_vertex_property(self):
         g = self.NXGraph()
         g.add_node(0, foo="node")

--- a/python/graphscope/framework/dag_utils.py
+++ b/python/graphscope/framework/dag_utils.py
@@ -496,9 +496,7 @@ def to_directed(graph):
     Returns:
         Operation
     """
-    check_argument(
-        graph.graph_type == types_pb2.DYNAMIC_PROPERTY
-    )
+    check_argument(graph.graph_type == types_pb2.DYNAMIC_PROPERTY)
     config = {
         types_pb2.GRAPH_NAME: utils.s_to_attr(graph.key),
     }
@@ -521,9 +519,7 @@ def to_undirected(graph):
     Returns:
         Operation
     """
-    check_argument(
-        graph.graph_type == types_pb2.DYNAMIC_PROPERTY
-    )
+    check_argument(graph.graph_type == types_pb2.DYNAMIC_PROPERTY)
     config = {
         types_pb2.GRAPH_NAME: utils.s_to_attr(graph.key),
     }
@@ -535,6 +531,7 @@ def to_undirected(graph):
         output_types=types_pb2.GRAPH,
     )
     return op
+
 
 def clear_edges(graph):
     """Create clear edges operation for nx graph.
@@ -556,6 +553,7 @@ def clear_edges(graph):
         output_types=types_pb2.GRAPH,
     )
     return op
+
 
 def unload_app(app):
     """Unload a loaded app.

--- a/python/graphscope/framework/dag_utils.py
+++ b/python/graphscope/framework/dag_utils.py
@@ -487,6 +487,76 @@ def copy_graph(graph, copy_type="identical"):
     return op
 
 
+def to_directed(graph):
+    """Create to_directed operation for nx graph.
+
+    Args:
+        graph (:class:`nx.Graph`): A nx graph.
+
+    Returns:
+        Operation
+    """
+    check_argument(
+        graph.graph_type == types_pb2.DYNAMIC_PROPERTY
+    )
+    config = {
+        types_pb2.GRAPH_NAME: utils.s_to_attr(graph.key),
+    }
+
+    op = Operation(
+        graph.session_id,
+        types_pb2.TO_DIRECTED,
+        config=config,
+        output_types=types_pb2.GRAPH,
+    )
+    return op
+
+
+def to_undirected(graph):
+    """Create to_undirected operation for nx graph.
+
+    Args:
+        graph (:class:`nx.Graph`): A nx graph.
+
+    Returns:
+        Operation
+    """
+    check_argument(
+        graph.graph_type == types_pb2.DYNAMIC_PROPERTY
+    )
+    config = {
+        types_pb2.GRAPH_NAME: utils.s_to_attr(graph.key),
+    }
+
+    op = Operation(
+        graph.session_id,
+        types_pb2.TO_UNDIRECTED,
+        config=config,
+        output_types=types_pb2.GRAPH,
+    )
+    return op
+
+def clear_edges(graph):
+    """Create clear edges operation for nx graph.
+
+    Args:
+        graph (:class:`nx.Graph`): A nx graph.
+
+    Returns:
+        An op to modify edges on the graph.
+    """
+    check_argument(graph.graph_type == types_pb2.DYNAMIC_PROPERTY)
+    config = {
+        types_pb2.GRAPH_NAME: utils.s_to_attr(graph.key),
+    }
+    op = Operation(
+        graph.session_id,
+        types_pb2.CLEAR_EDGES,
+        config=config,
+        output_types=types_pb2.GRAPH,
+    )
+    return op
+
 def unload_app(app):
     """Unload a loaded app.
 

--- a/python/graphscope/framework/utils.py
+++ b/python/graphscope/framework/utils.py
@@ -252,16 +252,14 @@ def unify_type(t):
         elif t in ("empty", "grape::emptytype"):
             return types_pb2.NULLVALUE
     elif isinstance(t, type):
-        if t is int:
-            return types_pb2.LONG
-        elif t is float:
-            return types_pb2.DOUBLE
-        elif t is str:
-            return types_pb2.STRING
-        elif t is bool:
-            return types_pb2.BOOLEAN
-        elif t is list:
-            return types_pb2.LIST
+        unify_types = {
+            int: types_pb2.LONG,
+            float: types_pb2.DOUBLE,
+            str: types_pb2.STRING,
+            bool: types_pb2.BOOLEAN,
+            list: types_pb2.LIST,
+        }
+        return unify_types[t]
     elif isinstance(t, int):  # types_pb2.DataType
         return t
     raise TypeError("Not supported type {}".format(t))

--- a/python/graphscope/framework/utils.py
+++ b/python/graphscope/framework/utils.py
@@ -258,6 +258,10 @@ def unify_type(t):
             return types_pb2.DOUBLE
         elif t is str:
             return types_pb2.STRING
+        elif t is bool:
+            return types_pb2.BOOLEAN
+        elif t is list:
+            return types_pb2.LIST
     elif isinstance(t, int):  # types_pb2.DataType
         return t
     raise TypeError("Not supported type {}".format(t))


### PR DESCRIPTION


## What do these changes do?
- implement deepcopy version of netowrkx to_directed /to_undirected api;
- implement clear_edge of networkx Graph.
- open the related test cases.

## Related issue number
#62 