### PR TITLE
Push docs for tags as well.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -80,7 +80,7 @@ jobs:
         fi
 
     - name: Upload Docs
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
       shell: bash
       run: |
         shopt -s extglob
@@ -118,6 +118,6 @@ jobs:
         rm -rf ../python || true
 
         git add -A
-        git commit --amend --no-edit -m "Generate latest docs on CI, from commit ${{ github.sha }}."
+        git commit --amend --no-edit -m "Generate latest docs on CI, from commit ${{ github.sha }}." --author "github-actions <github-actions@github.com>" -s --date="$(date -R)"
         git push -f origin gh-pages
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

We previously expect maintainers push the "release" commit and "tag" to the main branch at the same time, but seems we don't do in that way.

This commit pushes docs for tags as well to ensure docs for our releases are pushed to gh-pages branch as expected.

