### PR TITLE
[networkx] implement deepcopy subgraph/edge_subgraph in engine, not return a view

### DIFF
--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -14,6 +14,7 @@
  */
 
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -637,7 +638,6 @@ bl::result<rpc::GraphDef> GrapeInstance::toUnDirected(
     const rpc::GSParams& params) {
 #ifdef EXPERIMENTAL_ON
   BOOST_LEAF_AUTO(src_graph_name, params.Get<std::string>(rpc::GRAPH_NAME));
-  // BOOST_LEAF_AUTO(copy_type, params.Get<std::string>(rpc::COPY_TYPE));
 
   BOOST_LEAF_AUTO(src_wrapper,
                   object_manager_.GetObject<IFragmentWrapper>(src_graph_name));
@@ -652,6 +652,52 @@ bl::result<rpc::GraphDef> GrapeInstance::toUnDirected(
                   "GS is compiled without folly");
 #endif  // EXPERIMENTAL_ON
 }
+
+#ifdef EXPERIMENTAL_ON
+bl::result<rpc::GraphDef> GrapeInstance::induceSubGraph(
+    const rpc::GSParams& params,
+    const std::unordered_set<typename DynamicFragment::oid_t>& induced_vertices,
+    const std::vector<std::pair<typename DynamicFragment::oid_t,
+                                typename DynamicFragment::oid_t>>&
+        induced_edges) {
+  BOOST_LEAF_AUTO(src_graph_name, params.Get<std::string>(rpc::GRAPH_NAME));
+
+  BOOST_LEAF_AUTO(src_wrapper,
+                  object_manager_.GetObject<IFragmentWrapper>(src_graph_name));
+  std::string sub_graph_name = "graph_" + generateId();
+
+  VLOG(1) << "Inducing subgraph from " << src_graph_name
+          << ", graph name: " << sub_graph_name;
+
+  auto fragment =
+      std::static_pointer_cast<DynamicFragment>(src_wrapper->fragment());
+
+  auto sub_vm_ptr =
+      std::make_shared<typename DynamicFragment::vertex_map_t>(comm_spec_);
+  sub_vm_ptr->Init();
+  typename DynamicFragment::partitioner_t partitioner;
+  partitioner.Init(fragment->fnum());
+  typename DynamicFragment::vid_t gid;
+  for (auto& v : induced_vertices) {
+    auto fid = partitioner.GetPartitionId(v);
+    if (fid == fragment->fid() && fragment->HasNode(v)) {
+      sub_vm_ptr->AddVertex(fid, v, gid);
+    }
+  }
+  sub_vm_ptr->Construct();
+
+  auto sub_graph_def = src_wrapper->graph_def();
+  sub_graph_def.set_key(sub_graph_name);
+  auto sub_frag = std::make_shared<DynamicFragment>(sub_vm_ptr);
+  sub_frag->InduceSubgraph(fragment, induced_vertices, induced_edges);
+
+  auto wrapper = std::make_shared<FragmentWrapper<DynamicFragment>>(
+      sub_graph_name, sub_graph_def, sub_frag);
+
+  BOOST_LEAF_CHECK(object_manager_.PutObject(wrapper));
+  return wrapper->graph_def();
+}
+#endif  // EXPERIMENTAL_ON
 
 bl::result<void> GrapeInstance::clearEdges(const rpc::GSParams& params) {
 #ifdef EXPERIMENTAL_ON
@@ -894,6 +940,46 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
   case rpc::TO_UNDIRECTED: {
 #ifdef EXPERIMENTAL_ON
     BOOST_LEAF_AUTO(graph_def, toUnDirected(params));
+    r->set_graph_def(graph_def);
+#else
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
+                    "GS is built with experimental off");
+#endif
+    break;
+  }
+  case rpc::INDUCE_SUBGRAPH: {
+#ifdef EXPERIMENTAL_ON
+    std::unordered_set<DynamicFragment::oid_t> induced_vertices;
+    std::vector<std::pair<DynamicFragment::oid_t, DynamicFragment::oid_t>>
+        induced_edges;
+    auto line_parser_ptr = std::make_unique<DynamicLineParser>();
+    if (params.HasKey(rpc::NODES)) {
+      // induce subgraph from nodes.
+      int size = cmd.params.at(rpc::NODES).list().s_size();
+      induced_vertices.reserve(size);
+      DynamicFragment::oid_t oid;
+      DynamicFragment::vdata_t vdata;
+      for (int i = 0; i < size; ++i) {
+        line_parser_ptr->LineParserForVFile(
+            cmd.params.at(rpc::NODES).list().s(i), oid, vdata);
+        induced_vertices.insert(oid);
+      }
+    } else if (params.HasKey(rpc::EDGES)) {
+      // induce subgraph from edges.
+      int size = cmd.params.at(rpc::EDGES).list().s_size();
+      induced_edges.reserve(size);
+      DynamicFragment::oid_t u_oid, v_oid;
+      DynamicFragment::edata_t edata;
+      for (int i = 0; i < size; ++i) {
+        line_parser_ptr->LineParserForEFile(
+            cmd.params.at(rpc::EDGES).list().s(i), u_oid, v_oid, edata);
+        induced_vertices.insert(u_oid);
+        induced_vertices.insert(v_oid);
+        induced_edges.emplace_back(u_oid, v_oid);
+      }
+    }
+    BOOST_LEAF_AUTO(graph_def,
+                    induceSubGraph(params, induced_vertices, induced_edges));
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,

--- a/analytical_engine/core/grape_instance.h
+++ b/analytical_engine/core/grape_instance.h
@@ -21,6 +21,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -33,6 +34,7 @@
 #include "grape/worker/comm_spec.h"
 
 #include "core/context/i_context.h"
+#include "core/fragment/dynamic_fragment.h"
 #include "core/object/object_manager.h"
 #include "core/server/dispatcher.h"
 #include "core/server/graphscope_service.h"
@@ -125,6 +127,16 @@ class GrapeInstance : public Subscriber {
   bl::result<rpc::GraphDef> toUnDirected(const rpc::GSParams& params);
 
   bl::result<rpc::GraphDef> createGraphView(const rpc::GSParams& params);
+
+#ifdef EXPERIMENTAL_ON
+  bl::result<rpc::GraphDef> induceSubGraph(
+      const rpc::GSParams& params,
+      const std::unordered_set<typename DynamicFragment::oid_t>&
+          induced_vertices,
+      const std::vector<std::pair<typename DynamicFragment::oid_t,
+                                  typename DynamicFragment::oid_t>>&
+          induced_edges);
+#endif  // EXPERIMENTAL_ON
 
   bl::result<rpc::GraphDef> addLabelsToGraph(const rpc::GSParams& params);
 

--- a/proto/types.proto
+++ b/proto/types.proto
@@ -91,6 +91,7 @@ enum OperationType {
   TO_UNDIRECTED = 18;  // return graph, generate undirected graph from directed graph
   CLEAR_EDGES = 19;  // clear edges
   VIEW_GRAPH = 20;
+  INDUCE_SUBGRAPH = 21;  // clear edges
 
   // data
   CONTEXT_TO_NUMPY = 50;

--- a/python/graphscope/experimental/nx/classes/graph.py
+++ b/python/graphscope/experimental/nx/classes/graph.py
@@ -1802,7 +1802,7 @@ class Graph(object):
             return g
 
     def subgraph(self, nodes):
-        """Returns a SubGraph view of the subgraph induced on `nodes`.
+        """Returns a SubGraph of the subgraph induced on `nodes`.
 
         The induced subgraph of the graph contains the nodes in `nodes`
         and the edges between those nodes.
@@ -1814,42 +1814,8 @@ class Graph(object):
 
         Returns
         -------
-        G : SubGraph View
-            A subgraph view of the graph. The graph structure cannot be
-            changed but node/edge attributes can and are shared with the
-            original graph.
-
-        Notes
-        -----
-        The graph, edge and node attributes are shared with the original graph.
-        Changes to the graph structure is ruled out by the view, but changes
-        to attributes are reflected in the original graph.
-
-        To create a subgraph with its own copy of the edge/node attributes use:
-        G.subgraph(nodes).copy()
-
-        For an inplace reduction of a graph to a subgraph you can remove nodes:
-        G.remove_nodes_from([n for n in G if n not in set(nodes)])
-
-        Subgraph views are sometimes NOT what you want. In most cases where
-        you want to do more than simply look at the induced edges, it makes
-        more sense to just create the subgraph as its own graph with code like:
-
-        ::
-
-            # Create a subgraph SG based on a (possibly multigraph) G
-            SG = G.__class__()
-            SG.add_nodes_from((n, G.nodes[n]) for n in largest_wcc)
-            if SG.is_multigraph:
-                SG.add_edges_from((n, nbr, key, d)
-                    for n, nbrs in G.adj.items() if n in largest_wcc
-                    for nbr, keydict in nbrs.items() if nbr in largest_wcc
-                    for key, d in keydict.items())
-            else:
-                SG.add_edges_from((n, nbr, d)
-                    for n, nbrs in G.adj.items() if n in largest_wcc
-                    for nbr, d in nbrs.items() if nbr in largest_wcc)
-            SG.graph.update(G.graph)
+        G : Graph
+            A subgraph of the graph.
 
         Examples
         --------
@@ -1858,9 +1824,6 @@ class Graph(object):
         >>> list(H.edges)
         [(0, 1), (1, 2)]
         """
-        # NB: fallback subgraph
-        # ng = to_networkx_graph(self)
-        # return ng.subgraph(nodes)
         induced_nodes = []
         for n in nodes:
             induced_nodes.append(json.dumps([n]))
@@ -1889,17 +1852,6 @@ class Graph(object):
             An edge-induced subgraph of this graph with the same edge
             attributes.
 
-        Notes
-        -----
-        The graph, edge, and node attributes in the returned subgraph
-        view are references to the corresponding attributes in the original
-        graph. The view is read-only.
-
-        To create a full graph version of the subgraph with its own copy
-        of the edge or node attributes, use::
-
-            >>> G.edge_subgraph(edges).copy()  # doctest: +SKIP
-
         Examples
         --------
         >>> G = nx.path_graph(5)
@@ -1910,9 +1862,6 @@ class Graph(object):
         [(0, 1), (3, 4)]
 
         """
-        # NB: fallback edge subgraph
-        # ng = to_networkx_graph(self)
-        # return ng.edge_subgraph(edges)
         induced_edges = []
         for e in edges:
             u, v = e

--- a/python/graphscope/experimental/nx/classes/graph.py
+++ b/python/graphscope/experimental/nx/classes/graph.py
@@ -1245,7 +1245,8 @@ class Graph(object):
 
         """
         if u is None:
-            return int(self.size())
+            op = dag_utils.report_graph(self, types_pb2.EDGE_NUM)
+            return int(op.eval()) // 2
         elif self.has_edge(u, v):
             return 1
         else:
@@ -1858,8 +1859,18 @@ class Graph(object):
         [(0, 1), (1, 2)]
         """
         # NB: fallback subgraph
-        ng = to_networkx_graph(self)
-        return ng.subgraph(nodes)
+        # ng = to_networkx_graph(self)
+        # return ng.subgraph(nodes)
+        induced_nodes = []
+        for n in nodes:
+            induced_nodes.append(json.dumps([n]))
+        g = self.__class__(create_empty_in_engine=False)
+        g.graph.update(self.graph)
+        op = dag_utils.create_subgraph(self, nodes=induced_nodes)
+        graph_def = op.eval()
+        g._key = graph_def.key
+        g._schema = copy.deepcopy(self._schema)
+        return g
 
     def edge_subgraph(self, edges):
         """Returns the subgraph induced by the specified edges.
@@ -1900,8 +1911,19 @@ class Graph(object):
 
         """
         # NB: fallback edge subgraph
-        ng = to_networkx_graph(self)
-        return ng.edge_subgraph(edges)
+        # ng = to_networkx_graph(self)
+        # return ng.edge_subgraph(edges)
+        induced_edges = []
+        for e in edges:
+            u, v = e
+            induced_edges.append(json.dumps([u, v]))
+        g = self.__class__(create_empty_in_engine=False)
+        g.graph.update(self.graph)
+        op = dag_utils.create_subgraph(self, edges=induced_edges)
+        graph_def = op.eval()
+        g._key = graph_def.key
+        g._schema = copy.deepcopy(self._schema)
+        return g
 
     @parse_ret_as_dict
     def batch_get_node(self, location):

--- a/python/graphscope/experimental/nx/tests/algorithms/builtin/test_ctx_builtin.py
+++ b/python/graphscope/experimental/nx/tests/algorithms/builtin/test_ctx_builtin.py
@@ -77,11 +77,18 @@ class TestBuiltInApp:
 
         data_dir = os.path.expandvars("${GS_TEST_DIR}")
         p2p_file = os.path.expandvars("${GS_TEST_DIR}/dynamic/p2p-31_dynamic.edgelist")
+        p2p_sub_file = os.path.expandvars("${GS_TEST_DIR}/dynamic/p2p-31_subgraph_dynamic.edgelist")
         cls.p2p = nx.read_edgelist(
             p2p_file, nodetype=int, data=True, create_using=nx.DiGraph
         )
         cls.p2p_undirected = nx.read_edgelist(
             p2p_file, nodetype=int, data=True, create_using=nx.Graph
+        )
+        cls.p2p_subgraph = nx.read_edgelist(
+            p2p_sub_file, nodetype=int, data=True, create_using=nx.DiGraph
+        )
+        cls.p2p_subgraph_undirected = nx.read_edgelist(
+            p2p_sub_file, nodetype=int, data=True, create_using=nx.Graph
         )
         cls.p2p_length_ans = dict(
             pd.read_csv(
@@ -142,20 +149,22 @@ class TestBuiltInApp:
         ans = dict(ret.values)
         assert replace_with_inf(ans) == self.p2p_length_ans
 
-        # test subgraph and edge_subgraph with p2p_undirected
-        SG = self.p2p_undirected.subgraph(self.p2p_undirected.nodes)
+    def test_subgraph_single_source_dijkstra_path_length(self):
+        # test subgraph and edge_subgraph with p2p_subgraph_undirected
+        ret = nx.builtin.single_source_dijkstra_path_length(self.p2p_subgraph_undirected, 6)
+        SG = self.p2p_undirected.subgraph(self.p2p_subgraph_undirected.nodes)
         ret_sg = nx.builtin.single_source_dijkstra_path_length(SG, 6)
         assert dict(ret.values) == dict(ret_sg.values)
-        ESG = self.p2p_undirected.edge_subgraph(self.p2p_undirected.edges)
+        ESG = self.p2p_undirected.edge_subgraph(self.p2p_subgraph_undirected.edges)
         ret_esg = nx.builtin.single_source_dijkstra_path_length(ESG, 6)
         assert dict(ret.values) == dict(ret_esg.values)
 
         # test subgraph and edge_subgraph with p2p directed
-        ret2 = nx.builtin.single_source_dijkstra_path_length(self.p2p, 6)
-        SDG = self.p2p.subgraph(self.p2p.nodes)
+        ret2 = nx.builtin.single_source_dijkstra_path_length(self.p2p_subgraph, 6)
+        SDG = self.p2p.subgraph(self.p2p_subgraph.nodes)
         ret_sdg = nx.builtin.single_source_dijkstra_path_length(SDG, 6)
         assert dict(ret2.values) == dict(ret_sdg.values)
-        ESDG = self.p2p.edge_subgraph(self.p2p.edges)
+        ESDG = self.p2p.edge_subgraph(self.p2p_subgraph.edges)
         ret_esdg = nx.builtin.single_source_dijkstra_path_length(ESDG, 6)
         assert dict(ret2.values) == dict(ret_esdg.values)
 

--- a/python/graphscope/experimental/nx/tests/algorithms/builtin/test_ctx_builtin.py
+++ b/python/graphscope/experimental/nx/tests/algorithms/builtin/test_ctx_builtin.py
@@ -142,6 +142,23 @@ class TestBuiltInApp:
         ans = dict(ret.values)
         assert replace_with_inf(ans) == self.p2p_length_ans
 
+        # test subgraph and edge_subgraph with p2p_undirected
+        SG = self.p2p_undirected.subgraph(self.p2p_undirected.nodes)
+        ret_sg = nx.builtin.single_source_dijkstra_path_length(SG, 6)
+        assert dict(ret.values) == dict(ret_sg.values)
+        ESG = self.p2p_undirected.edge_subgraph(self.p2p_undirected.edges)
+        ret_esg = nx.builtin.single_source_dijkstra_path_length(ESG, 6)
+        assert dict(ret.values) == dict(ret_esg.values)
+
+        # test subgraph and edge_subgraph with p2p directed
+        ret2 = nx.builtin.single_source_dijkstra_path_length(self.p2p, 6)
+        SDG = self.p2p.subgraph(self.p2p.nodes)
+        ret_sdg = nx.builtin.single_source_dijkstra_path_length(SDG, 6)
+        assert dict(ret2.values) == dict(ret_sdg.values)
+        ESDG = self.p2p.edge_subgraph(self.p2p.edges)
+        ret_esdg = nx.builtin.single_source_dijkstra_path_length(ESDG, 6)
+        assert dict(ret2.values) == dict(ret_esdg.values)
+
     def test_shortest_path(self):
         ctx1 = nx.builtin.shortest_path(self.grid, source=1, weight="weight")
         ret1 = dict(ctx1.to_numpy("r"))

--- a/python/graphscope/experimental/nx/tests/algorithms/builtin/test_ctx_builtin.py
+++ b/python/graphscope/experimental/nx/tests/algorithms/builtin/test_ctx_builtin.py
@@ -77,7 +77,9 @@ class TestBuiltInApp:
 
         data_dir = os.path.expandvars("${GS_TEST_DIR}")
         p2p_file = os.path.expandvars("${GS_TEST_DIR}/dynamic/p2p-31_dynamic.edgelist")
-        p2p_sub_file = os.path.expandvars("${GS_TEST_DIR}/dynamic/p2p-31_subgraph_dynamic.edgelist")
+        p2p_sub_file = os.path.expandvars(
+            "${GS_TEST_DIR}/dynamic/p2p-31_dynamic_subgraph.edgelist"
+        )
         cls.p2p = nx.read_edgelist(
             p2p_file, nodetype=int, data=True, create_using=nx.DiGraph
         )
@@ -151,7 +153,9 @@ class TestBuiltInApp:
 
     def test_subgraph_single_source_dijkstra_path_length(self):
         # test subgraph and edge_subgraph with p2p_subgraph_undirected
-        ret = nx.builtin.single_source_dijkstra_path_length(self.p2p_subgraph_undirected, 6)
+        ret = nx.builtin.single_source_dijkstra_path_length(
+            self.p2p_subgraph_undirected, 6
+        )
         SG = self.p2p_undirected.subgraph(self.p2p_subgraph_undirected.nodes)
         ret_sg = nx.builtin.single_source_dijkstra_path_length(SG, 6)
         assert dict(ret.values) == dict(ret_sg.values)

--- a/python/graphscope/experimental/nx/tests/classes/test_digraph.py
+++ b/python/graphscope/experimental/nx/tests/classes/test_digraph.py
@@ -19,10 +19,10 @@
 
 import pytest
 from networkx.classes.tests.test_digraph import BaseAttrDiGraphTester
-from networkx.classes.tests.test_digraph import TestEdgeSubgraph
 from networkx.testing import assert_nodes_equal
 
 from graphscope.experimental import nx
+from graphscope.experimental.nx.tests.classes.test_graph import TestEdgeSubgraph
 from graphscope.experimental.nx.tests.classes.test_graph import TestGraph
 
 
@@ -136,6 +136,7 @@ class TestDiGraph(BaseAttrDiGraphTester, TestGraph):
         assert [(y, x)] == list(G.reverse().edges())
 
 
+@pytest.mark.usefixtures("graphscope_session")
 class TestEdgeSubgraph(TestEdgeSubgraph):
     def setup_method(self):
         # Create a doubly-linked path graph on five nodes.
@@ -143,7 +144,7 @@ class TestEdgeSubgraph(TestEdgeSubgraph):
         G = nx.path_graph(5, nx.DiGraph)
         # Add some node, edge, and graph attributes.
         for i in range(5):
-            G.nodes[i]["name"] = "node{}".format(i)
+            G.nodes[i]["name"] = f"node{i}"
         G.edges[0, 1]["name"] = "edge01"
         G.edges[3, 4]["name"] = "edge34"
         G.graph["name"] = "graph"
@@ -151,18 +152,20 @@ class TestEdgeSubgraph(TestEdgeSubgraph):
         self.G = G
         self.H = G.edge_subgraph([(0, 1), (3, 4)])
 
-    @pytest.mark.skip(reason="edge_subgraph now is fallback with networkx, not view")
-    def test_node_attr_dict(self):
-        pass
+    def test_correct_edges(self):
+        """Tests that the subgraph has the correct edges."""
+        assert [(0, 1, "edge01"), (3, 4, "edge34")] == sorted(self.H.edges(data="name"))
 
-    @pytest.mark.skip(reason="edge_subgraph now is fallback with networkx, not view")
-    def test_edge_attr_dict(self):
-        pass
+    def test_pred_succ(self):
+        """Test that nodes are added to predecessors and successors.
 
-    @pytest.mark.skip(reason="edge_subgraph now is fallback with networkx, not view")
-    def test_graph_attr_dict(self):
-        pass
+        For more information, see GitHub issue #2370.
 
-    @pytest.mark.skip(reason="edge_subgraph now is fallback with networkx, not view")
-    def test_remove_node(self):
-        pass
+        """
+        G = nx.DiGraph()
+        G.add_edge(0, 1)
+        H = G.edge_subgraph([(0, 1)])
+        assert list(H.predecessors(0)) == []
+        assert list(H.successors(0)) == [1]
+        assert list(H.predecessors(1)) == [0]
+        assert list(H.successors(1)) == []

--- a/python/graphscope/experimental/nx/tests/classes/test_graphviews.py
+++ b/python/graphscope/experimental/nx/tests/classes/test_graphviews.py
@@ -172,4 +172,3 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
         assert G.__class__.__name__ == "OrderedMultiGraph"
         G = G.copy(as_view=True)
         assert G.__class__.__name__ == "OrderedMultiGraph"
-

--- a/python/graphscope/experimental/nx/tests/classes/test_graphviews.py
+++ b/python/graphscope/experimental/nx/tests/classes/test_graphviews.py
@@ -104,75 +104,48 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
     def test_pickle(self):
         pass
 
+    # subgraph is deepcopy subgraph in graphscope.nx
     def test_subgraph_of_subgraph(self):
         SGv = nx.subgraph(self.G, range(3, 7))
         SDGv = nx.subgraph(self.DG, range(3, 7))
         for G in self.graphs + [SGv, SDGv]:
-            SG = nx.induced_subgraph(G, [4, 5, 6])
-            assert list(SG) == [4, 5, 6]
+            SG = G.subgraph([4, 5, 6])
+            assert sorted(list(SG)) == [4, 5, 6]
             SSG = SG.subgraph([6, 7])
             assert list(SSG) == [6]
-            # subgraph-subgraph chain is short-cut in base class method
-            assert SSG._graph is G
 
+    @pytest.mark.skip(reason="not restricted view in graphscope.nx")
     def test_restricted_induced_subgraph_chains(self):
-        """Test subgraph chains that both restrict and show nodes/edges.
+        pass
 
-        A restricted_view subgraph should allow induced subgraphs using
-        G.subgraph that automagically without a chain (meaning the result
-        is a subgraph view of the original graph not a subgraph-of-subgraph.
-        """
-        hide_nodes = [3, 4, 5]
-        hide_edges = [(6, 7)]
-        RG = nx.restricted_view(self.G, hide_nodes, hide_edges)
-        nodes = [4, 5, 6, 7, 8]
-        SG = nx.induced_subgraph(RG, nodes)
-        SSG = RG.subgraph(nodes)
-        assert RG._graph is self.G
-        assert SSG._graph is self.G
-        assert SG._graph is RG
-        assert_edges_equal(SG.edges, SSG.edges)
-        # should be same as morphing the graph
-        CG = self.G.copy()
-        CG.remove_nodes_from(hide_nodes)
-        CG.remove_edges_from(hide_edges)
-        assert_edges_equal(CG.edges(nodes), SSG.edges)
-        CG.remove_nodes_from([0, 1, 2, 3])
-        assert_edges_equal(CG.edges, SSG.edges)
-        # switch order: subgraph first, then restricted view
-        SSSG = self.G.subgraph(nodes)
-        RSG = nx.restricted_view(SSSG, hide_nodes, hide_edges)
-        assert RSG._graph is not self.G
-        assert_edges_equal(RSG.edges, CG.edges)
-
-    @pytest.mark.skip(reason="not support order-like graph")
     def test_subgraph_copy(self):
         for origG in self.graphs:
-            G = nx.OrderedGraph(origG)
-            SG = G.subgraph([4, 5, 6])
+            SG = origG.subgraph([4, 5, 6])
             H = SG.copy()
-            assert type(G) == type(H)
+            assert type(origG) == type(H)
 
-    @pytest.mark.skip(reason="not support yet")
+    def test_subgraph_todirected(self):
+        SG = self.G.subgraph([4, 5, 6])
+        SSG = SG.to_directed()
+        assert sorted(SSG) == [4, 5, 6]
+        assert sorted(SSG.edges) == [(4, 5), (5, 4), (5, 6), (6, 5)]
+
     def test_subgraph_toundirected(self):
-        SG = nx.induced_subgraph(self.G, [4, 5, 6])
-        # FIXME: not match like networkx.
-        SSG = SG.to_undirected(as_view=True)
-        assert list(SSG) == [4, 5, 6]
-        assert sorted(SSG.edges) == [(4, 5), (5, 6)]
+        SG = self.G.subgraph([4, 5, 6])
+        SSG = SG.to_undirected()
+        assert sorted(list(SSG)) == [4, 5, 6]
+        assert sorted(SSG.edges) == [(5, 4), (6, 5)]
 
     def test_reverse_subgraph_toundirected(self):
-        G = self.DG.reverse(copy=False)
+        # a view can not project subgraph in graphscope.nx
+        G = self.DG.reverse()
         SG = G.subgraph([4, 5, 6])
-        # FIXME: not match like networkx.
-        SSG = SG.to_undirected(as_view=True)
-        assert list(SSG) == [4, 5, 6]
-        assert sorted(SSG.edges) == [(4, 5), (5, 6)]
+        SSG = SG.to_undirected()
+        assert sorted(list(SSG)) == [4, 5, 6]
+        assert sorted(SSG.edges) == [(5, 4), (6, 5)]
 
     def test_reverse_reverse_copy(self):
         G = self.DG.reverse(copy=False)
-        # FIXME: not match networkx
-        # H = G.reverse(copy=True)
         H = G.reverse(copy=False)
         assert H.nodes == self.DG.nodes
         assert H.edges == self.DG.edges
@@ -181,9 +154,9 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
         G = self.G.copy()
         SG = G.subgraph([4, 5, 6])
         SSG = SG.edge_subgraph([(4, 5), (5, 4)])
-        USSG = SSG.to_undirected(as_view=True)
-        assert list(USSG) == [4, 5]
-        assert sorted(USSG.edges) == [(4, 5)]
+        USSG = SSG.to_undirected()
+        assert sorted(list(USSG)) == [4, 5]
+        assert sorted(USSG.edges) == [(5, 4)]
 
     @pytest.mark.skip(reason="not support multigraph.")
     def test_copy_multidisubgraph(self):
@@ -200,14 +173,3 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
         G = G.copy(as_view=True)
         assert G.__class__.__name__ == "OrderedMultiGraph"
 
-    @pytest.mark.skip(reason="subgraph now is fallback with networkx, not view")
-    def test_subgraph_of_subgraph(self):
-        pass
-
-    @pytest.mark.skip(reason="subgraph now is fallback with networkx, not view")
-    def test_restricted_induced_subgraph_chains(self):
-        pass
-
-    @pytest.mark.skip(reason="subgraph now is view, but to_directted is deepcopy")
-    def test_subgraph_todirected(self):
-        pass

--- a/python/graphscope/experimental/nx/tests/classes/test_graphviews.py
+++ b/python/graphscope/experimental/nx/tests/classes/test_graphviews.py
@@ -134,7 +134,7 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
         SG = self.G.subgraph([4, 5, 6])
         SSG = SG.to_undirected()
         assert sorted(list(SSG)) == [4, 5, 6]
-        assert sorted(SSG.edges) == [(5, 4), (6, 5)]
+        assert sorted(SSG.edges) == [(4, 5), (6, 5)]
 
     def test_reverse_subgraph_toundirected(self):
         # a view can not project subgraph in graphscope.nx
@@ -142,7 +142,7 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
         SG = G.subgraph([4, 5, 6])
         SSG = SG.to_undirected()
         assert sorted(list(SSG)) == [4, 5, 6]
-        assert sorted(SSG.edges) == [(5, 4), (6, 5)]
+        assert sorted(SSG.edges) == [(4, 5), (6, 5)]
 
     def test_reverse_reverse_copy(self):
         G = self.DG.reverse(copy=False)
@@ -156,7 +156,7 @@ class TestChainsOfViews(test_gvs.TestChainsOfViews):
         SSG = SG.edge_subgraph([(4, 5), (5, 4)])
         USSG = SSG.to_undirected()
         assert sorted(list(USSG)) == [4, 5]
-        assert sorted(USSG.edges) == [(5, 4)]
+        assert sorted(USSG.edges) == [(5, 4)] or sorted(USSG.edges) == [(4, 5)]
 
     @pytest.mark.skip(reason="not support multigraph.")
     def test_copy_multidisubgraph(self):

--- a/python/graphscope/framework/dag_utils.py
+++ b/python/graphscope/framework/dag_utils.py
@@ -582,10 +582,12 @@ def clear_edges(graph):
 
 
 def create_subgraph(graph, nodes=None, edges=None):
-    """Create to_undirected operation for nx graph.
+    """Create subgraph operation for nx graph.
 
     Args:
         graph (:class:`nx.Graph`): A nx graph.
+        nodes (list): the nodes to induce a subgraph.
+        edges (list): the edges to induce a edge-induced subgraph.
 
     Returns:
         Operation

--- a/python/graphscope/framework/dag_utils.py
+++ b/python/graphscope/framework/dag_utils.py
@@ -581,6 +581,33 @@ def clear_edges(graph):
     return op
 
 
+def create_subgraph(graph, nodes=None, edges=None):
+    """Create to_undirected operation for nx graph.
+
+    Args:
+        graph (:class:`nx.Graph`): A nx graph.
+
+    Returns:
+        Operation
+    """
+    check_argument(graph.graph_type == types_pb2.DYNAMIC_PROPERTY)
+    config = {
+        types_pb2.GRAPH_NAME: utils.s_to_attr(graph.key),
+    }
+    if nodes is not None:
+        config[types_pb2.NODES] = utils.list_str_to_attr(nodes)
+    if edges is not None:
+        config[types_pb2.EDGES] = utils.list_str_to_attr(edges)
+
+    op = Operation(
+        graph.session_id,
+        types_pb2.INDUCE_SUBGRAPH,
+        config=config,
+        output_types=types_pb2.GRAPH,
+    )
+    return op
+
+
 def unload_app(app):
     """Unload a loaded app.
 


### PR DESCRIPTION
## What do these changes do?

implement true subgraph/edge_subgraph in engine, not return a view.

## Related issue number
#62 

todo:

- [x] refact and pass the subgraph/edge_subgraph test cases
- [x] test with p2p
