### PR TITLE
Fix error when selecting from empty graph

### DIFF
--- a/analytical_engine/core/utils/transform_utils.h
+++ b/analytical_engine/core/utils/transform_utils.h
@@ -882,6 +882,9 @@ class TransformUtils<
       return vineyard::TypeToInt<int64_t>::value;
     } else if (folly_type == folly::dynamic::STRING) {
       return vineyard::TypeToInt<std::string>::value;
+    } else {
+      // if is folly::NULLT, return 0, means np.dtype(void) in numpy
+      return 0;
     }
     return -1;
   }

--- a/python/graphscope/nx/tests/test_ctx_builtin.py
+++ b/python/graphscope/nx/tests/test_ctx_builtin.py
@@ -162,6 +162,7 @@ class TestBuiltInApp:
                 "{}/p2p-31-kcore".format(data_dir), sep=" ", header=None, prefix=""
             ).values
         )
+        cls.empty_pagerank_ans = {}
 
     def assert_result_almost_equal(self, r1, r2):
         assert len(r1) == len(r2)
@@ -339,3 +340,8 @@ class TestBuiltInApp:
         assert len(ans) == 1022
         ans = nx.builtin.all_simple_paths(self.p2p_undirected, 1, [4, 6], cutoff=5)
         assert len(ans) == 1675
+
+    def test_pagerank_on_empty(self):
+        eg = nx.null_graph()
+        ans = nx.builtin.pagerank(eg)
+        self.assert_result_almost_equal(ans, self.empty_pagerank_ans)


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Fix an error when selecting from empty graph by setting the corresponding numpy dtype of `folly::NULLT` to `np.dtype('void')`.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1194

