### PR TITLE
Add version check to coordinator & client, fixes #1435

### DIFF
--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -309,11 +309,11 @@ class CoordinatorServiceServicer(
         sv = version.parse(__version__)
         cv = version.parse(self._request.version)
         if sv.major != cv.major or sv.minor != cv.minor:
-            logger.warning(
-                "Version between client and server is inconsistent: %s vs %s",
-                self._request.version,
-                __version__,
-            )
+            error_msg = f"Version between client and server is inconsistent: {self._request.version} vs {__version__}"
+            logger.warning(error_msg)
+            context.set_code(error_codes_pb2.CONNECTION_ERROR)
+            context.set_details(error_msg)
+            return message_pb2.ConnectSessionResponse()
 
         return message_pb2.ConnectSessionResponse(
             session_id=self._session_id,

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -610,6 +610,9 @@ class CoordinatorServiceServicer(
 
         while not dag_manager.empty():
             run_dag_on, dag, dag_bodies = dag_manager.next_dag()
+            error_code = None
+            head = None
+            bodies = None
             try:
                 # run on analytical engine
                 if run_dag_on == GSEngine.analytical_engine:

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -610,7 +610,7 @@ class CoordinatorServiceServicer(
 
         while not dag_manager.empty():
             run_dag_on, dag, dag_bodies = dag_manager.next_dag()
-            error_code = None
+            error_code = error_codes_pb2.COORDINATOR_INTERNAL_ERROR
             head = None
             bodies = None
             try:

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -664,9 +664,6 @@ class Session(object):
         if kw:
             raise ValueError("Value not recognized: ", list(kw.keys()))
 
-        # The version of client and coordinator must be same
-        self.check_version_compatible()
-
         if self._config_params["addr"]:
             logger.info(
                 "Connecting graphscope session with address: %s",
@@ -1313,13 +1310,6 @@ class Session(object):
         # the uploaded file may be placed in the same directory
         garfile.append("{}".format(resource_name.split("/")[-1]), bytes_)
         self._grpc_client.add_lib(garfile.read_bytes().getvalue())
-
-    def check_version_compatible(self):
-        if self._config_params["k8s_gs_image"] != gs_config.k8s_gs_image:
-            raise RuntimeError(
-                "Version between k8s_gs_image and client is inconsistent"
-            )
-
 
 session = Session
 

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -421,7 +421,8 @@ class Session(object):
 
             k8s_coordinator_mem (str, optional): Minimum number of memory request for coordinator pod. Defaults to '4Gi'.
 
-            etcd_addrs (str, optional): The addr of external etcd cluster, with formats like 'etcd01:port,etcd02:port,etcd03:port'
+            etcd_addrs (str, optional): The addr of external etcd cluster,
+                with formats like 'etcd01:port,etcd02:port,etcd03:port'
 
             k8s_etcd_num_pods (int, optional): The number of etcd pods. Defaults to 3.
 

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -664,8 +664,7 @@ class Session(object):
             raise ValueError("Value not recognized: ", list(kw.keys()))
 
         # The version of client and coordinator must be same
-        if self._config_params["k8s_gs_image"] != gs_config.k8s_gs_image:
-            raise RuntimeError("Version between k8s_gs_image and client is inconsistent")
+        self.check_version_compatible()
 
         if self._config_params["addr"]:
             logger.info(
@@ -1313,6 +1312,10 @@ class Session(object):
         # the uploaded file may be placed in the same directory
         garfile.append("{}".format(resource_name.split("/")[-1]), bytes_)
         self._grpc_client.add_lib(garfile.read_bytes().getvalue())
+
+    def check_version_compatible(self):
+        if self._config_params["k8s_gs_image"] != gs_config.k8s_gs_image:
+            raise RuntimeError("Version between k8s_gs_image and client is inconsistent")
 
 
 session = Session

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -1311,6 +1311,7 @@ class Session(object):
         garfile.append("{}".format(resource_name.split("/")[-1]), bytes_)
         self._grpc_client.add_lib(garfile.read_bytes().getvalue())
 
+
 session = Session
 
 

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -67,6 +67,7 @@ from graphscope.proto import graph_def_pb2
 from graphscope.proto import message_pb2
 from graphscope.proto import op_def_pb2
 from graphscope.proto import types_pb2
+from graphscope.version import __version__
 
 DEFAULT_CONFIG_FILE = os.environ.get(
     "GS_CONFIG_PATH", os.path.expanduser("~/.graphscope/session.json")
@@ -659,6 +660,10 @@ class Session(object):
         # There should be no more custom keyword arguments.
         if kw:
             raise ValueError("Value not recognized: ", list(kw.keys()))
+
+        # The version of client and coordinator must be same
+        if self._config_params["k8s_gs_image"] != gs_config.k8s_gs_image:
+            raise RuntimeError("Version between k8s_gs_image and client is inconsistent")
 
         if self._config_params["addr"]:
             logger.info(

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -1315,7 +1315,9 @@ class Session(object):
 
     def check_version_compatible(self):
         if self._config_params["k8s_gs_image"] != gs_config.k8s_gs_image:
-            raise RuntimeError("Version between k8s_gs_image and client is inconsistent")
+            raise RuntimeError(
+                "Version between k8s_gs_image and client is inconsistent"
+            )
 
 
 session = Session

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -421,6 +421,8 @@ class Session(object):
 
             k8s_coordinator_mem (str, optional): Minimum number of memory request for coordinator pod. Defaults to '4Gi'.
 
+            etcd_addrs (str, optional): The addr of external etcd cluster, with formats like 'etcd01:port,etcd02:port,etcd03:port'
+
             k8s_etcd_num_pods (int, optional): The number of etcd pods. Defaults to 3.
 
             k8s_etcd_cpu (float, optional): Minimum number of CPU cores request for etcd pod. Defaults to 0.5.


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
1.Client cannot create coordinator which not compatible to it's version.
2.Coordinator throws an Exception when a not compatible client connect to it, and then the client throws it to user.
3.add a legacy doc of session param etcd_addrs.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1435

