### PR TITLE
Fetch stdout and stderr log of grape engine separately

### DIFF
--- a/analytical_engine/core/grape_engine.cc
+++ b/analytical_engine/core/grape_engine.cc
@@ -14,6 +14,7 @@
  */
 
 #include <csignal>
+#include <limits>
 #include <thread>
 #include <utility>
 
@@ -154,28 +155,21 @@ class RedirectLogSink : public google::LogSink {
                     const char* message, size_t message_len) {
     // we redirect GLOG_ERROR message to stderr, others to stdout
     if (severity != google::GLOG_ERROR) {
-      std::cerr << google::LogSink::ToString(
-              severity,
-              full_filename,
-              line,
-              tm_time,
-              message,
-              message_len) << std::endl;;
+      std::cerr << google::LogSink::ToString(severity, full_filename, line,
+                                              tm_time, message, message_len)
+                << std::endl;;
     } else {
-      std::cout << google::LogSink::ToString(
-              severity,
-              full_filename,
-              line,
-              tm_time,
-              message,
-              message_len) << std::endl;;
+      std::cout << google::LogSink::ToString(severity, full_filename, line,
+                                             tm_time, message, message_len)
+                << std::endl;;
     }
   }
 };
 
 int main(int argc, char* argv[]) {
   int exit_code = 0;
-  FLAGS_logtostderr = false;
+  // not output any log to stderr by glog.
+  FLAGS_stderrthreshold = std::numeric_limits<int>::max();
 
   grape::gflags::SetUsageMessage(
       "Usage: mpiexec [mpi_opts] ./grape_engine [grape_opts]");

--- a/analytical_engine/core/grape_engine.cc
+++ b/analytical_engine/core/grape_engine.cc
@@ -151,17 +151,17 @@ extern "C" void master_signal_handler(int sig, siginfo_t* info, void* context) {
 class RedirectLogSink : public google::LogSink {
   virtual void send(google::LogSeverity severity, const char* full_filename,
                     const char* base_filename, int line,
-                    const struct ::tm* tm_time,
-                    const char* message, size_t message_len) {
+                    const struct ::tm* tm_time, const char* message,
+                    size_t message_len) {
     // we redirect GLOG_ERROR message to stderr, others to stdout
     if (severity != google::GLOG_ERROR) {
       std::cerr << google::LogSink::ToString(severity, full_filename, line,
-                                              tm_time, message, message_len)
-                << std::endl;;
+                                             tm_time, message, message_len)
+                << std::endl;
     } else {
       std::cout << google::LogSink::ToString(severity, full_filename, line,
                                              tm_time, message, message_len)
-                << std::endl;;
+                << std::endl;
     }
   }
 };

--- a/analytical_engine/core/grape_engine.cc
+++ b/analytical_engine/core/grape_engine.cc
@@ -146,9 +146,36 @@ extern "C" void master_signal_handler(int sig, siginfo_t* info, void* context) {
   }
 }
 
+// A custom sinker to redirect glog messages to stdout/stderr.
+class RedirectLogSink : public google::LogSink {
+  virtual void send(google::LogSeverity severity, const char* full_filename,
+                    const char* base_filename, int line,
+                    const struct ::tm* tm_time,
+                    const char* message, size_t message_len) {
+    // we redirect GLOG_ERROR message to stderr, others to stdout
+    if (severity != google::GLOG_ERROR) {
+      std::cerr << google::LogSink::ToString(
+              severity,
+              full_filename,
+              line,
+              tm_time,
+              message,
+              message_len) << std::endl;;
+    } else {
+      std::cout << google::LogSink::ToString(
+              severity,
+              full_filename,
+              line,
+              tm_time,
+              message,
+              message_len) << std::endl;;
+    }
+  }
+};
+
 int main(int argc, char* argv[]) {
   int exit_code = 0;
-  FLAGS_stderrthreshold = 0;
+  FLAGS_logtostderr = false;
 
   grape::gflags::SetUsageMessage(
       "Usage: mpiexec [mpi_opts] ./grape_engine [grape_opts]");
@@ -161,6 +188,8 @@ int main(int argc, char* argv[]) {
 
   google::InitGoogleLogging(argv[0]);
   google::InstallFailureSignalHandler();
+  RedirectLogSink redirect_log_sink;
+  google::AddLogSink(&redirect_log_sink);
 
   // InitMPI
   grape::InitMPIComm();

--- a/analytical_engine/core/grape_engine.cc
+++ b/analytical_engine/core/grape_engine.cc
@@ -153,8 +153,8 @@ class RedirectLogSink : public google::LogSink {
                     const char* base_filename, int line,
                     const struct ::tm* tm_time, const char* message,
                     size_t message_len) {
-    // we redirect GLOG_ERROR message to stderr, others to stdout
-    if (severity != google::GLOG_ERROR) {
+    // we redirect GLOG_ERROR/GLOG_WARNING message to stderr, others to stdout
+    if (severity == google::GLOG_ERROR || severity == google::GLOG_WARNING) {
       std::cerr << google::LogSink::ToString(severity, full_filename, line,
                                              tm_time, message, message_len)
                 << std::endl;

--- a/coordinator/gscoordinator/cluster.py
+++ b/coordinator/gscoordinator/cluster.py
@@ -1018,14 +1018,18 @@ class KubernetesClusterLauncher(Launcher):
             cmd,
             env=env,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.PIPE,
             encoding="utf-8",
         )
 
         stdout_watcher = PipeWatcher(
             self._analytical_engine_process.stdout, sys.stdout, drop=True
         )
+        stderr_watcher = PipeWatcher(
+            self._analytical_engine_process.stderr, sys.stderr, drop=True
+        )
         setattr(self._analytical_engine_process, "stdout_watcher", stdout_watcher)
+        setattr(self._analytical_engine_process, "stderr_watcher", stderr_watcher)
 
     def _delete_dangling_coordinator(self):
         # delete service

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -680,15 +680,21 @@ class CoordinatorServiceServicer(
     def FetchLogs(self, request, context):
         while self._streaming_logs:
             try:
-                message = sys.stdout.poll(timeout=3)
+                info_message = sys.stdout.poll(timeout=2)
             except queue.Empty:
-                pass
-            else:
+                info_message = ""
+            try:
+                error_message = sys.stderr.poll(timeout=2)
+            except queue.Empty:
+                error_message = ""
+
+            if info_message or error_message:
                 if self._streaming_logs:
                     yield self._make_response(
                         message_pb2.FetchLogsResponse,
                         error_codes_pb2.OK,
-                        message=message,
+                        info_message=info_message,
+                        error_message=error_message,
                     )
 
     def CloseSession(self, request, context):

--- a/coordinator/gscoordinator/launcher.py
+++ b/coordinator/gscoordinator/launcher.py
@@ -370,13 +370,15 @@ class LocalLauncher(Launcher):
             encoding="utf-8",
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.PIPE,
             bufsize=1,
         )
 
         logger.info("Server is initializing analytical engine.")
         stdout_watcher = PipeWatcher(process.stdout, sys.stdout)
+        stderr_watcher = PipeWatcher(process.stderr, sys.stderr)
         setattr(process, "stdout_watcher", stdout_watcher)
+        setattr(process, "stderr_watcher", stderr_watcher)
 
         self._analytical_engine_process = process
 

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -123,7 +123,9 @@ message FetchLogsResponse {
   ResponseStatus status = 1;
 
   // log info.
-  string message = 2;
+  string info_message = 2;
+  // log error.
+  string error_message = 3;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/python/graphscope/client/rpc.py
+++ b/python/graphscope/client/rpc.py
@@ -195,9 +195,12 @@ class GRPCClient(object):
         responses = self._stub.FetchLogs(request)
         for resp in responses:
             resp = check_grpc_response(resp)
-            message = resp.message.rstrip()
-            if message:
-                logger.info(message, extra={"simple": True})
+            info = resp.info_message.rstrip()
+            if info:
+                logger.info(info, extra={"simple": True})
+            error = resp.error_message.rstrip()
+            if error:
+                logger.error(error, extra={"simple": True})
 
     @catch_grpc_error
     def _close_session_impl(self):

--- a/python/graphscope/deploy/hosts/cluster.py
+++ b/python/graphscope/deploy/hosts/cluster.py
@@ -120,7 +120,7 @@ class HostsClusterLauncher(Launcher):
             encoding="utf-8",
             stdin=subprocess.DEVNULL,
             stdout=sys.stdout if gs_config.show_log else subprocess.DEVNULL,
-            stderr=sys.stderr if gs_config.show_log else subprocess.DEVNULL,
+            stderr=sys.stderr,
             bufsize=1,
             env=env,
         )


### PR DESCRIPTION

## What do these changes do?
 - This pull request revise the fetch log implement of client tp get stdout and stderr log separately. 
 - In engine side, we use a RedirectLogSink to process LOG(ERROR) and OTHERS LOG of glog separately.

## Related issue number
Fixes #729 

