### PR TITLE
Fixes the copy_class hack for `argmap` in networkx.

### DIFF
--- a/k8s/gsruntime.Dockerfile
+++ b/k8s/gsruntime.Dockerfile
@@ -4,8 +4,13 @@
 FROM centos:7
 
 # yum install gcc7, cat not merge in one layer
-RUN yum install -y centos-release-scl && yum clean all && rm -fr /var/cache/yum
-RUN yum install -y devtoolset-7-gcc-* && yum clean all && rm -fr /var/cache/yum
+RUN yum install -y centos-release-scl && \
+    yum clean all && \
+    rm -fr /var/cache/yum
+RUN yum install -y devtoolset-7-gcc-* \
+                   devtoolset-7-libasan-devel.x86_64 && \
+    yum clean all && \
+    rm -fr /var/cache/yum
 RUN echo "source scl_source enable devtoolset-7" >> /etc/bashrc && source /etc/bashrc
 SHELL ["/usr/bin/scl", "enable", "devtoolset-7"]
 

--- a/python/graphscope/nx/tests/algorithms/builtin/test_shortest_paths.py
+++ b/python/graphscope/nx/tests/algorithms/builtin/test_shortest_paths.py
@@ -4,6 +4,7 @@ from graphscope import nx
 from graphscope.nx.tests.utils import replace_with_inf
 
 
+@pytest.mark.usefixtures("graphscope_session")
 class TestRunGenericPath:
     def setup_method(self):
         self.edges = [(0, 1), (0, 2), (1, 2), (2, 3), (1, 4)]

--- a/python/graphscope/nx/utils/compat.py
+++ b/python/graphscope/nx/utils/compat.py
@@ -214,6 +214,17 @@ def replace_module_context(  # noqa: C901
                 continue
 
             if inspect.isclass(var):
+                # special case for `argmap`: `copy_class` cannot handle complex
+                # arguments properly.
+                #
+                # see also: https://github.com/alibaba/GraphScope/pull/507
+                if var.__name__ == "argmap":
+                    global_ctx[var_name] = var
+                    setattr(module, var_name, var)
+                    if expand:
+                        setattr(mod, var_name, var)
+                    continue
+
                 target_class = copy_class(var)
                 for dec in decorators:
                     target_class = dec(target_class)


### PR DESCRIPTION
Its `__init__` has following signature

```
class argmap:
    def __init__(self, func, *args, try_finally=False):
```

and we cannot handle that currently.

Follow-up work for #507.
