### PR TITLE
Rename occurances of repository name "libvineyard" to "v6d".

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,8 @@ the latest main branch, using the following commands:
 
 [1]: https://github.com/alibaba/GraphScope/blob/main/LICENSE
 [2]: https://github.com/alibaba/GraphScope/blob/main/README.md
-[3]: https://github.com/alibaba/libvineyard/issues/new/new
-[4]: https://github.com/alibaba/libvineyard/pulls
+[3]: https://github.com/v6d-io/v6d/issues/new/new
+[4]: https://github.com/v6d-io/v6d/pulls
 [5]: https://cla-assistant.io/alibaba/GraphScope
 [6]: https://graphscope.io/docs
 [7]: https://github.com/pypa/manylinux

--- a/analytical_engine/README-zh.md
+++ b/analytical_engine/README-zh.md
@@ -7,7 +7,7 @@ GraphScope 中的图分析引擎继承自 **GRAPE**，该系统实现了论文 [
 
 与现有系统不同，GRAPE 通过自动并行化整体的单机顺序图算法，[即插即用](https://github.com/alibaba/libgrape-lite/blob/master/examples/analytical_apps/sssp/sssp_auto.h)已有的图算法程序，使其很容易的运行在分布式环境，高效处理大规模图。除了易于编程之外，**GRAPE** 还被设计为[高效](https://github.com/alibaba/libgrape-lite/blob/master/Performance.md)和[高度可拓展](https://github.com/alibaba/libgrape-lite/blob/master/examples/gnn_sampler)的，以应对现实图应用程序多变的规模，多样性和复杂性。
 
-GRAPE 的核心轻量版本以 [libgrape-lite](https://github.com/alibaba/libgrape-lite/) 开源。GraphScope 中的分析引擎扩展了 libgrape-lite 的功能，支持了可变子图，[vineyard](https://github.com/alibaba/libvineyard/) 支持以及引擎的服务模式等。
+GRAPE 的核心轻量版本以 [libgrape-lite](https://github.com/alibaba/libgrape-lite/) 开源。GraphScope 中的分析引擎扩展了 libgrape-lite 的功能，支持了可变子图，[vineyard](https://github.com/v6d-io/v6d) 支持以及引擎的服务模式等。
 
 ## Java PIE SDK
 

--- a/analytical_engine/README.md
+++ b/analytical_engine/README.md
@@ -6,7 +6,7 @@ The analytical engine in GraphScope originated from **GRAPE**, a system that imp
 
 GRAPE differs from prior systems in its ability to parallelize sequential graph algorithms as a whole by following the PIE programming model from the paper. Sequential algorithms can be easily ["plugged into"](https://github.com/alibaba/libgrape-lite/blob/master/examples/analytical_apps/sssp/sssp_auto.h) **GRAPE** with only minor changes and get parallelized to handle large graphs efficiently. In addition to the ease of programming, **GRAPE** is designed to be [highly efficient](https://github.com/alibaba/libgrape-lite/blob/master/Performance.md) and [flexible](https://github.com/alibaba/libgrape-lite/blob/master/examples/gnn_sampler), to cope the scale, variety and complexity from real-life graph applications.
 
-A lightweight version of GRAPE is open-sourced as [libgrape-lite](https://github.com/alibaba/libgrape-lite/). The analytical engine extends libgrape-lite with features for mutable fragments, [vineyard](https://github.com/alibaba/libvineyard/) support, and the service mode for the engine, etc.
+A lightweight version of GRAPE is open-sourced as [libgrape-lite](https://github.com/alibaba/libgrape-lite/). The analytical engine extends libgrape-lite with features for mutable fragments, [vineyard](https://github.com/v6d-io/v6d) support, and the service mode for the engine, etc.
 
 ## Java PIE SDK
 

--- a/docs/interactive_engine.rst
+++ b/docs/interactive_engine.rst
@@ -158,7 +158,7 @@ GIE supports the property graph model and Gremlin traversal language defined by 
 Property graph constraints
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The current release (MaxGraph) leverages `Vineyard <https://github.com/alibaba/libvineyard>`_ to supply an in-memory store for *immutable* graph data that can be partitioned across multiple servers.  By design, it introduces the following constraints:
+The current release (MaxGraph) leverages `Vineyard <https://github.com/v6d-io/v6d>`_ to supply an in-memory store for *immutable* graph data that can be partitioned across multiple servers.  By design, it introduces the following constraints:
 
 - Each graph has a schema comprised of the edge labels, property keys, and vertex labels used therein.
 

--- a/docs/zh/interactive_engine.rst
+++ b/docs/zh/interactive_engine.rst
@@ -158,7 +158,7 @@ GIE支持Apache TinkerPop定义的属性图模型和Gremlin遍历查询，且实
 属性图模型约束
 ~~~~~~~~~~~~~
 
-目前的MaxGraph技术预览版利用了 `Vineyard <https://github.com/alibaba/libvineyard>`_ 项目提供的分布式内存存储作为输入图，它支持一次载入 *不可修改* 的图模型数据，和图分片存储在分布式集群。当前设计有下面的一些限制：
+目前的MaxGraph技术预览版利用了 `Vineyard <https://github.com/v6d-io/v6d>`_ 项目提供的分布式内存存储作为输入图，它支持一次载入 *不可修改* 的图模型数据，和图分片存储在分布式集群。当前设计有下面的一些限制：
 
 - Schema（模式）约束：每个图的数据需要满足事先定义的Schema，包括点、边的类型名称（label）和属性名及值类型。
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -96,13 +96,13 @@ graphscope-darwin-py3:
 	# Avoid copy vineyard library with the same basename by:
 	# 	1) reinstall vineyard to /usr/local and
 	# 	2) rm /opt/vineyard/lib
-	cd /tmp && git clone -b ${VINEYARD_VERSION} https://github.com/alibaba/libvineyard.git --depth=1 && \
-		cd libvineyard && git submodule update --init && \
+	cd /tmp && git clone -b ${VINEYARD_VERSION} https://github.com/v6d-io/v6d.git --depth=1 && \
+		cd v6d && git submodule update --init && \
 		mkdir -p build && cd build && \
 		cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local && \
 		sudo make install -j`nproc` && \
 		sudo rm -fr /opt/vineyard/lib
-	sudo rm -fr /tmp/libvineyard /tmp/libgrape-lite
+	sudo rm -fr /tmp/v6d /tmp/libgrape-lite
 	# build graphscope
 	cd $(WORKING_DIR)/../ && \
 		make install && \

--- a/k8s/gsvineyard.Dockerfile
+++ b/k8s/gsvineyard.Dockerfile
@@ -16,29 +16,29 @@ RUN sudo mkdir -p /opt/vineyard && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.13 https://github.com/alibaba/libvineyard.git --depth=1 && \
-    cd libvineyard && \
+    git clone -b v0.3.13 https://github.com/v6d-io/v6d.git --depth=1 && \
+    cd v6d && \
     git submodule update --init && \
-    mkdir -p /tmp/libvineyard/build && \
-    cd /tmp/libvineyard/build && \
+    mkdir -p /tmp/v6d/build && \
+    cd /tmp/v6d/build && \
     cmake .. -DCMAKE_PREFIX_PATH=/opt/vineyard \
              -DCMAKE_INSTALL_PREFIX=/opt/vineyard \
              -DBUILD_SHARED_LIBS=ON && \
     make install vineyard_client_python -j && \
-    cd /tmp/libvineyard && \
+    cd /tmp/v6d && \
     python3 setup.py bdist_wheel && \
     cd dist && \
     auditwheel repair --plat=manylinux2014_x86_64 ./*.whl && \
     mkdir -p /opt/vineyard/dist && \
     cp -f wheelhouse/* /opt/vineyard/dist && \
     pip3 install wheelhouse/*.whl && \
-    cd /tmp/libvineyard/modules/io && \
+    cd /tmp/v6d/modules/io && \
     python3 setup.py bdist_wheel && \
     cp -f dist/* /opt/vineyard/dist && \
     pip3 install dist/* && \
     sudo cp -r /opt/vineyard/* /usr/local/ && \
     cd /tmp && \
-    rm -fr /tmp/libvineyard /tmp/libgrape-lite
+    rm -fr /tmp/v6d /tmp/libgrape-lite
 
 # build & install fastffi
 RUN cd /opt/ && \

--- a/k8s/ubuntu/gsvineyard.Dockerfile
+++ b/k8s/ubuntu/gsvineyard.Dockerfile
@@ -14,26 +14,26 @@ RUN cd /tmp && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.13 https://github.com/alibaba/libvineyard.git --depth=1 && \
-    cd libvineyard && \
+    git clone -b v0.3.13 https://github.com/v6d-io/v6d.git --depth=1 && \
+    cd v6d && \
     git submodule update --init && \
-    mkdir -p /tmp/libvineyard/build && \
-    cd /tmp/libvineyard/build && \
+    mkdir -p /tmp/v6d/build && \
+    cd /tmp/v6d/build && \
     cmake .. -DBUILD_VINEYARD_PYPI_PACKAGES=ON \
              -DBUILD_SHARED_LIBS=ON && \
     make install vineyard_client_python -j && \
-    cd /tmp/libvineyard && \
+    cd /tmp/v6d && \
     python3 setup.py bdist_wheel && \
     cd dist && \
     mkdir -p /opt/vineyard/dist && \
     cp -f ./*.whl /opt/vineyard/dist && \
     pip3 install ./*.whl && \
-    cd /tmp/libvineyard/modules/io && \
+    cd /tmp/v6d/modules/io && \
     python3 setup.py bdist_wheel && \
     cp -f dist/* /opt/vineyard/dist && \
     pip3 install dist/* && \
     cd /tmp && \
-    rm -fr /tmp/libvineyard /tmp/libgrape-lite && \
+    rm -fr /tmp/v6d /tmp/libgrape-lite && \
     useradd -m graphscope -u 1001 && \
     echo 'graphscope ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     cp -r ~/.cargo /home/graphscope/.cargo && \

--- a/python/graphscope/framework/loader.py
+++ b/python/graphscope/framework/loader.py
@@ -125,8 +125,8 @@ class Loader(object):
                 Defaults to True.
 
         Notes:
-            Data is resolved by drivers in `libvineyard <https://github.com/alibaba/libvineyard>`_ .
-            See more additional info in `Loading Graph` section of Docs, and implementations in `libvineyard`.
+            Data is resolved by drivers in `vineyard <https://github.com/v6d-io/v6d>`_ .
+            See more additional info in `Loading Graph` section of Docs, and implementations in `vineyard`.
         """
         self.protocol = ""
         # For numpy or pandas, source is the serialized raw bytes

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -490,10 +490,10 @@ install_vineyard() {
     return 0
   fi
 
-  check_and_remove_dir "/tmp/libvineyard"
+  check_and_remove_dir "/tmp/v6d"
   git clone -b ${V6D_BRANCH} --single-branch --depth=1 \
-      https://github.com/alibaba/libvineyard.git /tmp/libvineyard
-  pushd /tmp/libvineyard
+      https://github.com/v6d-io/v6d.git /tmp/v6d
+  pushd /tmp/v6d
   git submodule update --init
   mkdir -p build && pushd build
   cmake .. -DCMAKE_INSTALL_PREFIX=${DEPS_PREFIX} \
@@ -503,7 +503,7 @@ install_vineyard() {
   sudo make install && popd
   popd
 
-  rm -fr /tmp/libvineyard
+  rm -fr /tmp/v6d
 }
 
 ##########################


### PR DESCRIPTION
## What do these changes do?

To keep things consistent.

## Related issue number

N/A

