### PR TITLE
Add readiness probe to graphscope-store frontend.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,7 +536,7 @@ jobs:
       image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.4
     steps:
 
-    #- name: "Debug: Package dependancies for tmate"
+    #- name: "Debug: Package dependencies for tmate"
       #run: |
         #sudo yum update -y
         #sudo yum install -y xz
@@ -689,7 +689,6 @@ jobs:
         export NODE_IP=$(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}")
         helm test ci --timeout 5m0s
         cd ${GITHUB_WORKSPACE}/python
-        sleep 120
         python3 -m pytest -s -vvv tests/kubernetes/test_store_service.py -k test_demo_after_restart
 
     - name: Clean

--- a/charts/graphscope-store/templates/frontend/statefulset.yaml
+++ b/charts/graphscope-store/templates/frontend/statefulset.yaml
@@ -129,6 +129,16 @@ spec:
               containerPort: 60000
             - name: gaia-engine
               containerPort: 60001
+          {{- if .Values.frontend.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: port
+            initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.frontend.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.frontend.livenessProbe.successThreshold }}
+          {{- end }}
           {{- if .Values.frontend.resources }}
           resources: {{- toYaml .Values.frontend.resources | nindent 12 }}
           {{- end }}

--- a/charts/graphscope-store/templates/frontend/statefulset.yaml
+++ b/charts/graphscope-store/templates/frontend/statefulset.yaml
@@ -129,15 +129,15 @@ spec:
               containerPort: 60000
             - name: gaia-engine
               containerPort: 60001
-          {{- if .Values.frontend.livenessProbe.enabled }}
-          livenessProbe:
+          {{- if .Values.frontend.readinessProbe.enabled }}
+          readinessProbe:
             tcpSocket:
               port: port
-            initialDelaySeconds: {{ .Values.frontend.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.frontend.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.frontend.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.frontend.livenessProbe.periodSeconds }}
-            successThreshold: {{ .Values.frontend.livenessProbe.successThreshold }}
+            initialDelaySeconds: {{ .Values.frontend.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.frontend.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.frontend.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.frontend.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.frontend.readinessProbe.successThreshold }}
           {{- end }}
           {{- if .Values.frontend.resources }}
           resources: {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/charts/graphscope-store/values.yaml
+++ b/charts/graphscope-store/values.yaml
@@ -330,18 +330,18 @@ frontend:
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
-    enabled: true
+    enabled: false
     initialDelaySeconds: 120
     periodSeconds: 10
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
   readinessProbe:
-    enabled: false
+    enabled: true
     initialDelaySeconds: 30
-    periodSeconds: 10
+    periodSeconds: 30
     timeoutSeconds: 1
-    failureThreshold: 3
+    failureThreshold: 10
     successThreshold: 1
 
   initContainers: []

--- a/charts/graphscope-store/values.yaml
+++ b/charts/graphscope-store/values.yaml
@@ -330,7 +330,7 @@ frontend:
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
-    enabled: false
+    enabled: true
     initialDelaySeconds: 120
     periodSeconds: 10
     timeoutSeconds: 1


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Add readinessProbe to graphscope-store frontend, to ensure the service remains unavailable until the GRPC service is started.

Now we can rely on helm test, the sleep trick in `ci.yml` has been removed.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #785

