### PR TITLE
Ensure graphscope.proto preponderate over outside `proto` directory.

### DIFF
--- a/python/graphscope/proto/__init__.py
+++ b/python/graphscope/proto/__init__.py
@@ -19,4 +19,39 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+# ensure graphscope.proto preponderate over outside `proto` directory.
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from . import attr_value_pb2
+from . import coordinator_service_pb2
+from . import coordinator_service_pb2_grpc
+from . import data_types_pb2
+from . import ddl_service_pb2
+from . import ddl_service_pb2_grpc
+from . import engine_service_pb2
+from . import engine_service_pb2_grpc
+from . import error_codes_pb2
+from . import graph_def_pb2
+from . import message_pb2
+from . import op_def_pb2
+from . import query_args_pb2
+from . import types_pb2
+
+del attr_value_pb2
+del coordinator_service_pb2
+del coordinator_service_pb2_grpc
+del data_types_pb2
+del ddl_service_pb2
+del ddl_service_pb2_grpc
+del engine_service_pb2
+del engine_service_pb2_grpc
+del error_codes_pb2
+del graph_def_pb2
+del message_pb2
+del op_def_pb2
+del query_args_pb2
+del types_pb2
+
+sys.path.pop(0)


### PR DESCRIPTION
As some other packages (i.e., `proto-plus-python`) may install a `proto` directory in the root path.

## Related issue number

Fixes #400.

