### PR TITLE
add unified tinkerpop version variable to reduce duplicate constant i…

### DIFF
--- a/research/gaia/gremlin/compiler/pom.xml
+++ b/research/gaia/gremlin/compiler/pom.xml
@@ -19,6 +19,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <tinkerpop.version>3.4.12</tinkerpop.version>
     </properties>
 
     <dependencyManagement>
@@ -36,32 +37,32 @@
             <dependency>
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>gremlin-core</artifactId>
-                <version>3.4.12</version>
+                <version>${tinkerpop.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>gremlin-console</artifactId>
-                <version>3.4.12</version>
+                <version>${tinkerpop.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>tinkergraph-gremlin</artifactId>
-                <version>3.4.12</version>
+                <version>${tinkerpop.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>gremlin-server</artifactId>
-                <version>3.4.12</version>
+                <version>${tinkerpop.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>gremlin-driver</artifactId>
-                <version>3.4.12</version>
+                <version>${tinkerpop.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tinkerpop</groupId>
                 <artifactId>gremlin-test</artifactId>
-                <version>3.4.12</version>
+                <version>${tinkerpop.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
…n pom

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

add unified tinkerpop version variable to reduce duplicate constant in the pom

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

