### PR TITLE
Assocate the interactive query instance to Traversal object.

### DIFF
--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -1102,8 +1102,6 @@ class Session(object):
             if self.eager():
                 interactive_query = _wrapper
                 graph._attach_interactive_instance(interactive_query)
-                # hack for vldb gremlin process
-                __graphscope_interactive_query__.append(interactive_query)
         return _wrapper
 
     def learning(self, graph, nodes=None, edges=None, gen_labels=None):
@@ -1345,9 +1343,6 @@ class _DefaultSessionStack(object):
 
 
 _default_session_stack = _DefaultSessionStack()  # pylint: disable=protected-access
-
-
-__graphscope_interactive_query__ = []
 
 
 def g(incoming_data=None, oid_type="int64", directed=True, generate_eid=True):

--- a/python/graphscope/interactive/graph_traversal.py
+++ b/python/graphscope/interactive/graph_traversal.py
@@ -88,10 +88,9 @@ def patch_for_gremlin_python():  # noqa: C901
     def toList(self):
         import pickle
 
-        import graphscope
-        from graphscope.client.session import __graphscope_interactive_query__
-
-        interactive = __graphscope_interactive_query__[0]
+        interactive = getattr(self.graph, "__interactive", None)
+        if interactive is None:
+            raise RuntimeError("Unable to find associated interactive query instance")
         bytecode_pickle = pickle.dumps(self.bytecode)
         rlt = interactive.execute(
             bytecode_pickle, request_options={"engine": "gae_traversal"}
@@ -106,10 +105,9 @@ def patch_for_gremlin_python():  # noqa: C901
     def toSet(self):
         import pickle
 
-        import graphscope
-        from graphscope.client.session import __graphscope_interactive_query__
-
-        interactive = __graphscope_interactive_query__[0]
+        interactive = getattr(self.graph, "__interactive", None)
+        if interactive is None:
+            raise RuntimeError("Unable to find associated interactive query instance")
         bytecode_pickle = pickle.dumps(self.bytecode)
         rlt = interactive.execute(
             bytecode_pickle, request_options={"engine": "gae_traversal"}

--- a/python/graphscope/interactive/query.py
+++ b/python/graphscope/interactive/query.py
@@ -25,6 +25,7 @@ from enum import Enum
 
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.anonymous_traversal import traversal
+from gremlin_python.structure.graph import Graph as TraversalGraph
 
 from graphscope.config import GSConfig as gs_config
 from graphscope.framework.dag import DAGNode
@@ -307,7 +308,13 @@ class InteractiveQuery(object):
             raise RuntimeError(
                 "Interactive query is unavailable with %s status.", str(self._status)
             )
-        return traversal().withRemote(DriverRemoteConnection(self._graph_url, "g"))
+        graph = TraversalGraph()
+        setattr(graph, "__interactive", self)
+        return (
+            traversal()
+            .withGraph(graph)
+            .withRemote(DriverRemoteConnection(self._graph_url, "g"))
+        )
 
     def close(self):
         """Close interactive instance and release resources"""


### PR DESCRIPTION


## What do these changes do?

Drop the "global variable" hack.

## Related issue number

N/A
