### PR TITLE
Guard folly headers when NETWORKX=OFF

### DIFF
--- a/analytical_engine/apps/bfs/bfs_generic.h
+++ b/analytical_engine/apps/bfs/bfs_generic.h
@@ -127,7 +127,6 @@ class BFSGeneric : public AppBase<FRAG_T, BFSGenericContext<FRAG_T>>,
     auto& visited = ctx.visited;
     auto& predecessor = ctx.predecessor;
     auto source_id = ctx.source_id;
-    size_t row_num = 0;
     std::vector<std::pair<vid_t, vid_t>> bfs_edges;
 
     if (output_format == "edges") {

--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -20,8 +20,11 @@
 
 #include "boost/algorithm/string.hpp"
 #include "boost/algorithm/string/split.hpp"
+
+#ifdef NETWORKX
 #include "folly/dynamic.h"
 #include "folly/json.h"
+#endif
 
 #include "vineyard/io/io/io_factory.h"
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Fix the build error when `NETWORKX=OFF`
Remove a warning.
