### PR TITLE
[BugFix] Fix analytical engine can't not compile with NETWORKX=OFF

### DIFF
--- a/analytical_engine/core/fragment/dynamic_fragment.h
+++ b/analytical_engine/core/fragment/dynamic_fragment.h
@@ -16,6 +16,8 @@
 #ifndef ANALYTICAL_ENGINE_CORE_FRAGMENT_DYNAMIC_FRAGMENT_H_
 #define ANALYTICAL_ENGINE_CORE_FRAGMENT_DYNAMIC_FRAGMENT_H_
 
+#ifdef NETWORKX
+
 #include <limits>
 #include <map>
 #include <memory>
@@ -1502,4 +1504,5 @@ class DynamicFragmentMutator {
 
 }  // namespace gs
 
-#endif  // ANALYTICAL_ENGINE_CORE_FRAGMENT_DYNAMIC_FRAGMENT_H_
+#endif // NETWORKX
+#endif // ANALYTICAL_ENGINE_CORE_FRAGMENT_DYNAMIC_FRAGMENT_H_

--- a/analytical_engine/core/fragment/dynamic_fragment.h
+++ b/analytical_engine/core/fragment/dynamic_fragment.h
@@ -1504,5 +1504,5 @@ class DynamicFragmentMutator {
 
 }  // namespace gs
 
-#endif // NETWORKX
-#endif // ANALYTICAL_ENGINE_CORE_FRAGMENT_DYNAMIC_FRAGMENT_H_
+#endif  // NETWORKX
+#endif  // ANALYTICAL_ENGINE_CORE_FRAGMENT_DYNAMIC_FRAGMENT_H_


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1408 

