### PR TITLE
Fixes the error printing, and propogate errors in `Query` to client.

### DIFF
--- a/analytical_engine/core/app/app_invoker.h
+++ b/analytical_engine/core/app/app_invoker.h
@@ -191,12 +191,12 @@ class AppInvoker {
   }
 
  public:
-  static bl::result<void> Query(std::shared_ptr<worker_t> worker,
-                                const rpc::QueryArgs& query_args) {
+  static bl::result<nullptr_t> Query(std::shared_ptr<worker_t> worker,
+                                     const rpc::QueryArgs& query_args) {
     constexpr std::size_t args_num = ArgsNum<context_init_func_t>::value - 1;
     CHECK_OR_RAISE(args_num == query_args.args_size());
     query_impl(worker, query_args, std::make_index_sequence<args_num>());
-    return {};
+    return nullptr;
   }
 };
 

--- a/analytical_engine/core/io/property_parser.h
+++ b/analytical_engine/core/io/property_parser.h
@@ -317,9 +317,9 @@ inline std::vector<std::map<int, rpc::AttrValue>> DistributeGraph(
     for (const auto& item : items) {
       std::vector<AttrMap> vec;
       if (item.name() == "vertex") {
-        vec = std::move(DistributeVertex(item.attr(), num));
+        vec = DistributeVertex(item.attr(), num);
       } else if (item.name() == "edge") {
-        vec = std::move(DistributeEdge(item.attr(), num));
+        vec = DistributeEdge(item.attr(), num);
       }
       named_items.emplace_back(item.name(), std::move(vec));
     }

--- a/analytical_engine/core/object/app_entry.h
+++ b/analytical_engine/core/object/app_entry.h
@@ -41,7 +41,8 @@ typedef void DeleteWorkerT(void* worker_handler);
 typedef void QueryT(void* worker_handler, const rpc::QueryArgs& query_args,
                     const std::string& context_key,
                     std::shared_ptr<IFragmentWrapper> frag_wrapper,
-                    std::shared_ptr<IContextWrapper>& ctx_wrapper);
+                    std::shared_ptr<IContextWrapper>& ctx_wrapper,
+                    bl::result<nullptr_t>& wrapper_error);
 
 /**
  * @brief AppEntry is a class manages an application.
@@ -91,7 +92,12 @@ class AppEntry : public GSObject {
       const std::string& context_key,
       std::shared_ptr<IFragmentWrapper>& frag_wrapper) {
     std::shared_ptr<IContextWrapper> ctx_wrapper;
-    query_(worker_handler, query_args, context_key, frag_wrapper, ctx_wrapper);
+    bl::result<nullptr_t> wrapper_error;
+    query_(worker_handler, query_args, context_key, frag_wrapper, ctx_wrapper,
+           wrapper_error);
+    if (!wrapper_error) {
+      return std::move(wrapper_error);
+    }
     return ctx_wrapper;
   }
 

--- a/analytical_engine/frame/app_frame.cc
+++ b/analytical_engine/frame/app_frame.cc
@@ -73,12 +73,17 @@ void DeleteWorker(void* worker_handler) {
 void Query(void* worker_handler, const gs::rpc::QueryArgs& query_args,
            const std::string& context_key,
            std::shared_ptr<gs::IFragmentWrapper> frag_wrapper,
-           std::shared_ptr<gs::IContextWrapper>& ctx_wrapper) {
+           std::shared_ptr<gs::IContextWrapper>& ctx_wrapper,
+           gs::bl::result<nullptr_t>& wrapper_error) {
   auto worker = static_cast<worker_handler_t*>(worker_handler)->worker;
-  gs::AppInvoker<_APP_TYPE>::Query(worker, query_args);
-  auto ctx = worker->GetContext();
+  auto result = gs::AppInvoker<_APP_TYPE>::Query(worker, query_args);
+  if (!result) {
+    wrapper_error = std::move(result);
+    return;
+  }
 
   if (!context_key.empty()) {
+    auto ctx = worker->GetContext();
     ctx_wrapper = gs::CtxWrapperBuilder<typename _APP_TYPE::context_t>::build(
         context_key, frag_wrapper, ctx);
   }

--- a/analytical_engine/frame/cython_app_frame.cc
+++ b/analytical_engine/frame/cython_app_frame.cc
@@ -158,12 +158,17 @@ void DeleteWorker(void* worker_handler) {
 void Query(void* worker_handler, const gs::rpc::QueryArgs& query_args,
            const std::string& context_key,
            std::shared_ptr<gs::IFragmentWrapper> frag_wrapper,
-           std::shared_ptr<gs::IContextWrapper>& ctx_wrapper) {
+           std::shared_ptr<gs::IContextWrapper>& ctx_wrapper,
+           bl::result<nullptr_t>& wrapper_error) {
   auto worker = static_cast<worker_handler_t*>(worker_handler)->worker;
-  gs::AppInvoker<_APP_TYPE>::Query(worker, query_args);
-  auto ctx = worker->GetContext();
+  auto result = gs::AppInvoker<_APP_TYPE>::Query(worker, query_args);
+  if (!wrapper_error) {
+    wrapper_error = std::move(result);
+    return;
+  }
 
   if (!context_key.empty()) {
+    auto ctx = worker->GetContext();
     ctx_wrapper = gs::CtxWrapperBuilder<typename _APP_TYPE::context_t>::build(
         context_key, frag_wrapper, ctx);
   }

--- a/analytical_engine/frame/cython_app_frame.cc
+++ b/analytical_engine/frame/cython_app_frame.cc
@@ -159,10 +159,10 @@ void Query(void* worker_handler, const gs::rpc::QueryArgs& query_args,
            const std::string& context_key,
            std::shared_ptr<gs::IFragmentWrapper> frag_wrapper,
            std::shared_ptr<gs::IContextWrapper>& ctx_wrapper,
-           bl::result<nullptr_t>& wrapper_error) {
+           gs::bl::result<nullptr_t>& wrapper_error) {
   auto worker = static_cast<worker_handler_t*>(worker_handler)->worker;
   auto result = gs::AppInvoker<_APP_TYPE>::Query(worker, query_args);
-  if (!wrapper_error) {
+  if (!result) {
     wrapper_error = std::move(result);
     return;
   }

--- a/analytical_engine/frame/cython_pie_app_frame.cc
+++ b/analytical_engine/frame/cython_pie_app_frame.cc
@@ -146,12 +146,17 @@ void DeleteWorker(void* worker_handler) {
 void Query(void* worker_handler, const gs::rpc::QueryArgs& query_args,
            const std::string& context_key,
            std::shared_ptr<gs::IFragmentWrapper> frag_wrapper,
-           std::shared_ptr<gs::IContextWrapper>& ctx_wrapper) {
+           std::shared_ptr<gs::IContextWrapper>& ctx_wrapper,
+           gs::bl::result<nullptr_t>& wrapper_error) {
   auto worker = static_cast<worker_handler_t*>(worker_handler)->worker;
-  gs::AppInvoker<_APP_TYPE>::Query(worker, query_args);
-  auto ctx = worker->GetContext();
+  auto result = gs::AppInvoker<_APP_TYPE>::Query(worker, query_args);
+  if (!result) {
+    wrapper_error = std::move(result);
+    return;
+  }
 
   if (!context_key.empty()) {
+    auto ctx = worker->GetContext();
     ctx_wrapper = gs::CtxWrapperBuilder<typename _APP_TYPE::context_t>::build(
         context_key, frag_wrapper, ctx);
   }

--- a/coordinator/gscoordinator/io_utils.py
+++ b/coordinator/gscoordinator/io_utils.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 #
 
-import sys
 from queue import Queue
 
 from tqdm import tqdm
@@ -65,7 +64,7 @@ class StdStreamWrapper(object):
         line = self._filter_progress(line)
         if line is None:
             return
-        line = line.encode("ascii", "ignore").decode("ascii").strip()
+        line = line.encode("ascii", "ignore").decode("ascii")
         self._stream_backup.write(line)
         if not self._drop:
             self._lines.put(line)

--- a/python/graphscope/analytical/udf/wrapper.py
+++ b/python/graphscope/analytical/udf/wrapper.py
@@ -59,7 +59,7 @@ def wrap_init(
         pass
 
     def call(self, graph, **kwargs):
-        app_assets = load_app(algo=module_name, gar=garfile.read_bytes())
+        app_assets = load_app(gar=garfile.read_bytes(), algo=module_name)
         return app_assets(graph, **kwargs)
 
     setattr(algo, "__decorated__", True)  # can't decorate on a decorated class

--- a/python/graphscope/deploy/hosts/cluster.py
+++ b/python/graphscope/deploy/hosts/cluster.py
@@ -141,7 +141,9 @@ class HostsClusterLauncher(Launcher):
         )
         stdout_watcher = PipeWatcher(process.stdout, sys.stdout)
         if not gs_config.show_log:
-            stdout_watcher.addFilter(lambda line: "Loading" in line and "it/s]" in line)
+            stdout_watcher.add_filter(
+                lambda line: "Loading" in line and "it/s]" in line
+            )
         setattr(process, "stdout_watcher", stdout_watcher)
         stderr_watcher = PipeWatcher(process.stderr, sys.stderr)
         setattr(process, "stderr_watcher", stderr_watcher)

--- a/python/graphscope/framework/app.py
+++ b/python/graphscope/framework/app.py
@@ -450,7 +450,7 @@ def load_app(gar=None, algo=None, context=None, **kwargs):
         TypeError: File is not a zip file.
 
     Examples:
-        >>> sssp = load_app(algo='sssp', gar='./resource.gar')
+        >>> sssp = load_app(gar='./resource.gar', algo='sssp')
         >>> sssp(src=4)
 
         which will have following `.gs_conf.yaml` in resource.gar:
@@ -458,6 +458,7 @@ def load_app(gar=None, algo=None, context=None, **kwargs):
             - algo: sssp
               type: cpp_pie
               class_name: grape:SSSP
+              context_type: vertex_data
               src: sssp/sssp.h
               compatible_graph:
                 - gs::ArrowProjectedFragment

--- a/python/graphscope/framework/errors.py
+++ b/python/graphscope/framework/errors.py
@@ -45,14 +45,25 @@ __all__ = [
 ]
 
 
+class _ReprableString(str):
+    """A special class that prevents `repr()` adding extra `""` to `str`.
+
+    It is used to optimize the user experiences to preseve `\n` when printing exceptions.
+    """
+
+    def __repr__(self) -> str:
+        return self
+
+
 class GSError(Exception):
     """Base class of GraphScope errors."""
 
     def __init__(self, message=None, detail=None):
-        message = repr(message) if message is not None else None
+        if message is not None and not isinstance(message, str):
+            message = repr(message)
         if isinstance(detail, op_def_pb2.OpDef):
             message = f'{message or ""} op={detail}'
-        super().__init__(message)
+        super().__init__(_ReprableString(message))
 
     def __str__(self):
         return self.args[0] or ""

--- a/python/graphscope/framework/utils.py
+++ b/python/graphscope/framework/utils.py
@@ -25,7 +25,6 @@ import shutil
 import socket
 import string
 import subprocess
-import sys
 import tempfile
 import threading
 import time
@@ -77,18 +76,15 @@ class PipeWatcher(object):
     def drop(self, drop=True):
         self._drop = drop
 
-    def addFilter(self, func):
+    def add_filter(self, func):
         if not (func in self._filters):
             self._filters.append(func)
 
     def _filter(self, line):
-        rv = True
         for func in self._filters:
-            result = func(line)  # assume callable - will raise if not
-            if not result:
-                rv = False
-                break
-        return rv
+            if not func(line):  # assume callable - will raise if not
+                return False
+        return True
 
 
 class PipeMerger(object):

--- a/python/graphscope/tests/unittest/test_udf_app.py
+++ b/python/graphscope/tests/unittest/test_udf_app.py
@@ -951,7 +951,11 @@ def test_load_app_from_gar(random_gar, not_exist_gar, non_zipfile_gar):
 
 
 def test_error_on_create_cython_app(
-    graphscope_session, dynamic_property_graph, random_gar, empty_gar
+    graphscope_session,
+    p2p_property_graph,
+    dynamic_property_graph,
+    random_gar,
+    empty_gar,
 ):
     SSSP_Pregel.to_gar(random_gar)
     with pytest.raises(InvalidArgumentError, match="App is uncompatible with graph"):
@@ -959,11 +963,11 @@ def test_error_on_create_cython_app(
         a1(dynamic_property_graph, src=4)
     # algo not found in gar resource
     with pytest.raises(InvalidArgumentError, match="App not found in gar: sssp"):
-        a2 = load_app(algo="sssp", gar=random_gar)
+        a2 = load_app(gar=random_gar, algo="sssp")
         a2(p2p_property_graph, src=6)
     # no `.gs_conf.yaml` in empty gar, raise KeyError exception
     with pytest.raises(KeyError):
-        a3 = load_app(algo="SSSP_Pregel", gar=empty_gar)
+        a3 = load_app(gar=empty_gar, algo="SSSP_Pregel")
         a3(p2p_property_graph, src=6)
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

This PR fixes several issues about exceptions,

1. We have `CHECK_OR_RAISE(args_num == query_args.args_size());` but it still succeeds (and returns a uninitialized context) on client-side, as the error is not propogated from app frame to GAE engine.
2. Eliminates the too deep nested stack when printing `AnalyticalEngineInternalError`s, as it is hard to understand.
3. A `_ReprableString` is used to ensure `\n` are rendered in our exceptions to make it more readable.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

None

