### PR TITLE
Install the inplace vineyard-io as well.

### DIFF
--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -72,7 +72,10 @@ jobs:
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
         # install tensorflow for graphlearn if os is ubuntu20.04
-        if [ "${OS}" == "ubuntu-20.04" ];then pip3 install pytest tensorflow --user; fi
+        if [ "${OS}" == "ubuntu-20.04" ];
+        then
+            pip3 install pytest tensorflow --user;
+        fi
 
         # prelaunch the etcd
         /usr/local/bin/etcd --data-dir=/tmp/default.etcd&

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -399,8 +399,18 @@ install_vineyard() {
   make vineyard_client_python -j${NUM_PROC}
   sudo make install
   popd
+
+  # install vineyard-python
   python3 setup.py bdist_wheel
   pip3 install -U ./dist/*.whl --user
+
+  # install vineyard-io
+  pushd modules/io
+  rm -rf build/lib.* build/bdist.*
+  python3 setup.py bdist_wheel
+  pip3 install -U ./dist/*.whl --user
+  popd
+
   popd
   rm -fr /tmp/libvineyard
 }


### PR DESCRIPTION
Fixes CI failure: https://github.com/alibaba/GraphScope/runs/3101487940?check_suite_focus=true