### PR TITLE
Limit the condition of ci actions to the alibaba/graphscope repo, as it may require self-hosted runners.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
     # Require the user id of the self-hosted is 1001, which may need to be
     # configured manually when a new self-hosted runner is added.
     runs-on: self-hosted
+    if: ${{ github.repository == 'alibaba/GraphScope' }}
     steps:
     - name: Clean Up
       run: |
@@ -187,6 +188,7 @@ jobs:
 
   mini-test:
     runs-on: ubuntu-20.04
+    if: ${{ github.repository == 'alibaba/GraphScope' }}
     needs: [build-wheels]
     steps:
       - uses: actions/checkout@v2.3.2
@@ -236,7 +238,7 @@ jobs:
   python-unittest:
     runs-on: ubuntu-20.04
     needs: [build-wheels, changes]
-    if: needs.changes.outputs.gae-python == 'true' || (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope')
+    if: ${{ (needs.changes.outputs.gae-python == 'true' || github.ref == 'refs/heads/main') && github.repository == 'alibaba/GraphScope' }}
     defaults:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
@@ -293,7 +295,7 @@ jobs:
   networkx-basic-test:
     runs-on: ubuntu-20.04
     needs: [build-wheels, changes]
-    if: needs.changes.outputs.networkx == 'true' || (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope')
+    if: ${{ (needs.changes.outputs.networkx == 'true' || github.ref == 'refs/heads/main') && github.repository == 'alibaba/GraphScope' }}
     defaults:
       run:
         shell: bash
@@ -377,7 +379,7 @@ jobs:
   networkx-algo-and-generator-test:
     runs-on: ubuntu-20.04
     needs: [build-wheels, changes]
-    if: needs.changes.outputs.networkx == 'true'
+    if: ${{ needs.changes.outputs.networkx == 'true' && github.repository == 'alibaba/GraphScope' }}
     strategy:
       matrix:
         deployment: ["standalone", "distributed"]
@@ -459,7 +461,7 @@ jobs:
   gie-test:
     runs-on: self-hosted
     needs: [build-wheels, changes]
-    if: needs.changes.outputs.gie-function-test == 'true' || (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope')
+    if: ${{ (needs.changes.outputs.gie-function-test == 'true' || github.ref == 'refs/heads/main') && github.repository == 'alibaba/GraphScope' }}
     steps:
       - name: Clean up
         run: |
@@ -517,6 +519,7 @@ jobs:
 
   k8s-test:
     runs-on: self-hosted
+    if: ${{ github.repository == 'alibaba/GraphScope' }}
     needs: [build-wheels]
     steps:
       - name: Clean up

--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   build-gae:
     runs-on: ubuntu-20.04
+    if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
       image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.19
       options:

--- a/.github/workflows/gaia.yml
+++ b/.github/workflows/gaia.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   gaia-test:
     runs-on: ubuntu-20.04
+    if: ${{ github.repository == 'alibaba/GraphScope' }}
     defaults:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}

--- a/.github/workflows/gss.yml
+++ b/.github/workflows/gss.yml
@@ -42,6 +42,7 @@ jobs:
     # can `ssh localhost` without password, which may need to
     # be configured manually when a new self-hosted runner is added.
     runs-on: self-hosted
+    if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
       image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.3.19
     defaults:
@@ -117,6 +118,7 @@ jobs:
 
   helm-test:
     runs-on: self-hosted
+    if: ${{ github.repository == 'alibaba/GraphScope' }}
     needs: [gremlin-test]
     strategy:
       matrix:


### PR DESCRIPTION

## What do these changes do?

Limit the condition of ci actions to the `alibaba/graphscope` repo, as it may require self-hosted runners.
