### PR TITLE
Charts: Fix the GraphScope store mount volume permission issue

### DIFF
--- a/charts/graphscope-store/templates/coordinator/statefulset.yaml
+++ b/charts/graphscope-store/templates/coordinator/statefulset.yaml
@@ -129,6 +129,12 @@ spec:
             - name: config
               mountPath: /etc/graphscope-store/my.cnf.tpl
               subPath: my.cnf
+
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+
       volumes:
         - name: config
           configMap:

--- a/charts/graphscope-store/templates/store/statefulset.yaml
+++ b/charts/graphscope-store/templates/store/statefulset.yaml
@@ -143,6 +143,11 @@ spec:
               mountPath: /etc/graphscope-store/my.cnf.tpl
               subPath: my.cnf
 
+      securityContext:
+        runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
+
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
I think this could fix the below problems:

1. `statefulset.apps/graphscope-store-store`

```
Caused by: java.nio.file.AccessDeniedException: /var/lib/graphscope-store/8
```

2. `statefulset.apps/graphscope-store-coordinator`

```
Caused by: java.nio.file.AccessDeniedException: /etc/graphscope-store/my.meta/query_snapshot_info
```
