### PR TITLE
[graphscope] add mapping of partition id to server id in GraphPartitionManager

### DIFF
--- a/interactive_engine/src/executor/runtime/src/store/ffi.rs
+++ b/interactive_engine/src/executor/runtime/src/store/ffi.rs
@@ -1411,6 +1411,10 @@ impl GraphPartitionManager for VineyardPartitionManager {
         }
     }
 
+    fn get_server_id(&self, _pid: u32) -> i32 {
+        unimplemented!()
+    }
+
     fn get_process_partition_list(&self) -> Vec<u32> {
         let mut partition_id_list = Vec::new();
         let mut partition_count: i32 = 0;

--- a/interactive_engine/src/executor/runtime/src/store/ffi.rs
+++ b/interactive_engine/src/executor/runtime/src/store/ffi.rs
@@ -1411,6 +1411,7 @@ impl GraphPartitionManager for VineyardPartitionManager {
         }
     }
 
+    // TODO(bingqing): check with vineyard
     fn get_server_id(&self, _pid: u32) -> i32 {
         unimplemented!()
     }

--- a/interactive_engine/src/executor/runtime/src/store/v2/global_graph.rs
+++ b/interactive_engine/src/executor/runtime/src/store/v2/global_graph.rs
@@ -493,6 +493,10 @@ impl GraphPartitionManager for GlobalGraph {
         floor_mod(vid, partition_count as i64) as i32
     }
 
+    fn get_server_id(&self, _pid: u32) -> i32 {
+        unimplemented!()
+    }
+
     fn get_process_partition_list(&self) -> Vec<u32> {
         self.graph_partitions.keys().into_iter().map(|x|*x).collect::<Vec<u32>>()
     }

--- a/interactive_engine/src/executor/runtime/src/store/v2/global_graph.rs
+++ b/interactive_engine/src/executor/runtime/src/store/v2/global_graph.rs
@@ -493,6 +493,7 @@ impl GraphPartitionManager for GlobalGraph {
         floor_mod(vid, partition_count as i64) as i32
     }
 
+    // TODO(haixia): impl for v2 store
     fn get_server_id(&self, _pid: u32) -> i32 {
         unimplemented!()
     }

--- a/interactive_engine/src/executor/store/src/api/graph_partition.rs
+++ b/interactive_engine/src/executor/store/src/api/graph_partition.rs
@@ -52,6 +52,7 @@ impl GraphPartitionManager for ConstantPartitionManager {
     }
 
     fn get_server_id(&self, _pid: u32) -> i32 {
+        //TODO(bingqing)
         unimplemented!()
     }
 
@@ -97,6 +98,7 @@ impl<V, VI, E, EI> GraphPartitionManager for FixedStorePartitionManager<V, VI, E
     }
 
     fn get_server_id(&self, _pid: u32) -> i32 {
+        // TODO(bingqing)
         unimplemented!()
     }
 

--- a/interactive_engine/src/executor/store/src/api/graph_partition.rs
+++ b/interactive_engine/src/executor/store/src/api/graph_partition.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 // Partition manager for graph query
 pub trait GraphPartitionManager: Send + Sync {
     fn get_partition_id(&self, vid: VertexId) -> i32;
+    fn get_server_id(&self, pid: PartitionId) -> i32;
     fn get_process_partition_list(&self) -> Vec<PartitionId>;
     fn get_vertex_id_by_primary_key(&self, label_id: LabelId, key: &String) -> Option<(PartitionId, VertexId)>;
 }
@@ -48,6 +49,10 @@ impl ConstantPartitionManager {
 impl GraphPartitionManager for ConstantPartitionManager {
     fn get_partition_id(&self, _vid: i64) -> i32 {
         self.partition_id as i32
+    }
+
+    fn get_server_id(&self, _pid: u32) -> i32 {
+        unimplemented!()
     }
 
     fn get_process_partition_list(&self) -> Vec<PartitionId> {
@@ -89,6 +94,10 @@ impl<V, VI, E, EI> GraphPartitionManager for FixedStorePartitionManager<V, VI, E
           EI: Iterator<Item=E> {
     fn get_partition_id(&self, vid: VertexId) -> i32 {
         self.graph.as_ref().get_partition_id(vid) as i32
+    }
+
+    fn get_server_id(&self, _pid: u32) -> i32 {
+        unimplemented!()
     }
 
     fn get_process_partition_list(&self) -> Vec<PartitionId> {


### PR DESCRIPTION
Add a function in GraphPartitionManager for GAIA Integration: 
`fn get_server_id(&self, pid: PartitionId) -> i32;`
