### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -203,26 +203,26 @@ jobs:
         tar xzf Python-3.7.9.tgz
         cd Python-3.7.9 && ./configure --enable-optimizations --enable-shared
         make altinstall
-        python3.7 -m pip install --upgrade pip --user
+        python3 -m pip install --upgrade pip --user
 
         # install graphscope-client
         cd ${GITHUB_WORKSPACE}/artifacts
         tar -zxf ./wheel-${{ github.sha }}/client.tar.gz
         pushd python/dist/wheelhouse
-        for f in * ; do python3.7 -m pip install $f --user || true; done
+        for f in * ; do python3 -m pip install $f --user || true; done
         popd
 
         # install graphscope
         tar -zxf ./wheel-${{ github.sha }}/graphscope.tar.gz
         pushd coordinator/dist/wheelhouse
-        python3.7 -m pip install ./*.whl --user
+        python3 -m pip install ./*.whl --user
         popd
         pushd coordinator/dist
-        python3.7 -m pip install ./*.whl --user || true
+        python3 -m pip install ./*.whl --user || true
         popd
 
         # install tensorflow
-        python3.7 -m pip install pytest "tensorflow<=2.5.2" --user
+        python3 -m pip install pytest "tensorflow<=2.5.2" --user
         # install jdk
         dnf install -y java-11-openjdk-devel
 
@@ -232,5 +232,6 @@ jobs:
       run: |
         # python3-Cython version is too old, use cython installed by pip in $HOME/.local/bin
         export PATH=$HOME/.local/bin:$PATH
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib:/usr/lib:/usr/local/lib
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
-        python3.7 -m pytest -s -v $(dirname $(python3.7 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
+        python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -201,28 +201,28 @@ jobs:
         # install python3.7
         cd /tmp && wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz
         tar xzf Python-3.7.9.tgz
-        cd Python-3.7.9 && ./configure --enable-optimizations
-        make install
-        python3 -m pip install --upgrade pip --user
+        cd Python-3.7.9 && ./configure --enable-optimizations --enable-shared
+        make altinstall
+        python3.7 -m pip install --upgrade pip --user
 
         # install graphscope-client
         cd ${GITHUB_WORKSPACE}/artifacts
         tar -zxf ./wheel-${{ github.sha }}/client.tar.gz
         pushd python/dist/wheelhouse
-        for f in * ; do python3 -m pip install $f --user || true; done
+        for f in * ; do python3.7 -m pip install $f --user || true; done
         popd
 
         # install graphscope
         tar -zxf ./wheel-${{ github.sha }}/graphscope.tar.gz
         pushd coordinator/dist/wheelhouse
-        python3 -m pip install ./*.whl --user
+        python3.7 -m pip install ./*.whl --user
         popd
         pushd coordinator/dist
-        python3 -m pip install ./*.whl --user || true
+        python3.7 -m pip install ./*.whl --user || true
         popd
 
         # install tensorflow
-        python3 -m pip install pytest "tensorflow<=2.5.2" --user
+        python3.7 -m pip install pytest "tensorflow<=2.5.2" --user
         # install jdk
         dnf install -y java-11-openjdk-devel
 
@@ -233,4 +233,4 @@ jobs:
         # python3-Cython version is too old, use cython installed by pip in $HOME/.local/bin
         export PATH=$HOME/.local/bin:$PATH
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
-        python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
+        python3.7 -m pytest -s -v $(dirname $(python3.7 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -7,6 +7,9 @@ on:
     # last modified the cron syntax in the workflow file.
     # Trigger the workflow at 03:00(CST) every day.
     - cron:  '00 19 * * *'
+  pull_request:
+    branches:
+      - main
   push:
     tags:
       - "v*"
@@ -17,7 +20,7 @@ env:
 
 jobs:
   build-wheels:
-    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
 
     steps:
@@ -127,7 +130,7 @@ jobs:
         sudo docker push ${{ env.GS_IMAGE }}:${{ steps.tag.outputs.TAG }}
 
   ubuntu-python-test:
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     needs: [build-wheels]
     strategy:
@@ -177,7 +180,7 @@ jobs:
         python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
 
   centos-test:
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     needs: [build-wheels]
     container:

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -132,7 +132,7 @@ jobs:
     needs: [build-wheels]
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/download-artifact@v2
@@ -193,10 +193,13 @@ jobs:
     - name: Prepare Environment
       shell: bash
       run: |
-        yum install -y gcc gcc-c++ make cmake
+        dnf install -y gcc gcc-c++ openssl-devel bzip2-devel libffi-devel wget make cmake git
 
-        # install git and python3
-        yum install -y git python3-pip python3-devel
+        # install python3.7
+        cd /tmp && wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz
+        tar xzf Python-3.7.9.tgz
+        cd Python-3.7.9 && ./configure --enable-optimizations
+        make install
         python3 -m pip install --upgrade pip --user
 
         # install graphscope-client
@@ -218,7 +221,7 @@ jobs:
         # install tensorflow
         python3 -m pip install pytest "tensorflow<=2.5.2" --user
         # install jdk
-        yum install -y java-11-openjdk-devel
+        dnf install -y java-11-openjdk-devel
 
     - name: Run Minimum Test
       env:

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -202,7 +202,7 @@ jobs:
         cd /tmp && wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz
         tar xzf Python-3.7.9.tgz
         cd Python-3.7.9 && ./configure --enable-optimizations --enable-shared
-        make altinstall
+        make install
         python3 -m pip install --upgrade pip --user
 
         # install graphscope-client

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -7,9 +7,6 @@ on:
     # last modified the cron syntax in the workflow file.
     # Trigger the workflow at 03:00(CST) every day.
     - cron:  '00 19 * * *'
-  pull_request:
-    branches:
-      - main
   push:
     tags:
       - "v*"
@@ -20,7 +17,7 @@ env:
 
 jobs:
   build-wheels:
-    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
 
     steps:
@@ -130,7 +127,7 @@ jobs:
         sudo docker push ${{ env.GS_IMAGE }}:${{ steps.tag.outputs.TAG }}
 
   ubuntu-python-test:
-    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     needs: [build-wheels]
     strategy:
@@ -180,7 +177,7 @@ jobs:
         python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
 
   centos-test:
-    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     needs: [build-wheels]
     container:
@@ -196,10 +193,10 @@ jobs:
     - name: Prepare Environment
       shell: bash
       run: |
-        dnf install -y gcc gcc-c++ openssl-devel bzip2-devel libffi-devel wget make cmake git
+        dnf install -y gcc gcc-c++  make cmake
 
-        # install python3
-        dnf install -y python38 python38-devel
+        # install git and python3
+        dnf install -y git python38 python38-devel
         python3 -m pip install --upgrade pip --user
 
         # install graphscope-client

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -198,11 +198,8 @@ jobs:
       run: |
         dnf install -y gcc gcc-c++ openssl-devel bzip2-devel libffi-devel wget make cmake git
 
-        # install python3.7
-        cd /tmp && wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz
-        tar xzf Python-3.7.9.tgz
-        cd Python-3.7.9 && ./configure --enable-optimizations --enable-shared
-        make install
+        # install python3
+        dnf install -y python38 python38-devel
         python3 -m pip install --upgrade pip --user
 
         # install graphscope-client
@@ -232,6 +229,5 @@ jobs:
       run: |
         # python3-Cython version is too old, use cython installed by pip in $HOME/.local/bin
         export PATH=$HOME/.local/bin:$PATH
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/lib:/usr/lib:/usr/local/lib
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
         python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2.3.2
@@ -97,7 +97,7 @@ jobs:
     needs: [build-wheels, build-client-wheels]
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/download-artifact@v2
@@ -115,7 +115,7 @@ jobs:
         tar -zxf ./wheel-macos-${{ github.sha }}-${{ matrix.python-version }}/client.tar.gz
         mv ${GITHUB_WORKSPACE}/artifacts/python/dist/wheelhouse/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
 
-        if [ "$PYTHON" == "3.6" ]; then
+        if [ "$PYTHON" == "3.7" ]; then
           tar -zxf ./wheel-macos-${{ github.sha }}/graphscope.tar.gz
           mv ${GITHUB_WORKSPACE}/artifacts/coordinator/dist/wheelhouse/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
         fi
@@ -142,7 +142,7 @@ jobs:
     needs: [build-wheels, build-client-wheels]
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/download-artifact@v2

--- a/README-zh.md
+++ b/README-zh.md
@@ -34,7 +34,7 @@ GraphScope 支持本地运行，或在 [Kubernetes (k8s)](https://kubernetes.io/
 pip3 install graphscope
 ```
 
-注意 `graphscope` 的版本要求，需要 `Python` >= 3.6 及 `pip` >= 19.0.
+注意 `graphscope` 的版本要求，需要 `Python` >= 3.7 及 `pip` >= 19.0.
 
 GraphScope 包在大多数流行的Linux发行版 （Ubuntu 18.04+ / Centos 7+) 与 macOS 10.15+ 上测试通过，对于 Windows 用户，需要在 WSL2 上安装 Ubuntu 来使用 GraphScope。
 

--- a/coordinator/setup.py
+++ b/coordinator/setup.py
@@ -382,7 +382,6 @@ setup(
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/docs/frequently_asked_questions.rst
+++ b/docs/frequently_asked_questions.rst
@@ -5,7 +5,7 @@ If you don't find an answer to your question here, feel free to file a `Issues`_
 
 1. What are the minimum resources and system requirements required to run GraphScope?
 
-    To use GraphScope Python interface, **Python >= 3.6** and **pip >= 19.0** is required.
+    To use GraphScope Python interface, **Python >= 3.7** and **pip >= 19.0** is required.
     GraphScope engine can be deployed in standalone mode or distributed mode. For standalone deployment, the mininum requirement is  **4 cores CPU** and **8G memory**.
 
     GraphScope is tested and supported on the following systems:
@@ -29,7 +29,7 @@ If you don't find an answer to your question here, feel free to file a `Issues`_
     To enable verbose logging, turn on it by this:
 
     .. code:: python
-       
+
        graphscope.set_option(show_log=True)
 
     If you are running GraphScope in k8s, you can use `kubectl describe/logs <https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands>`_ to check the log/status of the cluster. If the disk storage is accessible(on local or via Pods), you may also find logs in `/tmp/gs/runtime/logs`.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 GraphScope is tested and supported on the following 64-bit systems:
 
 - gcc 7.1+
-- Python 3.6 - 3.9
+- Python 3.7 - 3.9
 - Ubuntu 18.04 or later
 - CentOS 7 or later
 - macOS 11.2.1 (Big Sur) or later, with both Intel chip and Apple M1 chip
@@ -32,7 +32,7 @@ Install GraphScope Client for Kubernetes
 For quickly getting started, we set up a local kubernetes cluster and take advantage of pre-built Docker images as follows.
 The following dependencies or tools are required.
 
-- Python 3.6 - 3.9
+- Python 3.7 - 3.9
 - Local Kubernetes cluster set-up tool (e.g. `Kind <https://kind.sigs.k8s.io>`_)
 
 On Windows and macOS, you can follow the official guides to install them and enable Kubernetes in Docker.

--- a/docs/zh/installation.rst
+++ b/docs/zh/installation.rst
@@ -4,7 +4,7 @@
 GraphScope 目前支持的平台如下:
 
 - gcc 7.1+
-- Python 3.6 - 3.9
+- Python 3.7 - 3.9
 - Ubuntu 18.04 or later
 - CentOS 7 or later
 - macOS 11.2.1 (Big Sur) or later, with both Intel chip and Apple M1 chip
@@ -33,7 +33,7 @@ GraphScope 以 `Python 程序包 <https://pypi.org/project/graphscope>`_ 的形�
 
 首先需要预先安装以下依赖。
 
-- Python 3.6 - 3.9 (with pip)
+- Python 3.7 - 3.9 (with pip)
 - Local Kubernetes cluster set-up tool (e.g. `Kind <https://kind.sigs.k8s.io>`_)
 
 对于 Windows 和 MacOS 的用户，可通过官方文档来安装上述依赖, 并在 Docker 中开启 Kubernetes 功能。

--- a/python/graphscope/__init__.py
+++ b/python/graphscope/__init__.py
@@ -17,6 +17,7 @@
 #
 
 import sys
+
 if sys.version_info[:2] < (3, 7):
     m = "Python 3.7 or later is required for GraphScope (%d.%d detected)."
     raise ImportError(m % sys.version_info[:2])

--- a/python/graphscope/__init__.py
+++ b/python/graphscope/__init__.py
@@ -16,6 +16,12 @@
 # limitations under the License.
 #
 
+import sys
+if sys.version_info[:2] < (3, 7):
+    m = "Python 3.7 or later is required for GraphScope (%d.%d detected)."
+    raise ImportError(m % sys.version_info[:2])
+del sys
+
 from graphscope.analytical.app import *
 from graphscope.analytical.udf import declare
 from graphscope.analytical.udf.types import Vertex

--- a/python/graphscope/__init__.py
+++ b/python/graphscope/__init__.py
@@ -16,13 +16,6 @@
 # limitations under the License.
 #
 
-import sys
-
-if sys.version_info[:2] < (3, 7):
-    m = "Python 3.7 or later is required for GraphScope (%d.%d detected)."
-    raise ImportError(m % sys.version_info[:2])
-del sys
-
 from graphscope.analytical.app import *
 from graphscope.analytical.udf import declare
 from graphscope.analytical.udf.types import Vertex

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -252,9 +252,9 @@ init_basic_packages() {
 check_dependencies() {
   log "Checking dependencies for building GraphScope."
 
-  # check python3 >= 3.6
+  # check python3 >= 3.7
   if ! command -v python3 &> /dev/null ||
-     [[ "$(python3 -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')" -lt "36" ]]; then
+     [[ "$(python3 -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')" -lt "37" ]]; then
     if [[ "${PLATFORM}" == *"CentOS"* ]]; then
       packages_to_install+=(python3-devel)
     else
@@ -876,8 +876,8 @@ check_dependencies_version_k8s() {
     exit 1
   fi
   ver=$(python3 -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
-  if [ "$ver" -lt "36" ]; then
-    err "GraphScope requires python 3.6 or greater. Current version is ${python3 -V}"
+  if [ "$ver" -lt "37" ]; then
+    err "GraphScope requires python 3.7 or greater. Current version is ${python3 -V}"
     exit 1
   fi
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

since the NetworkX dependency has been bump up to 2.6 and it has droped support for Python3.6,  the GraphScope should drop support for python 3.6.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1269 

