### PR TITLE
Correct the lifecycle of graph with session

### DIFF
--- a/docs/reference/session.rst
+++ b/docs/reference/session.rst
@@ -18,6 +18,7 @@ Session Functions
 
    graphscope.session
    graphscope.get_default_session
+   graphscope.has_default_session
    graphscope.set_option
    graphscope.get_option
    graphscope.g

--- a/python/graphscope/__init__.py
+++ b/python/graphscope/__init__.py
@@ -23,6 +23,7 @@ from graphscope.client.connection import conn
 from graphscope.client.session import Session
 from graphscope.client.session import g
 from graphscope.client.session import get_default_session
+from graphscope.client.session import has_default_session
 from graphscope.client.session import get_option
 from graphscope.client.session import graphlearn
 from graphscope.client.session import gremlin

--- a/python/graphscope/__init__.py
+++ b/python/graphscope/__init__.py
@@ -23,10 +23,10 @@ from graphscope.client.connection import conn
 from graphscope.client.session import Session
 from graphscope.client.session import g
 from graphscope.client.session import get_default_session
-from graphscope.client.session import has_default_session
 from graphscope.client.session import get_option
 from graphscope.client.session import graphlearn
 from graphscope.client.session import gremlin
+from graphscope.client.session import has_default_session
 from graphscope.client.session import session
 from graphscope.client.session import set_option
 from graphscope.framework.errors import *

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -1389,14 +1389,19 @@ def default_session(session):
     return _default_session_stack.get_controller(session)
 
 
+def has_default_session():
+    """True if default session exists in current context."""
+    return not _default_session_stack.empty()
+
+
 def get_default_session():
     """Returns the default session for the current context.
 
-    Raises:
-        RuntimeError: Default session is not exist.
+    Note that a new session will be created if there is no
+    default session in current context.
 
     Returns:
-        The default :class:`Session`.
+        The default :class:`graphscope.Session`.
     """
     return _default_session_stack.get_default()
 
@@ -1421,6 +1426,9 @@ class _DefaultSessionStack(object):
             sess = session(cluster_type="hosts", num_workers=1)
             sess.as_default()
         return self.stack[-1]
+
+    def empty(self):
+        return len(self.stack) == 0
 
     def reset(self):
         self.stack = []

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -657,7 +657,7 @@ class Graph(GraphInterface):
         >>> import graphscope as gs
         >>> sess = gs.session()
         >>> graph = sess.g()
-        >>> graph = graph.add_vertices("person.csv","person")
+        >>> graph = graph.add_vertices("person.csv", "person")
         >>> graph = graph.add_vertices("software.csv", "software")
         >>> graph = graph.add_edges("knows.csv", "knows", src_label="person", dst_label="person")
         >>> graph = graph.add_edges("created.csv", "created", src_label="person", dst_label="software")
@@ -830,7 +830,10 @@ class Graph(GraphInterface):
         self._detached = True
 
     def loaded(self):
-        return self._key is not None
+        """True if current graph has been loaded in the session."""
+        if self._session.info["status"] == "active" and self._key is not None:
+            return True
+        return False
 
     def __str__(self):
         v_str = "\n".join([f"VERTEX: {label}" for label in self._v_labels])
@@ -850,11 +853,7 @@ class Graph(GraphInterface):
 
     def unload(self):
         """Unload this graph from graphscope engine."""
-        if self._session is None:
-            raise RuntimeError("The graph is not loaded")
-
-        if self._key is None:
-            self._session = None
+        if self._session.info["status"] != "active" or self._key is None:
             return
 
         # close interactive instances first
@@ -881,7 +880,6 @@ class Graph(GraphInterface):
         if not self._detached:
             rlt = self._session._wrapper(self._graph_node.unload())
         self._key = None
-        self._session = None
         return rlt
 
     def _project_to_simple(self, v_prop=None, e_prop=None):

--- a/python/graphscope/tests/unittest/test_graph.py
+++ b/python/graphscope/tests/unittest/test_graph.py
@@ -135,8 +135,8 @@ def test_unload(graphscope_session):
 
     assert not g.loaded()
 
-    with pytest.raises(RuntimeError, match="The graph is not loaded"):
-        g.unload()
+    # unload twice
+    g.unload()
 
     with pytest.raises(RuntimeError, match="The graph is not loaded"):
         pg = g.project(vertices={"host": []}, edges={"connect": []})


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

```python
import graphscope

sess = graphscope.session()
graph = load_graph(sess)

# close the session
sess.close()

# after session closed, graph status is still 'loaded'
print(g.loaded())
True
```

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

