### PR TITLE
Upgrade required vineyard version to 0.3.19

### DIFF
--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -170,7 +170,7 @@ endif ()
 find_package(libgrapelite REQUIRED)
 include_directories(${LIBGRAPELITE_INCLUDE_DIRS})
 
-find_package(vineyard 0.3.18 REQUIRED)
+find_package(vineyard 0.3.19 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -402,17 +402,15 @@ write_envs_config() {
       declare -r homebrew_prefix=/opt/homebrew
     fi
     {
-      # ensure we search /usr/bin at the first priority
-      echo "export PATH=/usr/bin:\$PATH"
       echo "export CC=${homebrew_prefix}/opt/llvm/bin/clang"
       echo "export CXX=${homebrew_prefix}/opt/llvm/bin/clang++"
       echo "export CPPFLAGS=-I${homebrew_prefix}/opt/llvm/include"
-      echo "export PATH=\$PATH:${homebrew_prefix}/opt/llvm/bin"
+      echo "export PATH=${homebrew_prefix}/opt/llvm/bin:\$PATH"
       if [ -z "${JAVA_HOME}" ]; then
         echo "export JAVA_HOME=\$(/usr/libexec/java_home -v11)"
       fi
-      echo "export PATH=\$PATH:\$HOME/.cargo/bin:\${JAVA_HOME}/bin:/usr/local/go/bin"
-      echo "export PATH=\$PATH:\$(go env GOPATH)/bin"
+      echo "export PATH=\$HOME/.cargo/bin:\${JAVA_HOME}/bin:/usr/local/go/bin:\$PATH"
+      echo "export PATH=\$(go env GOPATH)/bin:\$PATH"
       echo "export OPENSSL_ROOT_DIR=${homebrew_prefix}/opt/openssl"
       echo "export OPENSSL_LIBRARIES=${homebrew_prefix}/opt/openssl/lib"
       echo "export OPENSSL_SSL_LIBRARY=${homebrew_prefix}/opt/openssl/lib/libssl.dylib"
@@ -424,8 +422,8 @@ write_envs_config() {
       if [ -z "${JAVA_HOME}" ]; then
         echo "export JAVA_HOME=/usr/lib/jvm/default-java"
       fi
-      echo "export PATH=\$PATH:\${JAVA_HOME}/bin:\$HOME/.cargo/bin:/usr/local/go/bin"
-      echo "export PATH=\$PATH:\$(go env GOPATH)/bin"
+      echo "export PATH=\${JAVA_HOME}/bin:\$HOME/.cargo/bin:/usr/local/go/bin:\$PATH"
+      echo "export PATH=\$(go env GOPATH)/bin:\$PATH"
     } >> ${OUTPUT_ENV_FILE}
   else
     {
@@ -433,8 +431,8 @@ write_envs_config() {
       if [ -z "${JAVA_HOME}" ]; then
         echo "export JAVA_HOME=/usr/lib/jvm/java"
       fi
-      echo "export PATH=\$PATH:\${JAVA_HOME}/bin:\$HOME/.cargo/bin:/usr/local/go/bin"
-      echo "export PATH=\$PATH:\$(go env GOPATH)/bin"
+      echo "export PATH=\${JAVA_HOME}/bin:\$HOME/.cargo/bin:\$PATH:/usr/local/go/bin"
+      echo "export PATH=\$(go env GOPATH)/bin:\$PATH"
     } >> ${OUTPUT_ENV_FILE}
   fi
 }

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -402,15 +402,17 @@ write_envs_config() {
       declare -r homebrew_prefix=/opt/homebrew
     fi
     {
+      # ensure we search /usr/bin at the first priority
+      echo "export PATH=/usr/bin:\$PATH"
       echo "export CC=${homebrew_prefix}/opt/llvm/bin/clang"
       echo "export CXX=${homebrew_prefix}/opt/llvm/bin/clang++"
       echo "export CPPFLAGS=-I${homebrew_prefix}/opt/llvm/include"
-      echo "export PATH=${homebrew_prefix}/opt/llvm/bin:\$PATH"
+      echo "export PATH=\$PATH:${homebrew_prefix}/opt/llvm/bin"
       if [ -z "${JAVA_HOME}" ]; then
         echo "export JAVA_HOME=\$(/usr/libexec/java_home -v11)"
       fi
-      echo "export PATH=\$HOME/.cargo/bin:\${JAVA_HOME}/bin:/usr/local/go/bin:\$PATH"
-      echo "export PATH=\$(go env GOPATH)/bin:\$PATH"
+      echo "export PATH=\$PATH:\$HOME/.cargo/bin:\${JAVA_HOME}/bin:/usr/local/go/bin"
+      echo "export PATH=\$PATH:\$(go env GOPATH)/bin"
       echo "export OPENSSL_ROOT_DIR=${homebrew_prefix}/opt/openssl"
       echo "export OPENSSL_LIBRARIES=${homebrew_prefix}/opt/openssl/lib"
       echo "export OPENSSL_SSL_LIBRARY=${homebrew_prefix}/opt/openssl/lib/libssl.dylib"
@@ -422,8 +424,8 @@ write_envs_config() {
       if [ -z "${JAVA_HOME}" ]; then
         echo "export JAVA_HOME=/usr/lib/jvm/default-java"
       fi
-      echo "export PATH=\${JAVA_HOME}/bin:\$HOME/.cargo/bin:/usr/local/go/bin:\$PATH"
-      echo "export PATH=\$(go env GOPATH)/bin:\$PATH"
+      echo "export PATH=\$PATH:\${JAVA_HOME}/bin:\$HOME/.cargo/bin:/usr/local/go/bin"
+      echo "export PATH=\$PATH:\$(go env GOPATH)/bin"
     } >> ${OUTPUT_ENV_FILE}
   else
     {
@@ -431,8 +433,8 @@ write_envs_config() {
       if [ -z "${JAVA_HOME}" ]; then
         echo "export JAVA_HOME=/usr/lib/jvm/java"
       fi
-      echo "export PATH=\${JAVA_HOME}/bin:\$HOME/.cargo/bin:\$PATH:/usr/local/go/bin"
-      echo "export PATH=\$(go env GOPATH)/bin:\$PATH"
+      echo "export PATH=\$PATH:\${JAVA_HOME}/bin:\$HOME/.cargo/bin:/usr/local/go/bin"
+      echo "export PATH=\$PATH:\$(go env GOPATH)/bin"
     } >> ${OUTPUT_ENV_FILE}
   fi
 }
@@ -767,6 +769,8 @@ install_dependencies() {
       brew install ${packages_to_install[*]}
     fi
 
+
+
     if [[ "$(uname -m)" == "x86_64" ]]; then
       declare -r homebrew_prefix="/usr/local"
     else
@@ -778,9 +782,6 @@ install_dependencies() {
     export CC=${homebrew_prefix}/opt/llvm/bin/clang
     export CXX=${homebrew_prefix}/opt/llvm/bin/clang++
     export CPPFLAGS=-I${homebrew_prefix}/opt/llvm/include
-
-    # remove binutils installed by brew
-    brew uninstall binutils || true
   fi
 
   log "Installing python packages for vineyard codegen."


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

GraphScope can't compile with vineyard v0.3.18, the required version appears to have been forgotten to update.
The other locations of vineyard version are v0.3.19 already.

<!-- Please give a short brief about these changes. -->

<!-- Are there any issues opened that will be resolved by merging this change? -->

