### PR TITLE
Require vineyard (for serialization test, etc.), but only on x86_64.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,3 +12,5 @@ protobuf>=3.12.0
 PyYAML
 scipy
 tqdm
+vineyard>=0.2.12; sys_platform != "win32" and platform_machine == 'x86_64'
+vineyard-io>=0.2.12; sys_platform != "win32" and platform_machine == 'x86_64'


### PR DESCRIPTION

## What do these changes do?

Followup revision for #780, fixes #779 in a nicer way.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #779.

