### PR TITLE
Cancel other actions if failed to format/lint or generate docs.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -127,6 +127,13 @@ jobs:
           make graphscope-docs
         fi
 
+    - name: Stop the Actions
+      if: ${{ failure() }}
+      uses: styfle/cancel-workflow-action@0.9.1
+      with:
+        workflow_id: ci.yml,gae.yml,gaia.yml,gss.yml
+        access_token: ${{ github.token }}
+
     - name: Upload Docs
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
       shell: bash

--- a/.github/workflows/gss-dummy.yml
+++ b/.github/workflows/gss-dummy.yml
@@ -27,13 +27,13 @@ jobs:
     # Require the host is able to run docker without sudo and
     # can `ssh localhost` without password, which may need to
     # be configured manually when a new self-hosted runner is added.
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     steps:
     - run: 'echo "No action required" '
 
   helm-test:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     needs: [gremlin-test]
     strategy:


### PR DESCRIPTION
## What do these changes do?

Cancel other actions if failed to format/lint or generate docs, to avoid wasting the energy.

