### PR TITLE
Enhanced input validation and schema representation

### DIFF
--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -238,7 +238,6 @@ bl::result<std::string> GrapeInstance::query(const rpc::GSParams& params,
   std::string context_schema;
   if (ctx_wrapper != nullptr) {
     context_type = ctx_wrapper->context_type();
-    VLOG(0) << "context type: " << context_type;
     context_schema = ctx_wrapper->schema();
     BOOST_LEAF_CHECK(object_manager_.PutObject(ctx_wrapper));
   }

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -957,45 +957,8 @@ def _pre_process_for_project_op(op, op_result_pool, key_to_op, **kwargs):
     del op.attr[types_pb2.EDGE_COLLECTIONS]
 
 
-def _tranform_numpy_selector(context_type, schema, selector):
-    if context_type == "tensor":
-        selector = None
-    if context_type == "vertex_data":
-        selector = transform_vertex_data_selector(selector)
-    if context_type == "labeled_vertex_data":
-        selector = transform_labeled_vertex_data_selector(schema, selector)
-    if context_type == "vertex_property":
-        selector = transform_vertex_property_data_selector(selector)
-    if context_type == "labeled_vertex_property":
-        selector = transform_labeled_vertex_property_data_selector(schema, selector)
-    return selector
-
-
-def _tranform_dataframe_selector(context_type, schema, selector):
-    selector = json.loads(selector)
-    if context_type == "tensor":
-        selector = {key: None for key, value in selector.items()}
-    if context_type == "vertex_data":
-        selector = {
-            key: transform_vertex_data_selector(value)
-            for key, value in selector.items()
-        }
-    if context_type == "labeled_vertex_data":
-        selector = {
-            key: transform_labeled_vertex_data_selector(schema, value)
-            for key, value in selector.items()
-        }
-    if context_type == "vertex_property":
-        selector = {
-            key: transform_vertex_property_data_selector(value)
-            for key, value in selector.items()
-        }
-    if context_type == "labeled_vertex_property":
-        selector = {
-            key: transform_labeled_vertex_property_data_selector(schema, value)
-            for key, value in selector.items()
-        }
-    return json.dumps(selector)
+# Below are selector transformation part, which will transform label / property
+# names to corresponding id.
 
 
 def _transform_vertex_data_v(selector):
@@ -1048,7 +1011,7 @@ def _transform_labeled_vertex_property_data_r(schema, label, prop):
     return f"label{label_id}.{prop}"
 
 
-def transform_vertex_data_selector(selector):
+def transform_vertex_data_selector(schema, selector):
     """Optional values:
     vertex selector: 'v.id', 'v.data'
     edge selector: 'e.src', 'e.dst', 'e.data'
@@ -1070,7 +1033,7 @@ def transform_vertex_data_selector(selector):
     return selector
 
 
-def transform_vertex_property_data_selector(selector):
+def transform_vertex_property_data_selector(schema, selector):
     """Optional values:
     vertex selector: 'v.id', 'v.data'
     edge selector: 'e.src', 'e.dst', 'e.data'
@@ -1135,6 +1098,26 @@ def transform_labeled_vertex_property_data_selector(schema, selector):
     elif ret_type == "r":
         ret = _transform_labeled_vertex_property_data_r(schema, *segments)
     return f"{ret_type}:{ret}"
+
+
+_transform_selector_func_map = {
+    "tensor": lambda _: None,
+    "vertex_data": transform_vertex_data_selector,
+    "labeled_vertex_data": transform_labeled_vertex_data_selector,
+    "vertex_property": transform_vertex_property_data_selector,
+    "labeled_vertex_property": transform_labeled_vertex_property_data_selector,
+}
+
+
+def _tranform_numpy_selector(context_type, schema, selector):
+    return _transform_selector_func_map[context_type](schema, selector)
+
+
+def _tranform_dataframe_selector(context_type, schema, selector):
+    selector = json.loads(selector)
+    transform_func = _transform_selector_func_map[context_type]
+    selector = {key: transform_func(schema, value) for key, value in selector.items()}
+    return json.dumps(selector)
 
 
 def _extract_gar(app_dir: str, attr):

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -1101,7 +1101,7 @@ def transform_labeled_vertex_property_data_selector(schema, selector):
 
 
 _transform_selector_func_map = {
-    "tensor": lambda _: None,
+    "tensor": lambda _, _2: None,
     "vertex_data": transform_vertex_data_selector,
     "labeled_vertex_data": transform_labeled_vertex_data_selector,
     "vertex_property": transform_vertex_property_data_selector,

--- a/docs/reference/gnn_engine/graph_query_en.rst
+++ b/docs/reference/gnn_engine/graph_query_en.rst
@@ -76,7 +76,7 @@ interface of ``Nodes`` is shown as follows.
 
    @property
    def labels(self):
-   """ lable，numpy.ndarray(int32)，shape is ids.shape """
+   """ label，numpy.ndarray(int32)，shape is ids.shape """
 
 Compared to the ``Nodes`` interface, ``Edges`` does not have ``ids``
 interface. Instead, it has following four additional interfaces to
@@ -150,8 +150,8 @@ interfaces as follows.
 
 ## 2.1 Vertices Query We can get Nodes by traversing the graph, sampling
 or specifying the node id. Once we get the nodes, we can query their
-attributes, weights or lables. Query vertices with specified ids:
-``python def get_nodes(node_type, ids) ''' get the weights, lables and attributes by node type Args:   node_type(string): vertex type   ids(numpy.array): vertex id Return:   Nodes object '''``
+attributes, weights or labels. Query vertices with specified ids:
+``python def get_nodes(node_type, ids) ''' get the weights, labels and attributes by node type Args:   node_type(string): vertex type   ids(numpy.array): vertex id Return:   Nodes object '''``
 
 We use the following example to show the interface and usage
 ``get_nodes()``.

--- a/docs/reference/gnn_engine/quick_start_en.rst
+++ b/docs/reference/gnn_engine/quick_start_en.rst
@@ -195,7 +195,7 @@ data format is described through ``gl.Decoder``.
 
    N_FEATURE = 1433
 
-   # Describe the vertex data format，with lable and attributes
+   # Describe the vertex data format，with label and attributes
    node_decoder = gl.Decoder(labeled=True, attr_types=["float"] * N_FEATURE)
 
    # Describe the edge data format, with weights.

--- a/python/graphscope/analytical/app/sssp.py
+++ b/python/graphscope/analytical/app/sssp.py
@@ -68,4 +68,6 @@ def property_sssp(graph, src=0):
         :class:`graphscope.framework.context.LabeledVertexDataContext`:
             A context with each vertex assigned with the shortest distance from the src, evaluated in eager mode.
     """
-    return AppAssets(algo="property_sssp", context="labeled_vertex_data")(graph, src)
+    return AppAssets(algo="property_sssp", context="labeled_vertex_property")(
+        graph, src
+    )

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -419,7 +419,7 @@ class VertexPropertyContextDAGNode(BaseContextDAGNode):
         - `v.id`: Get the Id of vertices
         - `v.data`: Get the data of vertices
             If there is any, means origin data on the graph, not results
-        - `v.lable_id`: Get the label ID of each vertex.
+        - `v.label_id`: Get the label ID of each vertex.
 
     - The syntax of selector of edge is (not supported yet):
         - `e.src`: Get the source Id of edges

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -562,6 +562,8 @@ class LabeledVertexPropertyContextDAGNode(BaseContextDAGNode):
         elif stype == "r":
             if len(segments) != 2:
                 raise SyntaxError(err_msg)
+        else:
+            raise SyntaxError(err_msg)
         return True
 
 

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -302,16 +302,15 @@ class VertexDataContextDAGNode(BaseContextDAGNode):
     def context_type(self):
         return "vertex_data"
 
-
-def _build_schema(self, result_properties):
-    v_items = [["v", "id"], ["v", "data"]]
-    r_items = [["r", ""]]
-    index = pd.MultiIndex.from_tuples(
-        itertools.chain(v_items, r_items), names=["type", "property"]
-    )
-    v_values = [f"{t}.{p}" for t, p in v_items]
-    r_values = [f"{t}" for t, _ in r_items]
-    return pd.Series(v_values + r_values, index=index, name="Context schema")
+    def _build_schema(self, result_properties):
+        v_items = [["v", "id"], ["v", "data"]]
+        r_items = [["r", ""]]
+        index = pd.MultiIndex.from_tuples(
+            itertools.chain(v_items, r_items), names=["type", "property"]
+        )
+        v_values = [f"{t}.{p}" for t, p in v_items]
+        r_values = [f"{t}" for t, _ in r_items]
+        return pd.Series(v_values + r_values, index=index, name="Context schema")
 
     def _check_selector(self, selector):
         """
@@ -534,14 +533,14 @@ class LabeledVertexPropertyContextDAGNode(BaseContextDAGNode):
 
         for label in schema.vertex_labels:
             label_id = schema.get_vertex_label_id(label)
-            props = label_property_dict.get(label_id, [])
+            props = label_property_dict.get(str(label_id), [])
             r_items.extend([["r", label, prop] for prop in props])
 
         index = pd.MultiIndex.from_tuples(
             itertools.chain(v_items, r_items), names=["type", "label", "property"]
         )
         v_values = [f"{t}:{l}.{p}" for t, l, p in v_items]
-        r_values = [f"{t}:{l}" for t, l, _ in r_items]
+        r_values = [f"{t}:{l}.{p}" for t, l, p in r_items]
         return pd.Series(v_values + r_values, index=index, name="Context schema")
 
     def _check_selector(self, selector):

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -20,7 +20,6 @@ import collections
 import hashlib
 import itertools
 import json
-import textwrap
 from copy import deepcopy
 from typing import Mapping
 
@@ -128,10 +127,6 @@ class BaseContextDAGNode(DAGNode):
 
     def _build_schema(self, result_properties):
         raise NotImplementedError()
-
-    def _format_hints(self, hints, prefix="    "):
-        ret = "\n".join([", ".join(sub_list) for sub_list in hints])
-        return textwrap.indent(ret, prefix)
 
     def to_numpy(self, selector, vertex_range=None, axis=0):
         """Get the context data as a numpy array.
@@ -325,8 +320,10 @@ class VertexDataContextDAGNode(BaseContextDAGNode):
         if selector is None:
             raise InvalidArgumentError("Selector in vertex data context cannot be None")
         segments = selector.split(".")
-        hints = self._format_hints([["v.id", "v.data"], ["r"]])
-        err_msg = f"Invalid selector: `{selector}`, choose from\n{hints}"
+        err_msg = f"Invalid selector: `{selector}`. "
+        err_msg += (
+            "Please inspect the result with `ret.schema` and choose a valid selector."
+        )
         if segments[0] == "v":
             if selector not in ("v.id", "v.data"):
                 raise SyntaxError(err_msg)
@@ -393,10 +390,10 @@ class LabeledVertexDataContextDAGNode(BaseContextDAGNode):
                 "Selector in labeled vertex data context cannot be None"
             )
         segments = selector.split(":")
-        hints = self._format_hints(
-            [["v:label_name.id", "v:label_name.property_name"], ["r:label_name"]]
+        err_msg = f"Invalid selector: `{selector}`. "
+        err_msg += (
+            "Please inspect the result with `ret.schema` and choose a valid selector."
         )
-        err_msg = f"Invalid selector: `{selector}`, choose from\n {hints}"
         if len(segments) != 2:
             raise SyntaxError(err_msg)
         stype, segments = segments[0], segments[1]
@@ -464,10 +461,10 @@ class VertexPropertyContextDAGNode(BaseContextDAGNode):
                 "Selector in vertex property context cannot be None"
             )
         segments = selector.split(".")
-        hints = self._format_hints(
-            [["v.id", "v.data", "v.label_id"], ["r:column_name"]]
+        err_msg = f"Invalid selector: `{selector}`. "
+        err_msg += (
+            "Please inspect the result with `ret.schema` and choose a valid selector."
         )
-        err_msg = f"Invalid selector: `{selector}`, choose from\n {hints}"
         if len(segments) != 2:
             raise SyntaxError(err_msg)
         if segments[0] == "v":
@@ -549,13 +546,10 @@ class LabeledVertexPropertyContextDAGNode(BaseContextDAGNode):
                 "Selector in labeled vertex property context cannot be None"
             )
         segments = selector.split(":")
-        hints = self._format_hints(
-            [
-                ["v:label_name.id", "v:label_name.property_name"],
-                ["r:label_name.column_name"],
-            ]
+        err_msg = f"Invalid selector: `{selector}`. "
+        err_msg += (
+            "Please inspect the result with `ret.schema` and choose a valid selector."
         )
-        err_msg = f"Invalid selector: `{selector}`, choose from\n {hints}"
         if len(segments) != 2:
             raise SyntaxError(err_msg)
         stype, segments = segments[0], segments[1]

--- a/python/graphscope/framework/graph_schema.py
+++ b/python/graphscope/framework/graph_schema.py
@@ -415,7 +415,7 @@ class GraphSchema:
 
     def get_vertex_label_id(self, label):
         if label not in self._v_label_index:
-            raise ValueError(f"{label} not exists.")
+            raise KeyError(f"{label} not exists.")
         idx = self._v_label_index[label]
         if not self._valid_vertices[idx]:
             raise ValueError(f"Vertex {label} not exists in graph")
@@ -423,7 +423,7 @@ class GraphSchema:
 
     def get_edge_label_id(self, label):
         if label not in self._e_label_index:
-            raise ValueError(f"{label} not exists.")
+            raise KeyError(f"{label} not exists.")
         idx = self._e_label_index[label]
         if not self._valid_edges[idx]:
             raise ValueError(f"Edge {label} not exists in graph")

--- a/python/graphscope/framework/graph_schema.py
+++ b/python/graphscope/framework/graph_schema.py
@@ -392,6 +392,8 @@ class GraphSchema:
         return [entry.relations for entry in self._valid_edge_labels()]
 
     def get_relationships(self, label):
+        if label not in self._e_label_index:
+            raise ValueError(f"{label} not exists.")
         label_id = self._e_label_index[label]
         if not self._valid_edges[label_id]:
             raise ValueError(f"{label} not exists.")
@@ -412,12 +414,16 @@ class GraphSchema:
         return self._edge_labels[self.get_edge_label_id(label)].properties
 
     def get_vertex_label_id(self, label):
+        if label not in self._v_label_index:
+            raise ValueError(f"{label} not exists.")
         idx = self._v_label_index[label]
         if not self._valid_vertices[idx]:
             raise ValueError(f"Vertex {label} not exists in graph")
         return idx
 
     def get_edge_label_id(self, label):
+        if label not in self._e_label_index:
+            raise ValueError(f"{label} not exists.")
         idx = self._e_label_index[label]
         if not self._valid_edges[idx]:
             raise ValueError(f"Edge {label} not exists in graph")

--- a/python/graphscope/framework/graph_schema.py
+++ b/python/graphscope/framework/graph_schema.py
@@ -393,7 +393,7 @@ class GraphSchema:
 
     def get_relationships(self, label):
         if label not in self._e_label_index:
-            raise ValueError(f"{label} not exists.")
+            raise KeyError(f"{label} not exists.")
         label_id = self._e_label_index[label]
         if not self._valid_edges[label_id]:
             raise ValueError(f"{label} not exists.")

--- a/python/graphscope/tests/unittest/test_app.py
+++ b/python/graphscope/tests/unittest/test_app.py
@@ -48,7 +48,7 @@ def test_create_app():
     # builtin-ldbc compatible graph: arrow_projected dynamic_projected
     # builtin-property compatible graph: arrow_property, append_only
     # builtin-property app on property graph
-    a1 = AppAssets(algo="property_sssp", context="labeled_vertex_data")
+    a1 = AppAssets(algo="property_sssp", context="labeled_vertex_property")
     # builtin app on arrow projected graph
     a2 = AppAssets(algo="sssp", context="vertex_data")
     # on dynamic projected graph

--- a/python/graphscope/tests/unittest/test_lazy.py
+++ b/python/graphscope/tests/unittest/test_lazy.py
@@ -158,20 +158,26 @@ def test_unload_app(sess):
     g = arrow_property_graph(sess)
 
     # case 1
-    a1 = AppDAGNode(g, AppAssets(algo="property_sssp", context="labeled_vertex_data"))
+    a1 = AppDAGNode(
+        g, AppAssets(algo="property_sssp", context="labeled_vertex_property")
+    )
     ua1 = a1.unload()
     assert sess.run(ua1) is None
 
     # case 2
     # unload app twice
-    a1 = AppDAGNode(g, AppAssets(algo="property_sssp", context="labeled_vertex_data"))
+    a1 = AppDAGNode(
+        g, AppAssets(algo="property_sssp", context="labeled_vertex_property")
+    )
     ua1 = a1.unload()
     assert sess.run(ua1) is None
     assert sess.run(ua1) is None
 
     # case 3
     # load app after unload
-    a1 = AppDAGNode(g, AppAssets(algo="property_sssp", context="labeled_vertex_data"))
+    a1 = AppDAGNode(
+        g, AppAssets(algo="property_sssp", context="labeled_vertex_property")
+    )
     ua1 = a1.unload()
     assert sess.run(ua1) is None
     c1 = a1(src=20)

--- a/python/graphscope/tests/unittest/test_lazy.py
+++ b/python/graphscope/tests/unittest/test_lazy.py
@@ -237,10 +237,10 @@ def test_error_selector_context(sess):
     c = property_sssp(g, 20)
     with pytest.raises(
         InvalidArgumentError,
-        match="Selector in labeled vertex data context cannot be None",
+        match="Selector in labeled vertex property context cannot be None",
     ):
         r = c.to_numpy(selector=None)
-    with pytest.raises(ValueError, match="not enough values to unpack"):
+    with pytest.raises(SyntaxError, match="Invalid selector"):
         # missing ":" in selectot
         r = c.to_numpy("r.v0.dist_0")
     with pytest.raises(SyntaxError, match="Invalid selector"):
@@ -254,9 +254,7 @@ def test_error_selector_context(sess):
     # vertex data context
     pg = g.project(vertices={"v0": ["id"]}, edges={"e0": ["weight"]})
     c = sssp(pg, 20)
-    with pytest.raises(
-        SyntaxError, match="Selector of v must be 'v.id', 'v.data' or 'v.label_id'"
-    ):
+    with pytest.raises(SyntaxError, match="Invalid selector"):
         r = c.to_dataframe({"id": "v.ID"})
     with pytest.raises(ValueError, match="selector of to_dataframe must be a dict"):
         r = c.to_dataframe("id")


### PR DESCRIPTION
1. More rigid input validation for selector
2. Use `pd.Series` and `pd.MultiIndex` to pretty print the schema
3. Fix a bug that context type of property sssp doesn't consistent across Python and C++

Schema example:

* VertexData
```python
>>> ret.schema
type  property
v     id            v.id
      data        v.data
r                      r
```

* VertexProperty
```ipython
>>> ret.schema
type  property
v     id            v.id
      data        v.data
r     auth        r.auth
      hub          r.hub
```

* LabeledVertexData
```ipython
>>> ret.schema
type  label     property
v     person    id                v:person.id
                name            v:person.name
                age              v:person.age
      software  id              v:software.id
                name          v:software.name
                lang          v:software.lang
r     person                         r:person
      software                     r:software
```


* LabeledVertexProperty
```ipython
>>> ret.schema
type  label     property
v     person    id                v:person.id
                name            v:person.name
                age              v:person.age
      software  id              v:software.id
                name          v:software.name
                lang          v:software.lang
r     person    dist_0        r:person.dist_0
      software  dist_1      r:software.dist_1
```

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes 1 ~ 7 issues of #1179

