### PR TITLE
[Bug Fix]: add u128 in Primitive in Object

### DIFF
--- a/research/gaia/dyn_type/src/error.rs
+++ b/research/gaia/dyn_type/src/error.rs
@@ -35,6 +35,7 @@ impl fmt::Display for CastError {
             RawType::Byte => write!(f, "can't cast i8 into {}", self.target),
             RawType::Integer => write!(f, "can't cast i32 into {}", self.target),
             RawType::Long => write!(f, "can't cast i64 into {}", self.target),
+            RawType::LLLong => write!(f, "can't cast u128 into {}", self.target),
             RawType::Float => write!(f, "can't cast f64 into {}", self.target),
             RawType::Blob(len) => write!(f, "can't cast Blob({}) into {}", len, self.target),
             RawType::String => write!(f, "can't cast String into {}", self.target),

--- a/research/gaia/dyn_type/src/error.rs
+++ b/research/gaia/dyn_type/src/error.rs
@@ -35,7 +35,7 @@ impl fmt::Display for CastError {
             RawType::Byte => write!(f, "can't cast i8 into {}", self.target),
             RawType::Integer => write!(f, "can't cast i32 into {}", self.target),
             RawType::Long => write!(f, "can't cast i64 into {}", self.target),
-            RawType::LLLong => write!(f, "can't cast u128 into {}", self.target),
+            RawType::ULLong => write!(f, "can't cast u128 into {}", self.target),
             RawType::Float => write!(f, "can't cast f64 into {}", self.target),
             RawType::Blob(len) => write!(f, "can't cast Blob({}) into {}", len, self.target),
             RawType::String => write!(f, "can't cast String into {}", self.target),

--- a/research/gaia/dyn_type/src/object.rs
+++ b/research/gaia/dyn_type/src/object.rs
@@ -28,6 +28,7 @@ pub enum RawType {
     Byte,
     Integer,
     Long,
+    LLLong,
     Float,
     String,
     Blob(usize),
@@ -39,6 +40,7 @@ pub enum Primitives {
     Byte(i8),
     Integer(i32),
     Long(i64),
+    LLLong(u128),
     Float(f64),
 }
 
@@ -75,6 +77,7 @@ impl Primitives {
             Primitives::Byte(_) => RawType::Byte,
             Primitives::Integer(_) => RawType::Integer,
             Primitives::Long(_) => RawType::Long,
+            Primitives::LLLong(_) => RawType::LLLong,
             Primitives::Float(_) => RawType::Float,
         }
     }
@@ -94,6 +97,9 @@ impl Primitives {
             Primitives::Long(v) => {
                 i8::try_from(*v).map_err(|_| CastError::new::<i8>(RawType::Long))
             }
+            Primitives::LLLong(v) => {
+                i8::try_from(*v).map_err(|_| CastError::new::<i8>(RawType::LLLong))
+            }
             Primitives::Float(_) => Err(CastError::new::<i8>(RawType::Float)),
         }
     }
@@ -108,6 +114,9 @@ impl Primitives {
             Primitives::Long(v) => {
                 i16::try_from(*v).map_err(|_| CastError::new::<i16>(RawType::Long))
             }
+            Primitives::LLLong(v) => {
+                i16::try_from(*v).map_err(|_| CastError::new::<i16>(RawType::LLLong))
+            }
             Primitives::Float(_) => Err(CastError::new::<i16>(RawType::Float)),
         }
     }
@@ -120,6 +129,9 @@ impl Primitives {
             Primitives::Long(v) => {
                 i32::try_from(*v).map_err(|_| CastError::new::<i32>(RawType::Long))
             }
+            Primitives::LLLong(v) => {
+                i32::try_from(*v).map_err(|_| CastError::new::<i32>(RawType::LLLong))
+            }
             Primitives::Float(_) => Err(CastError::new::<i32>(RawType::Float)),
         }
     }
@@ -130,6 +142,9 @@ impl Primitives {
             Primitives::Byte(v) => Ok(*v as i64),
             Primitives::Integer(v) => Ok(*v as i64),
             Primitives::Long(v) => Ok(*v),
+            Primitives::LLLong(v) => {
+                i64::try_from(*v).map_err(|_| CastError::new::<i64>(RawType::LLLong))
+            }
             Primitives::Float(_) => Err(CastError::new::<i64>(RawType::Float)),
         }
     }
@@ -140,6 +155,9 @@ impl Primitives {
             Primitives::Byte(v) => Ok(*v as i128),
             Primitives::Integer(v) => Ok(*v as i128),
             Primitives::Long(v) => Ok(*v as i128),
+            Primitives::LLLong(v) => {
+                i128::try_from(*v).map_err(|_| CastError::new::<i128>(RawType::LLLong))
+            }
             Primitives::Float(_) => Err(CastError::new::<i128>(RawType::Float)),
         }
     }
@@ -155,6 +173,9 @@ impl Primitives {
             }
             Primitives::Long(v) => {
                 u8::try_from(*v).map_err(|_| CastError::new::<u8>(RawType::Long))
+            }
+            Primitives::LLLong(v) => {
+                u8::try_from(*v).map_err(|_| CastError::new::<u8>(RawType::LLLong))
             }
             Primitives::Float(_) => Err(CastError::new::<u8>(RawType::Float)),
         }
@@ -172,6 +193,9 @@ impl Primitives {
             Primitives::Long(v) => {
                 u16::try_from(*v).map_err(|_| CastError::new::<u16>(RawType::Long))
             }
+            Primitives::LLLong(v) => {
+                u16::try_from(*v).map_err(|_| CastError::new::<u16>(RawType::LLLong))
+            }
             Primitives::Float(_) => Err(CastError::new::<u16>(RawType::Float)),
         }
     }
@@ -188,6 +212,9 @@ impl Primitives {
             Primitives::Long(v) => {
                 u32::try_from(*v).map_err(|_| CastError::new::<u32>(RawType::Long))
             }
+            Primitives::LLLong(v) => {
+                u32::try_from(*v).map_err(|_| CastError::new::<u32>(RawType::LLLong))
+            }
             Primitives::Float(_) => Err(CastError::new::<u32>(RawType::Float)),
         }
     }
@@ -203,6 +230,9 @@ impl Primitives {
             }
             Primitives::Long(v) => {
                 u64::try_from(*v).map_err(|_| CastError::new::<u64>(RawType::Long))
+            }
+            Primitives::LLLong(v) => {
+                u64::try_from(*v).map_err(|_| CastError::new::<u64>(RawType::LLLong))
             }
             Primitives::Float(_) => Err(CastError::new::<u64>(RawType::Float)),
         }
@@ -225,6 +255,7 @@ impl Primitives {
             Primitives::Long(v) => {
                 u128::try_from(*v).map_err(|_| CastError::new::<u128>(RawType::Long))
             }
+            Primitives::LLLong(v) => Ok(*v),
             Primitives::Float(_) => Err(CastError::new::<u128>(RawType::Float)),
         }
     }
@@ -241,6 +272,10 @@ impl Primitives {
             Primitives::Long(v) => {
                 let t = i16::try_from(*v).map_err(|_| CastError::new::<f64>(RawType::Long))?;
                 f64::try_from(t).map_err(|_| CastError::new::<f64>(RawType::Long))
+            }
+            Primitives::LLLong(v) => {
+                let t = i16::try_from(*v).map_err(|_| CastError::new::<f64>(RawType::LLLong))?;
+                f64::try_from(t).map_err(|_| CastError::new::<f64>(RawType::LLLong))
             }
             Primitives::Float(v) => Ok(*v),
         }
@@ -359,6 +394,10 @@ impl PartialEq for Primitives {
                 Primitives::Float(o) => (*v as f64).eq(o),
                 _ => other.as_i64().map(|o| o == *v).unwrap_or(false),
             },
+            Primitives::LLLong(v) => match other {
+                Primitives::Float(o) => (*v as f64).eq(o),
+                _ => other.as_u128().map(|o| o == *v).unwrap_or(false),
+            },
             Primitives::Float(v) => other.as_f64().map(|o| o == *v).unwrap_or(false),
         }
     }
@@ -380,6 +419,10 @@ impl PartialOrd for Primitives {
             Primitives::Long(v) => match other {
                 Primitives::Float(o) => (*v as f64).partial_cmp(o),
                 _ => other.as_i64().map(|o| v.cmp(&o)).ok(),
+            },
+            Primitives::LLLong(v) => match other {
+                Primitives::Float(o) => (*v as f64).partial_cmp(o),
+                _ => other.as_u128().map(|o| v.cmp(&o)).ok(),
             },
             Primitives::Float(v) => other.as_f64().map(|o| v.partial_cmp(&o)).unwrap_or(None),
         }
@@ -793,11 +836,18 @@ impl Eq for Object {}
 impl PartialOrd for Object {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self {
-            Object::Primitive(p) => other.as_primitive().map(|o| p.partial_cmp(&o)).unwrap_or(None),
-            Object::Blob(v) => other.as_bytes().map(|o| v.as_ref().partial_cmp(o)).unwrap_or(None),
-            Object::String(v) => {
-                other.as_str().map(|o| v.as_str().partial_cmp(o.as_ref())).unwrap_or(None)
-            }
+            Object::Primitive(p) => other
+                .as_primitive()
+                .map(|o| p.partial_cmp(&o))
+                .unwrap_or(None),
+            Object::Blob(v) => other
+                .as_bytes()
+                .map(|o| v.as_ref().partial_cmp(o))
+                .unwrap_or(None),
+            Object::String(v) => other
+                .as_str()
+                .map(|o| v.as_str().partial_cmp(o.as_ref()))
+                .unwrap_or(None),
             // TODO(longbin) Should be able to compare a DynType
             Object::DynOwned(_) => None,
         }
@@ -819,13 +869,18 @@ impl<'a> PartialEq for BorrowObject<'a> {
 impl<'a> PartialOrd for BorrowObject<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self {
-            BorrowObject::Primitive(p) => {
-                other.as_primitive().map(|o| p.partial_cmp(&o)).unwrap_or(None)
-            }
-            BorrowObject::String(v) => {
-                other.as_str().map(|o| (*v).partial_cmp(o.as_ref())).unwrap_or(None)
-            }
-            BorrowObject::Blob(v) => other.as_bytes().map(|o| (*v).partial_cmp(o)).unwrap_or(None),
+            BorrowObject::Primitive(p) => other
+                .as_primitive()
+                .map(|o| p.partial_cmp(&o))
+                .unwrap_or(None),
+            BorrowObject::String(v) => other
+                .as_str()
+                .map(|o| (*v).partial_cmp(o.as_ref()))
+                .unwrap_or(None),
+            BorrowObject::Blob(v) => other
+                .as_bytes()
+                .map(|o| (*v).partial_cmp(o))
+                .unwrap_or(None),
             // TODO(longbin) Should be able to compare a DynType
             BorrowObject::DynRef(_) => None,
         }
@@ -865,6 +920,9 @@ impl Hash for Object {
                 }
                 Primitives::Float(v) => {
                     integer_decode(*v).hash(state);
+                }
+                Primitives::LLLong(v) => {
+                    v.hash(state);
                 }
             },
             Object::String(s) => {
@@ -954,8 +1012,7 @@ impl From<u64> for Object {
         if i <= (i64::MAX as u64) {
             Object::Primitive(Primitives::Long(i as i64))
         } else {
-            let b = i.to_le_bytes().to_vec().into_boxed_slice();
-            Object::Blob(b)
+            Object::Primitive(Primitives::LLLong(i as u128))
         }
     }
 }
@@ -967,13 +1024,8 @@ impl From<usize> for Object {
 }
 
 impl From<u128> for Object {
-    fn from(i: u128) -> Self {
-        if i <= (i64::MAX as u128) {
-            Object::Primitive(Primitives::Long(i as i64))
-        } else {
-            let b = i.to_le_bytes().to_vec().into_boxed_slice();
-            Object::Blob(b)
-        }
+    fn from(u: u128) -> Self {
+        Object::Primitive(Primitives::LLLong(u))
     }
 }
 

--- a/research/gaia/dyn_type/src/object.rs
+++ b/research/gaia/dyn_type/src/object.rs
@@ -28,7 +28,7 @@ pub enum RawType {
     Byte,
     Integer,
     Long,
-    LLLong,
+    ULLong,
     Float,
     String,
     Blob(usize),
@@ -40,7 +40,7 @@ pub enum Primitives {
     Byte(i8),
     Integer(i32),
     Long(i64),
-    LLLong(u128),
+    ULLong(u128),
     Float(f64),
 }
 
@@ -77,7 +77,7 @@ impl Primitives {
             Primitives::Byte(_) => RawType::Byte,
             Primitives::Integer(_) => RawType::Integer,
             Primitives::Long(_) => RawType::Long,
-            Primitives::LLLong(_) => RawType::LLLong,
+            Primitives::ULLong(_) => RawType::ULLong,
             Primitives::Float(_) => RawType::Float,
         }
     }
@@ -97,8 +97,8 @@ impl Primitives {
             Primitives::Long(v) => {
                 i8::try_from(*v).map_err(|_| CastError::new::<i8>(RawType::Long))
             }
-            Primitives::LLLong(v) => {
-                i8::try_from(*v).map_err(|_| CastError::new::<i8>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                i8::try_from(*v).map_err(|_| CastError::new::<i8>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<i8>(RawType::Float)),
         }
@@ -114,8 +114,8 @@ impl Primitives {
             Primitives::Long(v) => {
                 i16::try_from(*v).map_err(|_| CastError::new::<i16>(RawType::Long))
             }
-            Primitives::LLLong(v) => {
-                i16::try_from(*v).map_err(|_| CastError::new::<i16>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                i16::try_from(*v).map_err(|_| CastError::new::<i16>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<i16>(RawType::Float)),
         }
@@ -129,8 +129,8 @@ impl Primitives {
             Primitives::Long(v) => {
                 i32::try_from(*v).map_err(|_| CastError::new::<i32>(RawType::Long))
             }
-            Primitives::LLLong(v) => {
-                i32::try_from(*v).map_err(|_| CastError::new::<i32>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                i32::try_from(*v).map_err(|_| CastError::new::<i32>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<i32>(RawType::Float)),
         }
@@ -142,8 +142,8 @@ impl Primitives {
             Primitives::Byte(v) => Ok(*v as i64),
             Primitives::Integer(v) => Ok(*v as i64),
             Primitives::Long(v) => Ok(*v),
-            Primitives::LLLong(v) => {
-                i64::try_from(*v).map_err(|_| CastError::new::<i64>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                i64::try_from(*v).map_err(|_| CastError::new::<i64>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<i64>(RawType::Float)),
         }
@@ -155,8 +155,8 @@ impl Primitives {
             Primitives::Byte(v) => Ok(*v as i128),
             Primitives::Integer(v) => Ok(*v as i128),
             Primitives::Long(v) => Ok(*v as i128),
-            Primitives::LLLong(v) => {
-                i128::try_from(*v).map_err(|_| CastError::new::<i128>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                i128::try_from(*v).map_err(|_| CastError::new::<i128>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<i128>(RawType::Float)),
         }
@@ -174,8 +174,8 @@ impl Primitives {
             Primitives::Long(v) => {
                 u8::try_from(*v).map_err(|_| CastError::new::<u8>(RawType::Long))
             }
-            Primitives::LLLong(v) => {
-                u8::try_from(*v).map_err(|_| CastError::new::<u8>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                u8::try_from(*v).map_err(|_| CastError::new::<u8>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<u8>(RawType::Float)),
         }
@@ -193,8 +193,8 @@ impl Primitives {
             Primitives::Long(v) => {
                 u16::try_from(*v).map_err(|_| CastError::new::<u16>(RawType::Long))
             }
-            Primitives::LLLong(v) => {
-                u16::try_from(*v).map_err(|_| CastError::new::<u16>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                u16::try_from(*v).map_err(|_| CastError::new::<u16>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<u16>(RawType::Float)),
         }
@@ -212,8 +212,8 @@ impl Primitives {
             Primitives::Long(v) => {
                 u32::try_from(*v).map_err(|_| CastError::new::<u32>(RawType::Long))
             }
-            Primitives::LLLong(v) => {
-                u32::try_from(*v).map_err(|_| CastError::new::<u32>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                u32::try_from(*v).map_err(|_| CastError::new::<u32>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<u32>(RawType::Float)),
         }
@@ -231,8 +231,8 @@ impl Primitives {
             Primitives::Long(v) => {
                 u64::try_from(*v).map_err(|_| CastError::new::<u64>(RawType::Long))
             }
-            Primitives::LLLong(v) => {
-                u64::try_from(*v).map_err(|_| CastError::new::<u64>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                u64::try_from(*v).map_err(|_| CastError::new::<u64>(RawType::ULLong))
             }
             Primitives::Float(_) => Err(CastError::new::<u64>(RawType::Float)),
         }
@@ -255,7 +255,7 @@ impl Primitives {
             Primitives::Long(v) => {
                 u128::try_from(*v).map_err(|_| CastError::new::<u128>(RawType::Long))
             }
-            Primitives::LLLong(v) => Ok(*v),
+            Primitives::ULLong(v) => Ok(*v),
             Primitives::Float(_) => Err(CastError::new::<u128>(RawType::Float)),
         }
     }
@@ -273,9 +273,9 @@ impl Primitives {
                 let t = i16::try_from(*v).map_err(|_| CastError::new::<f64>(RawType::Long))?;
                 f64::try_from(t).map_err(|_| CastError::new::<f64>(RawType::Long))
             }
-            Primitives::LLLong(v) => {
-                let t = i16::try_from(*v).map_err(|_| CastError::new::<f64>(RawType::LLLong))?;
-                f64::try_from(t).map_err(|_| CastError::new::<f64>(RawType::LLLong))
+            Primitives::ULLong(v) => {
+                let t = i16::try_from(*v).map_err(|_| CastError::new::<f64>(RawType::ULLong))?;
+                f64::try_from(t).map_err(|_| CastError::new::<f64>(RawType::ULLong))
             }
             Primitives::Float(v) => Ok(*v),
         }
@@ -394,7 +394,7 @@ impl PartialEq for Primitives {
                 Primitives::Float(o) => (*v as f64).eq(o),
                 _ => other.as_i64().map(|o| o == *v).unwrap_or(false),
             },
-            Primitives::LLLong(v) => match other {
+            Primitives::ULLong(v) => match other {
                 Primitives::Float(o) => (*v as f64).eq(o),
                 _ => other.as_u128().map(|o| o == *v).unwrap_or(false),
             },
@@ -420,7 +420,7 @@ impl PartialOrd for Primitives {
                 Primitives::Float(o) => (*v as f64).partial_cmp(o),
                 _ => other.as_i64().map(|o| v.cmp(&o)).ok(),
             },
-            Primitives::LLLong(v) => match other {
+            Primitives::ULLong(v) => match other {
                 Primitives::Float(o) => (*v as f64).partial_cmp(o),
                 _ => other.as_u128().map(|o| v.cmp(&o)).ok(),
             },
@@ -836,18 +836,11 @@ impl Eq for Object {}
 impl PartialOrd for Object {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self {
-            Object::Primitive(p) => other
-                .as_primitive()
-                .map(|o| p.partial_cmp(&o))
-                .unwrap_or(None),
-            Object::Blob(v) => other
-                .as_bytes()
-                .map(|o| v.as_ref().partial_cmp(o))
-                .unwrap_or(None),
-            Object::String(v) => other
-                .as_str()
-                .map(|o| v.as_str().partial_cmp(o.as_ref()))
-                .unwrap_or(None),
+            Object::Primitive(p) => other.as_primitive().map(|o| p.partial_cmp(&o)).unwrap_or(None),
+            Object::Blob(v) => other.as_bytes().map(|o| v.as_ref().partial_cmp(o)).unwrap_or(None),
+            Object::String(v) => {
+                other.as_str().map(|o| v.as_str().partial_cmp(o.as_ref())).unwrap_or(None)
+            }
             // TODO(longbin) Should be able to compare a DynType
             Object::DynOwned(_) => None,
         }
@@ -869,18 +862,13 @@ impl<'a> PartialEq for BorrowObject<'a> {
 impl<'a> PartialOrd for BorrowObject<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self {
-            BorrowObject::Primitive(p) => other
-                .as_primitive()
-                .map(|o| p.partial_cmp(&o))
-                .unwrap_or(None),
-            BorrowObject::String(v) => other
-                .as_str()
-                .map(|o| (*v).partial_cmp(o.as_ref()))
-                .unwrap_or(None),
-            BorrowObject::Blob(v) => other
-                .as_bytes()
-                .map(|o| (*v).partial_cmp(o))
-                .unwrap_or(None),
+            BorrowObject::Primitive(p) => {
+                other.as_primitive().map(|o| p.partial_cmp(&o)).unwrap_or(None)
+            }
+            BorrowObject::String(v) => {
+                other.as_str().map(|o| (*v).partial_cmp(o.as_ref())).unwrap_or(None)
+            }
+            BorrowObject::Blob(v) => other.as_bytes().map(|o| (*v).partial_cmp(o)).unwrap_or(None),
             // TODO(longbin) Should be able to compare a DynType
             BorrowObject::DynRef(_) => None,
         }
@@ -921,7 +909,7 @@ impl Hash for Object {
                 Primitives::Float(v) => {
                     integer_decode(*v).hash(state);
                 }
-                Primitives::LLLong(v) => {
+                Primitives::ULLong(v) => {
                     v.hash(state);
                 }
             },
@@ -1012,7 +1000,7 @@ impl From<u64> for Object {
         if i <= (i64::MAX as u64) {
             Object::Primitive(Primitives::Long(i as i64))
         } else {
-            Object::Primitive(Primitives::LLLong(i as u128))
+            Object::Primitive(Primitives::ULLong(i as u128))
         }
     }
 }
@@ -1025,7 +1013,7 @@ impl From<usize> for Object {
 
 impl From<u128> for Object {
     fn from(u: u128) -> Self {
-        Object::Primitive(Primitives::LLLong(u))
+        Object::Primitive(Primitives::ULLong(u))
     }
 }
 

--- a/research/gaia/dyn_type/src/serde.rs
+++ b/research/gaia/dyn_type/src/serde.rs
@@ -37,6 +37,10 @@ impl Encode for Primitives {
                 writer.write_u8(3)?;
                 f.write_to(writer)?;
             }
+            Primitives::LLLong(lll) => {
+                writer.write_u8(4)?;
+                lll.write_to(writer)?;
+            }
         }
         Ok(())
     }
@@ -61,6 +65,10 @@ impl Decode for Primitives {
             3 => {
                 let f = <f64>::read_from(reader)?;
                 Ok(Primitives::Float(f))
+            }
+            4 => {
+                let lll = <u128>::read_from(reader)?;
+                Ok(Primitives::LLLong(lll))
             }
             _ => Err(io::Error::new(io::ErrorKind::Other, "unreachable")),
         }

--- a/research/gaia/dyn_type/src/serde.rs
+++ b/research/gaia/dyn_type/src/serde.rs
@@ -37,9 +37,9 @@ impl Encode for Primitives {
                 writer.write_u8(3)?;
                 f.write_to(writer)?;
             }
-            Primitives::LLLong(lll) => {
+            Primitives::ULLong(ull) => {
                 writer.write_u8(4)?;
-                lll.write_to(writer)?;
+                ull.write_to(writer)?;
             }
         }
         Ok(())
@@ -68,7 +68,7 @@ impl Decode for Primitives {
             }
             4 => {
                 let lll = <u128>::read_from(reader)?;
-                Ok(Primitives::LLLong(lll))
+                Ok(Primitives::ULLong(lll))
             }
             _ => Err(io::Error::new(io::ErrorKind::Other, "unreachable")),
         }

--- a/research/gaia/gremlin/gremlin_core/src/result_process.rs
+++ b/research/gaia/gremlin/gremlin_core/src/result_process.rs
@@ -132,6 +132,7 @@ fn object_to_pb_value(value: &Object) -> common_pb::Value {
                 }
                 Primitives::Integer(v) => common_pb::value::Item::I32(*v),
                 Primitives::Long(v) => common_pb::value::Item::I64(*v),
+                Primitives::LLLong(v) => common_pb::value::Item::Blob(v.to_be_bytes().to_vec()),
                 Primitives::Float(v) => common_pb::value::Item::F64(*v),
             }
         }

--- a/research/gaia/gremlin/gremlin_core/src/result_process.rs
+++ b/research/gaia/gremlin/gremlin_core/src/result_process.rs
@@ -26,18 +26,15 @@ use crate::structure::{Edge, GraphElement, Label, PropKey, Vertex, VertexOrEdge}
 use dyn_type::object::{Object, Primitives};
 
 fn label_to_pb(label: Option<&Label>) -> Option<result_pb::Label> {
-    label.map(|lab|
-        match lab {
-            // we will only pass label by id for current storages
-            Label::Str(_) => {
-                unreachable!()
-            }
-            Label::Id(label_id) => {
-                result_pb::Label{ item: Some(result_pb::label::Item::NameId(*label_id as i32)) }
-
-            }
+    label.map(|lab| match lab {
+        // we will only pass label by id for current storages
+        Label::Str(_) => {
+            unreachable!()
         }
-    )
+        Label::Id(label_id) => {
+            result_pb::Label { item: Some(result_pb::label::Item::NameId(*label_id as i32)) }
+        }
+    })
 }
 
 fn vertex_to_pb(v: &Vertex) -> result_pb::Vertex {
@@ -132,7 +129,7 @@ fn object_to_pb_value(value: &Object) -> common_pb::Value {
                 }
                 Primitives::Integer(v) => common_pb::value::Item::I32(*v),
                 Primitives::Long(v) => common_pb::value::Item::I64(*v),
-                Primitives::LLLong(v) => common_pb::value::Item::Blob(v.to_be_bytes().to_vec()),
+                Primitives::ULLong(v) => common_pb::value::Item::Blob(v.to_be_bytes().to_vec()),
                 Primitives::Float(v) => common_pb::value::Item::F64(*v),
             }
         }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix a bug in where step, e.g.,  g.V(-1).as('a').out().in().where(eq('a')). 

The reason is that in where step, it will set the expected value (i.e., global id referred by tag 'a') as a type of Object (in this case it is Object::Blob). However, when it comes to comparing with the output of in() step, we have the actual global_id of type u128, and the type inference in rust will also regard the expected value as u128. Thus, the bug occurs when we try to get Object::Blob value as a u128 value.

The solution is to add u128 as a primitive in Object, since it is commonly used in runtime (as it is the type of global id).


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

