### PR TITLE
Allow feed a `context_type` when loading custom gars.

### DIFF
--- a/python/graphscope/framework/app.py
+++ b/python/graphscope/framework/app.py
@@ -178,7 +178,8 @@ class AppAssets(DAGNode):
         config = yaml.safe_load(archive.read(DEFAULT_GS_CONFIG_FILE))
         for meta in config["app"]:
             if self._algo == meta["algo"]:
-                self._context_type = meta["context_type"]
+                if "context_type" in meta:
+                    self._context_type = meta["context_type"]
                 self._type = meta["type"]
                 self._meta = meta
                 return
@@ -421,7 +422,7 @@ class UnloadedApp(DAGNode):
         self._session.dag.add_op(self._op)
 
 
-def load_app(algo, gar=None, **kwargs):
+def load_app(algo, gar=None, context=None, **kwargs):
     """Load an app from gar.
     bytes or the resource of the specified path or bytes.
 
@@ -453,12 +454,12 @@ def load_app(algo, gar=None, **kwargs):
                 - gs::ArrowProjectedFragment
     """
     if isinstance(gar, (BytesIO, bytes)):
-        return AppAssets(str(algo), None, gar, **kwargs)
+        return AppAssets(str(algo), context, gar, **kwargs)
     elif isinstance(gar, str):
         with open(gar, "rb") as f:
             content = f.read()
         if not zipfile.is_zipfile(gar):
             raise InvalidArgumentError("{} is not a zip file.".format(gar))
-        return AppAssets(str(algo), None, content, **kwargs)
+        return AppAssets(str(algo), context, content, **kwargs)
     else:
         raise InvalidArgumentError("Wrong type with {}".format(gar))


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

It is quite strange that builtin gars accept a `context` argument for context type, but when loading custom gars it is not allowed.

When there's a `context_type` entry in the gar config, it would still be overwrite, but we need to check if the value is available first.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A

