### PR TITLE
Upgrade the version of databind, fixes the dependent bot warnings.

### DIFF
--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -45,6 +45,7 @@
     <curator.new.version>5.1.0</curator.new.version>
     <curator.version>2.12.0</curator.version>
     <jackson.version>2.13.2</jackson.version>
+    <jackson.databind.version>2.13.2.1</jackson.databind.version>
     <maven.surefire.version>2.22.2</maven.surefire.version>
     <os.maven.plugin.version>1.6.2</os.maven.plugin.version>
     <protoc.version>3.18.0</protoc.version>
@@ -235,7 +236,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
+        <version>${jackson.databind.version}</version>
       </dependency>
 
       <dependency>

--- a/research/query_service/ir/compiler/pom.xml
+++ b/research/query_service/ir/compiler/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <jackson.version>2.13.2</jackson.version>
+        <jackson.databind.version>2.13.2.1</jackson.databind.version>
         <commons.langs.version>3.12.0</commons.langs.version>
         <commons.io.version>2.7</commons.io.version>
         <protobuf.version>3.18.2</protobuf.version>
@@ -94,7 +95,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION


## What do these changes do?

Upgrade the `jackson.databind`, not `jackson`.

See also:
  - https://github.com/alibaba/GraphScope/pull/1415
  - https://github.com/alibaba/GraphScope/pull/1423
