### PR TITLE
Revise error messages and handling of GRPC exception.

### DIFF
--- a/analytical_engine/core/context/column.h
+++ b/analytical_engine/core/context/column.h
@@ -60,7 +60,7 @@ class Column : public IColumn {
   using vertex_array_t = typename fragment_t::template vertex_array_t<DATA_T>;
   static_assert(std::is_pod<DATA_T>::value ||
                     std::is_same<DATA_T, std::string>::value,
-                "Unsupported data type");
+                "Unsupported data type in Column, expect POD value or string.");
 
   Column(const std::string& name, vertex_range_t range) {
     this->set_name(name);

--- a/analytical_engine/core/context/selector.h
+++ b/analytical_engine/core/context/selector.h
@@ -134,12 +134,12 @@ class Selector {
       std::string prop_name = sm[1];
       if (prop_name.empty()) {
         RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                        "Empty property name: " + prop_name);
+                        "Property name not found, the selector is: " + selector);
       }
       return Selector(prop_name);
     }
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Unmatched selector: " + selector);
+                    "Invalid syntax, the selector is: " + selector);
   }
 
   /**
@@ -282,12 +282,12 @@ class LabeledSelector : public Selector {
 
       if (prop_name.empty()) {
         RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                        "Empty property name: " + prop_name);
+                        "Property name not found, the selector is: " + selector);
       }
       return LabeledSelector(label_id, prop_name);
     }
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Unmatched selector: " + selector);
+                    "Invalid syntax, the selector is: " + selector);
   }
 
   /**

--- a/analytical_engine/core/context/selector.h
+++ b/analytical_engine/core/context/selector.h
@@ -133,8 +133,9 @@ class Selector {
     } else if (std::regex_match(selector, sm, r_result_prop)) {
       std::string prop_name = sm[1];
       if (prop_name.empty()) {
-        RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                        "Property name not found, the selector is: " + selector);
+        RETURN_GS_ERROR(
+            vineyard::ErrorCode::kInvalidValueError,
+            "Property name not found, the selector is: " + selector);
       }
       return Selector(prop_name);
     }
@@ -281,8 +282,9 @@ class LabeledSelector : public Selector {
       std::string prop_name = sm[2];
 
       if (prop_name.empty()) {
-        RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                        "Property name not found, the selector is: " + selector);
+        RETURN_GS_ERROR(
+            vineyard::ErrorCode::kInvalidValueError,
+            "Property name not found, the selector is: " + selector);
       }
       return LabeledSelector(label_id, prop_name);
     }

--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -605,8 +605,8 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::convertGraph(
 
   VLOG(1) << "Converting graph, src graph name: " << src_graph_name
           << ", dst graph name: " << dst_graph_name << ", dst graph type: "
-          << rpc::graph::GraphTypePb_Name(dst_graph_type);
-  << ", type_sig: " << type_sig;
+          << rpc::graph::GraphTypePb_Name(dst_graph_type)
+          << ", type_sig: " << type_sig;
 
   BOOST_LEAF_AUTO(g_utils,
                   object_manager_.GetObject<PropertyGraphUtils>(type_sig));
@@ -907,7 +907,7 @@ bl::result<void> GrapeInstance::registerGraphType(const rpc::GSParams& params) {
   } else {
     RETURN_GS_ERROR(
         vineyard::ErrorCode::kInvalidValueError,
-        "Unsupported graph type: " << rpc::graph::GraphTypePb_Name(graph_type));
+        "Unsupported graph type: " + rpc::graph::GraphTypePb_Name(graph_type));
   }
 }
 

--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -101,7 +101,8 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::loadGraph(
     return graph_def;
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
   }
   case rpc::graph::ARROW_PROPERTY: {
@@ -119,8 +120,9 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::loadGraph(
     return wrapper->graph_def();
   }
   default:
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Unsupported graph type " + rpc::graph::GraphTypePb_Name(graph_type));
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidValueError,
+        "Unsupported graph type " + rpc::graph::GraphTypePb_Name(graph_type));
   }
 }
 
@@ -153,7 +155,8 @@ bl::result<std::string> GrapeInstance::loadApp(const rpc::GSParams& params) {
   BOOST_LEAF_AUTO(lib_path, params.Get<std::string>(rpc::APP_LIBRARY_PATH));
 
   auto app = std::make_shared<AppEntry>(app_name, lib_path);
-  VLOG(1) << "Loading application, application name: " << app_name << " , library path: " << lib_path;
+  VLOG(1) << "Loading application, application name: " << app_name
+          << " , library path: " << lib_path;
   BOOST_LEAF_CHECK(app->Init());
   BOOST_LEAF_CHECK(object_manager_.PutObject(app));
   return app_name;
@@ -241,9 +244,11 @@ bl::result<std::string> GrapeInstance::reportGraph(
   auto graph_type = wrapper->graph_def().graph_type();
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is:  " + rpc::graph::GraphTypePb_Name(graph_type) +
-                        ", graph id: " + graph_name);
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidValueError,
+        "GraphType must be DYNAMIC_PROPERTY, the origin graph type is:  " +
+            rpc::graph::GraphTypePb_Name(graph_type) +
+            ", graph id: " + graph_name);
   }
   auto fragment =
       std::static_pointer_cast<DynamicFragment>(wrapper->fragment());
@@ -251,7 +256,8 @@ bl::result<std::string> GrapeInstance::reportGraph(
   return reporter.Report(fragment, params);
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it "
+                  "with NETWORKX=ON");
 #endif  // NETWORKX
 }
 
@@ -265,9 +271,11 @@ bl::result<void> GrapeInstance::modifyVertices(
   auto graph_type = wrapper->graph_def().graph_type();
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is:  " + rpc::graph::GraphTypePb_Name(graph_type) +
-                        ", graph id: " + graph_name);
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidValueError,
+        "GraphType must be DYNAMIC_PROPERTY, the origin graph type is:  " +
+            rpc::graph::GraphTypePb_Name(graph_type) +
+            ", graph id: " + graph_name);
   }
 
   auto fragment =
@@ -276,7 +284,8 @@ bl::result<void> GrapeInstance::modifyVertices(
   return {};
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it "
+                  "with NETWORKX=ON");
 #endif
 }
 
@@ -290,9 +299,10 @@ bl::result<void> GrapeInstance::modifyEdges(
   auto graph_type = wrapper->graph_def().graph_type();
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " + std::to_string(graph_type) +
-                        ", graph name: " + graph_name);
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidValueError,
+        "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " +
+            std::to_string(graph_type) + ", graph name: " + graph_name);
   }
 
   auto fragment =
@@ -300,7 +310,8 @@ bl::result<void> GrapeInstance::modifyEdges(
   fragment->ModifyEdges(edges, modify_type);
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it "
+                  "with NETWORKX=ON");
 #endif  // NETWORKX
   return {};
 }
@@ -483,7 +494,7 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
         id, wrapper->ToVineyardTensor(comm_spec_, *client_, selector, range));
   } else {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                  "Unsupported context type: " + std::string(ctx_type));
+                    "Unsupported context type: " + std::string(ctx_type));
   }
 
   auto s_id = vineyard::ObjectIDToString(id);
@@ -550,7 +561,7 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
                               comm_spec_, *client_, selectors, range));
   } else {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                  "Unsupported context type: " + std::string(ctx_type));
+                    "Unsupported context type: " + std::string(ctx_type));
   }
 
   auto s_id = vineyard::ObjectIDToString(id);
@@ -593,9 +604,9 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::convertGraph(
   std::string dst_graph_name = "graph_" + generateId();
 
   VLOG(1) << "Converting graph, src graph name: " << src_graph_name
-          << ", dst graph name: " << dst_graph_name
-          << ", dst graph type: " << rpc::graph::GraphTypePb_Name(dst_graph_type);
-          << ", type_sig: " << type_sig;
+          << ", dst graph name: " << dst_graph_name << ", dst graph type: "
+          << rpc::graph::GraphTypePb_Name(dst_graph_type);
+  << ", type_sig: " << type_sig;
 
   BOOST_LEAF_AUTO(g_utils,
                   object_manager_.GetObject<PropertyGraphUtils>(type_sig));
@@ -656,7 +667,8 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::toDirected(
   return dst_wrapper->graph_def();
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it "
+                  "with NETWORKX=ON");
 #endif  // NETWORKX
 }
 
@@ -675,7 +687,8 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::toUnDirected(
   return dst_wrapper->graph_def();
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it "
+                  "with NETWORKX=ON");
 #endif  // NETWORKX
 }
 
@@ -733,8 +746,11 @@ bl::result<void> GrapeInstance::clearGraph(const rpc::GSParams& params) {
   auto graph_type = wrapper->graph_def().graph_type();
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " + rpc::graph::GraphTypePb_Name(graph_type) + ", graph id: " + graph_name);
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidValueError,
+        "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " +
+            rpc::graph::GraphTypePb_Name(graph_type) +
+            ", graph id: " + graph_name);
   }
 
   auto vm_ptr = std::shared_ptr<DynamicFragment::vertex_map_t>(
@@ -745,7 +761,8 @@ bl::result<void> GrapeInstance::clearGraph(const rpc::GSParams& params) {
   fragment->ClearGraph(vm_ptr);
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it "
+                  "with NETWORKX=ON");
 #endif  // NETWORKX
   return {};
 }
@@ -758,8 +775,11 @@ bl::result<void> GrapeInstance::clearEdges(const rpc::GSParams& params) {
   auto graph_type = wrapper->graph_def().graph_type();
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " + rpc::graph::GraphTypePb_Name(graph_type) + ", graph id: " + graph_name);
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidValueError,
+        "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " +
+            rpc::graph::GraphTypePb_Name(graph_type) +
+            ", graph id: " + graph_name);
   }
 
   auto fragment =
@@ -767,7 +787,8 @@ bl::result<void> GrapeInstance::clearEdges(const rpc::GSParams& params) {
   fragment->ClearEdges();
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it "
+                  "with NETWORKX=ON");
 #endif  // NETWORKX
   return {};
 }
@@ -791,7 +812,8 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::createGraphView(
   return view_wrapper->graph_def();
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it "
+                  "with NETWORKX=ON");
 #endif  // NETWORKX
 }
 
@@ -864,7 +886,8 @@ bl::result<void> GrapeInstance::registerGraphType(const rpc::GSParams& params) {
   BOOST_LEAF_AUTO(type_sig, params.Get<std::string>(rpc::TYPE_SIGNATURE));
   BOOST_LEAF_AUTO(lib_path, params.Get<std::string>(rpc::GRAPH_LIBRARY_PATH));
 
-  VLOG(1) << "Registering Graph, graph type: " << rpc::graph::GraphTypePb_Name(graph_type)
+  VLOG(1) << "Registering Graph, graph type: "
+          << rpc::graph::GraphTypePb_Name(graph_type)
           << ", Type sigature: " << type_sig << ", lib path: " << lib_path;
 
   if (object_manager_.HasObject(type_sig)) {
@@ -948,7 +971,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     BOOST_LEAF_CHECK(modifyVertices(params, vertices_to_modify));
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }
@@ -963,7 +987,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     BOOST_LEAF_CHECK(modifyEdges(params, edges_to_modify));
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }
@@ -973,7 +998,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }
@@ -988,7 +1014,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }
@@ -998,7 +1025,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1038,7 +1066,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1047,7 +1076,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     BOOST_LEAF_CHECK(clearGraph(params));
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1056,7 +1086,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     BOOST_LEAF_CHECK(clearEdges(params));
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1066,7 +1097,8 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
     break;
   }

--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -101,7 +101,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::loadGraph(
     return graph_def;
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
   }
   case rpc::graph::ARROW_PROPERTY: {
@@ -120,7 +120,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::loadGraph(
   }
   default:
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Unsupported graph type " + std::to_string(graph_type));
+                    "Unsupported graph type " + rpc::graph::GraphTypePb_Name(graph_type));
   }
 }
 
@@ -153,7 +153,7 @@ bl::result<std::string> GrapeInstance::loadApp(const rpc::GSParams& params) {
   BOOST_LEAF_AUTO(lib_path, params.Get<std::string>(rpc::APP_LIBRARY_PATH));
 
   auto app = std::make_shared<AppEntry>(app_name, lib_path);
-
+  VLOG(1) << "Loading application, application name: " << app_name << " , library path: " << lib_path;
   BOOST_LEAF_CHECK(app->Init());
   BOOST_LEAF_CHECK(object_manager_.PutObject(app));
   return app_name;
@@ -242,7 +242,7 @@ bl::result<std::string> GrapeInstance::reportGraph(
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Error graph type: " + std::to_string(graph_type) +
+                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is:  " + rpc::graph::GraphTypePb_Name(graph_type) +
                         ", graph id: " + graph_name);
   }
   auto fragment =
@@ -251,7 +251,7 @@ bl::result<std::string> GrapeInstance::reportGraph(
   return reporter.Report(fragment, params);
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GS is compiled without folly");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif  // NETWORKX
 }
 
@@ -266,7 +266,7 @@ bl::result<void> GrapeInstance::modifyVertices(
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Error graph type: " + std::to_string(graph_type) +
+                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is:  " + rpc::graph::GraphTypePb_Name(graph_type) +
                         ", graph id: " + graph_name);
   }
 
@@ -276,7 +276,7 @@ bl::result<void> GrapeInstance::modifyVertices(
   return {};
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GS is compiled without folly");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
 }
 
@@ -291,8 +291,8 @@ bl::result<void> GrapeInstance::modifyEdges(
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Error graph type: " + std::to_string(graph_type) +
-                        ", graph id: " + graph_name);
+                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " + std::to_string(graph_type) +
+                        ", graph name: " + graph_name);
   }
 
   auto fragment =
@@ -300,7 +300,7 @@ bl::result<void> GrapeInstance::modifyEdges(
   fragment->ModifyEdges(edges, modify_type);
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GS is compiled without folly");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif  // NETWORKX
   return {};
 }
@@ -357,7 +357,7 @@ bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::contextToNumpy(
     BOOST_LEAF_AUTO(selector, LabeledSelector::parse(s_selector));
     return wrapper->ToNdArray(comm_spec_, selector, range);
   }
-  RETURN_GS_ERROR(vineyard::ErrorCode::kIllegalStateError,
+  RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
                   "Unsupported context type: " + std::string(ctx_type));
 }
 
@@ -423,7 +423,7 @@ bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::contextToDataframe(
     BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selectors));
     return wrapper->ToDataframe(comm_spec_, selectors, range);
   }
-  RETURN_GS_ERROR(vineyard::ErrorCode::kIllegalStateError,
+  RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
                   "Unsupported context type: " + std::string(ctx_type));
 }
 
@@ -482,7 +482,8 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
     BOOST_LEAF_ASSIGN(
         id, wrapper->ToVineyardTensor(comm_spec_, *client_, selector, range));
   } else {
-    CHECK(false);
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
+                  "Unsupported context type: " + std::string(ctx_type));
   }
 
   auto s_id = vineyard::ObjectIDToString(id);
@@ -548,7 +549,8 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
     BOOST_LEAF_ASSIGN(id, vd_ctx_wrapper->ToVineyardDataframe(
                               comm_spec_, *client_, selectors, range));
   } else {
-    CHECK(false);
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
+                  "Unsupported context type: " + std::string(ctx_type));
   }
 
   auto s_id = vineyard::ObjectIDToString(id);
@@ -592,7 +594,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::convertGraph(
 
   VLOG(1) << "Converting graph, src graph name: " << src_graph_name
           << ", dst graph name: " << dst_graph_name
-          << ", dst graph type: " << dst_graph_type
+          << ", dst graph type: " << rpc::graph::GraphTypePb_Name(dst_graph_type);
           << ", type_sig: " << type_sig;
 
   BOOST_LEAF_AUTO(g_utils,
@@ -618,9 +620,9 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::convertGraph(
     return dst_graph_wrapper->graph_def();
   }
   RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                  "Unsupported conversion direction, from " +
-                      std::to_string(src_graph_type) + " to " +
-                      std::to_string(dst_graph_type));
+                  "Unsupported conversion direction from " +
+                      rpc::graph::GraphTypePb_Name(src_graph_type) + " to " +
+                      rpc::graph::GraphTypePb_Name(dst_graph_type));
 }
 
 bl::result<rpc::graph::GraphDefPb> GrapeInstance::copyGraph(
@@ -654,7 +656,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::toDirected(
   return dst_wrapper->graph_def();
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GS is compiled without folly");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif  // NETWORKX
 }
 
@@ -673,7 +675,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::toUnDirected(
   return dst_wrapper->graph_def();
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GS is compiled without folly");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif  // NETWORKX
 }
 
@@ -732,8 +734,7 @@ bl::result<void> GrapeInstance::clearGraph(const rpc::GSParams& params) {
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Error graph type: " + std::to_string(graph_type) +
-                        ", graph id: " + graph_name);
+                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " + rpc::graph::GraphTypePb_Name(graph_type) + ", graph id: " + graph_name);
   }
 
   auto vm_ptr = std::shared_ptr<DynamicFragment::vertex_map_t>(
@@ -744,7 +745,7 @@ bl::result<void> GrapeInstance::clearGraph(const rpc::GSParams& params) {
   fragment->ClearGraph(vm_ptr);
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GS is compiled without folly");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif  // NETWORKX
   return {};
 }
@@ -758,8 +759,7 @@ bl::result<void> GrapeInstance::clearEdges(const rpc::GSParams& params) {
 
   if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Error graph type: " + std::to_string(graph_type) +
-                        ", graph id: " + graph_name);
+                    "GraphType must be DYNAMIC_PROPERTY, the origin graph type is: " + rpc::graph::GraphTypePb_Name(graph_type) + ", graph id: " + graph_name);
   }
 
   auto fragment =
@@ -767,7 +767,7 @@ bl::result<void> GrapeInstance::clearEdges(const rpc::GSParams& params) {
   fragment->ClearEdges();
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GS is compiled without folly");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif  // NETWORKX
   return {};
 }
@@ -779,7 +779,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::createGraphView(
   BOOST_LEAF_AUTO(graph_name, params.Get<std::string>(rpc::GRAPH_NAME));
   BOOST_LEAF_AUTO(view_type, params.Get<std::string>(rpc::VIEW_TYPE));
 
-  VLOG(1) << "Get graph view, dst graph name: " << view_id
+  VLOG(1) << "Creating graph view, dst graph name: " << view_id
           << ", view type: " << view_type;
 
   BOOST_LEAF_AUTO(wrapper,
@@ -791,7 +791,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::createGraphView(
   return view_wrapper->graph_def();
 #else
   RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                  "GS is compiled without folly");
+                  "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif  // NETWORKX
 }
 
@@ -803,7 +803,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::addLabelsToGraph(
       object_manager_.GetObject<ILabeledFragmentWrapper>(graph_name));
   if (src_wrapper->graph_def().graph_type() != rpc::graph::ARROW_PROPERTY) {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "AddEdges is only avaiable for ArrowFragment");
+                    "AddLabelsToGraph is only avaiable for ArrowFragment");
   }
 
   auto src_frag_id =
@@ -864,11 +864,11 @@ bl::result<void> GrapeInstance::registerGraphType(const rpc::GSParams& params) {
   BOOST_LEAF_AUTO(type_sig, params.Get<std::string>(rpc::TYPE_SIGNATURE));
   BOOST_LEAF_AUTO(lib_path, params.Get<std::string>(rpc::GRAPH_LIBRARY_PATH));
 
-  VLOG(1) << "Registering Graph, graph type: " << graph_type
-          << ", Type sig: " << type_sig << ", lib path: " << lib_path;
+  VLOG(1) << "Registering Graph, graph type: " << rpc::graph::GraphTypePb_Name(graph_type)
+          << ", Type sigature: " << type_sig << ", lib path: " << lib_path;
 
   if (object_manager_.HasObject(type_sig)) {
-    VLOG(1) << "Graph already registered, sig: " << type_sig;
+    VLOG(1) << "Graph already registered, signature is: " << type_sig;
     return {};
   }
 
@@ -884,7 +884,7 @@ bl::result<void> GrapeInstance::registerGraphType(const rpc::GSParams& params) {
   } else {
     RETURN_GS_ERROR(
         vineyard::ErrorCode::kInvalidValueError,
-        "Only ArrowProperty/ArrowProjected/DynamicProjected are accepted");
+        "Unsupported graph type: " << rpc::graph::GraphTypePb_Name(graph_type));
   }
 }
 
@@ -948,7 +948,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     BOOST_LEAF_CHECK(modifyVertices(params, vertices_to_modify));
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -963,7 +963,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     BOOST_LEAF_CHECK(modifyEdges(params, edges_to_modify));
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -973,7 +973,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -988,7 +988,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -998,7 +998,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1038,7 +1038,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1047,7 +1047,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     BOOST_LEAF_CHECK(clearGraph(params));
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1056,7 +1056,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     BOOST_LEAF_CHECK(clearEdges(params));
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1066,7 +1066,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
     r->set_graph_def(graph_def);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "GS is built with networkx off");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
     break;
   }
@@ -1135,7 +1135,7 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
   }
   default:
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                    "Unknown command type: " + std::to_string(cmd.type));
+                    "Unsupported command type: " + std::to_string(cmd.type));
   }
   return r;
 }

--- a/analytical_engine/core/object/fragment_wrapper.h
+++ b/analytical_engine/core/object/fragment_wrapper.h
@@ -630,8 +630,9 @@ class FragmentWrapper<ArrowProjectedFragment<OID_T, VID_T, VDATA_T, EDATA_T>>
   bl::result<std::shared_ptr<IFragmentWrapper>> ToUnDirected(
       const grape::CommSpec& comm_spec,
       const std::string& dst_graph_name) override {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Cannot convert to the undirected DynamicProjectedFragment");
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidOperationError,
+        "Cannot convert to the undirected DynamicProjectedFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> CreateGraphView(
@@ -850,8 +851,9 @@ class FragmentWrapper<DynamicProjectedFragment<VDATA_T, EDATA_T>>
   bl::result<std::shared_ptr<IFragmentWrapper>> ToUnDirected(
       const grape::CommSpec& comm_spec,
       const std::string& dst_graph_name) override {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Cannot convert to the undirected DynamicProjectedFragment");
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidOperationError,
+        "Cannot convert to the undirected DynamicProjectedFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> CreateGraphView(

--- a/analytical_engine/core/object/fragment_wrapper.h
+++ b/analytical_engine/core/object/fragment_wrapper.h
@@ -468,11 +468,11 @@ class FragmentWrapper<vineyard::ArrowFragment<OID_T, VID_T>>
     }
     case SelectorType::kVertexData: {
       auto prop_id = selector.property_id();
-      auto graph_prop_num = fragment_->vertex_property_num(label_id);
+      auto vertex_prop_num = fragment_->vertex_property_num(label_id);
 
-      if (prop_id >= graph_prop_num) {
+      if (prop_id >= vertex_prop_num) {
         RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                        "Invalid property id: " + std::to_string(prop_id));
+                        "property id out of range: " + std::to_string(prop_id));
       }
 
       if (comm_spec.fid() == 0) {
@@ -564,21 +564,21 @@ class FragmentWrapper<vineyard::ArrowFragment<OID_T, VID_T>>
       const grape::CommSpec& comm_spec,
       const std::string& dst_graph_name) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not to directed ArrowFragment");
+                    "Cannot convert to the directed ArrowFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> ToUnDirected(
       const grape::CommSpec& comm_spec,
       const std::string& dst_graph_name) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not to undirected ArrowFragment");
+                    "Cannot convert to the undirected ArrowFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> CreateGraphView(
       const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
       const std::string& copy_type) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Cannot generate a graph view over an ArrowFragment.");
+                    "Cannot generate a graph view over the ArrowFragment.");
   }
 
  private:
@@ -617,28 +617,28 @@ class FragmentWrapper<ArrowProjectedFragment<OID_T, VID_T, VDATA_T, EDATA_T>>
       const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
       const std::string& copy_type) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not copy ArrowProjectedFragment");
+                    "Cannot copy the ArrowProjectedFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> ToDirected(
       const grape::CommSpec& comm_spec,
       const std::string& dst_graph_name) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not to directed DynamicProjectedFragment");
+                    "Cannot convert to the directed DynamicProjectedFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> ToUnDirected(
       const grape::CommSpec& comm_spec,
       const std::string& dst_graph_name) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not to undirected DynamicProjectedFragment");
+                    "Cannot convert to the undirected DynamicProjectedFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> CreateGraphView(
       const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
       const std::string& copy_type) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not view ArrowProjectedFragment");
+                    "Cannot generate a view over the ArrowProjectedFragment");
   }
 
  private:
@@ -837,28 +837,28 @@ class FragmentWrapper<DynamicProjectedFragment<VDATA_T, EDATA_T>>
       const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
       const std::string& copy_type) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not copy DynamicProjectedFragment");
+                    "Cannot copy the DynamicProjectedFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> ToDirected(
       const grape::CommSpec& comm_spec,
       const std::string& dst_graph_name) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not to directed DynamicProjectedFragment");
+                    "Cannot convert to the directed DynamicProjectedFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> ToUnDirected(
       const grape::CommSpec& comm_spec,
       const std::string& dst_graph_name) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Can not to undirected DynamicProjectedFragment");
+                    "Cannot convert to the undirected DynamicProjectedFragment");
   }
 
   bl::result<std::shared_ptr<IFragmentWrapper>> CreateGraphView(
       const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
       const std::string& copy_type) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Cannot generate a graph view over an ArrowFragment.");
+                    "Cannot generate a graph view over the ArrowFragment.");
   }
 
  private:

--- a/analytical_engine/core/object/graph_utils.h
+++ b/analytical_engine/core/object/graph_utils.h
@@ -126,7 +126,8 @@ class PropertyGraphUtils : public GSObject {
     return wrapper;
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kUnsupportedOperationError,
-                    "GraphScope is compiled with NETWORKX=OFF, please recompile with NETWORKX=ON");
+                    "GraphScope is compiled with NETWORKX=OFF, please "
+                    "recompile with NETWORKX=ON");
 #endif
   }
 
@@ -141,7 +142,8 @@ class PropertyGraphUtils : public GSObject {
     return wrapper;
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kUnsupportedOperationError,
-                    "GraphScope is compiled with NETWORKX=OFF, please recompile with NETWORKX=ON");
+                    "GraphScope is compiled with NETWORKX=OFF, please "
+                    "recompile with NETWORKX=ON");
 #endif
   }
 

--- a/analytical_engine/core/object/graph_utils.h
+++ b/analytical_engine/core/object/graph_utils.h
@@ -126,7 +126,7 @@ class PropertyGraphUtils : public GSObject {
     return wrapper;
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kUnsupportedOperationError,
-                    "GS is compiled with NETWORKX=OFF");
+                    "GraphScope is compiled with NETWORKX=OFF, please recompile with NETWORKX=ON");
 #endif
   }
 
@@ -141,7 +141,7 @@ class PropertyGraphUtils : public GSObject {
     return wrapper;
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kUnsupportedOperationError,
-                    "GS is compiled with NETWORKX=OFF");
+                    "GraphScope is compiled with NETWORKX=OFF, please recompile with NETWORKX=ON");
 #endif
   }
 

--- a/analytical_engine/core/object/gs_object.h
+++ b/analytical_engine/core/object/gs_object.h
@@ -36,7 +36,7 @@ inline const char* ObjectTypeToString(ObjectType ob_type) {
   case ObjectType::kFragmentWrapper:
     return "FragmentWrapper";
   case ObjectType::kLabeledFragmentWrapper:
-    return "LABELED_FRAGMENT_WRAPPER";
+    return "LabeledFragmentWrapper";
   case ObjectType::kAppEntry:
     return "AppEntry";
   case ObjectType::kContextWrapper:

--- a/analytical_engine/core/server/analytical_server.cc
+++ b/analytical_engine/core/server/analytical_server.cc
@@ -28,6 +28,7 @@ void AnalyticalServer::StartServer() {
   grpc::ServerBuilder builder;
   builder.SetMaxReceiveMessageSize(std::numeric_limits<int>::max());
   builder.SetMaxSendMessageSize(std::numeric_limits<int>::max());
+
   builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(&service);
 

--- a/analytical_engine/core/server/analytical_server.cc
+++ b/analytical_engine/core/server/analytical_server.cc
@@ -12,9 +12,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "core/server/analytical_server.h"
+
 #include <limits>
 
-#include "core/server/analytical_server.h"
 #include "core/server/graphscope_service.h"
 
 namespace gs {

--- a/analytical_engine/core/server/graphscope_service.cc
+++ b/analytical_engine/core/server/graphscope_service.cc
@@ -38,7 +38,6 @@ Status GraphScopeService::HeartBeat(::grpc::ServerContext* context,
                                           RunStepResponse* response) {
   CHECK(request->has_dag_def());
   const DagDef& dag_def = request->dag_def();
-  auto* res_status = response->mutable_status();
   std::unordered_map<std::string, OpResult*> op_key_to_result;
 
   for (const auto& op : dag_def.op()) {
@@ -67,7 +66,7 @@ Status GraphScopeService::HeartBeat(::grpc::ServerContext* context,
             std::string error_msg =
                 "BUG: Multiple workers return different graph def.";
             LOG(ERROR) << error_msg;
-            return Status::(StatusCode::INTERNAL, error_msg);
+            return Status(StatusCode::INTERNAL, error_msg);
           }
         }
       } else {
@@ -116,7 +115,7 @@ Status GraphScopeService::HeartBeat(::grpc::ServerContext* context,
           op_result->set_code(rpc::Code::WORKER_RESULTS_INCONSISTENT_ERROR);
           op_result->set_error_msg(ss.str());
           LOG(ERROR) << ss.str();
-          return Status::(StatusCode::INTERNAL, ss.str());
+          return Status(StatusCode::INTERNAL, ss.str());
         }
       }
       break;

--- a/analytical_engine/core/server/graphscope_service.cc
+++ b/analytical_engine/core/server/graphscope_service.cc
@@ -28,8 +28,8 @@ using ::grpc::Status;
 using ::grpc::StatusCode;
 
 Status GraphScopeService::HeartBeat(::grpc::ServerContext* context,
-                                            const HeartBeatRequest* request,
-                                            HeartBeatResponse* response) {
+                                    const HeartBeatRequest* request,
+                                    HeartBeatResponse* response) {
   return Status::OK;
 }
 
@@ -62,8 +62,10 @@ Status GraphScopeService::HeartBeat(::grpc::ServerContext* context,
         if (!graph_def.key().empty()) {
           if (op_result->graph_def().key().empty()) {
             op_result->mutable_graph_def()->CopyFrom(graph_def);
-          } else if (!::google::protobuf::util::MessageDifferencer::Equals(graph_def, op_result->graph_def())) {
-            std::string error_msg = "BUG: Multiple workers return different graph def.";
+          } else if (!::google::protobuf::util::MessageDifferencer::Equals(
+                         graph_def, op_result->graph_def())) {
+            std::string error_msg =
+                "BUG: Multiple workers return different graph def.";
             LOG(ERROR) << error_msg;
             return Status::(StatusCode::INTERNAL, error_msg);
           }

--- a/analytical_engine/core/server/graphscope_service.cc
+++ b/analytical_engine/core/server/graphscope_service.cc
@@ -30,9 +30,6 @@ using ::grpc::StatusCode;
 Status GraphScopeService::HeartBeat(::grpc::ServerContext* context,
                                             const HeartBeatRequest* request,
                                             HeartBeatResponse* response) {
-  ResponseStatus* res_status = response->mutable_status();
-  res_status->set_code(rpc::Code::OK);
-
   return Status::OK;
 }
 

--- a/analytical_engine/frame/project_frame.cc
+++ b/analytical_engine/frame/project_frame.cc
@@ -55,10 +55,11 @@ class ProjectSimpleFrame<
   static bl::result<std::shared_ptr<IFragmentWrapper>> Project(
       std::shared_ptr<IFragmentWrapper>& input_wrapper,
       const std::string& projected_graph_name, const rpc::GSParams& params) {
-        auto graph_type = input_wrapper->graph_def().graph_type();
+    auto graph_type = input_wrapper->graph_def().graph_type();
     if (graph_type != rpc::graph::ARROW_PROPERTY) {
       RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                      "graph_type should be ARROW_PROPERTY, got " + rpc::graph::GraphTypePb_Name(graph_type));
+                      "graph_type should be ARROW_PROPERTY, got " +
+                          rpc::graph::GraphTypePb_Name(graph_type));
     }
 
     BOOST_LEAF_AUTO(v_label_id, params.Get<int64_t>(rpc::V_LABEL_ID));
@@ -138,11 +139,11 @@ class ProjectSimpleFrame<gs::DynamicProjectedFragment<VDATA_T, EDATA_T>> {
   static bl::result<std::shared_ptr<IFragmentWrapper>> Project(
       std::shared_ptr<IFragmentWrapper>& input_wrapper,
       const std::string& projected_graph_name, const rpc::GSParams& params) {
-                auto graph_type = input_wrapper->graph_def().graph_type();
-    if (graph_type !=
-        rpc::graph::DYNAMIC_PROPERTY) {
+    auto graph_type = input_wrapper->graph_def().graph_type();
+    if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
       RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                      "graph_type should be DYNAMIC_PROPERTY, got " + rpc::graph::GraphTypePb_Name(graph_type));
+                      "graph_type should be DYNAMIC_PROPERTY, got " +
+                          rpc::graph::GraphTypePb_Name(graph_type));
     }
     BOOST_LEAF_AUTO(v_prop_key, params.Get<std::string>(rpc::V_PROP_KEY));
     BOOST_LEAF_AUTO(e_prop_key, params.Get<std::string>(rpc::E_PROP_KEY));

--- a/analytical_engine/frame/project_frame.cc
+++ b/analytical_engine/frame/project_frame.cc
@@ -55,9 +55,10 @@ class ProjectSimpleFrame<
   static bl::result<std::shared_ptr<IFragmentWrapper>> Project(
       std::shared_ptr<IFragmentWrapper>& input_wrapper,
       const std::string& projected_graph_name, const rpc::GSParams& params) {
-    if (input_wrapper->graph_def().graph_type() != rpc::graph::ARROW_PROPERTY) {
+        auto graph_type = input_wrapper->graph_def().graph_type();
+    if (graph_type != rpc::graph::ARROW_PROPERTY) {
       RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                      "graph_type should be ARROW_PROPERTY");
+                      "graph_type should be ARROW_PROPERTY, got " + rpc::graph::GraphTypePb_Name(graph_type));
     }
 
     BOOST_LEAF_AUTO(v_label_id, params.Get<int64_t>(rpc::V_LABEL_ID));
@@ -137,10 +138,11 @@ class ProjectSimpleFrame<gs::DynamicProjectedFragment<VDATA_T, EDATA_T>> {
   static bl::result<std::shared_ptr<IFragmentWrapper>> Project(
       std::shared_ptr<IFragmentWrapper>& input_wrapper,
       const std::string& projected_graph_name, const rpc::GSParams& params) {
-    if (input_wrapper->graph_def().graph_type() !=
+                auto graph_type = input_wrapper->graph_def().graph_type();
+    if (graph_type !=
         rpc::graph::DYNAMIC_PROPERTY) {
       RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                      "graph_type should be DYNAMIC_PROPERTY");
+                      "graph_type should be DYNAMIC_PROPERTY, got " + rpc::graph::GraphTypePb_Name(graph_type));
     }
     BOOST_LEAF_AUTO(v_prop_key, params.Get<std::string>(rpc::V_PROP_KEY));
     BOOST_LEAF_AUTO(e_prop_key, params.Get<std::string>(rpc::E_PROP_KEY));

--- a/analytical_engine/frame/property_graph_frame.cc
+++ b/analytical_engine/frame/property_graph_frame.cc
@@ -213,7 +213,8 @@ void ToArrowFragment(
         return std::dynamic_pointer_cast<gs::IFragmentWrapper>(wrapper);
 #else
         RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                        "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                        "GraphScope is built with NETWORKX=OFF, please "
+                        "recompile it with NETWORKX=ON");
 #endif
       });
 }
@@ -262,7 +263,8 @@ void ToDynamicFragment(
     return std::dynamic_pointer_cast<gs::IFragmentWrapper>(wrapper);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
+                    "GraphScope is built with NETWORKX=OFF, please recompile "
+                    "it with NETWORKX=ON");
 #endif
   });
 }

--- a/analytical_engine/frame/property_graph_frame.cc
+++ b/analytical_engine/frame/property_graph_frame.cc
@@ -213,7 +213,7 @@ void ToArrowFragment(
         return std::dynamic_pointer_cast<gs::IFragmentWrapper>(wrapper);
 #else
         RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                        "GS is compiled without folly");
+                        "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
       });
 }
@@ -229,7 +229,7 @@ void ToDynamicFragment(
     if (wrapper_in->graph_def().graph_type() !=
         gs::rpc::graph::ARROW_PROPERTY) {
       RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                      "Source fragment it not ArrowFragment.");
+                      "Source fragment must be ArrowFragment.");
     }
     auto arrow_frag =
         std::static_pointer_cast<_GRAPH_TYPE>(wrapper_in->fragment());
@@ -262,7 +262,7 @@ void ToDynamicFragment(
     return std::dynamic_pointer_cast<gs::IFragmentWrapper>(wrapper);
 #else
     RETURN_GS_ERROR(vineyard::ErrorCode::kUnimplementedMethod,
-                    "GS is compiled without folly");
+                    "GraphScope is built with NETWORKX=OFF, please recompile it with NETWORKX=ON");
 #endif
   });
 }

--- a/coordinator/gscoordinator/cluster.py
+++ b/coordinator/gscoordinator/cluster.py
@@ -313,7 +313,7 @@ class KubernetesClusterLauncher(Launcher):
 
     def distribute_file(self, path):
         dir = os.path.dirname(path)
-        # TODO(dongze): This command may fail, and it will cause the cluster to stuck.
+        # TODO(dongze): This command may fail, and it will cause the cluster to stuck. #761
         for pod in self._pod_name_list:
             subprocess.check_call(
                 [

--- a/coordinator/gscoordinator/cluster.py
+++ b/coordinator/gscoordinator/cluster.py
@@ -313,6 +313,7 @@ class KubernetesClusterLauncher(Launcher):
 
     def distribute_file(self, path):
         dir = os.path.dirname(path)
+        # TODO(dongze): This command may fail, and it will cause the cluster to stuck.
         for pod in self._pod_name_list:
             subprocess.check_call(
                 [
@@ -813,6 +814,7 @@ class KubernetesClusterLauncher(Launcher):
         logger.info("Etcd is ready, endpoint is {}".format(self._etcd_endpoint))
 
         # create interactive engine service
+        logger.info("Creating interactive engine service...")
         self._create_interactive_engine_service()
 
         if self._saved_locals["with_mars"]:
@@ -820,6 +822,7 @@ class KubernetesClusterLauncher(Launcher):
             self._create_mars_scheduler()
             self._create_mars_service()
 
+        logger.info("Creating engine replicaset...")
         self._create_engine_replicaset()
         if not self._exists_vineyard_daemonset(
             self._saved_locals["vineyard_daemonset"]
@@ -1076,7 +1079,7 @@ class KubernetesClusterLauncher(Launcher):
             self._resource_object = []
 
             if is_dangling:
-                logger.info("Dangling coordinator detected, clean up soon.")
+                logger.info("Dangling coordinator detected, cleaning up...")
                 # delete everything inside namespace of graphscope instance
                 if self._saved_locals["delete_namespace"]:
                     # delete namespace created by graphscope

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -893,9 +893,9 @@ class CoordinatorServiceServicer(
             dag = op_def_pb2.DagDef()
             dag.op.extend([new_op_def])
             self.run_on_coordinator(self._session_id, coordinator_dag, [])
-            resp = self.run_on_analytical_engine(self._session_id, dag, [])
+            results = self.run_on_analytical_engine(self._session_id, dag, [])
             logger.info("subgraph has been loaded")
-            return resp.results[-1]
+            return results[-1]
 
         # generate a random graph name
         now_time = datetime.datetime.now().strftime("%Y%m%d%H%M%S")

--- a/coordinator/gscoordinator/launcher.py
+++ b/coordinator/gscoordinator/launcher.py
@@ -350,6 +350,8 @@ class LocalLauncher(Launcher):
         self._start_analytical_engine()
         # create zetcd
         self._launch_zetcd()
+        if self.poll() is not None and self.poll() != 0:
+            raise RuntimeError("Initializing analytical engine failed.")
 
     def _start_analytical_engine(self):
         rmcp = ResolveMPICmdPrefix()

--- a/coordinator/gscoordinator/launcher.py
+++ b/coordinator/gscoordinator/launcher.py
@@ -221,7 +221,7 @@ class LocalLauncher(Launcher):
             "'{}'".format(";".join(engine_params)),
             str(enable_gaia),
         ]
-        logger.info("Create GIE instance with command: {0}".format(" ".join(cmd)))
+        logger.info("Create GIE instance with command: %s", " ".join(cmd))
         process = subprocess.Popen(
             cmd,
             start_new_session=True,
@@ -243,7 +243,7 @@ class LocalLauncher(Launcher):
             self._session_workspace,
             str(object_id),
         ]
-        logger.info("Close GIE instance with command: {0}".format(" ".join(cmd)))
+        logger.info("Close GIE instance with command: %s", " ".join(cmd))
         process = subprocess.Popen(
             cmd,
             start_new_session=True,
@@ -313,15 +313,15 @@ class LocalLauncher(Launcher):
     def _create_vineyard(self):
         if not self._vineyard_socket:
             ts = get_timestamp()
-            vineyard_socket = "{0}{1}".format(self._vineyard_socket_prefix, ts)
+            vineyard_socket = f"{self._vineyard_socket_prefix}{ts}"
             cmd = [self._find_vineyardd()]
             cmd.extend(["--socket", vineyard_socket])
             cmd.extend(["--size", self._shared_mem])
-            cmd.extend(["--etcd_prefix", "vineyard.gsa.{0}".format(ts)])
+            cmd.extend(["--etcd_prefix", f"vineyard.gsa.{ts}"])
             env = os.environ.copy()
             env["GLOG_v"] = str(self._glog_level)
 
-            logger.info("Launch vineyardd with command: {0}".format(" ".join(cmd)))
+            logger.info("Launch vineyardd with command: %s", " ".join(cmd))
 
             process = subprocess.Popen(
                 cmd,
@@ -357,7 +357,7 @@ class LocalLauncher(Launcher):
 
         master = self._hosts.split(",")[0]
         rpc_port = self._get_free_port(master)
-        self._analytical_engine_endpoint = "{}:{}".format(master, str(rpc_port))
+        self._analytical_engine_endpoint = f"{master}:{rpc_port}"
 
         cmd.append(ANALYTICAL_ENGINE_PATH)
         cmd.extend(["--host", "0.0.0.0"])
@@ -374,7 +374,7 @@ class LocalLauncher(Launcher):
         env = os.environ.copy()
         env.update(mpi_env)
 
-        logger.info("Launch analytical engine with command: {}".format(" ".join(cmd)))
+        logger.info("Launch analytical engine with command: %s", " ".join(cmd))
 
         process = subprocess.Popen(
             cmd,
@@ -403,9 +403,7 @@ class LocalLauncher(Launcher):
 
         server_list = []
         for i in range(self._num_workers):
-            server_list.append(
-                "localhost:{0}".format(str(self._get_free_port("localhost")))
-            )
+            server_list.append(f"localhost:{str(self._get_free_port('localhost'))}")
         hosts = ",".join(server_list)
         handle["server"] = hosts
         handle = base64.b64encode(json.dumps(handle).encode("utf-8")).decode("utf-8")

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -44,6 +44,7 @@ from string import Template
 
 import yaml
 from graphscope.framework import utils
+from graphscope.framework.errors import CompilationError
 from graphscope.framework.graph_schema import GraphSchema
 from graphscope.proto import attr_value_pb2
 from graphscope.proto import graph_def_pb2
@@ -281,7 +282,8 @@ def compile_app(workspace: str, library_name, attr, engine_config: dict):
     setattr(make_process, "stderr_watcher", make_stderr_watcher)
     make_process.wait()
     lib_path = get_lib_path(app_dir, library_name)
-    assert os.path.isfile(lib_path), "Error occurs when building the frame library."
+    if not os.path.isfile(lib_path):
+        raise CompilationError(f"Failed to compile app {app_class}")
     return lib_path
 
 
@@ -366,7 +368,9 @@ def compile_graph_frame(workspace: str, library_name, attr: dict, engine_config:
     setattr(make_process, "stderr_watcher", make_stderr_watcher)
     make_process.wait()
     lib_path = get_lib_path(library_dir, library_name)
-    assert os.path.isfile(lib_path), "Error occurs when building the frame library."
+    if not os.path.isfile(lib_path):
+        raise CompilationError(f"Failed to compile graph {graph_class}")
+
     return lib_path
 
 

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -21,18 +21,6 @@ import "proto/error_codes.proto";
 import "proto/op_def.proto";
 import "proto/types.proto";
 
-message ResponseStatus {
-  enum NullDetail { NULL_DETAIL = 0; }
-
-  Code code = 1;
-  string error_msg = 2;
-  oneof detail {
-    NullDetail null = 3;
-    OpDef op = 4;
-    // pickle coordinator python exception
-    bytes full_exception = 5;
-  }
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 //
@@ -56,8 +44,6 @@ message ConnectSessionRequest {
 }
 
 message ConnectSessionResponse {
-  ResponseStatus status = 1;
-
   // The session handle to be used in subsequent calls for the created session.
   //
   // The client must arrange to call CloseSession with this returned
@@ -80,7 +66,6 @@ message HeartBeatRequest {
 }
 
 message HeartBeatResponse {
-  ResponseStatus status = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -103,8 +88,6 @@ message RunStepRequest {
 }
 
 message RunStepResponse {
-  ResponseStatus status = 1;
-
   // list of result of ops in dag
   repeated OpResult results = 2;
 }
@@ -120,8 +103,6 @@ message FetchLogsRequest {
 }
 
 message FetchLogsResponse {
-  ResponseStatus status = 1;
-
   // log info.
   string info_message = 2;
   // log error.
@@ -141,5 +122,4 @@ message CloseSessionRequest {
 }
 
 message CloseSessionResponse {
-  ResponseStatus status = 1;
 }

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 
 package gs.rpc;
 
-import "proto/error_codes.proto";
 import "proto/op_def.proto";
 import "proto/types.proto";
 

--- a/proto/message.proto
+++ b/proto/message.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 
 package gs.rpc;
 
+import "proto/error_codes.proto";
 import "proto/op_def.proto";
 import "proto/types.proto";
 
@@ -88,7 +89,11 @@ message RunStepRequest {
 
 message RunStepResponse {
   // list of result of ops in dag
-  repeated OpResult results = 2;
+  repeated OpResult results = 1;
+
+  Code code = 2;
+  string error_msg = 3;
+  bytes full_exception = 4;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/python/graphscope/client/connection.py
+++ b/python/graphscope/client/connection.py
@@ -68,7 +68,7 @@ class Graph:
     def insert_edge(self, edge: EdgeRecordKey, properties: dict):
         return self.insert_edges([[edge, properties]])
 
-    def insert_edges(self, edges=list):
+    def insert_edges(self, edges: list):
         request = to_write_requests_pb("EDGE", edges, write_service_pb2.INSERT)
         return self._conn.batch_write(request)
 

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -974,9 +974,7 @@ class Session(object):
             self._coordinator_endpoint = self._launcher.coordinator_endpoint
 
         # waiting service ready
-        self._grpc_client = GRPCClient(
-            self._coordinator_endpoint, self._config_params["reconnect"]
-        )
+        self._grpc_client = GRPCClient(self._launcher, self._config_params["reconnect"])
         self._grpc_client.waiting_service_ready(
             timeout_seconds=self._config_params["timeout_seconds"],
         )

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -332,7 +332,7 @@ class Session(object):
         with_mars=gs_config.with_mars,
         enable_gaia=gs_config.enable_gaia,
         reconnect=False,
-        **kw
+        **kw,
     ):
         """Construct a new GraphScope session.
 
@@ -617,7 +617,7 @@ class Session(object):
                     )
                 if param == "k8s_vineyard_shared_mem":
                     warnings.warn(
-                        "Please use vineyard_shared_mem instead",
+                        "Please use 'vineyard_shared_mem' instead",
                         category=DeprecationWarning,
                     )
                 kw.pop(param, None)
@@ -627,7 +627,7 @@ class Session(object):
 
         # There should be no more custom keyword arguments.
         if kw:
-            raise ValueError("Not recognized value: ", list(kw.keys()))
+            raise ValueError("Value not recognized: ", list(kw.keys()))
 
         if self._config_params["addr"]:
             logger.info(
@@ -764,7 +764,7 @@ class Session(object):
             if self._grpc_client:
                 try:
                     self._grpc_client.send_heartbeat()
-                except GRPCError as exc:
+                except Exception as exc:
                     logger.warning(exc)
                     self._disconnected = True
                 else:
@@ -846,7 +846,7 @@ class Session(object):
     def _check_closed(self, msg=None):
         """Internal: raise a ValueError if session is closed"""
         if self.closed:
-            raise ValueError("Operation on closed session." if msg is None else msg)
+            raise ValueError(msg or "Operation on closed session.")
 
     # Context manager
     def __enter__(self):
@@ -964,7 +964,9 @@ class Session(object):
                 **self._config_params,
             )
         else:
-            raise RuntimeError("Session initialize failed.")
+            raise RuntimeError(
+                f"Unrecognized cluster type {types_pb2.ClusterType.Name(self._cluster_type)}."
+            )
 
         # launching graphscope service
         if self._launcher is not None:
@@ -1131,8 +1133,7 @@ class Session(object):
 
         if sys.platform != "linux" and sys.platform != "linux2":
             raise RuntimeError(
-                "The learning engine currently supports Linux only, doesn't support %s"
-                % sys.platform
+                f"The learning engine currently only supports running on Linux, got {sys.platform}"
             )
 
         if not graph.graph_type == graph_def_pb2.ARROW_PROPERTY:
@@ -1155,8 +1156,8 @@ class Session(object):
     def nx(self):
         if not self.eager():
             raise RuntimeError(
-                "Networkx module need session to be eager mode. "
-                "The session is lazy mode."
+                "Networkx module need the session to be eager mode. "
+                "Current session is lazy mode."
             )
         if self._nx:
             return self._nx
@@ -1230,7 +1231,7 @@ def set_option(**kwargs):
     # check exists
     for k, v in kwargs.items():
         if not hasattr(gs_config, k):
-            raise ValueError("No such option {} exists.".format(k))
+            raise ValueError(f"No such option {k} exists.")
 
     for k, v in kwargs.items():
         setattr(gs_config, k, v)

--- a/python/graphscope/deploy/hosts/cluster.py
+++ b/python/graphscope/deploy/hosts/cluster.py
@@ -67,6 +67,11 @@ class HostsClusterLauncher(Launcher):
         self._proc = None
         self._closed = True
 
+    def poll(self):
+        if self._proc is not None:
+            return self._proc.poll()
+        return -1
+
     def _launch_coordinator(self):
         if self._port is None:
             port = random.randint(60801, 63801)
@@ -134,7 +139,7 @@ class HostsClusterLauncher(Launcher):
         Raises:
             RuntimeError: If instance launch failed or timeout.
 
-        Returns: tulpe of process and endpoint
+        Returns: tuple of process and endpoint
         """
         try:
             self._launch_coordinator()

--- a/python/graphscope/deploy/kubernetes/cluster.py
+++ b/python/graphscope/deploy/kubernetes/cluster.py
@@ -154,6 +154,12 @@ class KubernetesClusterLauncher(Launcher):
     def __del__(self):
         self.stop()
 
+    # TODO(dongze): Check the coordinator pod status, like the poll in Popen
+    # we can use this to determine the coordinator status,
+    # None for pending, 0 for successed (not likely), other int value for failed.
+    def poll(self):
+        return 0
+
     def get_namespace(self):
         """Get kubernetes namespace which graphscope instance running on.
 

--- a/python/graphscope/deploy/launcher.py
+++ b/python/graphscope/deploy/launcher.py
@@ -46,3 +46,7 @@ class Launcher(metaclass=ABCMeta):
     @abstractmethod
     def stop(self, wait=False):
         pass
+
+    @abstractmethod
+    def poll(self):
+        pass

--- a/python/graphscope/framework/errors.py
+++ b/python/graphscope/framework/errors.py
@@ -135,7 +135,7 @@ class FatalError(GSError):
 
 class GRPCError(GSError):
     def __init__(self, message):
-        message = "RPC failed, the engine might have crashed: %s" % message
+        message = "RPC failed: %s" % message
         super().__init__(message)
 
 

--- a/python/graphscope/framework/errors.py
+++ b/python/graphscope/framework/errors.py
@@ -43,7 +43,6 @@ __all__ = [
     "UnknownError",
     "FatalError",
     "GRPCError",
-    "check_grpc_response",
     "check_argument",
 ]
 
@@ -161,30 +160,6 @@ _gs_error_types = {
     error_codes_pb2.UNKNOWN_ERROR: UnknownError,
     error_codes_pb2.FATAL_ERROR: FatalError,
 }
-
-
-def check_grpc_response(response):
-    status = response.status
-    if status.code == error_codes_pb2.OK:
-        return response
-
-    if status.WhichOneof("detail") is None:
-        detail = None
-    else:
-        detail = getattr(status, status.WhichOneof("detail"), None)
-
-    error_type = _gs_error_types.get(status.code)
-    if error_type:
-        if error_type == CoordinatorInternalError:
-            e = pickle.loads(detail)
-            raise (e)
-        raise error_type(status.error_msg, detail)
-    else:
-        raise RuntimeError(
-            "Undefined error: {}: {}, {}".format(
-                status.code, status.error_msg, status.detail
-            )
-        )
 
 
 def check_argument(condition, message=None):

--- a/python/graphscope/nx/tests/test_nx.py
+++ b/python/graphscope/nx/tests/test_nx.py
@@ -590,7 +590,7 @@ class TestImportNetworkxModuleWithSession(object):
     def test_error_import_with_wrong_session(self):
         with pytest.raises(
             RuntimeError,
-            match="Networkx module need session to be eager mode. The session is lazy mode.",
+            match="Networkx module need the session to be eager mode. Current session is lazy mode.",
         ):
             nx = self.session_lazy.nx()
         self.session_lazy.close()

--- a/python/tests/unittest/test_app.py
+++ b/python/tests/unittest/test_app.py
@@ -80,7 +80,7 @@ def test_errors_on_create_app(arrow_property_graph, arrow_project_graph):
 
     # algo not exist
     with pytest.raises(
-        graphscope.CompilationError,
+        KeyError,
         match="Algorithm does not exist in the gar resource",
     ):
         a = AppAssets(algo="invalid", context="vertex_data")


### PR DESCRIPTION
This PR does the following:
1. In analytical server side when something wrong happens, return a GRPC Status with a StatusCode indicating error kinds and details messages (which will in `INTERNAL` for most of cases),
2. In coordinator we catch all exceptions or responses in engines, do some work, and set the error code and dump exception details in response,
3. For rpc calls other than `RunStep` (which is much simple) we set context codes and details, so we can eliminate the ResponseStatus in most of protos,
4. Revised error messages that will be carried to make it more intuitive,
5. Check for coordinator status in initializing stage,
6. separate coordinator failure from analytical engine failure in heartbeat code.