### PR TITLE
Upload codecover report only in ubuntu20 platform

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,6 +51,7 @@ jobs:
 
     - name: Upload Coverage
       uses: codecov/codecov-action@v2
+      if: matrix.os == 'ubuntu-20.04'
       with:
         file: ./python/coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

