### PR TITLE
Fix local CI by catching exception in sess.close

### DIFF
--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -811,8 +811,11 @@ class Session(object):
 
         # clean up
         if self._config_params["addr"] is None:
-            if self._launcher:
-                self._launcher.stop()
+            try:
+                if self._launcher:
+                    self._launcher.stop()
+            except Exception:
+                pass
             self._pod_name_list = []
 
     def _close_interactive_instance(self, instance):

--- a/python/graphscope/deploy/hosts/cluster.py
+++ b/python/graphscope/deploy/hosts/cluster.py
@@ -154,6 +154,6 @@ class HostsClusterLauncher(Launcher):
         if not self._closed:
             if self._proc is not None:
                 self._proc.send_signal(signal.SIGINT)
-                self._proc.wait(timeout=60)
+                self._proc.wait(timeout=10)
                 self._proc = None
             self._closed = True


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The reason for the Local-CI failure is timeout when waiting for stopping vineyard in coordinator. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->



