### PR TITLE
Support `with` keyword in session

### DIFF
--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -781,6 +781,21 @@ class Session(object):
         except Exception:  # pylint: disable=broad-except
             pass
 
+    def __enter__(self):
+        """Register self as default session"""
+        self.as_default()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """Deregister self from the default session,
+        close the session and release the resources.
+        """
+        try:
+            self._deregister_default()
+            self.close()
+        except Exception:
+            pass
+
     def as_default(self):
         """Obtain a context manager that make this object as default session.
 

--- a/python/tests/test_session.py
+++ b/python/tests/test_session.py
@@ -255,3 +255,13 @@ def test_border_cases():
                 "e0": "twitter_property_e_0#header_row=true",
             }
         )
+
+
+def test_with():
+    with graphscope.session(cluster_type="hosts") as sess:
+        assert graphscope.get_default_session() == sess
+
+    sess = graphscope.session(cluster_type="hosts")
+    with sess:
+        pass
+    assert sess.info["status"] == "closed"


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
This PR enables `with` keyword in session, which can automatically release resourced when the context manager exits.
Moreover, use `with` will automatically set the session as the default session.

Two simple test cases has been added that can fully demonstrate its usage.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #393 

