### PR TITLE
Recover log4rs.yml of graphscope-store and fix the log output location

### DIFF
--- a/interactive_engine/conf/log4rs.yml
+++ b/interactive_engine/conf/log4rs.yml
@@ -17,12 +17,12 @@ appenders:
         limit: 200mb
       roller:
         kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/executor.log.{}"
+        pattern: "${env:LOG_DIRS:-/tmp/logs}/executor.log.{}"
         count: 4
   query:
     kind: env_rolling_file
     append: true
-    path: "${env:LOG_DIRS:-/home/admin/logs}/query.log"
+    path: "${env:LOG_DIRS:-/tmp/logs}/query.log"
     encoder:
       pattern: "{m}{n}"
     policy:
@@ -31,12 +31,12 @@ appenders:
         limit: 32mb
       roller:
         kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/query.log.{}"
+        pattern: "${env:LOG_DIRS:-/tmp/logs}/query.log.{}"
         count: 1
   store:
     kind: env_rolling_file
     append: true
-    path: "${env:LOG_DIRS:-/home/admin/logs}/store.log"
+    path: "${env:LOG_DIRS:-/tmp/logs}/store.log"
     encoder:
       pattern: "{m}{n}"
     policy:
@@ -45,12 +45,12 @@ appenders:
         limit: 32mb
       roller:
         kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/store.log.{}"
+        pattern: "${env:LOG_DIRS:-/tmp/logs}/store.log.{}"
         count: 1
   runtime:
     kind: env_rolling_file
     append: true
-    path: "${env:LOG_DIRS:-/home/admin/logs}/runtime.log"
+    path: "${env:LOG_DIRS:-/tmp/logs}/runtime.log"
     encoder:
       pattern: "{m}{n}"
     policy:
@@ -59,12 +59,12 @@ appenders:
         limit: 32mb
       roller:
         kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/runtime.log.{}"
+        pattern: "${env:LOG_DIRS:-/tmp/logs}/runtime.log.{}"
         count: 1
   alert:
     kind: env_rolling_file
     append: true
-    path: "${env:LOG_DIRS:-/home/admin/logs}/alert.log"
+    path: "${env:LOG_DIRS:-/tmp/logs}/alert.log"
     encoder:
       pattern: "{m}{n}"
     policy:
@@ -73,7 +73,7 @@ appenders:
         limit: 32mb
       roller:
         kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/alert.log.{}"
+        pattern: "${env:LOG_DIRS:-/tmp/logs}/alert.log.{}"
         count: 1
 
 root:

--- a/interactive_engine/distribution/src/bin/store_ctl.sh
+++ b/interactive_engine/distribution/src/bin/store_ctl.sh
@@ -65,7 +65,7 @@ _setup_maxgraph_env() {
   export LD_LIBRARY_PATH=${MAXGRAPH_HOME}/native:${LD_LIBRARY_PATH}:/usr/local/lib
 
   if [ -z "${LOG_DIR}" ]; then
-    LOG_DIR="/tmp/graphscope-store"
+    export LOG_DIR="/tmp/graphscope-store"
   fi
 
   mkdir -p ${LOG_DIR}

--- a/interactive_engine/distribution/src/conf/log4rs.yml
+++ b/interactive_engine/distribution/src/conf/log4rs.yml
@@ -7,7 +7,7 @@ appenders:
   file:
     kind: rolling_file
     append: true
-    path: "${env:LOG_DIR:-/tmp/graphscope-store}/rust.log"
+    path: "/tmp/graphscope-store/rust.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {h({l:<5})} (({f}:{L})) [{T}] {m}{n}"
     policy:
@@ -16,7 +16,7 @@ appenders:
         limit: 100mb
       roller:
         kind: fixed_window
-        pattern: "${env:LOG_DIR:-/tmp/graphscope-store}/rust.log.{}"
+        pattern: "/tmp/graphscope-store/rust.log.{}"
         count: 10
 
 root:

--- a/interactive_engine/distribution/src/conf/log4rs.yml
+++ b/interactive_engine/distribution/src/conf/log4rs.yml
@@ -7,7 +7,7 @@ appenders:
   file:
     kind: rolling_file
     append: true
-    path: "/tmp/graphscope-store/rust.log"
+    path: "/tmp/graphscope-store/store-executor.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {h({l:<5})} (({f}:{L})) [{T}] {m}{n}"
     policy:
@@ -16,7 +16,7 @@ appenders:
         limit: 100mb
       roller:
         kind: fixed_window
-        pattern: "/tmp/graphscope-store/rust.log.{}"
+        pattern: "/tmp/graphscope-store/store-executor.log.{}"
         count: 10
 
 root:

--- a/interactive_engine/distribution/src/conf/log4rs.yml
+++ b/interactive_engine/distribution/src/conf/log4rs.yml
@@ -1,109 +1,27 @@
-refresh_rate: 10 seconds
-
+refresh_rate: 30 seconds
 appenders:
   stdout:
     kind: console
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {h({l:<5})} (({f}:{L})) [{T}] {m}{n}"
-  executor:
-    kind: env_rolling_file
+  file:
+    kind: rolling_file
     append: true
-    path: "${env:LOG_DIRS:-./}/executor.log"
+    path: "${env:LOG_DIR:-/tmp/graphscope-store}/rust.log"
     encoder:
       pattern: "{d(%Y-%m-%d %H:%M:%S.%f)} {h({l:<5})} (({f}:{L})) [{T}] {m}{n}"
     policy:
       trigger:
         kind: size
-        limit: 200mb
+        limit: 100mb
       roller:
         kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/executor.log.{}"
-        count: 4
-  query:
-    kind: env_rolling_file
-    append: true
-    path: "${env:LOG_DIRS:-/home/admin/logs}/query.log"
-    encoder:
-      pattern: "{m}{n}"
-    policy:
-      trigger:
-        kind: size
-        limit: 32mb
-      roller:
-        kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/query.log.{}"
-        count: 1
-  store:
-    kind: env_rolling_file
-    append: true
-    path: "${env:LOG_DIRS:-/home/admin/logs}/store.log"
-    encoder:
-      pattern: "{m}{n}"
-    policy:
-      trigger:
-        kind: size
-        limit: 32mb
-      roller:
-        kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/store.log.{}"
-        count: 1
-  runtime:
-    kind: env_rolling_file
-    append: true
-    path: "${env:LOG_DIRS:-/home/admin/logs}/runtime.log"
-    encoder:
-      pattern: "{m}{n}"
-    policy:
-      trigger:
-        kind: size
-        limit: 32mb
-      roller:
-        kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/runtime.log.{}"
-        count: 1
-  alert:
-    kind: env_rolling_file
-    append: true
-    path: "${env:LOG_DIRS:-/home/admin/logs}/alert.log"
-    encoder:
-      pattern: "{m}{n}"
-    policy:
-      trigger:
-        kind: size
-        limit: 32mb
-      roller:
-        kind: fixed_window
-        pattern: "${env:LOG_DIRS:-/home/admin/logs}/alert.log.{}"
-        count: 1
+        pattern: "${env:LOG_DIR:-/tmp/graphscope-store}/rust.log.{}"
+        count: 10
 
 root:
   level: info
   appenders:
-  - executor
+    - file
+    - console
 
-loggers:
-  maxgraph-store:
-    level: info
-    additive: false
-    appenders:
-    - executor
-  logging-query:
-    level: info
-    additive: false
-    appenders:
-      - query
-  logging-store:
-    level: info
-    additive: false
-    appenders:
-      - store
-  logging-runtime:
-    level: info
-    additive: false
-    appenders:
-      - runtime
-  logging-alert:
-    level: info
-    additive: false
-    appenders:
-      - alert

--- a/interactive_engine/distribution/src/conf/logback.xml
+++ b/interactive_engine/distribution/src/conf/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <property name="log_dir" value="${log.dir:-./logs}"/>
+    <property name="log_dir" value="${log.dir:-/tmp/graphscope}"/>
     <property name="log_name" value="${log.name:-maxgraph}"/>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log_dir}/${log_name}.log</file>

--- a/interactive_engine/distribution/src/conf/logback.xml
+++ b/interactive_engine/distribution/src/conf/logback.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <property name="log_dir" value="${log.dir:-/tmp/graphscope}"/>
+    <property name="log_dir" value="${log.dir:-/tmp/graphscope-store}"/>
     <property name="log_name" value="${log.name:-maxgraph}"/>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log_dir}/${log_name}.log</file>

--- a/interactive_engine/distribution/src/conf/logback_debug.xml
+++ b/interactive_engine/distribution/src/conf/logback_debug.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <property name="log_dir" value="${log.dir:-./logs}"/>
+    <property name="log_dir" value="${log.dir:-/tmp/graphscope}"/>
     <property name="log_name" value="${log.name:-maxgraph}"/>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log_dir}/${log_name}.log</file>

--- a/interactive_engine/distribution/src/conf/logback_debug.xml
+++ b/interactive_engine/distribution/src/conf/logback_debug.xml
@@ -1,5 +1,5 @@
 <configuration>
-    <property name="log_dir" value="${log.dir:-/tmp/graphscope}"/>
+    <property name="log_dir" value="${log.dir:-/tmp/graphscope-store}"/>
     <property name="log_name" value="${log.name:-maxgraph}"/>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${log_dir}/${log_name}.log</file>


### PR DESCRIPTION

## What do these changes do?
- the log4rs.yml has been unified in [commit](https://github.com/alibaba/GraphScope/commit/032ed994a874525f55cf16f7bd05462cccbb491c). Since the `store-ctl` has been separate from `giectl`,  the log4rs.yml need to be recovered too.
- fix the log output location of `logback.yml` and `log4rs.yml`

## Related issue number

Fixes #813 

