### PR TITLE
Shrink wheel size by split graphscope package

### DIFF
--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -55,7 +55,7 @@ jobs:
         # package
         cd ${GITHUB_WORKSPACE}
         tar -zcf client.tar.gz python/dist/wheelhouse/*.whl
-        tar -zcf graphscope.tar.gz coordinator/dist/wheelhouse/*.whl
+        tar -zcf graphscope.tar.gz coordinator/dist/
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -24,7 +24,7 @@ on:
       - 'tutorials/**'
 
 jobs:
-  build:
+  build-wheels:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -46,10 +46,11 @@ jobs:
         if [ -z "${r}" ];then export hn=$(hostname); sudo -E bash -c 'echo "127.0.0.1 ${hn}" >> /etc/hosts'; fi
         cat /etc/hosts
 
-        cd k8s
-        # graphscope
+        cd ${GITHUB_WORKSPACE}/k8s
+        # build graphscope wheels
         sudo make graphscope-py3-package
-        # graphscope client
+
+        # build client wheels
         sudo make graphscope-client-py3-package
 
         # package

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -69,24 +69,27 @@ jobs:
 
   test:
     runs-on: ${{ matrix.os }}
-    needs: [build]
+    needs: [build-wheels]
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2.3.2
       with:
         submodules: true
 
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - uses: actions/download-artifact@v2
       with:
         path: artifacts
 
     - name: Run Test on ${{ matrix.python-version }}
-      env:
-        PYTHON: ${{ matrix.python-version }}
       shell: bash
       run: |
         pushd artifacts

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -92,24 +92,26 @@ jobs:
     - name: Run Test on ${{ matrix.python-version }}
       shell: bash
       run: |
+        python3 -c "import sys; print(sys.version)"
+
         pushd artifacts
         # install graphscope-client
         tar -zxf ./wheel-linux-${{ github.sha }}/client.tar.gz
         pushd python/dist/wheelhouse
-        for f in * ; do pip3 install $f || true; done
+        for f in * ; do python3 -m pip install $f || true; done
         popd
         # install graphscope
         tar -zxf ./wheel-linux-${{ github.sha }}/graphscope.tar.gz
         pushd coordinator/dist/wheelhouse
-        pip3 install ./*.whl
+        python3 -m pip install ./*.whl
         popd
         pushd coordinator/dist
-        pip3 install ./*.whl
+        python3 -m pip install ./*.whl
         popd
         popd
 
         # run test
-        pip3 install pytest "tensorflow<=2.5.2" --user;
+        python3 -m pip install pytest "tensorflow<=2.5.2" --user;
         sudo apt update -y && sudo apt install openjdk-11-jdk -y
         cp ${GITHUB_WORKSPACE}/python/tests/local/test_standalone.py /tmp/test_standalone.py
         python3 -m pytest -s -v /tmp/test_standalone.py

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -99,6 +99,9 @@ jobs:
         pushd coordinator/dist/wheelhouse
         pip3 install ./*.whl
         popd
+        pushd coordinator/dist
+        pip3 install ./*.whl
+        popd
         popd
 
         # run test

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -104,6 +104,9 @@ jobs:
         pushd coordinator/dist/wheelhouse
         pip3 install ./*.whl --user
         popd
+        pushd coordinator/dist
+        pip3 install ./*.whl --user
+        popd
         popd
 
         # run test

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -86,7 +86,7 @@ jobs:
       with:
         path: artifacts
 
-    - name: Build Client Wheel with ${{ matrix.python-version }}
+    - name: Test Client Wheel with ${{ matrix.python-version }}
       shell: bash
       run: |
         # build graphscope client wheel
@@ -97,16 +97,6 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         tar -zcf client.tar.gz python/dist/*.whl
 
-    - name: Upload Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: wheel-macos-${{ github.sha }}-${{ matrix.python-version }}
-        path: client.tar.gz
-        retention-days: 5
-
-    - name: Run Test with ${{ matrix.python-version }}
-      shell: bash
-      run: |
         # install client
         cd ${GITHUB_WORKSPACE}/python/dist
         for f in ./*.whl ; do pip3 install $f --user || true; done
@@ -125,3 +115,11 @@ jobs:
         # export PATH=/Users/runner/Library/Python/3.9/bin:${PATH}
         cp ${GITHUB_WORKSPACE}/python/tests/local/test_standalone.py /tmp/test_standalone.py
         python3 -m pytest -s -v /tmp/test_standalone.py
+
+    - name: Upload Artifact
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheel-macos-${{ github.sha }}-${{ matrix.python-version }}
+        path: client.tar.gz
+        retention-days: 5

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -24,7 +24,7 @@ on:
       - 'tutorials/**'
 
 jobs:
-  build:
+  build-wheels:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -43,26 +43,18 @@ jobs:
       run: |
         /bin/bash ${GITHUB_WORKSPACE}/scripts/install_deps.sh --dev --vineyard_prefix /opt/vineyard --verbose
 
-        # avoid access node by DNS hostnames
-        r=`cat /etc/hosts | grep $(hostname) || true`
-        if [ -z "${r}" ];then export hn=$(hostname); sudo -E bash -c 'echo "127.0.0.1 ${hn}" >> /etc/hosts'; fi
-        cat /etc/hosts
-
-    - name: Build Wheel Package
+    - name: Build Server Wheel
       run: |
         # source environment variable
         source ~/.graphscope_env
         echo ${CC}
 
-        cd k8s
-        # graphscope
+        # build graphscope server wheel
+        cd ${GITHUB_WORKSPACE}/k8s
         sudo -E make graphscope-py3-package
-        # graphscope client
-        sudo -E make graphscope-client-py3-package
 
         # package
         cd ${GITHUB_WORKSPACE}
-        tar -zcf client.tar.gz python/dist/*.whl
         tar -zcf graphscope.tar.gz coordinator/dist/wheelhouse/*.whl
 
     - name: Upload Artifact
@@ -70,46 +62,56 @@ jobs:
       with:
         name: wheel-macos-${{ github.sha }}
         path: |
-          client.tar.gz
           graphscope.tar.gz
         retention-days: 5
 
-  test:
+  build-and-test-client-wheels:
     runs-on: ${{ matrix.os }}
-    needs: [build]
+    needs: [build-wheels]
     strategy:
       matrix:
         os: [macos-10.15]
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2.3.2
       with:
         submodules: true
 
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - uses: actions/download-artifact@v2
       with:
         path: artifacts
 
-    - name: Run Test
+    - name: Build Client Wheel with ${{ matrix.python-version }}
       shell: bash
       run: |
-        pushd artifacts
-        # install graphscope-client
-        tar -zxf ./wheel-macos-${{ github.sha }}/client.tar.gz
-        pushd python/dist
+        # build graphscope client wheel
+        cd ${GITHUB_WORKSPACE}/k8s
+        sudo -E make graphscope-client-py3-package
+
+    - name: Run Test with ${{ matrix.python-version }}
+      shell: bash
+      run: |
+        # install client
+        cd ${GITHUB_WORKSPACE}/python/dist
         for f in * ; do pip3 install $f --user || true; done
-        popd
+
         # install graphscope
+        cd ${GITHUB_WORKSPACE}/artifacts
         tar -zxf ./wheel-macos-${{ github.sha }}/graphscope.tar.gz
         pushd coordinator/dist/wheelhouse
         pip3 install ./*.whl --user
-        popd
         popd
 
         # run test
         # waiting for graphlearn supported on macos
         # pip3 install pytest "tensorflow<=2.5.2" --user;
         pip3 install pytest --user
-        export PATH=/Users/runner/Library/Python/3.9/bin:${PATH}
+        # export PATH=/Users/runner/Library/Python/3.9/bin:${PATH}
         cp ${GITHUB_WORKSPACE}/python/tests/local/test_standalone.py /tmp/test_standalone.py
         python3 -m pytest -s -v /tmp/test_standalone.py

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -77,21 +77,22 @@ jobs:
       with:
         submodules: true
 
+    - uses: actions/download-artifact@v2
+      with:
+        path: artifacts
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: actions/download-artifact@v2
-      with:
-        path: artifacts
-
     - name: Test Client Wheel with ${{ matrix.python-version }}
-      shell: bash
       run: |
+        python3 -c "import sys; print(sys.version)"
+
         # build graphscope client wheel
         cd ${GITHUB_WORKSPACE}/k8s
-        sudo -E make graphscope-client-py3-package
+        make graphscope-client-py3-package
 
         # package
         cd ${GITHUB_WORKSPACE}
@@ -99,19 +100,19 @@ jobs:
 
         # install client
         cd ${GITHUB_WORKSPACE}/python/dist
-        for f in ./*.whl ; do pip3 install $f --user || true; done
+        for f in ./*.whl ; do python3 -m pip install $f --user || true; done
 
         # install graphscope
         cd ${GITHUB_WORKSPACE}/artifacts
         tar -zxf ./wheel-macos-${{ github.sha }}/graphscope.tar.gz
         pushd coordinator/dist/wheelhouse
-        pip3 install ./*.whl --user
+        python3 -m pip install ./*.whl --user
         popd
 
         # run test
         # waiting for graphlearn supported on macos
         # pip3 install pytest "tensorflow<=2.5.2" --user;
-        pip3 install pytest --user
+        python3 -m pip install pytest --user
         # export PATH=/Users/runner/Library/Python/3.9/bin:${PATH}
         cp ${GITHUB_WORKSPACE}/python/tests/local/test_standalone.py /tmp/test_standalone.py
         python3 -m pytest -s -v /tmp/test_standalone.py

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -61,8 +61,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: wheel-macos-${{ github.sha }}
-        path: |
-          graphscope.tar.gz
+        path: graphscope.tar.gz
         retention-days: 5
 
   build-and-test-client-wheels:
@@ -93,6 +92,17 @@ jobs:
         # build graphscope client wheel
         cd ${GITHUB_WORKSPACE}/k8s
         sudo -E make graphscope-client-py3-package
+
+        # package
+        cd ${GITHUB_WORKSPACE}
+        tar -zcf client.tar.gz python/dist/*.whl
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: wheel-macos-${{ github.sha }}-${{ matrix.python-version }}
+        path: client.tar.gz
+        retention-days: 5
 
     - name: Run Test with ${{ matrix.python-version }}
       shell: bash

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -113,7 +113,7 @@ jobs:
         # waiting for graphlearn supported on macos
         # pip3 install pytest "tensorflow<=2.5.2" --user;
         python3 -m pip install pytest --user
-        # export PATH=/Users/runner/Library/Python/3.9/bin:${PATH}
+        export PATH=${HOME}/.local/bin:${PATH}
         cp ${GITHUB_WORKSPACE}/python/tests/local/test_standalone.py /tmp/test_standalone.py
         python3 -m pytest -s -v /tmp/test_standalone.py
 

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -104,9 +104,6 @@ jobs:
         pushd coordinator/dist/wheelhouse
         pip3 install ./*.whl --user
         popd
-        pushd coordinator/dist
-        pip3 install ./*.whl --user
-        popd
         popd
 
         # run test

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -64,7 +64,7 @@ jobs:
         path: graphscope.tar.gz
         retention-days: 5
 
-  build-and-test-client-wheels:
+  test:
     runs-on: ${{ matrix.os }}
     needs: [build-wheels]
     strategy:
@@ -109,7 +109,7 @@ jobs:
       run: |
         # install client
         cd ${GITHUB_WORKSPACE}/python/dist
-        for f in * ; do pip3 install $f --user || true; done
+        for f in ./*.whl ; do pip3 install $f --user || true; done
 
         # install graphscope
         cd ${GITHUB_WORKSPACE}/artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.6
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.8
       options:
         --shm-size 4096m
 
@@ -132,7 +132,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.6
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.8
     steps:
     - name: Install Dependencies
       run: |
@@ -177,7 +177,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.6
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.8
     steps:
     - uses: actions/checkout@v2.3.2
       with:
@@ -549,7 +549,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.6
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.8
     steps:
 
     #- name: "Debug: Package dependencies for tmate"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.8
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.9
       options:
         --shm-size 4096m
 
@@ -132,7 +132,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.8
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.9
     steps:
     - name: Install Dependencies
       run: |
@@ -177,7 +177,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.8
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.9
     steps:
     - uses: actions/checkout@v2.3.2
       with:
@@ -549,7 +549,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.8
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.9
     steps:
 
     #- name: "Debug: Package dependencies for tmate"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 MKFILE_PATH 			:= $(abspath $(lastword $(MAKEFILE_LIST)))
 WORKING_DIR 			:= $(dir $(MKFILE_PATH))
 OS                      := $(shell uname -s)

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -153,7 +153,7 @@ endif ()
 find_package(libgrapelite REQUIRED)
 include_directories(${LIBGRAPELITE_INCLUDE_DIRS})
 
-find_package(vineyard 0.3.8 REQUIRED)
+find_package(vineyard 0.3.9 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -153,7 +153,7 @@ endif ()
 find_package(libgrapelite REQUIRED)
 include_directories(${LIBGRAPELITE_INCLUDE_DIRS})
 
-find_package(vineyard 0.3.6 REQUIRED)
+find_package(vineyard 0.3.8 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/coordinator/foo/__init__.py
+++ b/coordinator/foo/__init__.py
@@ -1,0 +1,20 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2021 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Dummy package dir for gs-lib gs-engine gs-jython package
+"""

--- a/coordinator/gscoordinator/template/CMakeLists.template
+++ b/coordinator/gscoordinator/template/CMakeLists.template
@@ -152,7 +152,7 @@ if (libgrapelite_FOUND)
 endif()
 
 # find vineyard-----------------------------------------
-find_package(vineyard 0.3.6 QUIET)
+find_package(vineyard 0.3.8 QUIET)
 if (vineyard_FOUND)
   include_directories(AFTER SYSTEM ${VINEYARD_INCLUDE_DIRS})
 endif()

--- a/coordinator/gscoordinator/template/CMakeLists.template
+++ b/coordinator/gscoordinator/template/CMakeLists.template
@@ -152,7 +152,7 @@ if (libgrapelite_FOUND)
 endif()
 
 # find vineyard-----------------------------------------
-find_package(vineyard 0.3.8 QUIET)
+find_package(vineyard 0.3.9 QUIET)
 if (vineyard_FOUND)
   include_directories(AFTER SYSTEM ${VINEYARD_INCLUDE_DIRS})
 endif()

--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -6,5 +6,5 @@ grpcio
 kubernetes
 protobuf
 PyYAML
-vineyard>=0.3.6
-vineyard-io>=0.3.6
+vineyard>=0.3.8
+vineyard-io>=0.3.8

--- a/coordinator/setup.py
+++ b/coordinator/setup.py
@@ -45,11 +45,14 @@ def get_version(file):
 
 
 def get_lib_suffix():
+    suffix = ""
     if platform.system() == "Linux":
-        return "so"
+        suffix = "so"
     elif platform.system() == "Darwin":
-        return "dylib"
-    raise RuntimeError("Get library suffix failed on {0}".format(platform.system()))
+        suffix = "dylib"
+    else:
+        raise RuntimeError("Get library suffix failed on {0}".format(platform.system()))
+    return suffix
 
 
 repo_root = os.path.dirname(os.path.abspath(__file__))

--- a/coordinator/setup.py
+++ b/coordinator/setup.py
@@ -123,12 +123,12 @@ def _get_extra_data():
             "/opt/graphscope/lib/jython-standalone*.jar": os.path.join(
                 RUNTIME_ROOT, "lib"
             ),
-            "/opt/graphscope/lib/groovy*.jar": os.path.join(RUNTIME_ROOT, "lib"),
-            "/opt/graphscope/lib/grpc*.jar": os.path.join(RUNTIME_ROOT, "lib"),
-            "/opt/graphscope/lib/curator*.jar": os.path.join(RUNTIME_ROOT, "lib"),
-            "/opt/graphscope/lib/hadoop*.jar": os.path.join(RUNTIME_ROOT, "lib"),
-            "/opt/graphscope/lib/gremlin*.jar": os.path.join(RUNTIME_ROOT, "lib"),
-            "/opt/graphscope/lib/conscrypt*.jar": os.path.join(RUNTIME_ROOT, "lib"),
+            "/opt/graphscope/lib/*groovy*.jar": os.path.join(RUNTIME_ROOT, "lib"),
+            "/opt/graphscope/lib/*grpc*.jar": os.path.join(RUNTIME_ROOT, "lib"),
+            "/opt/graphscope/lib/*curator*.jar": os.path.join(RUNTIME_ROOT, "lib"),
+            "/opt/graphscope/lib/*hadoop*.jar": os.path.join(RUNTIME_ROOT, "lib"),
+            "/opt/graphscope/lib/*gremlin*.jar": os.path.join(RUNTIME_ROOT, "lib"),
+            "/opt/graphscope/lib/*conscrypt*.jar": os.path.join(RUNTIME_ROOT, "lib"),
         }
     elif name == "gs-engine":
         data = {

--- a/coordinator/setup.py
+++ b/coordinator/setup.py
@@ -49,7 +49,7 @@ version = get_version(os.path.join(repo_root, "..", "VERSION"))
 
 
 GRAPHSCOPE_REQUIRED_PACKAGES = [
-    f"gscoordinator >= {version}",
+    f"gs-coordinator >= {version}",
     f"gs-jython >= {version}",
     f"gs-lib >= {version}",
     f"gs-engine >= {version}",
@@ -67,12 +67,12 @@ def _get_extra_data():
     # into site-packages/graphscope.runtime
     #
     #  For shrink the package size less than "100M", we split graphscope into
-    #   1) gscoordinator: include python releated code of gscoordinator
+    #   1) gs-coordinator: include python releated code of gscoordinator
     #   2) gs-lib: lib dir exclude jython-standalone-**.jar
     #   3) gs-jython: only jython-standalone-**.jar, cause this jar is 40M
     #   4) gs-engine: other runtime info such as 'bin', 'conf', and 'include'
 
-    name = os.environ.get("package_name", "gscoordinator")
+    name = os.environ.get("package_name", "gs-coordinator")
     RUNTIME_ROOT = "graphscope.runtime"
 
     # data format:
@@ -94,12 +94,13 @@ def _get_extra_data():
         }
     elif name == "gs-engine":
         data = {
-            "/opt/graphscope/bin": os.path.join(RUNTIME_ROOT, "bin"),
-            "/opt/graphscope/conf": os.path.join(RUNTIME_ROOT, "conf"),
+            "/opt/graphscope/bin/": os.path.join(RUNTIME_ROOT, "bin"),
+            "/opt/graphscope/conf/": os.path.join(RUNTIME_ROOT, "conf"),
             "/opt/graphscope/include": os.path.join(RUNTIME_ROOT, "include"),
             "/usr/local/include/grape": os.path.join(RUNTIME_ROOT, "include"),
-            "/opt/graphscope/lib64": os.path.join(RUNTIME_ROOT, "lib64"),
+            "/opt/graphscope/lib64/": os.path.join(RUNTIME_ROOT, "lib64"),
             "/opt/vineyard/include/": os.path.join(RUNTIME_ROOT, "include"),
+            "/opt/graphscope/*.jar": os.path.join(RUNTIME_ROOT),
             os.path.join("/", tempfile.gettempprefix(), "gs", "builtin"): os.path.join(
                 RUNTIME_ROOT, "precompiled"
             ),
@@ -241,22 +242,22 @@ with open(
 
 
 def parsed_package_dir():
-    name = os.environ.get("package_name", "gscoordinator")
-    if name == "gscoordinator":
+    name = os.environ.get("package_name", "gs-coordinator")
+    if name == "gs-coordinator":
         return {".": "."}
     return {}
 
 
 def parsed_packages():
-    name = os.environ.get("package_name", "gscoordinator")
-    if name == "gscoordinator":
+    name = os.environ.get("package_name", "gs-coordinator")
+    if name == "gs-coordinator":
         return find_packages(".")
     return ["foo"]
 
 
 def parsed_packge_data():
-    name = os.environ.get("package_name", "gscoordinator")
-    if name == "gscoordinator":
+    name = os.environ.get("package_name", "gs-coordinator")
+    if name == "gs-coordinator":
         return {
             "gscoordinator": [
                 "builtin/app/builtin_app.gar",
@@ -268,8 +269,8 @@ def parsed_packge_data():
 
 
 def parsed_reqs():
-    name = os.environ.get("package_name", "gscoordinator")
-    if name == "gscoordinator":
+    name = os.environ.get("package_name", "gs-coordinator")
+    if name == "gs-coordinator":
         with open(
             os.path.join(repo_root, "requirements.txt"), "r", encoding="utf-8"
         ) as fp:
@@ -281,8 +282,8 @@ def parsed_reqs():
 
 
 def parsed_dev_reqs():
-    name = os.environ.get("package_name", "gscoordinator")
-    if name == "gscoordinator":
+    name = os.environ.get("package_name", "gs-coordinator")
+    if name == "gs-coordinator":
         with open(
             os.path.join(repo_root, "requirements-dev.txt"), "r", encoding="utf-8"
         ) as fp:
@@ -341,7 +342,7 @@ del version_file_path
 
 
 setup(
-    name=os.environ.get("package_name", "gscoordinator"),
+    name=os.environ.get("package_name", "gs-coordinator"),
     description="",
     include_package_data=True,
     long_description=long_description,

--- a/coordinator/setup.py
+++ b/coordinator/setup.py
@@ -109,7 +109,7 @@ def _get_extra_data():
                     "conscrypt",
                 ],
             ),
-            "/opt/vineyard/lib/libvineyard_internal_registry.{0}".format(
+            "/usr/local/lib/libvineyard_internal_registry.{0}".format(
                 get_lib_suffix()
             ): os.path.join(RUNTIME_ROOT, "lib"),
         }

--- a/coordinator/setup.py
+++ b/coordinator/setup.py
@@ -96,7 +96,7 @@ def _get_extra_data():
         data = {
             "/opt/graphscope/bin/": os.path.join(RUNTIME_ROOT, "bin"),
             "/opt/graphscope/conf/": os.path.join(RUNTIME_ROOT, "conf"),
-            "/opt/graphscope/include": os.path.join(RUNTIME_ROOT, "include"),
+            "/opt/graphscope/include/": os.path.join(RUNTIME_ROOT, "include"),
             "/usr/local/include/grape": os.path.join(RUNTIME_ROOT, "include"),
             "/opt/graphscope/lib64/": os.path.join(RUNTIME_ROOT, "lib64"),
             "/opt/vineyard/include/": os.path.join(RUNTIME_ROOT, "include"),

--- a/interactive_engine/assembly/bin/giectl
+++ b/interactive_engine/assembly/bin/giectl
@@ -244,6 +244,7 @@ start_executor() {
   mkdir -p ${log_dir} ${config_dir} ${pid_dir}
   # log4rs needs LOG_DIRS env
   export LOG_DIRS=${log_dir}
+  export LD_LIBRARY_PATH=${GRAPHSCOPE_HOME}/lib:${LD_LIBRARY_PATH}
 
   # set executor config file
   sed -e "s@GRAPH_NAME@${object_id}@g" \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -77,7 +77,7 @@ graphscope-darwin-py3:
 	# Avoid copy vineyard library with the same basename by:
 	# 	1) reinstall vineyard to /usr/local and
 	# 	2) rm /opt/vineyard/lib
-	cd /tmp && git clone -b v0.3.6 https://github.com/alibaba/libvineyard.git --depth=1 && \
+	cd /tmp && git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
 		cd libvineyard && git submodule update --init && \
 		mkdir -p build && cd build && \
 		cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local && \
@@ -124,7 +124,7 @@ graphscope-manylinux2014-py3:
 			cmake .. && \
 			sudo make -j`nproc` install && \
 			cd /tmp && \
-			git clone -b v0.3.6 https://github.com/alibaba/libvineyard.git --depth=1 && \
+			git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
 			cd libvineyard && \
 			git submodule update --init && \
 			mkdir -p build && cd build && \
@@ -192,7 +192,7 @@ graphscope-client-manylinux2014-py3:
 			cmake .. -DCMAKE_INSTALL_PREFIX=/opt/vineyard && \
 			sudo make -j`nproc` install && \
 			cd /tmp && \
-			git clone -b v0.3.6 https://github.com/alibaba/libvineyard.git --depth=1 && \
+			git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
 			cd libvineyard && \
 			git submodule update --init && \
 			mkdir -p build && cd build && \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -97,7 +97,6 @@ graphscope-darwin-py3:
 		sudo strip /opt/graphscope/bin/grape_engine && \
 		sudo strip /opt/graphscope/bin/executor && \
 		sudo strip /opt/graphscope/bin/gaia_executor && \
-		strip /tmp/gs/builtin/*/*.dylib || true && \
 		package_name=gs-lib python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		rm -fr build && \
 		package_name=gs-engine python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -92,11 +92,14 @@ graphscope-darwin-py3:
 	cd $(WORKING_DIR)/../coordinator && \
 		export WITH_EXTRA_DATA=ON && \
 		rm -fr build dist/*.whl || true && \
+		sudo strip /opt/graphscope/bin/grape_engine && \
 		sudo strip /opt/graphscope/bin/executor && \
 		sudo strip /opt/graphscope/bin/gaia_executor && \
 		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/executor && \
 		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/gaia_executor && \
 		package_name=gs-lib python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
+		rm -fr build && \
+		package_name=gs-include python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		rm -fr build && \
 		package_name=gs-engine python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		rm -fr build && \
@@ -150,11 +153,14 @@ graphscope-manylinux2014-py3:
 			export WITH_EXTRA_DATA=ON && \
 			cd /work/coordinator && \
 			rm -fr build dist/*.whl && \
+			sudo strip /opt/graphscope/bin/grape_engine && \
 			sudo strip /opt/graphscope/bin/executor && \
 			sudo strip /opt/graphscope/bin/gaia_executor && \
 			sudo strip /opt/graphscope/lib/*.so && \
 			strip /tmp/gs/builtin/*/*.so && \
 			package_name=gs-lib python3 setup.py bdist_wheel && \
+			rm -fr build && \
+			package_name=gs-include python3 setup.py bdist_wheel && \
 			rm -fr build && \
 			package_name=gs-engine python3 setup.py bdist_wheel && \
 			rm -fr build && \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -92,7 +92,6 @@ graphscope-darwin-py3:
 	cd $(WORKING_DIR)/../coordinator && \
 		export WITH_EXTRA_DATA=ON && \
 		rm -fr build dist/*.whl || true && \
-		sudo strip /opt/graphscope/bin/grape_engine && \
 		sudo strip /opt/graphscope/bin/executor && \
 		sudo strip /opt/graphscope/bin/gaia_executor && \
 		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/executor && \
@@ -151,7 +150,6 @@ graphscope-manylinux2014-py3:
 			export WITH_EXTRA_DATA=ON && \
 			cd /work/coordinator && \
 			rm -fr build dist/*.whl && \
-			sudo strip /opt/graphscope/bin/grape_engine && \
 			sudo strip /opt/graphscope/bin/executor && \
 			sudo strip /opt/graphscope/bin/gaia_executor && \
 			sudo strip /opt/graphscope/lib/*.so && \
@@ -167,7 +165,7 @@ graphscope-manylinux2014-py3:
 			package_name=graphscope python3 setup.py bdist_wheel && \
 			cd dist && \
 			for wheel in `ls ./*.whl`; do \
-				auditwheel repair $$wheel --plat=manylinux2014_x86_64 --strip && rm $$wheel; \
+				auditwheel repair $$wheel --plat=manylinux2014_x86_64 && rm $$wheel; \
 			done'
 
 graphscope-client-darwin-py3:

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -87,8 +87,6 @@ graphscope-darwin-py3:
 	# build graphscope
 	cd $(WORKING_DIR)/../ && \
 		make install WITH_LEARNING_ENGINE=OFF && \
-		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/executor && \
-		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/gaia_executor && \
 		python3 $(WORKING_DIR)/precompile.py
 	# build and delocate wheel
 	cd $(WORKING_DIR)/../coordinator && \
@@ -97,13 +95,15 @@ graphscope-darwin-py3:
 		sudo strip /opt/graphscope/bin/grape_engine && \
 		sudo strip /opt/graphscope/bin/executor && \
 		sudo strip /opt/graphscope/bin/gaia_executor && \
+		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/executor && \
+		sudo install_name_tool -add_rpath /usr/local/lib /opt/graphscope/bin/gaia_executor && \
 		package_name=gs-lib python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		rm -fr build && \
 		package_name=gs-engine python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		rm -fr build && \
 		package_name=gs-jython python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		rm -fr build && \
-		package_name=gscoordinator python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
+		package_name=gs-coordinator python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		rm -fr build && \
 		pip3 install delocate && \
 		for wheel in `ls dist/*.whl`; do \
@@ -161,7 +161,7 @@ graphscope-manylinux2014-py3:
 			rm -fr build && \
 			package_name=gs-jython python3 setup.py bdist_wheel && \
 			rm -fr build && \
-			package_name=gscoordinator python3 setup.py bdist_wheel && \
+			package_name=gs-coordinator python3 setup.py bdist_wheel && \
 			rm -fr build && \
 			package_name=graphscope python3 setup.py bdist_wheel && \
 			cd dist && \
@@ -171,7 +171,9 @@ graphscope-manylinux2014-py3:
 
 graphscope-client-darwin-py3:
 	cd $(WORKING_DIR)/../python && \
-		rm -fr build dist/*.whl || true && \
+		rm -fr build || true && \
+		python3 -m pip install -r requirements.txt --user && \
+		python3 -m pip install -r requirements-dev.txt --user && \
 		export MACOSX_DEPLOYMENT_TARGET=10.9 && \
 		python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -77,7 +77,7 @@ graphscope-darwin-py3:
 	# Avoid copy vineyard library with the same basename by:
 	# 	1) reinstall vineyard to /usr/local and
 	# 	2) rm /opt/vineyard/lib
-	cd /tmp && git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
+	cd /tmp && git clone -b v0.3.9 https://github.com/alibaba/libvineyard.git --depth=1 && \
 		cd libvineyard && git submodule update --init && \
 		mkdir -p build && cd build && \
 		cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local && \
@@ -124,7 +124,7 @@ graphscope-manylinux2014-py3:
 			cmake .. && \
 			sudo make -j`nproc` install && \
 			cd /tmp && \
-			git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
+			git clone -b v0.3.9 https://github.com/alibaba/libvineyard.git --depth=1 && \
 			cd libvineyard && \
 			git submodule update --init && \
 			mkdir -p build && cd build && \
@@ -192,7 +192,7 @@ graphscope-client-manylinux2014-py3:
 			cmake .. -DCMAKE_INSTALL_PREFIX=/opt/vineyard && \
 			sudo make -j`nproc` install && \
 			cd /tmp && \
-			git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
+			git clone -b v0.3.9 https://github.com/alibaba/libvineyard.git --depth=1 && \
 			cd libvineyard && \
 			git submodule update --init && \
 			mkdir -p build && cd build && \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -94,6 +94,11 @@ graphscope-darwin-py3:
 	cd $(WORKING_DIR)/../coordinator && \
 		export WITH_EXTRA_DATA=ON && \
 		rm -fr build dist/*.whl || true && \
+		sudo strip /opt/graphscope/bin/grape_engine && \
+		sudo strip /opt/graphscope/bin/executor && \
+		sudo strip /opt/graphscope/bin/gaia_executor && \
+		sudo strip /opt/graphscope/lib/*.dylib && \
+		strip /tmp/gs/builtin/*/*.dylib && \
 		python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		pip3 install delocate && \
 		for wheel in `ls dist/*.whl`; do \
@@ -140,11 +145,24 @@ graphscope-manylinux2014-py3:
 			export WITH_EXTRA_DATA=ON && \
 			cd /work/coordinator && \
 			rm -fr build dist/*.whl && \
+			sudo strip /opt/graphscope/bin/grape_engine && \
 			sudo strip /opt/graphscope/bin/executor && \
 			sudo strip /opt/graphscope/bin/gaia_executor && \
-			python3 setup.py bdist_wheel && \
+			sudo strip /opt/graphscope/lib/*.so && \
+			strip /tmp/gs/builtin/*/*.so && \
+			package_name=gs-lib python3 setup.py bdist_wheel && \
+			rm -fr build && \
+			package_name=gs-engine python3 setup.py bdist_wheel && \
+			rm -fr build && \
+			package_name=gs-jython python3 setup.py bdist_wheel && \
+			rm -fr build && \
+			package_name=gscoordinator python3 setup.py bdist_wheel && \
+			rm -fr build && \
+			package_name=graphscope python3 setup.py bdist_wheel && \
 			cd dist && \
-			auditwheel repair ./*.whl --plat=manylinux2014_x86_64'
+			for wheel in `ls ./*.whl`; do \
+				auditwheel repair $$wheel --plat=manylinux2014_x86_64 --strip && rm $$wheel; \
+			done
 
 graphscope-client-darwin-py3:
 	cd $(WORKING_DIR)/../python && \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -97,13 +97,19 @@ graphscope-darwin-py3:
 		sudo strip /opt/graphscope/bin/grape_engine && \
 		sudo strip /opt/graphscope/bin/executor && \
 		sudo strip /opt/graphscope/bin/gaia_executor && \
-		sudo strip /opt/graphscope/lib/*.dylib && \
-		strip /tmp/gs/builtin/*/*.dylib && \
-		python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
+		strip /tmp/gs/builtin/*/*.dylib || true && \
+		package_name=gs-lib python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
+		rm -fr build && \
+		package_name=gs-engine python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
+		rm -fr build && \
+		package_name=gs-jython python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
+		rm -fr build && \
+		package_name=gscoordinator python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
+		rm -fr build && \
 		pip3 install delocate && \
 		for wheel in `ls dist/*.whl`; do \
 			delocate-listdeps -a -d $$wheel; \
-			delocate-wheel -w dist/wheelhouse -v $$wheel; \
+			delocate-wheel -w dist/wheelhouse -v $$wheel && rm $$wheel; \
 		done
 
 graphscope-manylinux2014-py3:
@@ -162,7 +168,7 @@ graphscope-manylinux2014-py3:
 			cd dist && \
 			for wheel in `ls ./*.whl`; do \
 				auditwheel repair $$wheel --plat=manylinux2014_x86_64 --strip && rm $$wheel; \
-			done
+			done'
 
 graphscope-client-darwin-py3:
 	cd $(WORKING_DIR)/../python && \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -105,6 +105,7 @@ graphscope-darwin-py3:
 		rm -fr build && \
 		package_name=gs-coordinator python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		rm -fr build && \
+		package_name=graphscope python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		pip3 install delocate && \
 		for wheel in `ls dist/*.whl`; do \
 			delocate-listdeps -a -d $$wheel; \

--- a/k8s/graphscope-store.Dockerfile
+++ b/k8s/graphscope-store.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=v0.3.8
+ARG BASE_VERSION=v0.3.9
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG CI=true

--- a/k8s/graphscope-store.Dockerfile
+++ b/k8s/graphscope-store.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=v0.3.6
+ARG BASE_VERSION=v0.3.8
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG CI=true

--- a/k8s/graphscope.Dockerfile
+++ b/k8s/graphscope.Dockerfile
@@ -4,7 +4,7 @@
 # the result image includes all runtime stuffs of graphscope, with analytical engine,
 # learning engine and interactive engine installed.
 
-ARG BASE_VERSION=v0.3.8
+ARG BASE_VERSION=v0.3.9
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG CI=true

--- a/k8s/graphscope.Dockerfile
+++ b/k8s/graphscope.Dockerfile
@@ -4,7 +4,7 @@
 # the result image includes all runtime stuffs of graphscope, with analytical engine,
 # learning engine and interactive engine installed.
 
-ARG BASE_VERSION=v0.3.6
+ARG BASE_VERSION=v0.3.8
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG CI=true

--- a/k8s/gsvineyard.Dockerfile
+++ b/k8s/gsvineyard.Dockerfile
@@ -47,7 +47,7 @@ RUN cd /opt/ && \
     cd fastFFI && \
     git checkout a166c6287f2efb938c27fb01b3d499932d484f9c && \
     export PATH=${PATH}:${LLVM11_HOME}/bin && \
-    mvn clean install
+    mvn clean install -DskipTests
 
 ENV LLVM4JNI_HOME=/opt/fastFFI/llvm4jni
 

--- a/k8s/gsvineyard.Dockerfile
+++ b/k8s/gsvineyard.Dockerfile
@@ -16,7 +16,7 @@ RUN sudo mkdir -p /opt/vineyard && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
+    git clone -b v0.3.9 https://github.com/alibaba/libvineyard.git --depth=1 && \
     cd libvineyard && \
     git submodule update --init && \
     mkdir -p /tmp/libvineyard/build && \

--- a/k8s/gsvineyard.Dockerfile
+++ b/k8s/gsvineyard.Dockerfile
@@ -16,7 +16,7 @@ RUN sudo mkdir -p /opt/vineyard && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.6 https://github.com/alibaba/libvineyard.git --depth=1 && \
+    git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
     cd libvineyard && \
     git submodule update --init && \
     mkdir -p /tmp/libvineyard/build && \

--- a/k8s/jupyter.Dockerfile
+++ b/k8s/jupyter.Dockerfile
@@ -18,6 +18,6 @@ WORKDIR /home/graphscope
 ENV PATH=${PATH}:/home/graphscope/.local/bin
 
 RUN python3 -m pip install --upgrade pip --user
-RUN python3 -m pip install jupyterlab graphscope --user
+RUN python3 -m pip install jupyterlab graphscope-client==0.8.0 --user
 
 CMD ["jupyter", "lab", "--port=8888", "--no-browser", "--ip=0.0.0.0"]

--- a/k8s/ubuntu/gsvineyard.Dockerfile
+++ b/k8s/ubuntu/gsvineyard.Dockerfile
@@ -14,7 +14,7 @@ RUN cd /tmp && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
+    git clone -b v0.3.9 https://github.com/alibaba/libvineyard.git --depth=1 && \
     cd libvineyard && \
     git submodule update --init && \
     mkdir -p /tmp/libvineyard/build && \

--- a/k8s/ubuntu/gsvineyard.Dockerfile
+++ b/k8s/ubuntu/gsvineyard.Dockerfile
@@ -14,7 +14,7 @@ RUN cd /tmp && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.6 https://github.com/alibaba/libvineyard.git --depth=1 && \
+    git clone -b v0.3.8 https://github.com/alibaba/libvineyard.git --depth=1 && \
     cd libvineyard && \
     git submodule update --init && \
     mkdir -p /tmp/libvineyard/build && \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -13,5 +13,5 @@ psutil
 PyYAML
 scipy
 tqdm
-vineyard>=0.3.6; sys_platform != "win32" and platform_machine == 'x86_64'
-vineyard-io>=0.3.6; sys_platform != "win32" and platform_machine == 'x86_64'
+vineyard>=0.3.8; sys_platform != "win32" and platform_machine == 'x86_64'
+vineyard-io>=0.3.8; sys_platform != "win32" and platform_machine == 'x86_64'

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.3.8"  # vineyard version
-readonly V6D_BRANCH="v0.3.8" # vineyard branch
+readonly V6D_VERSION="0.3.9"  # vineyard version
+readonly V6D_BRANCH="v0.3.9" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.3.6"  # vineyard version
-readonly V6D_BRANCH="v0.3.6" # vineyard branch
+readonly V6D_VERSION="0.3.8"  # vineyard version
+readonly V6D_BRANCH="v0.3.8" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

For shrink the package size less than "100M", we split graphscope into
- `gs-scoordinator`: include python releated code of gscoordinator
- `gs-lib`: lib dir exclude jython-standalone-**.jar
- `gs-jython`: only jython-standalone-**.jar, cause this jar is 40M
-  `gs-include`: header files
- `gs-engine`: other runtime info such as 'bin', 'conf', and 'include'

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #959 

