### PR TITLE
Set decorator>=5.0.5 since it's old version(4.4.2) may not compatible with NetworkX latest release

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ grpcio
 grpcio-tools
 kubernetes
 nest_asyncio
-networkx
+networkx<2.6
 numpy
 pandas
 protobuf>=3.12.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,7 +5,7 @@ grpcio
 grpcio-tools
 kubernetes
 nest_asyncio
-networkx<2.6
+networkx<=2.5.1
 numpy
 pandas
 protobuf>=3.12.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,11 +1,11 @@
 Cython==3.0a6
-decorator
+decorator>=5.0.5
 gremlinpython
 grpcio
 grpcio-tools
 kubernetes
 nest_asyncio
-networkx<=2.5.1
+networkx
 numpy
 pandas
 protobuf>=3.12.0


### PR DESCRIPTION
can reproduce with NetworkX 2.6.1 and decorator 4.4.2
```python
from networkx.utils.decorators import not_implemented_for
@not_implemented_for("directed")
 def sp_function(G):
      pass

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-5-b6e5bef0b8d8> in <module>
----> 1 @not_implemented_for("directed")
      2 def sp_function(G):
      3     pass
      4

~/.local/anaconda3/envs/graphscope/lib/python3.8/site-packages/networkx/utils/decorators.py in not_implemented_for(*graph_types)
     89         return g
     90
---> 91     return argmap(_not_implemented_for, 0)
     92
     93

TypeError: __init__() missing 1 required keyword-only argument: 'try_finally'
      
```
