### PR TITLE
Adapt to latest vineyard: the `Create()` API has changed.

### DIFF
--- a/analytical_engine/core/fragment/append_only_arrow_fragment.h
+++ b/analytical_engine/core/fragment/append_only_arrow_fragment.h
@@ -27,6 +27,7 @@
 #include "arrow/util/config.h"
 
 #include "grape/grape.h"
+#include "vineyard/common/util/config.h"
 #include "vineyard/graph/fragment/arrow_fragment.h"
 #include "vineyard/graph/vertex_map/arrow_vertex_map.h"
 
@@ -293,10 +294,19 @@ class AppendOnlyArrowFragment
   template <typename DATA_T>
   using vertex_array_t = grape::VertexArray<DATA_T, vid_t>;
 
+#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR) && \
+    VINEYARD_VERSION >= 2007
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<AppendOnlyArrowFragment<oid_t, vid_t>>{
+            new AppendOnlyArrowFragment<oid_t, vid_t>()});
+  }
+#else
   static std::shared_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
         std::make_shared<AppendOnlyArrowFragment<oid_t, vid_t>>());
   }
+#endif
 
  public:
   void Construct(const vineyard::ObjectMeta& meta) override {

--- a/analytical_engine/core/fragment/append_only_arrow_fragment.h
+++ b/analytical_engine/core/fragment/append_only_arrow_fragment.h
@@ -27,7 +27,7 @@
 #include "arrow/util/config.h"
 
 #include "grape/grape.h"
-#include "vineyard/common/util/config.h"
+#include "vineyard/common/util/version.h"
 #include "vineyard/graph/fragment/arrow_fragment.h"
 #include "vineyard/graph/vertex_map/arrow_vertex_map.h"
 

--- a/analytical_engine/core/fragment/append_only_arrow_fragment.h
+++ b/analytical_engine/core/fragment/append_only_arrow_fragment.h
@@ -294,13 +294,14 @@ class AppendOnlyArrowFragment
   template <typename DATA_T>
   using vertex_array_t = grape::VertexArray<DATA_T, vid_t>;
 
-#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR) && \
-    VINEYARD_VERSION >= 2007
+#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR)
+#if VINEYARD_VERSION >= 2007
   static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
         std::unique_ptr<AppendOnlyArrowFragment<oid_t, vid_t>>{
             new AppendOnlyArrowFragment<oid_t, vid_t>()});
   }
+#endif
 #else
   static std::shared_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(

--- a/analytical_engine/core/fragment/arrow_projected_fragment.h
+++ b/analytical_engine/core/fragment/arrow_projected_fragment.h
@@ -26,6 +26,7 @@
 #include "boost/lexical_cast.hpp"
 
 #include "vineyard/basic/ds/arrow_utils.h"
+#include "vineyard/common/util/config.h"
 #include "vineyard/graph/fragment/arrow_fragment.h"
 #include "vineyard/graph/vertex_map/arrow_vertex_map.h"
 
@@ -366,11 +367,20 @@ class ArrowProjectedFragment
   static constexpr grape::LoadStrategy load_strategy =
       grape::LoadStrategy::kBothOutIn;
 
+#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR) && \
+    VINEYARD_VERSION >= 2007
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<ArrowProjectedFragment<oid_t, vid_t, vdata_t, edata_t>>{
+            new ArrowProjectedFragment<oid_t, vid_t, vdata_t, edata_t>()});
+  }
+#else
   static std::shared_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
         std::make_shared<
             ArrowProjectedFragment<oid_t, vid_t, vdata_t, edata_t>>());
   }
+#endif
 
   ~ArrowProjectedFragment() {}
 

--- a/analytical_engine/core/fragment/arrow_projected_fragment.h
+++ b/analytical_engine/core/fragment/arrow_projected_fragment.h
@@ -26,7 +26,7 @@
 #include "boost/lexical_cast.hpp"
 
 #include "vineyard/basic/ds/arrow_utils.h"
-#include "vineyard/common/util/config.h"
+#include "vineyard/common/util/version.h"
 #include "vineyard/graph/fragment/arrow_fragment.h"
 #include "vineyard/graph/vertex_map/arrow_vertex_map.h"
 

--- a/analytical_engine/core/fragment/arrow_projected_fragment.h
+++ b/analytical_engine/core/fragment/arrow_projected_fragment.h
@@ -367,13 +367,14 @@ class ArrowProjectedFragment
   static constexpr grape::LoadStrategy load_strategy =
       grape::LoadStrategy::kBothOutIn;
 
-#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR) && \
-    VINEYARD_VERSION >= 2007
+#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR)
+#if VINEYARD_VERSION >= 2007
   static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
         std::unique_ptr<ArrowProjectedFragment<oid_t, vid_t, vdata_t, edata_t>>{
             new ArrowProjectedFragment<oid_t, vid_t, vdata_t, edata_t>()});
   }
+#endif
 #else
   static std::shared_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(

--- a/analytical_engine/core/vertex_map/arrow_projected_vertex_map.h
+++ b/analytical_engine/core/vertex_map/arrow_projected_vertex_map.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <vector>
 
+#include "vineyard/common/util/config.h"
 #include "vineyard/graph/fragment/property_graph_types.h"
 #include "vineyard/graph/vertex_map/arrow_vertex_map.h"
 
@@ -39,10 +40,19 @@ class ArrowProjectedVertexMap
   using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
 
  public:
+#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR) && \
+    VINEYARD_VERSION >= 2007
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<ArrowProjectedVertexMap<oid_t, vid_t>>{
+            new ArrowProjectedVertexMap<oid_t, vid_t>()});
+  }
+#else
   static std::shared_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
         std::make_shared<ArrowProjectedVertexMap<oid_t, vid_t>>());
   }
+#endif
 
   static std::shared_ptr<ArrowProjectedVertexMap<OID_T, VID_T>> Project(
       std::shared_ptr<vineyard::ArrowVertexMap<OID_T, VID_T>> vm,
@@ -149,10 +159,19 @@ class ArrowProjectedVertexMap<arrow::util::string_view, VID_T>
   using oid_array_t = arrow::LargeStringArray;
 
  public:
+#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR) && \
+    VINEYARD_VERSION >= 2007
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<ArrowProjectedVertexMap<oid_t, vid_t>>{
+            new ArrowProjectedVertexMap<oid_t, vid_t>()});
+  }
+#else
   static std::shared_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
         std::make_shared<ArrowProjectedVertexMap<oid_t, vid_t>>());
   }
+#endif
 
   static std::shared_ptr<ArrowProjectedVertexMap<oid_t, VID_T>> Project(
       std::shared_ptr<vineyard::ArrowVertexMap<oid_t, VID_T>> vm,

--- a/analytical_engine/core/vertex_map/arrow_projected_vertex_map.h
+++ b/analytical_engine/core/vertex_map/arrow_projected_vertex_map.h
@@ -19,7 +19,7 @@
 #include <memory>
 #include <vector>
 
-#include "vineyard/common/util/config.h"
+#include "vineyard/common/util/version.h"
 #include "vineyard/graph/fragment/property_graph_types.h"
 #include "vineyard/graph/vertex_map/arrow_vertex_map.h"
 

--- a/analytical_engine/core/vertex_map/arrow_projected_vertex_map.h
+++ b/analytical_engine/core/vertex_map/arrow_projected_vertex_map.h
@@ -40,13 +40,14 @@ class ArrowProjectedVertexMap
   using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
 
  public:
-#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR) && \
-    VINEYARD_VERSION >= 2007
+#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR)
+#if VINEYARD_VERSION >= 2007
   static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
         std::unique_ptr<ArrowProjectedVertexMap<oid_t, vid_t>>{
             new ArrowProjectedVertexMap<oid_t, vid_t>()});
   }
+#endif
 #else
   static std::shared_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
@@ -159,13 +160,14 @@ class ArrowProjectedVertexMap<arrow::util::string_view, VID_T>
   using oid_array_t = arrow::LargeStringArray;
 
  public:
-#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR) && \
-    VINEYARD_VERSION >= 2007
+#if defined(VINEYARD_VERSION) && defined(VINEYARD_VERSION_MAJOR)
+#if VINEYARD_VERSION >= 2007
   static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(
         std::unique_ptr<ArrowProjectedVertexMap<oid_t, vid_t>>{
             new ArrowProjectedVertexMap<oid_t, vid_t>()});
   }
+#endif
 #else
   static std::shared_ptr<vineyard::Object> Create() __attribute__((used)) {
     return std::static_pointer_cast<vineyard::Object>(


### PR DESCRIPTION
## What do these changes do?

The static `Create()` method returns a `std::unique_ptr` instead.

## Related issue number

N/A

