### PR TITLE
migrate cargo rocksdb dependency to 0.18.0 version

### DIFF
--- a/interactive_engine/executor/store/Cargo.toml
+++ b/interactive_engine/executor/store/Cargo.toml
@@ -23,15 +23,9 @@ log4rs = "0.8.0"
 grpcio = "=0.4.1"
 grpcio-sys = { version = "0.4.7", features = ["openssl-vendored"] }
 rand = "0.8.4"
-#rocksdb = "0.17.0"
+rocksdb = "0.18.0"
 
 maxgraph-common = { path = "../../rust-common" }
-
-# For temporal use to support restoring from a specified backup.
-# Change to a stable version of rust-rocksdb later.
-[dependencies.rocksdb]
-git = "https://github.com/GoldenLeaves/rust-rocksdb.git"
-rev = "082dfcfbb4b51e61d1c01672951b84cb464601e2"
 
 [build-dependencies]
 protoc-grpcio = "0.3.0"

--- a/interactive_engine/executor/store/Cargo.toml
+++ b/interactive_engine/executor/store/Cargo.toml
@@ -23,7 +23,8 @@ log4rs = "0.8.0"
 grpcio = "=0.4.1"
 grpcio-sys = { version = "0.4.7", features = ["openssl-vendored"] }
 rand = "0.8.4"
-rocksdb = "0.18.0"
+# deactivation of bzip2 due to https://github.com/rust-rocksdb/rust-rocksdb/issues/609
+rocksdb = { version = "0.18.0", features = ["snappy", "lz4", "zstd", "zlib"], default-features = false }
 
 maxgraph-common = { path = "../../rust-common" }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #525 

