### PR TITLE
Fixes building docs for graphlearning, and the scroll bar.

### DIFF
--- a/docs/_templates/css/custom.css
+++ b/docs/_templates/css/custom.css
@@ -9,6 +9,10 @@
 	}
 }
 
+.wy-side-scroll {
+	height: calc(100% - 142px) !important; /* 128 + 16 */
+}
+
 .rst-versions {
     bottom: 128px !important;
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ breathe_debug_trace_directives = True
 breathe_debug_trace_doxygen_ids = True
 breathe_debug_trace_qualification = True
 
-autodoc_mock_imports = ['vineyard', "graphlearn"]
+autodoc_mock_imports = ["graphlearn"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/reference/networkx/graphs.rst
+++ b/docs/reference/networkx/graphs.rst
@@ -34,6 +34,3 @@ Directed graphs with self loops
    :inherited-members:
    :members:
    :exclude-members: __repr__, __copy__, __deepcopy__, __str__, __weakref__
-
-
-.. include:: cython_sdk.rst

--- a/docs/reference/networkx/transformation.rst
+++ b/docs/reference/networkx/transformation.rst
@@ -42,5 +42,3 @@ Note: :class:`nx.Graph` and :class:`nx.DiGraph` not support to be created from a
 .. autofunction:: graphscope.nx.Graph.__init__
 .. autofunction:: graphscope.nx.Graph._init_with_arrow_property_graph
 .. autofunction:: graphscope.nx.Graph._convert_arrow_to_dynamic
-
-.. include:: cython_sdk.rst


### PR DESCRIPTION

## What do these changes do?

Remove the `vineyard` module from the mock import to ensure the doc could be generated.

This PR fixes a bug of the scroll bar on small screens (macbook 13) as well.

## Related issue number

Fixes N/A

