### PR TITLE
Don't export `/usr/local/opt/llvm/lib` to linker search path on MacOS.

### DIFF
--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -1,6 +1,6 @@
 name: Cancel Stale Runs
 
-on: [push, pull_request_target]
+on: [pull_request_target]
 
 jobs:
   cancel:

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -100,7 +100,9 @@ graphscope-darwin-py3:
 	sudo rm -fr /tmp/libvineyard /tmp/libgrape-lite
 	# build graphscope
 	cd $(WORKING_DIR)/../ && \
+		export LDFLAGS=-L/usr/local/opt/llvm/lib && \
 		make install WITH_LEARNING_ENGINE=OFF && \
+		unset LDFLAGS && \
 		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/executor && \
 		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/gaia_executor && \
 		python3 $(WORKING_DIR)/precompile.py

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -179,7 +179,6 @@ graphscope-client-manylinux2014-py3:
 			cmake .. -DCMAKE_PREFIX_PATH=/opt/vineyard \
 				-DCMAKE_INSTALL_PREFIX=/opt/vineyard \
 				-DBUILD_SHARED_LIBS=OFF \
-				-DBUILD_VINEYARD_IO_OSS=ON \
 				-DBUILD_VINEYARD_MIGRATION=OFF && \
 			sudo make install vineyard_client_python -j`nproc` && \
 			sudo cp -rf /opt/vineyard/* /usr/local/ && \

--- a/k8s/ubuntu/gsvineyard.Dockerfile
+++ b/k8s/ubuntu/gsvineyard.Dockerfile
@@ -20,8 +20,7 @@ RUN cd /tmp && \
     mkdir -p /tmp/libvineyard/build && \
     cd /tmp/libvineyard/build && \
     cmake .. -DBUILD_VINEYARD_PYPI_PACKAGES=ON \
-             -DBUILD_SHARED_LIBS=ON \
-             -DBUILD_VINEYARD_IO_OSS=ON && \
+             -DBUILD_SHARED_LIBS=ON && \
     make install vineyard_client_python -j && \
     cd /tmp/libvineyard && \
     python3 setup.py bdist_wheel && \

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -434,7 +434,6 @@ write_envs_config() {
       # packages_to_install contains llvm
       echo "export CC=/usr/local/opt/llvm/bin/clang"
       echo "export CXX=/usr/local/opt/llvm/bin/clang++"
-      echo "export LDFLAGS=-L/usr/local/opt/llvm/lib"
       echo "export CPPFLAGS=-I/usr/local/opt/llvm/include"
       echo "export PATH=/usr/local/opt/llvm/bin:\$PATH"
       if [ -z "${JAVA_HOME}" ]; then
@@ -699,7 +698,6 @@ install_dependencies() {
     export OPENSSL_SSL_LIBRARY=/usr/local/opt/openssl/lib/libssl.dylib
     export CC=/usr/local/opt/llvm/bin/clang
     export CXX=/usr/local/opt/llvm/bin/clang++
-    export LDFLAGS=-L/usr/local/opt/llvm/lib
     export CPPFLAGS=-I/usr/local/opt/llvm/include
   fi
 
@@ -798,11 +796,10 @@ install_vineyard() {
   if [[ "${PLATFORM}" == *"Darwin"* ]]; then
     cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
              -DBUILD_SHARED_LIBS=ON \
-             -DBUILD_VINEYARD_SERVER=OFF \
-             -DBUILD_VINEYARD_IO_OSS=ON -DBUILD_VINEYARD_TESTS=OFF
+             -DBUILD_VINEYARD_TESTS=OFF
   else
     cmake .. -DBUILD_SHARED_LIBS=ON \
-             -DBUILD_VINEYARD_IO_OSS=ON -DBUILD_VINEYARD_TESTS=OFF
+             -DBUILD_VINEYARD_TESTS=OFF
   fi
   make -j${NUM_PROC}
   make vineyard_client_python -j${NUM_PROC}

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -837,7 +837,10 @@ install_graphscope() {
   pushd ${SOURCE_DIR}
 
   if [[ "${PLATFORM}" == *"Darwin"* ]]; then
+    # need libomp.dylib to find MPI_CXX
+    export LDFLAGS=-L/usr/local/opt/llvm/lib
     make install WITH_LEARNING_ENGINE=OFF INSTALL_PREFIX=${INSTALL_PREFIX} NETWORKX=OFF BUILD_TYPE=${BUILD_TYPE}
+    unset LDFLAGS
   else
     make install WITH_LEARNING_ENGINE=ON INSTALL_PREFIX=${INSTALL_PREFIX} BUILD_TYPE=${BUILD_TYPE}
   fi


### PR DESCRIPTION
## What do these changes do?

Seems that there are conflicts between brew installed glog, and the `libc++.dylib`
in `/usr/local/opt/llvm/lib`.

The issue is tracked as v6d-io/v6d#565

## Related issue number

Fixes v6d-io/v6d#565

