### PR TITLE
[Bug Fix] fix nullptr in arrow_projected_fragment.h

### DIFF
--- a/analytical_engine/core/fragment/arrow_projected_fragment.h
+++ b/analytical_engine/core/fragment/arrow_projected_fragment.h
@@ -551,6 +551,22 @@ class ArrowProjectedFragment
     ivnum_ = static_cast<vid_t>(inner_vertices_.size());
     ovnum_ = static_cast<vid_t>(outer_vertices_.size());
     tvnum_ = static_cast<vid_t>(vertices_.size());
+    if (ivnum_ > 0) {
+      ienum_ = static_cast<size_t>(oe_offsets_end_->Value(ivnum_ - 1) -
+                                   oe_offsets_begin_->Value(0));
+      if (directed_) {
+        ienum_ += static_cast<size_t>(ie_offsets_end_->Value(ivnum_ - 1) -
+                                      ie_offsets_begin_->Value(0));
+      }
+    }
+    if (ovnum_ > 0) {
+      oenum_ = static_cast<size_t>(oe_offsets_end_->Value(tvnum_ - 1) -
+                                   oe_offsets_begin_->Value(ivnum_));
+      if (directed_) {
+        oenum_ += static_cast<size_t>(ie_offsets_end_->Value(tvnum_ - 1) -
+                                      ie_offsets_begin_->Value(ivnum_));
+      }
+    }
 
     vertex_label_num_ = fragment_->vertex_label_num_;
     edge_label_num_ = fragment_->edge_label_num_;
@@ -683,9 +699,7 @@ class ArrowProjectedFragment
 
   inline vid_t GetVerticesNum() const { return tvnum_; }
 
-  inline size_t GetEdgeNum() const {
-    return static_cast<size_t>(edge_data_array_->length());
-  }
+  inline size_t GetEdgeNum() const { return ienum_ + oenum_; }
 
   inline size_t GetTotalVerticesNum() const {
     return vm_ptr_->GetTotalVerticesNum();
@@ -1079,6 +1093,7 @@ class ArrowProjectedFragment
   bool directed_;
 
   vid_t ivnum_, ovnum_, tvnum_;
+  size_t ienum_{}, oenum_{};
 
   label_id_t vertex_label_num_, edge_label_num_;
   label_id_t vertex_label_, edge_label_;


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Arrow_projected_fragment causes a bug. When `edge_prop_` is -1. (A graph with no edge property).

https://github.com/alibaba/GraphScope/blob/699eea6cc187bdfaf9d5371ae5c5ba7b25963ffc/analytical_engine/core/fragment/arrow_projected_fragment.h#L573-L577
will set `edge_data_array_` to `nullptr`(correct)

https://github.com/alibaba/GraphScope/blob/699eea6cc187bdfaf9d5371ae5c5ba7b25963ffc/analytical_engine/core/fragment/arrow_projected_fragment.h#L686-L688
Unfortunately, a general method `GetEdgeNum()` will reference `edge_data_array_` without check.
