### PR TITLE
Bump up required vineyard version to v0.3.14 and reable HDFS IO tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,10 @@ jobs:
           make graphscope-image
           sudo docker tag graphscope/graphscope:${SHORT_SHA} ${{ env.GS_IMAGE }}:${SHORT_SHA}
 
+          cd ${GITHUB_WORKSPACE}/python
+          pip3 install -r requirements.txt
+          pip3 install -r requirements-dev.txt
+
           # build python client proto
           cd ${GITHUB_WORKSPACE}/python
           python3 setup.py build_proto

--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -32,7 +32,7 @@ jobs:
   build-gae:
     runs-on: ubuntu-20.04
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.13
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.14
       options:
         --shm-size 4096m
     steps:

--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -32,7 +32,7 @@ jobs:
   build-gae:
     runs-on: ubuntu-20.04
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.14
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.15
       options:
         --shm-size 4096m
     steps:

--- a/.github/workflows/gss.yml
+++ b/.github/workflows/gss.yml
@@ -43,7 +43,7 @@ jobs:
     # be configured manually when a new self-hosted runner is added.
     runs-on: self-hosted
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.14
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.15
     defaults:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/gss.yml
+++ b/.github/workflows/gss.yml
@@ -43,7 +43,7 @@ jobs:
     # be configured manually when a new self-hosted runner is added.
     runs-on: self-hosted
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.13
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.14
     defaults:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/networkx-forward-algo-nightly.yml
+++ b/.github/workflows/networkx-forward-algo-nightly.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.14
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.15
       options:
         --shm-size 4096m
 

--- a/.github/workflows/networkx-forward-algo-nightly.yml
+++ b/.github/workflows/networkx-forward-algo-nightly.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.13
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.14
       options:
         --shm-size 4096m
 

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -166,7 +166,7 @@ endif ()
 find_package(libgrapelite REQUIRED)
 include_directories(${LIBGRAPELITE_INCLUDE_DIRS})
 
-find_package(vineyard 0.3.13 REQUIRED)
+find_package(vineyard 0.3.14 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -166,7 +166,7 @@ endif ()
 find_package(libgrapelite REQUIRED)
 include_directories(${LIBGRAPELITE_INCLUDE_DIRS})
 
-find_package(vineyard 0.3.14 REQUIRED)
+find_package(vineyard 0.3.15 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -1407,7 +1407,6 @@ def launch_graphscope():
 
     # handle SIGTERM signal
     def terminate(signum, frame):
-        global coordinator_service_servicer
         coordinator_service_servicer._cleanup()
 
     signal.signal(signal.SIGTERM, terminate)

--- a/coordinator/gscoordinator/io_utils.py
+++ b/coordinator/gscoordinator/io_utils.py
@@ -66,6 +66,7 @@ class StdStreamWrapper(object):
             return
         line = line.encode("ascii", "ignore").decode("ascii")
         self._stream_backup.write(line)
+        self._stream_backup.flush()
         if not self._drop:
             self._lines.put(line)
 

--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -5,5 +5,5 @@ grpcio
 kubernetes
 protobuf
 PyYAML
-vineyard>=0.3.12
-vineyard-io>=0.3.12
+vineyard>=0.3.14; sys_platform != "win32"
+vineyard-io>=0.3.14; sys_platform != "win32"

--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -5,5 +5,5 @@ grpcio
 kubernetes
 protobuf
 PyYAML
-vineyard>=0.3.14; sys_platform != "win32"
-vineyard-io>=0.3.14; sys_platform != "win32"
+vineyard>=0.3.15; sys_platform != "win32"
+vineyard-io>=0.3.15; sys_platform != "win32"

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -40,7 +40,7 @@ else
 endif
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.3.13
+VINEYARD_VERSION ?= v0.3.14
 PROFILE ?= release
 
 

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -40,7 +40,7 @@ else
 endif
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.3.14
+VINEYARD_VERSION ?= v0.3.15
 PROFILE ?= release
 
 

--- a/k8s/graphscope-dev.Dockerfile
+++ b/k8s/graphscope-dev.Dockerfile
@@ -4,7 +4,7 @@
 # the result image includes all runtime stuffs of graphscope, with analytical engine,
 # learning engine and interactive engine installed.
 
-ARG BASE_VERSION=v0.3.14
+ARG BASE_VERSION=v0.3.15
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG NETWORKX=ON

--- a/k8s/graphscope-dev.Dockerfile
+++ b/k8s/graphscope-dev.Dockerfile
@@ -4,7 +4,7 @@
 # the result image includes all runtime stuffs of graphscope, with analytical engine,
 # learning engine and interactive engine installed.
 
-ARG BASE_VERSION=v0.3.13
+ARG BASE_VERSION=v0.3.14
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG NETWORKX=ON

--- a/k8s/graphscope-store.Dockerfile
+++ b/k8s/graphscope-store.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=v0.3.13
+ARG BASE_VERSION=v0.3.14
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG CI=true

--- a/k8s/graphscope-store.Dockerfile
+++ b/k8s/graphscope-store.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=v0.3.14
+ARG BASE_VERSION=v0.3.15
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG CI=true

--- a/k8s/graphscope.Dockerfile
+++ b/k8s/graphscope.Dockerfile
@@ -24,6 +24,17 @@ RUN sed -i 's/archive.ubuntu.com/mirrors.ustc.edu.cn/g' /etc/apt/sources.list &&
       curl git openjdk-8-jdk python3-pip sudo && \
     apt clean && rm -fr /var/lib/apt/lists/*
 
+# install hadoop
+RUN cd /tmp && \
+    curl -LO https://archive.apache.org/dist/hadoop/core/hadoop-2.8.4/hadoop-2.8.4.tar.gz && \
+    tar zxf hadoop-2.8.4.tar.gz -C /usr/local && \
+    rm -rf hadoop-2.8.4.tar.gz
+
+ENV HADOOP_HOME /usr/local/hadoop-2.8.4
+ENV HADOOP_CONF_DIR $HADOOP_HOME/etc/hadoop
+ENV HADOOP_COMMON_LIB_NATIVE_DIR $HADOOP_HOME/lib/native
+ENV PATH $PATH:$HADOOP_HOME/bin
+
 # kubectl v1.19.2
 RUN cd /tmp && export KUBE_VER=v1.19.2 && \
     curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBE_VER}/bin/linux/amd64/kubectl && \

--- a/k8s/gsvineyard.Dockerfile
+++ b/k8s/gsvineyard.Dockerfile
@@ -27,7 +27,7 @@ RUN sudo mkdir -p /opt/vineyard && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.14 https://github.com/v6d-io/v6d.git --depth=1 && \
+    git clone -b v0.3.15 https://github.com/v6d-io/v6d.git --depth=1 && \
     cd v6d && \
     git submodule update --init && \
     mkdir -p /tmp/v6d/build && \

--- a/k8s/gsvineyard.Dockerfile
+++ b/k8s/gsvineyard.Dockerfile
@@ -5,6 +5,17 @@
 ARG BASE_VERSION=latest
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-runtime:$BASE_VERSION
 
+# build & install fastffi
+RUN cd /opt/ && \
+    sudo git clone https://github.com/alibaba/fastFFI.git && \
+    sudo chown -R $(id -u):$(id -g) /opt/fastFFI && \
+    cd fastFFI && \
+    git checkout a166c6287f2efb938c27fb01b3d499932d484f9c && \
+    export PATH=${PATH}:${LLVM11_HOME}/bin && \
+    mvn clean install -DskipTests
+
+ENV LLVM4JNI_HOME=/opt/fastFFI/llvm4jni
+
 RUN sudo mkdir -p /opt/vineyard && \
     sudo chown -R $(id -u):$(id -g) /opt/vineyard && \
     cd /tmp && \
@@ -16,7 +27,7 @@ RUN sudo mkdir -p /opt/vineyard && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.13 https://github.com/v6d-io/v6d.git --depth=1 && \
+    git clone -b v0.3.14 https://github.com/v6d-io/v6d.git --depth=1 && \
     cd v6d && \
     git submodule update --init && \
     mkdir -p /tmp/v6d/build && \
@@ -39,15 +50,3 @@ RUN sudo mkdir -p /opt/vineyard && \
     sudo cp -r /opt/vineyard/* /usr/local/ && \
     cd /tmp && \
     rm -fr /tmp/v6d /tmp/libgrape-lite
-
-# build & install fastffi
-RUN cd /opt/ && \
-    sudo git clone https://github.com/alibaba/fastFFI.git && \
-    sudo chown -R $(id -u):$(id -g) /opt/fastFFI && \
-    cd fastFFI && \
-    git checkout a166c6287f2efb938c27fb01b3d499932d484f9c && \
-    export PATH=${PATH}:${LLVM11_HOME}/bin && \
-    mvn clean install -DskipTests
-
-ENV LLVM4JNI_HOME=/opt/fastFFI/llvm4jni
-

--- a/k8s/ubuntu/gsvineyard.Dockerfile
+++ b/k8s/ubuntu/gsvineyard.Dockerfile
@@ -14,7 +14,7 @@ RUN cd /tmp && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.14 https://github.com/v6d-io/v6d.git --depth=1 && \
+    git clone -b v0.3.15 https://github.com/v6d-io/v6d.git --depth=1 && \
     cd v6d && \
     git submodule update --init && \
     mkdir -p /tmp/v6d/build && \

--- a/k8s/ubuntu/gsvineyard.Dockerfile
+++ b/k8s/ubuntu/gsvineyard.Dockerfile
@@ -14,7 +14,7 @@ RUN cd /tmp && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.3.13 https://github.com/v6d-io/v6d.git --depth=1 && \
+    git clone -b v0.3.14 https://github.com/v6d-io/v6d.git --depth=1 && \
     cd v6d && \
     git submodule update --init && \
     mkdir -p /tmp/v6d/build && \

--- a/python/graphscope/framework/utils.py
+++ b/python/graphscope/framework/utils.py
@@ -61,6 +61,7 @@ class PipeWatcher(object):
                 if self._filter(line):
                     try:
                         self._sink.write(line)
+                        self._sink.flush()
                         if not self._drop:
                             self._lines.put(line)
                     except:  # noqa: E722

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -112,6 +112,7 @@ def p2p_property_dir():
     return "/testingdata/property"
 
 
+@pytest.mark.skipif("HDFS_HOST" in os.environ, "HDFS not specified")
 def test_demo_on_hdfs(gs_session_distributed):
     graph = gs_session_distributed.g()
     graph = graph.add_vertices(

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -112,7 +112,7 @@ def p2p_property_dir():
     return "/testingdata/property"
 
 
-@pytest.mark.skipif("HDFS_HOST" in os.environ, reason="HDFS not specified")
+@pytest.mark.skipif("HDFS_HOST" not in os.environ, reason="HDFS not specified")
 def test_demo_on_hdfs(gs_session_distributed):
     graph = gs_session_distributed.g()
     graph = graph.add_vertices(

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -112,7 +112,6 @@ def p2p_property_dir():
     return "/testingdata/property"
 
 
-@pytest.mark.skip(reason="waiting for vineyard_read_vineyard_dataframe in v6d package")
 def test_demo_on_hdfs(gs_session_distributed):
     graph = gs_session_distributed.g()
     graph = graph.add_vertices(
@@ -261,7 +260,7 @@ def test_query_modern_graph(
     modern_bytecode(g)
 
 
-@pytest.mark.skip(reason="waiting for vineyard_read_vineyard_dataframe in v6d package")
+@pytest.mark.skip(reason="waiting for vineyard_serialize in v6d package")
 def test_serialize_roundtrip(gs_session_distributed, p2p_property_dir):
     graph = gs_session_distributed.g(generate_eid=False)
     graph = graph.add_vertices(f"{p2p_property_dir}/p2p-31_property_v_0", "person")

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -112,7 +112,7 @@ def p2p_property_dir():
     return "/testingdata/property"
 
 
-@pytest.mark.skipif("HDFS_HOST" in os.environ, "HDFS not specified")
+@pytest.mark.skipif("HDFS_HOST" in os.environ, reason="HDFS not specified")
 def test_demo_on_hdfs(gs_session_distributed):
     graph = gs_session_distributed.g()
     graph = graph.add_vertices(

--- a/python/graphscope/tests/unittest/test_context.py
+++ b/python/graphscope/tests/unittest/test_context.py
@@ -111,7 +111,6 @@ def test_add_column(arrow_property_graph, property_context):
     assert "result_1" in [p.name for p in g2.schema.get_vertex_properties("v1")]
 
 
-@pytest.mark.skip(reason="waiting for vineyard_read_vineyard_dataframe in v6d package")
 def test_context_output(simple_context):
     simple_context.output(
         fd="file:///tmp/rlt.csv",

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,5 +14,5 @@ pyarrow
 PyYAML
 scipy
 tqdm
-vineyard>=0.3.14; sys_platform != "win32"
-vineyard-io>=0.3.14; sys_platform != "win32"
+vineyard>=0.3.15; sys_platform != "win32"
+vineyard-io>=0.3.15; sys_platform != "win32"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -14,5 +14,5 @@ pyarrow
 PyYAML
 scipy
 tqdm
-vineyard>=0.3.12; sys_platform != "win32" and platform_machine == 'x86_64'
-vineyard-io>=0.3.12; sys_platform != "win32" and platform_machine == 'x86_64'
+vineyard>=0.3.14; sys_platform != "win32"
+vineyard-io>=0.3.14; sys_platform != "win32"

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.3.14"  # vineyard version
-readonly V6D_BRANCH="v0.3.14" # vineyard branch
+readonly V6D_VERSION="0.3.15"  # vineyard version
+readonly V6D_BRANCH="v0.3.15" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.3.13"  # vineyard version
-readonly V6D_BRANCH="v0.3.13" # vineyard branch
+readonly V6D_VERSION="0.3.14"  # vineyard version
+readonly V6D_BRANCH="v0.3.14" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true


### PR DESCRIPTION

## What do these changes do?

Upgrade vineyard to v0.3.14 to leverage the new IO adaptors to make hdfs IO works.

## Related issue number

Fixes #1183 

