### PR TITLE
Keep the global symbol to avoid it been stripped on Mac.

### DIFF
--- a/analytical_engine/exported_symbols_osx.lds
+++ b/analytical_engine/exported_symbols_osx.lds
@@ -1,0 +1,1 @@
+__ZN2gs7dynamic5Value10allocator_E

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -111,7 +111,7 @@ graphscope-darwin-py3:
 	cd $(WORKING_DIR)/../coordinator && \
 		export WITH_EXTRA_DATA=ON && \
 		rm -fr build dist/*.whl || true && \
-		sudo strip /opt/graphscope/bin/grape_engine && \
+		sudo strip -s $(WORKING_DIR)/analytical_engine/exported_symbols_osx.lds /opt/graphscope/bin/grape_engine && \
 		sudo strip /opt/graphscope/bin/executor && \
 		sudo strip /opt/graphscope/bin/gaia_executor && \
 		export DYLD_LIBRARY_PATH=/usr/local/lib:$$DYLD_LIBRARY_PATH && \


### PR DESCRIPTION

## What do these changes do?

Possible fixes the ci failure on Mac.