### PR TITLE
Local CI: use latest vineyard (v0.2.4).

### DIFF
--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -85,7 +85,7 @@ jobs:
 
     - name: Install libvineyard
       run: |
-        git clone -b main-v0.2.3 --single-branch --depth=1 https://github.com/alibaba/libvineyard.git
+        git clone -b v0.2.4 --single-branch --depth=1 https://github.com/alibaba/libvineyard.git
         cd libvineyard
         git submodule update --init
         mkdir build && pushd build


### PR DESCRIPTION

## What do these changes do?

Try to fix the failure on master.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A.

