### PR TITLE
Fix string oid graph transformation bug

### DIFF
--- a/analytical_engine/core/loader/arrow_to_dynamic_converter.h
+++ b/analytical_engine/core/loader/arrow_to_dynamic_converter.h
@@ -154,7 +154,6 @@ class ArrowToDynamicConverter {
         }
       }
     }
-    dst_vm_ptr->Construct();
 
     return dst_vm_ptr;
   }

--- a/python/graphscope/nx/tests/test_nx.py
+++ b/python/graphscope/nx/tests/test_nx.py
@@ -338,7 +338,6 @@ class TestGraphTransformation(object):
         nx_g = self.NXGraph(g, dist=True)
         self.assert_convert_success(g, nx_g)
 
-    @pytest.mark.skip(reason="FIXME: folly::hash failed.")
     def test_str_oid_gs_to_nx(self):
         g = self.str_oid_g
         nx_g = self.NXGraph(g, dist=True)


### PR DESCRIPTION
## What do these changes do?

- no need to call the vertex map construct, since every worker has the complete global vertex map.

