### PR TITLE
Bring back mars support, re-enable mars test in CI, and fixes several related issues.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,7 @@ jobs:
           python3 setup.py build_proto
 
           # install mars
-          python3 -m pip install git+https://github.com/mars-project/mars.git@92d4959511ff9fa107b458239e7c1022baec3325#egg=pymars
+          python3 -m pip install pymars==0.8.0
 
           # install pytest
           python3 -m pip install pytest pytest-cov

--- a/coordinator/gscoordinator/cluster.py
+++ b/coordinator/gscoordinator/cluster.py
@@ -147,8 +147,8 @@ class KubernetesClusterLauncher(Launcher):
     _etcd_container_name = "etcd"
     _engine_container_name = "engine"  # fixed
 
-    _mars_scheduler_container_name = "marsscheduler"  # fixed
-    _mars_worker_container_name = "marsworker"  # fixed
+    _mars_scheduler_container_name = "mars"  # fixed
+    _mars_worker_container_name = "mars"  # fixed
     _mars_scheduler_name_prefix = "marsscheduler-"
     _mars_service_name_prefix = "mars-"
 
@@ -1009,7 +1009,7 @@ class KubernetesClusterLauncher(Launcher):
         logger.debug("vineyard rpc runs on %s", self._vineyard_service_endpoint)
         if self._saved_locals["with_mars"]:
             self._mars_service_endpoint = (
-                "https://" + self._get_mars_scheduler_service_endpoint()
+                "http://" + self._get_mars_scheduler_service_endpoint()
             )
             logger.debug("mars scheduler runs on %s", self._mars_service_endpoint)
         logger.info("GraphScope engines pod is ready.")

--- a/coordinator/gscoordinator/cluster.py
+++ b/coordinator/gscoordinator/cluster.py
@@ -159,7 +159,8 @@ class KubernetesClusterLauncher(Launcher):
 
     _vineyard_service_port = 9600  # fixed
     _mars_scheduler_port = 7103  # fixed
-    _mars_worker_port = 7104  # fixed
+    _mars_scheduler_web_port = 7104  # fixed
+    _mars_worker_port = 7105  # fixed
 
     def __init__(
         self,
@@ -432,7 +433,7 @@ class KubernetesClusterLauncher(Launcher):
         service_builder = ServiceBuilder(
             self._mars_service_name,
             service_type=self._saved_locals["service_type"],
-            port=self._mars_scheduler_port,
+            port=[self._mars_scheduler_port, self._mars_scheduler_web_port],
             selector=labels,
         )
         self._resource_object.append(
@@ -520,6 +521,7 @@ class KubernetesClusterLauncher(Launcher):
                 mem=self._saved_locals["mars_scheduler_mem"],
                 preemptive=self._saved_locals["preemptive"],
                 port=self._mars_scheduler_port,
+                web_port=self._mars_scheduler_web_port,
             )
         for name in self._image_pull_secrets:
             scheduler_builder.add_image_pull_secret(name)
@@ -790,6 +792,7 @@ class KubernetesClusterLauncher(Launcher):
             namespace=self._saved_locals["namespace"],
             name=self._mars_service_name,
             service_type=self._saved_locals["service_type"],
+            query_port=self._mars_scheduler_web_port,
         )
         return endpoints[0]
 
@@ -1005,7 +1008,9 @@ class KubernetesClusterLauncher(Launcher):
         self._vineyard_service_endpoint = self._get_vineyard_service_endpoint()
         logger.debug("vineyard rpc runs on %s", self._vineyard_service_endpoint)
         if self._saved_locals["with_mars"]:
-            self._mars_service_endpoint = self._get_mars_scheduler_service_endpoint()
+            self._mars_service_endpoint = (
+                "https://" + self._get_mars_scheduler_service_endpoint()
+            )
             logger.debug("mars scheduler runs on %s", self._mars_service_endpoint)
         logger.info("GraphScope engines pod is ready.")
 

--- a/k8s/graphscope-dev.Dockerfile
+++ b/k8s/graphscope-dev.Dockerfile
@@ -67,7 +67,7 @@ COPY --from=builder /home/graphscope/gs/interactive_engine/executor/target/$prof
 COPY --from=builder /home/graphscope/gs/interactive_engine/assembly/target/maxgraph-assembly-0.0.1-SNAPSHOT.tar.gz /opt/graphscope/maxgraph-assembly-0.0.1-SNAPSHOT.tar.gz
 
 # install mars
-RUN pip3 install git+https://github.com/mars-project/mars.git@d09e1e4c3e32ceb05f42d0b5b79775b1ebd299fb#egg=pymars
+RUN python3 -m pip install pymars==0.8.0
 
 RUN sudo tar -xf /opt/graphscope/maxgraph-assembly-0.0.1-SNAPSHOT.tar.gz --strip-components 1 -C /opt/graphscope \
   && cd /usr/local/dist && pip3 install ./*.whl \

--- a/k8s/graphscope.Dockerfile
+++ b/k8s/graphscope.Dockerfile
@@ -69,7 +69,7 @@ RUN cd /home/graphscope/gs && \
         python3 -m pip install --no-cache-dir graphscope; \
     fi && \
     sudo rm -fr /home/graphscope/gs && cd ${HOME} && \
-    python3 -m pip install --no-cache-dir git+https://github.com/mars-project/mars.git@d09e1e4c3e32ceb05f42d0b5b79775b1ebd299fb#egg=pymars
+    python3 -m pip install --no-cache-dir pymars==0.8.0
 
 # init log directory
 RUN sudo mkdir /var/log/graphscope \

--- a/python/graphscope/config.py
+++ b/python/graphscope/config.py
@@ -65,9 +65,9 @@ class GSConfig(object):
 
     # mars resource configuration
     mars_worker_cpu = 0.2
-    mars_worker_mem = "512Mi"
+    mars_worker_mem = "4Mi"
     mars_scheduler_cpu = 0.2
-    mars_scheduler_mem = "512Mi"
+    mars_scheduler_mem = "2Mi"
 
     # launch graphscope with mars
     with_mars = False

--- a/python/graphscope/deploy/kubernetes/resource_builder.py
+++ b/python/graphscope/deploy/kubernetes/resource_builder.py
@@ -812,7 +812,7 @@ class GSEngineBuilder(ReplicaSetBuilder):
         self, name, image, cpu, mem, preemptive, port, scheduler_endpoint
     ):
         # compute n cpu, to avoid mars worker launches too many actors
-        if isinstance(cpu, str) and cpu[-1] == 'm':
+        if isinstance(cpu, str) and cpu[-1] == "m":
             n_cpu = math.ceil(int("200m"[:-1]) / 1000)
         if isinstance(cpu, (int, float)):
             n_cpu = math.ceil(cpu)

--- a/python/graphscope/deploy/kubernetes/utils.py
+++ b/python/graphscope/deploy/kubernetes/utils.py
@@ -213,7 +213,7 @@ class KubernetesPodWatcher(object):
                 )
 
 
-def get_service_endpoints(
+def get_service_endpoints(  # noqa: C901
     api_client,
     namespace,
     name,

--- a/python/graphscope/deploy/kubernetes/utils.py
+++ b/python/graphscope/deploy/kubernetes/utils.py
@@ -214,7 +214,12 @@ class KubernetesPodWatcher(object):
 
 
 def get_service_endpoints(
-    api_client, namespace, name, service_type, timeout_seconds=60
+    api_client,
+    namespace,
+    name,
+    service_type,
+    timeout_seconds=60,
+    query_port=None,
 ):
     """Get service endpoint by service name and service type.
 
@@ -259,7 +264,8 @@ def get_service_endpoints(
         for pod in pods.items:
             ips.append(pod.status.host_ip)
         for port in svc.spec.ports:
-            ports.append(port.node_port)
+            if query_port is None or port.port == query_port:
+                ports.append(port.node_port)
     elif service_type == "LoadBalancer":
         while True:
             svc = core_api.read_namespaced_service(name=name, namespace=namespace)
@@ -270,7 +276,8 @@ def get_service_endpoints(
                     else:
                         ips.append(ingress.ip)
                 for port in svc.spec.ports:
-                    ports.append(port.port)
+                    if query_port is None or port.port == query_port:
+                        ports.append(port.port)
                 break
             time.sleep(1)
             if time.time() - start_time > timeout_seconds:
@@ -278,7 +285,8 @@ def get_service_endpoints(
     elif service_type == "ClusterIP":
         ips.append(svc.spec.cluster_ip)
         for port in svc.spec.ports:
-            ports.append(port.port)
+            if query_port is None or port.port == query_port:
+                ports.append(port.port)
     else:
         raise K8sError("Service type {0} is not supported yet".format(service_type))
 

--- a/python/graphscope/tests/kubernetes/test_with_mars.py
+++ b/python/graphscope/tests/kubernetes/test_with_mars.py
@@ -49,7 +49,7 @@ def get_gs_image_on_ci_env():
 def gs_session():
     gs_image = get_gs_image_on_ci_env()
     sess = graphscope.session(
-        num_workers=1,
+        num_workers=2,
         k8s_gs_image=gs_image,
         k8s_coordinator_cpu=2,
         k8s_coordinator_mem="4Gi",

--- a/python/graphscope/tests/kubernetes/test_with_mars.py
+++ b/python/graphscope/tests/kubernetes/test_with_mars.py
@@ -68,7 +68,7 @@ def gs_session():
     sess.close()
 
 
-@pytest.mark.skip(reason="Requires our runtime image has Python>=3.7.")
+@pytest.mark.skipif('WITH_MARS' is not os.environ, reason="Mars tests is not enabled.")
 def test_mars_session(gs_session):
     from mars import new_session
     from mars import tensor as mt

--- a/python/graphscope/tests/kubernetes/test_with_mars.py
+++ b/python/graphscope/tests/kubernetes/test_with_mars.py
@@ -68,7 +68,7 @@ def gs_session():
     sess.close()
 
 
-@pytest.mark.skipif('WITH_MARS' is not os.environ, reason="Mars tests is not enabled.")
+@pytest.mark.skipif("WITH_MARS" is not os.environ, reason="Mars tests is not enabled.")
 def test_mars_session(gs_session):
     from mars import new_session
     from mars import tensor as mt


### PR DESCRIPTION

## What do these changes do?

The mars's web session is expose to the client, the default session won't work as we use the `fixed` backend for services when launching mars's scheduler.

The mars test is disable by default on CI, and can be enabled by export a environment variable `WITH_MARS`. The test case has been manually validated.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A

