### PR TITLE
loading_graph.rst: Context.superstep() change return type str -> int

### DIFF
--- a/docs/reference/cython_sdk.rst
+++ b/docs/reference/cython_sdk.rst
@@ -178,7 +178,7 @@ Pregel
 
         Get value from a aggregator.
 
-    .. py:method:: Context.superstep() -> str
+    .. py:method:: Context.superstep() -> int
        :noindex:
 
         Get current superstep, begin with 0.


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
loading_graph.rst: Context.superstep() change return type str -> int

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

