### PR TITLE
[GAIA/ENGINE] revert NetworkConfig to an old version

### DIFF
--- a/research/engine/pegasus/network/src/config.rs
+++ b/research/engine/pegasus/network/src/config.rs
@@ -155,12 +155,8 @@ pub struct ServerConfig {
 }
 
 impl ServerConfig {
-    pub fn new(server_id:u64, ip: String, port: u16) -> Self {
-        ServerConfig {
-            server_id,
-            ip,
-            port
-        }
+    pub fn new(server_id: u64, ip: String, port: u16) -> Self {
+        ServerConfig { server_id, ip, port }
     }
 
     pub fn get_ip(&self) -> &str {

--- a/research/engine/pegasus/server-v0/src/config.rs
+++ b/research/engine/pegasus/server-v0/src/config.rs
@@ -70,7 +70,7 @@ pub fn combine_config(
         let ip = local_host.get_ip().to_owned();
         let port = local_host.get_port();
         let config = if let Some(common_config) = common_config {
-            let network_config = NetworkConfig::new(server_id)
+            let network_config = NetworkConfig::new(server_id, ip, port)
                 .with_nonblocking(common_config.nonblocking)
                 .with_read_timeout_ms(common_config.read_timeout_ms)
                 .with_write_timeout_ms(common_config.write_timeout_ms)
@@ -81,7 +81,7 @@ pub fn combine_config(
                 .with_servers(Some(host_config.peers));
             Configuration { network: Some(network_config), max_pool_size: common_config.max_pool_size }
         } else {
-            let network_config = NetworkConfig::new(server_id).with_servers(Some(host_config.peers));
+            let network_config = NetworkConfig::new(server_id, ip, port).with_servers(Some(host_config.peers));
             Configuration { network: Some(network_config), max_pool_size: None }
         };
         Some(config)


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Revert NetworkConfig to an old version since the new version seems to be not compatible with startup_with ServerDetect.



<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

