### PR TITLE
Update dyn_type's pegasus::codec dependence

### DIFF
--- a/research/gaia/dyn_type/Cargo.toml
+++ b/research/gaia/dyn_type/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 dyn-clonable = "0.9.0"
 itertools = "0.9"
 lazy_static = "1.3.0"
-pegasus = { path = "../pegasus/pegasus" }
+pegasus_common = { path = "../pegasus/common" }

--- a/research/gaia/dyn_type/src/lib.rs
+++ b/research/gaia/dyn_type/src/lib.rs
@@ -15,7 +15,7 @@
 
 #[macro_use]
 extern crate lazy_static;
-extern crate pegasus;
+extern crate pegasus_common;
 
 extern crate dyn_clonable;
 

--- a/research/gaia/dyn_type/src/serde.rs
+++ b/research/gaia/dyn_type/src/serde.rs
@@ -15,7 +15,7 @@
 
 use crate::{de_dyn_obj, Object, Primitives};
 use core::any::TypeId;
-use pegasus::codec::{Decode, Encode, ReadExt, WriteExt};
+use pegasus_common::codec::{Decode, Encode, ReadExt, WriteExt};
 use std::io;
 
 impl Encode for Primitives {

--- a/research/gaia/dyn_type/src/serde_dyn.rs
+++ b/research/gaia/dyn_type/src/serde_dyn.rs
@@ -14,7 +14,7 @@
 //! limitations under the License.
 
 use crate::DynType;
-use pegasus::codec::{Decode, Encode};
+use pegasus_common::codec::{Decode, Encode};
 use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -32,7 +32,7 @@ lazy_static! {
 ///
 /// use dyn_type::object::Object;
 /// use dyn_type::{register_type, OwnedOrRef};
-/// use pegasus::preclude::{Encode, Decode};
+/// use pegasus_common::codec::{Encode, Decode};
 ///
 /// let dyn_ty_obj = vec![0_u64, 1, 2, 3];
 /// let obj = Object::DynOwned(Box::new(dyn_ty_obj));
@@ -101,7 +101,7 @@ impl<T: Any + Send + Sync + Clone + Debug + Encode> DynType for T {
 mod test {
     use super::*;
     use crate::{Object, OwnedOrRef};
-    use pegasus::codec::{ReadExt, WriteExt};
+    use pegasus_common::codec::{ReadExt, WriteExt};
 
     #[test]
     fn test_ser_dyn_type() {


### PR DESCRIPTION
To update the dyn_type's dependence of pegasus::codec to pegasus_common::codec.

This is because of potential cyclic dependence if using dyn_type in pegasus. 
