### PR TITLE
Fix docker-nightly ci with short sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,14 +315,7 @@ jobs:
         /usr/local/bin/etcd --data-dir=/tmp/default.etcd &
 
         export GS_TEST_DIR='/root/gstest'
-        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests/classes
-        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests/test_nx.py
-        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests/test_ctx_builtin.py
-        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests/algorithms/builtin \
-                          --ignore=python/graphscope/nx/tests/algorithms/builtin/test_shortest_paths.py
-        # a hack solution to avoid oom.
-        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests/algorithms/builtin/test_shortest_paths.py
-        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests/test_utils.py
+        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests
 
         pkill -TERM etcd || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,8 @@ jobs:
         /usr/local/bin/etcd --data-dir=/tmp/default.etcd &
 
         export GS_TEST_DIR='/root/gstest'
-        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests
+        python3 -m pytest --exitfirst -s -v python/graphscope/nx/tests \
+                          --ignore=python/graphscope/nx/tests/algorithms/forward
 
         pkill -TERM etcd || true
 

--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -27,15 +27,14 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         sudo make graphscope-store
 
-    - name: Set short sha to outputs
-      id: set_sha
-      run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+    - name: Add SHORT_SHA env with commit short sha
+      run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
     - name: Kubernetes test
       env:
         CHANGE_MINIKUBE_NONE_USER: true
-        GS_IMAGE: graphscope/graphscope:${{ steps.set_sha.outputs.short_sha }}
-        GIE_MANAGER_IMAGE: graphscope/maxgraph_standalone_manager:${{ steps.set_sha.outputs.short_sha }}
+        GS_IMAGE: graphscope/graphscope:${SHORT_SHA}
+        GIE_MANAGER_IMAGE: graphscope/maxgraph_standalone_manager${SHORT_SHA}
       run: |
         export GS_TEST_DIR=${GITHUB_WORKSPACE}/gstest
         if [ ! -d "${GS_TEST_DIR}" ]; then
@@ -50,11 +49,11 @@ jobs:
     - name: Release Nightly Images
       run: |
         echo ${{ secrets.ALIYUN_TOKEN }} | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
-        sudo docker tag graphscope/graphscope:${{ steps.set_sha.outputs.short_sha }} \
+        sudo docker tag graphscope/graphscope:${${SHORT_SHA}} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:nightly
-        sudo docker tag graphscope/maxgraph_standalone_manager:${{ steps.set_sha.outputs.short_sha }} \
+        sudo docker tag graphscope/maxgraph_standalone_manager:${${SHORT_SHA}} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:nightly
-        sudo docker tag graphscope/graphscope-store:${{ steps.set_sha.outputs.short_sha }} \
+        sudo docker tag graphscope/graphscope-store:${${SHORT_SHA}} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:nightly
 
         sudo docker push registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:nightly
@@ -64,9 +63,9 @@ jobs:
     - name: Clean
       if: always()
       run: |
-        sudo docker rmi -f graphscope/graphscope:${{ steps.set_sha.outputs.short_sha }} \
-            graphscope/maxgraph_standalone_manager:${{ steps.set_sha.outputs.short_sha }} \
-            graphscope/graphscope-store:${{ steps.set_sha.outputs.short_sha }} \
+        sudo docker rmi -f graphscope/graphscope:${${SHORT_SHA}} \
+            graphscope/maxgraph_standalone_manager:${${SHORT_SHA}} \
+            graphscope/graphscope-store:${${SHORT_SHA}} \
             registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:nightly \
             registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:nightly \
             registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:nightly || true

--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   docker-test:
+    if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: self-hosted
     steps:
     - name: Build graphscope image
@@ -26,11 +27,15 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         sudo make graphscope-store
 
+    - name: Set short sha to outputs
+      id: set_sha
+      run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+
     - name: Kubernetes test
       env:
         CHANGE_MINIKUBE_NONE_USER: true
-        GS_IMAGE: graphscope/graphscope:${{ github.sha }}
-        GIE_MANAGER_IMAGE: graphscope/maxgraph_standalone_manager:${{ github.sha }}
+        GS_IMAGE: graphscope/graphscope:${{ steps.set_sha.outputs.short_sha }}
+        GIE_MANAGER_IMAGE: graphscope/maxgraph_standalone_manager:${{ steps.set_sha.outputs.short_sha }}
       run: |
         export GS_TEST_DIR=${GITHUB_WORKSPACE}/gstest
         if [ ! -d "${GS_TEST_DIR}" ]; then
@@ -45,11 +50,11 @@ jobs:
     - name: Release Nightly Images
       run: |
         echo ${{ secrets.ALIYUN_TOKEN }} | sudo docker login --username=grape_dev registry.cn-hongkong.aliyuncs.com --password-stdin
-        sudo docker tag graphscope/graphscope:${{ github.sha }} \
+        sudo docker tag graphscope/graphscope:${{ steps.set_sha.outputs.short_sha }} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:nightly
-        sudo docker tag graphscope/maxgraph_standalone_manager:${{ github.sha }} \
+        sudo docker tag graphscope/maxgraph_standalone_manager:${{ steps.set_sha.outputs.short_sha }} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:nightly
-        sudo docker tag graphscope/graphscope-store:${{ github.sha }} \
+        sudo docker tag graphscope/graphscope-store:${{ steps.set_sha.outputs.short_sha }} \
                         registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:nightly
 
         sudo docker push registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:nightly
@@ -59,9 +64,9 @@ jobs:
     - name: Clean
       if: always()
       run: |
-        sudo docker rmi -f graphscope/graphscope:${{ github.sha }} \
-            graphscope/maxgraph_standalone_manager:${{ github.sha }} \
-            graphscope/graphscope-store:${{ github.sha}} \
+        sudo docker rmi -f graphscope/graphscope:${{ steps.set_sha.outputs.short_sha }} \
+            graphscope/maxgraph_standalone_manager:${{ steps.set_sha.outputs.short_sha }} \
+            graphscope/graphscope-store:${{ steps.set_sha.outputs.short_sha }} \
             registry.cn-hongkong.aliyuncs.com/graphscope/graphscope:nightly \
             registry.cn-hongkong.aliyuncs.com/graphscope/maxgraph_standalone_manager:nightly \
             registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:nightly || true

--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -27,14 +27,16 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         sudo make graphscope-store
 
-    - name: Add SHORT_SHA env with commit short sha
-      run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+    - name: Add envs to GITHUB_ENV
+      run: |
+        short_sha=$(git rev-parse --short HEAD)
+        echo "SHORT_SHA=${short_sha}" >> $GITHUB_ENV
+        echo "GS_IMAGE=graphscope/graphscope:${short_sha}" >> $GITHUB_ENV
+        echo "GIE_MANAGER_IMAGE=graphscope/maxgraph_standalone_manager:${short_sha}" >> $GITHUB_ENV
 
     - name: Kubernetes test
       env:
         CHANGE_MINIKUBE_NONE_USER: true
-        GS_IMAGE: graphscope/graphscope:${SHORT_SHA}
-        GIE_MANAGER_IMAGE: graphscope/maxgraph_standalone_manager${SHORT_SHA}
       run: |
         export GS_TEST_DIR=${GITHUB_WORKSPACE}/gstest
         if [ ! -d "${GS_TEST_DIR}" ]; then

--- a/python/graphscope/nx/tests/conftest.py
+++ b/python/graphscope/nx/tests/conftest.py
@@ -22,7 +22,7 @@ import pytest
 import graphscope
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def graphscope_session():
     graphscope.set_option(show_log=True)
     graphscope.set_option(initializing_interactive_engine=False)


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
- fix docker nightly ci with short sha
- make graphscope_session scope to `module` to fix #528 

