### PR TITLE
etcd: Increate the ETCD pods period seconds

### DIFF
--- a/python/graphscope/deploy/kubernetes/resource_builder.py
+++ b/python/graphscope/deploy/kubernetes/resource_builder.py
@@ -1145,7 +1145,7 @@ class GSEtcdBuilder(object):
 
     def build_liveness_probe(self):
         liveness_cmd = self.build_probe_cmd()
-        return ExecProbeBuilder(liveness_cmd, timeout=15, failure_thresh=8)
+        return ExecProbeBuilder(liveness_cmd, timeout=15, period=10, failure_thresh=8)
 
     def build_readiness_probe(self):
         readiness_cmd = self.build_probe_cmd()

--- a/python/graphscope/deploy/kubernetes/resource_builder.py
+++ b/python/graphscope/deploy/kubernetes/resource_builder.py
@@ -1145,13 +1145,8 @@ class GSEtcdBuilder(object):
         return ExecProbeBuilder(liveness_cmd, timeout=15, period=10, failure_thresh=8)
 
     def build_readiness_probe(self):
-        return HttpProbeBuilder(
-            path="/health",
-            port=self._listen_peer_service_port,
-            http_headers=[],
-            timeout=15,
-            period=10,
-            failure_thresh=8,
+        return TcpProbeBuilder(
+            self._listen_peer_service_port, timeout=15, period=10, failure_thresh=8
         )
 
 

--- a/python/graphscope/deploy/kubernetes/resource_builder.py
+++ b/python/graphscope/deploy/kubernetes/resource_builder.py
@@ -1135,21 +1135,24 @@ class GSEtcdBuilder(object):
 
         return pods_builders, svc_builders
 
-    def build_probe_cmd(self):
-        return [
+    def build_liveness_probe(self):
+        liveness_cmd = [
             "/bin/sh",
             "-ec",
             "ETCDCTL_API=3 etcdctl --endpoints=http://[127.0.0.1]:%s get foo"
             % str(self._listen_client_service_port),
         ]
-
-    def build_liveness_probe(self):
-        liveness_cmd = self.build_probe_cmd()
         return ExecProbeBuilder(liveness_cmd, timeout=15, period=10, failure_thresh=8)
 
     def build_readiness_probe(self):
-        readiness_cmd = self.build_probe_cmd()
-        return ExecProbeBuilder(readiness_cmd, timeout=15, period=10, failure_thresh=8)
+        return HttpProbeBuilder(
+            path="/health",
+            port=self._listen_peer_service_port,
+            http_headers=[],
+            timeout=15,
+            period=10,
+            failure_thresh=8,
+        )
 
 
 class GSGraphManagerBuilder(DeploymentBuilder):


### PR DESCRIPTION

## What do these changes do?

I just increased the ETCD pods default `livenessProbe.periodSeconds` from `2` to `10`,
with the previous config
`periodSeconds * failureThreshold = 2 * 8 = 16` is a bit small~