### PR TITLE
Fix macOS ci: change to llvm 8

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-11
+    runs-on: macOS-latest
     env:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
       OPENSSL_ROOT_DIR: /usr/local/opt/openssl
@@ -47,7 +47,7 @@ jobs:
         pushd ${GITHUB_WORKSPACE}
         brew install llvm@9
 
-        # write envs to .env
+        # write out envs to .env
         {
           echo "export CC=/usr/local/opt/llvm@9/bin/clang"
           echo "export CXX=/usr/local/opt/llvm@9/bin/clang++"

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -39,21 +39,21 @@ jobs:
         submodules: true
 
     - name: Setup tmate session
-      if: true
+      if: false
       uses: mxschmitt/action-tmate@v2
 
     - name: Install Dependencies for MacOS
       run: |
         pushd ${GITHUB_WORKSPACE}
-        brew install llvm@9
+        brew install llvm@8
 
         # write out envs to .env
         {
-          echo "export CC=/usr/local/opt/llvm@11/bin/clang"
-          echo "export CXX=/usr/local/opt/llvm@11/bin/clang++"
-          echo "export LDFLAGS=-L/usr/local/opt/llvm@11/lib"
-          echo "export CPPFLAGS=-I/usr/local/opt/llvm@11/include"
-          echo "export PATH=/usr/local/opt/llvm@11/bin:${JAVA_HOME}/bin:$PATH"
+          echo "export CC=/usr/local/opt/llvm@8/bin/clang"
+          echo "export CXX=/usr/local/opt/llvm@8/bin/clang++"
+          echo "export LDFLAGS=-L/usr/local/opt/llvm@8/lib"
+          echo "export CPPFLAGS=-I/usr/local/opt/llvm@8/include"
+          echo "export PATH=/usr/local/opt/llvm@8/bin:${JAVA_HOME}/bin:$PATH"
         } >> .env
 
         # install dependency

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -39,7 +39,7 @@ jobs:
         submodules: true
 
     - name: Setup tmate session
-      if: false
+      if: true
       uses: mxschmitt/action-tmate@v2
 
     - name: Install Dependencies for MacOS
@@ -49,11 +49,11 @@ jobs:
 
         # write out envs to .env
         {
-          echo "export CC=/usr/local/opt/llvm@9/bin/clang"
-          echo "export CXX=/usr/local/opt/llvm@9/bin/clang++"
-          echo "export LDFLAGS=-L/usr/local/opt/llvm@9/lib"
-          echo "export CPPFLAGS=-I/usr/local/opt/llvm@9/include"
-          echo "export PATH=/usr/local/opt/llvm@9/bin:${JAVA_HOME}/bin:$PATH"
+          echo "export CC=/usr/local/opt/llvm@11/bin/clang"
+          echo "export CXX=/usr/local/opt/llvm@11/bin/clang++"
+          echo "export LDFLAGS=-L/usr/local/opt/llvm@11/lib"
+          echo "export CPPFLAGS=-I/usr/local/opt/llvm@11/include"
+          echo "export PATH=/usr/local/opt/llvm@11/bin:${JAVA_HOME}/bin:$PATH"
         } >> .env
 
         # install dependency

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macOS-11
     env:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
       OPENSSL_ROOT_DIR: /usr/local/opt/openssl

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-11
     env:
       JAVA_HOME: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
       OPENSSL_ROOT_DIR: /usr/local/opt/openssl

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -61,12 +61,12 @@ function check_os_compatibility() {
       exit 1
     fi
     if ! command -v clang &> /dev/null; then
-      echo "clang could not be found, GraphScope require clang 9 or clang 10, you can install it manually."
+      echo "clang could not be found, GraphScope require clang 8 ~ 10, you can install it manually."
       exit 1
     fi
     ver=$(clang -v 2>&1 | head -n 1 | sed 's/.* \([0-9]*\)\..*/\1/')
-    if [[ "$ver" -lt "9" || "$ver" -gt "10" ]]; then
-      echo "GraphScope requires clang 9 or clang 10 on MacOS, current version is $ver."
+    if [[ "$ver" -lt "8" || "$ver" -gt "10" ]]; then
+      echo "GraphScope requires clang 8 ~ 10 on MacOS, current version is $ver."
       exit 1
     fi
   fi


### PR DESCRIPTION
## What do these changes do?
In MacOS runner image version 20210712.4, the llvm@9 we use in ci thinks 'preadv' and 'pwritev' is enable to use but it's available until MacOS 11.0, so we downgrade  llvm to 8.


