### PR TITLE
Subgraph: allow empty properties and duplicate properties.

### DIFF
--- a/interactive_engine/executor/runtime/native/graph_builder_ffi.cc
+++ b/interactive_engine/executor/runtime/native/graph_builder_ffi.cc
@@ -330,6 +330,15 @@ EdgeTypeBuilder build_edge_type(Schema schema, LabelId label,
   return ptr->CreateEntry("EDGE", label, name);
 }
 
+static bool entry_has_property(vineyard::Entry *entry, std::string const &name) {
+  for (auto const &prop: entry->props_) {
+    if (prop.name == name) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void build_vertex_property(VertexTypeBuilder vertex, PropertyId id,
                            const char *name, PropertyType prop_type) {
 #ifndef NDEBUG
@@ -338,6 +347,11 @@ void build_vertex_property(VertexTypeBuilder vertex, PropertyId id,
 #endif
   using entry_t = vineyard::Entry;
   auto entry_ptr = static_cast<entry_t *>(vertex);
+  if (entry_has_property(entry_ptr, name)) {
+    LOG(WARNING) << "detect duplicate vertex property name, ignored: " << name
+                 << ", id = " << id;
+    return;
+  }
   entry_ptr->AddProperty(/* id, */ name,
                          vineyard::detail::PropertyTypeToDataType(prop_type));
   entry_ptr->props_.rbegin()->id = id;
@@ -351,6 +365,11 @@ void build_edge_property(EdgeTypeBuilder edge, PropertyId id, const char *name,
 #endif
   using entry_t = vineyard::Entry;
   auto entry_ptr = static_cast<entry_t *>(edge);
+  if (entry_has_property(entry_ptr, name)) {
+    LOG(WARNING) << "detect duplicate edge property name, ignored: " << name
+                 << ", id = " << id;
+    return;
+  }
   entry_ptr->AddProperty(/* id, */ name,
                          vineyard::detail::PropertyTypeToDataType(prop_type));
   entry_ptr->props_.rbegin()->id = id;


### PR DESCRIPTION

## What do these changes do?

(As seems no one is familiar with the rust-side codebase, we workaround the issue the FFI wrapper).

Fixes the errors in #973 when subgraph op involved, where users feed `vid_field` to prorperies, causing (which will be finally addressed by #1022), and there are `null` columns in the input, causing missing property when feed v/e tables to vineyard to construct the subgraphs.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #973

