### PR TITLE
Make the `add_edges` behavior more Pythonic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         shell: scl enable devtoolset-7 -- bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.2.11
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:debug
       options:
         --shm-size 4096m
     strategy:
@@ -135,7 +135,7 @@ jobs:
       run:
         shell: scl enable devtoolset-7 -- bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.2.11
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:debug
     steps:
     - name: Install Dependencies
       run: |
@@ -176,7 +176,7 @@ jobs:
       run:
         shell: scl enable devtoolset-7 -- bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.2.11
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:debug
     steps:
     - uses: actions/checkout@v2.3.2
       with:
@@ -541,7 +541,7 @@ jobs:
       run:
         shell: scl enable devtoolset-7 -- bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.2.11
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:debug
     steps:
 
     #- name: "Debug: Package dependancies for tmate"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         shell: scl enable devtoolset-7 -- bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:debug
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.2.12
       options:
         --shm-size 4096m
     strategy:
@@ -135,7 +135,7 @@ jobs:
       run:
         shell: scl enable devtoolset-7 -- bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:debug
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.2.12
     steps:
     - name: Install Dependencies
       run: |
@@ -176,7 +176,7 @@ jobs:
       run:
         shell: scl enable devtoolset-7 -- bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:debug
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.2.12
     steps:
     - uses: actions/checkout@v2.3.2
       with:
@@ -541,7 +541,7 @@ jobs:
       run:
         shell: scl enable devtoolset-7 -- bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:debug
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.2.12
     steps:
 
     #- name: "Debug: Package dependancies for tmate"

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -119,7 +119,7 @@ endif ()
 find_package(libgrapelite REQUIRED)
 include_directories(${LIBGRAPELITE_INCLUDE_DIRS})
 
-find_package(vineyard 0.2.9 REQUIRED)
+find_package(vineyard 0.2.12 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/analytical_engine/core/loader/arrow_fragment_loader.h
+++ b/analytical_engine/core/loader/arrow_fragment_loader.h
@@ -66,6 +66,9 @@ class ArrowFragmentLoader {
 #else
   using partitioner_t = SegmentedPartitioner<oid_t>;
 #endif
+  using vertex_table_info_t =
+      std::map<std::string, std::shared_ptr<arrow::Table>>;
+  using edge_table_info_t = std::vector<InputTable>;
 
  public:
   ArrowFragmentLoader(vineyard::Client& client,
@@ -158,82 +161,55 @@ class ArrowFragmentLoader {
     BOOST_LEAF_AUTO(partial_v_tables, LoadVertexTables());
     BOOST_LEAF_AUTO(partial_e_tables, LoadEdgeTables());
 
+    auto frag = std::static_pointer_cast<vineyard::ArrowFragment<oid_t, vid_t>>(
+        client_.GetObject(frag_id));
+    auto schema = frag->schema();
+
+    std::map<std::string, label_id_t> vertex_label_to_index;
+    std::set<std::string> previous_labels;
+
+    for (auto& entry : schema.vertex_entries()) {
+      vertex_label_to_index[entry.label] = entry.id;
+      previous_labels.insert(entry.label);
+    }
+
+    BOOST_LEAF_AUTO(
+        v_e_tables,
+        preprocessInputs(partial_v_tables, partial_e_tables, previous_labels));
+
+    auto vertex_tables_with_label = v_e_tables.first;
+    auto edge_tables_with_label = v_e_tables.second;
+
     auto basic_fragment_loader = std::make_shared<
         vineyard::BasicEVFragmentLoader<OID_T, VID_T, partitioner_t>>(
         client_, comm_spec_, partitioner, directed_, true, generate_eid_);
-    auto frag = std::static_pointer_cast<vineyard::ArrowFragment<oid_t, vid_t>>(
-        client_.GetObject(frag_id));
-    for (auto table : partial_v_tables) {
-      auto meta = table->schema()->metadata();
-      if (meta == nullptr) {
-        RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                        "Metadata of input vertex tables shouldn't be empty.");
-      }
-      int label_meta_index = meta->FindKey(LABEL_TAG);
-      if (label_meta_index == -1) {
-        RETURN_GS_ERROR(
-            vineyard::ErrorCode::kInvalidValueError,
-            "Metadata of input vertex tables should contain label name.");
-      }
-      std::string label_name = meta->value(label_meta_index);
+
+    for (auto& pair : vertex_tables_with_label) {
       BOOST_LEAF_CHECK(
-          basic_fragment_loader->AddVertexTable(label_name, table));
+          basic_fragment_loader->AddVertexTable(pair.first, pair.second));
     }
-    partial_v_tables.clear();
     auto old_vm_ptr = frag->GetVertexMap();
     BOOST_LEAF_CHECK(
         basic_fragment_loader->ConstructVertices(old_vm_ptr->id()));
 
+    partial_v_tables.clear();
+    vertex_tables_with_label.clear();
+
     label_id_t pre_label_num = old_vm_ptr->label_num();
-    auto schema = frag->schema();
-    std::map<std::string, label_id_t> vertex_label_to_index;
-    for (auto& entry : schema.vertex_entries()) {
-      vertex_label_to_index[entry.label] = entry.id;
-    }
+
     auto new_labels_index = basic_fragment_loader->get_vertex_label_to_index();
     for (auto& pair : new_labels_index) {
       vertex_label_to_index[pair.first] = pair.second + pre_label_num;
     }
     basic_fragment_loader->set_vertex_label_to_index(
         std::move(vertex_label_to_index));
-    for (auto& table_vec : partial_e_tables) {
-      for (auto table : table_vec) {
-        auto meta = table->schema()->metadata();
-        if (meta == nullptr) {
-          RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                          "Metadata of input edge tables shouldn't be empty.");
-        }
-
-        int label_meta_index = meta->FindKey(LABEL_TAG);
-        if (label_meta_index == -1) {
-          RETURN_GS_ERROR(
-              vineyard::ErrorCode::kInvalidValueError,
-              "Metadata of input edge tables should contain label name.");
-        }
-        std::string label_name = meta->value(label_meta_index);
-
-        int src_label_meta_index = meta->FindKey(SRC_LABEL_TAG);
-        if (src_label_meta_index == -1) {
-          RETURN_GS_ERROR(
-              vineyard::ErrorCode::kInvalidValueError,
-              "Metadata of input edge tables should contain src label name.");
-        }
-        std::string src_label_name = meta->value(src_label_meta_index);
-
-        int dst_label_meta_index = meta->FindKey(DST_LABEL_TAG);
-        if (dst_label_meta_index == -1) {
-          RETURN_GS_ERROR(
-              vineyard::ErrorCode::kInvalidValueError,
-              "Metadata of input edge tables should contain dst label name.");
-        }
-        std::string dst_label_name = meta->value(dst_label_meta_index);
-
-        BOOST_LEAF_CHECK(basic_fragment_loader->AddEdgeTable(
-            src_label_name, dst_label_name, label_name, table));
-      }
+    for (auto& table : edge_tables_with_label) {
+      BOOST_LEAF_CHECK(basic_fragment_loader->AddEdgeTable(
+          table.src_label, table.dst_label, table.edge_label, table.table));
     }
 
-    partial_e_tables.clear();
+    partial_e_tables_.clear();
+    edge_tables_with_label.clear();
 
     BOOST_LEAF_CHECK(basic_fragment_loader->ConstructEdges(
         schema.all_edge_label_num(), schema.all_vertex_label_num()));
@@ -276,64 +252,7 @@ class ArrowFragmentLoader {
   }
 
   boost::leaf::result<vineyard::ObjectID> addEdges(vineyard::ObjectID frag_id) {
-    BOOST_LEAF_AUTO(partitioner, initPartitioner());
-    BOOST_LEAF_AUTO(partial_e_tables, LoadEdgeTables());
-
-    auto basic_fragment_loader = std::make_shared<
-        vineyard::BasicEVFragmentLoader<OID_T, VID_T, partitioner_t>>(
-        client_, comm_spec_, partitioner, directed_, true, generate_eid_);
-    auto frag = std::static_pointer_cast<vineyard::ArrowFragment<oid_t, vid_t>>(
-        client_.GetObject(frag_id));
-    auto schema = frag->schema();
-    std::map<std::string, label_id_t> vertex_label_to_index;
-    for (auto& entry : schema.vertex_entries()) {
-      vertex_label_to_index[entry.label] = entry.id;
-    }
-    basic_fragment_loader->set_vertex_label_to_index(
-        std::move(vertex_label_to_index));
-    basic_fragment_loader->set_vm_ptr(frag->GetVertexMap());
-    for (auto& table_vec : partial_e_tables) {
-      for (auto table : table_vec) {
-        auto meta = table->schema()->metadata();
-        if (meta == nullptr) {
-          RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                          "Metadata of input edge tables shouldn't be empty.");
-        }
-
-        int label_meta_index = meta->FindKey(LABEL_TAG);
-        if (label_meta_index == -1) {
-          RETURN_GS_ERROR(
-              vineyard::ErrorCode::kInvalidValueError,
-              "Metadata of input edge tables should contain label name.");
-        }
-        std::string label_name = meta->value(label_meta_index);
-
-        int src_label_meta_index = meta->FindKey(SRC_LABEL_TAG);
-        if (src_label_meta_index == -1) {
-          RETURN_GS_ERROR(
-              vineyard::ErrorCode::kInvalidValueError,
-              "Metadata of input edge tables should contain src label name.");
-        }
-        std::string src_label_name = meta->value(src_label_meta_index);
-
-        int dst_label_meta_index = meta->FindKey(DST_LABEL_TAG);
-        if (dst_label_meta_index == -1) {
-          RETURN_GS_ERROR(
-              vineyard::ErrorCode::kInvalidValueError,
-              "Metadata of input edge tables should contain dst label name.");
-        }
-        std::string dst_label_name = meta->value(dst_label_meta_index);
-
-        BOOST_LEAF_CHECK(basic_fragment_loader->AddEdgeTable(
-            src_label_name, dst_label_name, label_name, table));
-      }
-    }
-
-    partial_e_tables.clear();
-
-    BOOST_LEAF_CHECK(basic_fragment_loader->ConstructEdges(
-        frag->edge_label_num(), frag->vertex_label_num()));
-    return basic_fragment_loader->AddEdgesToFragment(frag);
+    return addVerticesAndEdges(frag_id);
   }
 
   boost::leaf::result<vineyard::ObjectID> LoadFragment() {
@@ -927,6 +846,78 @@ class ArrowFragmentLoader {
       }
     }
     return tables;
+  }
+
+  boost::leaf::result<std::pair<vertex_table_info_t, edge_table_info_t>>
+  preprocessInputs(
+      const std::vector<std::shared_ptr<arrow::Table>>& v_tables,
+      const std::vector<std::vector<std::shared_ptr<arrow::Table>>>& e_tables,
+      const std::set<std::string>& previous_vertex_labels =
+          std::set<std::string>()) {
+    vertex_table_info_t vertex_tables_with_label;
+    edge_table_info_t edge_tables_with_label;
+    std::set<std::string> deduced_labels;
+    for (auto table : v_tables) {
+      auto meta = table->schema()->metadata();
+      if (meta == nullptr) {
+        RETURN_GS_ERROR(ErrorCode::kInvalidValueError,
+                        "Metadata of input vertex files shouldn't be empty");
+      }
+
+      int label_meta_index = meta->FindKey(LABEL_TAG);
+      if (label_meta_index == -1) {
+        RETURN_GS_ERROR(
+            ErrorCode::kInvalidValueError,
+            "Metadata of input vertex files should contain label name");
+      }
+      std::string label_name = meta->value(label_meta_index);
+      vertex_tables_with_label[label_name] = table;
+    }
+
+    auto label_not_exists = [&](const std::string& label) {
+      return vertex_tables_with_label.find(label) ==
+                 vertex_tables_with_label.end() &&
+             previous_vertex_labels.find(label) == previous_vertex_labels.end();
+    };
+
+    for (auto& table_vec : e_tables) {
+      for (auto table : table_vec) {
+        auto meta = table->schema()->metadata();
+        int label_meta_index = meta->FindKey(LABEL_TAG);
+        std::string label_name = meta->value(label_meta_index);
+        int src_label_meta_index = meta->FindKey(SRC_LABEL_TAG);
+        std::string src_label_name = meta->value(src_label_meta_index);
+        int dst_label_meta_index = meta->FindKey(DST_LABEL_TAG);
+        std::string dst_label_name = meta->value(dst_label_meta_index);
+        edge_tables_with_label.emplace_back(src_label_name, dst_label_name,
+                                            label_name, table);
+        // Find vertex labels that need to be deduced, i.e. not assigned by user
+        // directly
+
+        if (label_not_exists(src_label_name)) {
+          deduced_labels.insert(src_label_name);
+        }
+        if (label_not_exists(dst_label_name)) {
+          deduced_labels.insert(dst_label_name);
+        }
+      }
+    }
+
+    if (!deduced_labels.empty()) {
+      FragmentLoaderUtils<OID_T, VID_T, partitioner_t> loader_utils(
+          comm_spec_, partitioner_);
+      BOOST_LEAF_AUTO(vertex_labels,
+                      loader_utils.GatherVertexLabels(edge_tables_with_label));
+      BOOST_LEAF_AUTO(vertex_label_to_index,
+                      loader_utils.GetVertexLabelToIndex(vertex_labels));
+      BOOST_LEAF_AUTO(v_tables_map, loader_utils.BuildVertexTableFromEdges(
+                                        edge_tables_with_label,
+                                        vertex_label_to_index, deduced_labels));
+      for (auto& pair : v_tables_map) {
+        vertex_tables_with_label[pair.first] = pair.second;
+      }
+    }
+    return std::make_pair(vertex_tables_with_label, edge_tables_with_label);
   }
 
   boost::leaf::result<vineyard::ObjectID> resolveVYObject(

--- a/coordinator/gscoordinator/template/CMakeLists.template
+++ b/coordinator/gscoordinator/template/CMakeLists.template
@@ -53,7 +53,7 @@ set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads REQUIRED)
 
 # find vineyard-----------------------------------------------------------------
-find_package(vineyard 0.2.9 REQUIRED)
+find_package(vineyard 0.2.12 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/interactive_engine/src/executor/runtime/native/CMakeLists.txt
+++ b/interactive_engine/src/executor/runtime/native/CMakeLists.txt
@@ -48,7 +48,7 @@ find_package(Threads REQUIRED)
 #  we need edge src/dst ids in etable.
 add_definitions(-DENDPOINT_LISTS)
 
-find_package(vineyard 0.2.9 REQUIRED)
+find_package(vineyard 0.2.12 REQUIRED)
 add_library(native_store global_store_ffi.cc
                          htap_ds_impl.cc
                          graph_builder_ffi.cc

--- a/k8s/graphscope-store.Dockerfile
+++ b/k8s/graphscope-store.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=v0.2.9
+ARG BASE_VERSION=v0.2.12
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG CI=true

--- a/k8s/graphscope.Dockerfile
+++ b/k8s/graphscope.Dockerfile
@@ -4,7 +4,7 @@
 # the result image includes all runtime stuffs of graphscope, with analytical engine,
 # learning engine and interactive engine installed.
 
-ARG BASE_VERSION=v0.2.11
+ARG BASE_VERSION=v0.2.12
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 SHELL ["/usr/bin/scl", "enable", "devtoolset-7"]

--- a/k8s/gsvineyard.Dockerfile
+++ b/k8s/gsvineyard.Dockerfile
@@ -17,7 +17,7 @@ RUN sudo mkdir -p /opt/vineyard && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.2.11 https://github.com/alibaba/libvineyard.git --depth=1 && \
+    git clone -b v0.2.12 https://github.com/alibaba/libvineyard.git --depth=1 && \
     cd libvineyard && \
     git submodule update --init && \
     mkdir -p /tmp/libvineyard/build && \

--- a/k8s/ubuntu/gsvineyard.Dockerfile
+++ b/k8s/ubuntu/gsvineyard.Dockerfile
@@ -14,7 +14,7 @@ RUN cd /tmp && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.2.11 https://github.com/alibaba/libvineyard.git --depth=1 && \
+    git clone -b v0.2.12 https://github.com/alibaba/libvineyard.git --depth=1 && \
     cd libvineyard && \
     git submodule update --init && \
     mkdir -p /tmp/libvineyard/build && \

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -428,9 +428,9 @@ class GraphDAGNode(DAGNode, GraphInterface):
     ):
         """Add edges to the graph, and return a new graph.
         Here the src_label and dst_label must be both specified or both unspecified,
-            i.   src_label and dst_label both unspecified and current graph has 0 vertex label.
+            i.   src_label and dst_label both unspecified and current graph has no vertex label.
                  We deduce vertex label from edge table, and set vertex label name to '_'.
-            ii.  src_label and dst_label both unspecified and current graph has 1 vertex label.
+            ii.  src_label and dst_label both unspecified and current graph has one vertex label.
                  We set src_label and dst label to this single vertex label.
             ii.  src_label and dst_label both specified and existed in current graph's vertex labels.
             iii. src_label and dst_label both specified and some are not existed in current graph's vertex labels.

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -456,18 +456,24 @@ class GraphDAGNode(DAGNode, GraphInterface):
 
         if src_label is None and dst_label is None:
             if not self._v_labels:
-                src_label = dst_label = '_'
+                src_label = dst_label = "_"
             else:
                 # Find previous max default label index
-                prev_default_label_indices = [label[1:] for label in self._v_labels if label.startswith('_')]
+                prev_default_label_indices = [
+                    label[1:] for label in self._v_labels if label.startswith("_")
+                ]
                 max_index = 0
                 for index in prev_default_label_indices:
                     try:
                         max_index = max(max_index, int(index))
                     except ValueError:
                         pass
-                src_label = dst_label = f'_{max_index + 1}'
-            logger.warning("Creating default vertex labels as no vertex label is assigned, src_label: %s and dst_label: %s...", src_label, dst_label)
+                src_label = dst_label = f"_{max_index + 1}"
+            logger.warning(
+                "Creating default vertex labels as no vertex label is assigned, src_label: %s and dst_label: %s...",
+                src_label,
+                dst_label,
+            )
 
         check_argument(
             src_field != dst_field, "src and dst field cannot refer to the same field"

--- a/python/tests/unittest/test_context.py
+++ b/python/tests/unittest/test_context.py
@@ -16,17 +16,12 @@
 # limitations under the License.
 #
 
-import os
 
 import pandas as pd
 import pytest
-import vineyard
 import vineyard.io
 
-from graphscope import hits
 from graphscope import lpa
-from graphscope import property_bfs
-from graphscope import property_sssp
 from graphscope import sssp
 from graphscope.framework.app import AppAssets
 from graphscope.framework.errors import InvalidArgumentError

--- a/python/tests/unittest/test_create_graph.py
+++ b/python/tests/unittest/test_create_graph.py
@@ -387,8 +387,6 @@ def test_error_on_non_default_and_non_existing_v_label(
 ):
     graph = graphscope_session.g()
     graph = graph.add_vertices(student_v, "student")
-    with pytest.raises(ValueError, match="src label or dst_label not existed in graph"):
-        graph = graph.add_edges(student_group_e, "group", src_label="v", dst_label="v")
     with pytest.raises(
         ValueError, match="must be both specified or either unspecified"
     ):

--- a/python/tests/unittest/test_graph.py
+++ b/python/tests/unittest/test_graph.py
@@ -312,19 +312,30 @@ def test_add_vertices_edges(graphscope_session):
     assert graph.schema.vertex_labels == ["person"]
     assert graph.schema.edge_labels == ["knows"]
 
-    with pytest.raises(ValueError, match="src label or dst_label not existed in graph"):
-        graph = graph.add_edges(
-            Loader(f"{prefix}/created.csv", delimiter="|"),
-            "created",
-            src_label="person",
-            dst_label="software",
-        )
+    graph_tmp = graph.add_edges(
+        Loader(f"{prefix}/created.csv", delimiter="|"),
+        "created",
+        src_label="src_label",
+        dst_label="dst_label",
+    )
+    assert "src_label" in graph_tmp.schema.vertex_labels
+    assert "dst_label" in graph_tmp.schema.vertex_labels
 
     graph = graph.add_vertices(
         Loader(f"{prefix}/software.csv", delimiter="|"), "software"
     )
-    with pytest.raises(ValueError, match="Ambiguous vertex label"):
-        graph = graph.add_edges(Loader(f"{prefix}/knows.csv", delimiter="|"), "created")
+
+    graph_tmp = graph.add_edges(
+        Loader(f"{prefix}/created.csv", delimiter="|"), "new_elabel"
+    )
+    assert "_" in graph_tmp.schema.vertex_labels
+    assert "new_elabel" in graph_tmp.schema.edge_labels
+
+    graph_tmp = graph.add_edges(
+        Loader(f"{prefix}/created.csv", delimiter="|"), "new_elabel_1"
+    )
+    assert "_1" in graph_tmp.schema.vertex_labels
+    assert "new_elabel_1" in graph_tmp.schema.edge_labels
 
     with pytest.raises(ValueError, match="already existed in graph"):
         graph = graph.add_edges(

--- a/python/tests/unittest/test_session.py
+++ b/python/tests/unittest/test_session.py
@@ -18,16 +18,11 @@
 
 import json
 import os
-import shutil
-import subprocess
-import sys
 import tempfile
-import time
 
 import pytest
 
 import graphscope
-from graphscope.client.session import DEFAULT_CONFIG_FILE
 
 COORDINATOR_HOME = os.path.join(os.path.dirname(__file__), "../", "../coordinator")
 new_data_dir = os.path.expandvars("${GS_TEST_DIR}/new_property/v2_e2")

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.2.11"  # vineyard version
-readonly V6D_BRANCH="v0.2.11" # vineyard branch
+readonly V6D_VERSION="0.2.12"  # vineyard version
+readonly V6D_BRANCH="v0.2.12" # vineyard branch
 readonly LLVM_VERSION=9  # llvm version we use in Darwin platform
 
 readonly SOURCE_DIR="$( cd "$(dirname $0)/.." >/dev/null 2>&1 ; pwd -P )"


### PR DESCRIPTION
Now the `add_edges` will always deduce the vertex tables when not found in existed labels
Fixes #727 