### PR TITLE
Fix: add  data cache clean in gremlin_test.sh

### DIFF
--- a/interactive_engine/src/gaia-adaptor/gremlin_test.sh
+++ b/interactive_engine/src/gaia-adaptor/gremlin_test.sh
@@ -5,8 +5,8 @@ cd ${base_dir}/../.. && mvn clean install -DskipTests -Pv2
 cd ./distribution/target/ && tar xvzf maxgraph.tar.gz && cd maxgraph
 
 # start server
-current_dir=$(pwd)
-sed -e "s@LOG4RS_CONFIG@${current_dir}/conf/log4rs.yml@g" \
+maxgraph_dir=$(pwd)
+sed -e "s@LOG4RS_CONFIG@${maxgraph_dir}/conf/log4rs.yml@g" \
     conf/config.template > /tmp/max_node_gaia.config
 LOG_NAME=maxnode MAXGRAPH_CONF_FILE=/tmp/max_node_gaia.config ./bin/store_ctl.sh max_node_gaia &
 sleep 20
@@ -16,6 +16,8 @@ echo "localhost:12312" > ${base_dir}/src/test/resources/graph.endpoint
 cd ${base_dir} && mvn test
 exit_code=$?
 ps -ef | grep "com.alibaba.graphscope.gaia.MaxNode" | grep -v grep | awk '{print $2}' | xargs kill -9
+# clean data
+rm -fr ${maxgraph_dir}/data || true
 if [ $exit_code -ne 0 ]; then
     echo "gaia_on_maxgraph_store gremlin test fail"
     exit 1


### PR DESCRIPTION
## What do these changes do?
add data cache clean in gremlin_test.sh to avoid failed when we manually run the test.

## Related issue number

Fixes #661 

