### PR TITLE
Correctly handle the lifecycle of graph

### DIFF
--- a/python/graphscope/framework/app.py
+++ b/python/graphscope/framework/app.py
@@ -71,6 +71,8 @@ def project_to_simple(func):
             else:
                 projected = graph._project_to_simple()
             projected._base_graph = graph
+        else:
+            projected = graph
         return func(projected, *args[1:], **kwargs)
 
     return wrapper

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -258,7 +258,7 @@ class BaseContextDAGNode(DAGNode):
         op = dag_utils.output(df, fd, **kwargs)
         return ResultDAGNode(self, op)
 
-    def unload(self):
+    def _unload(self):
         op = dag_utils.unload_context(self)
         return UnloadedContext(self._session, op)
 
@@ -590,13 +590,6 @@ class Context(object):
         self._context_node.evaluated = True
         self._saved_signature = self.signature
 
-    def __del__(self):
-        # cleanly ignore all exceptions, cause session may already closed / destroyed.
-        try:
-            self.unload()
-        except Exception:  # pylint: disable=broad-except
-            pass
-
     @property
     def op(self):
         return self._context_node.op
@@ -680,8 +673,8 @@ class Context(object):
         df = self.to_dataframe(selector, vertex_range)
         df.to_csv(fd, header=True, index=False)
 
-    def unload(self):
-        return self._session._wrapper(self._context_node.unload())
+    def __del__(self):
+        return self._session._wrapper(self._context_node._unload())
 
 
 class DynamicVertexDataContext(collections.abc.Mapping):

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -590,6 +590,13 @@ class Context(object):
         self._context_node.evaluated = True
         self._saved_signature = self.signature
 
+    def __del__(self):
+        # cleanly ignore all exceptions, cause session may already closed / destroyed.
+        try:
+            self._unload()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     @property
     def op(self):
         return self._context_node.op
@@ -673,7 +680,7 @@ class Context(object):
         df = self.to_dataframe(selector, vertex_range)
         df.to_csv(fd, header=True, index=False)
 
-    def __del__(self):
+    def _unload(self):
         return self._session._wrapper(self._context_node._unload())
 
 

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -683,6 +683,13 @@ class Graph(GraphInterface):
         self._interactive_instance_list = []
         self._learning_instance_list = []
 
+    def __del__(self):
+        # cleanly ignore all exceptions, cause session may already closed / destroyed.
+        try:
+            self._unload()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
     def _close_interactive_instances(self):
         # Close related interactive instances when graph unloaded.
         # Since the graph is gone, quering via interactive client is meaningless.
@@ -838,7 +845,7 @@ class Graph(GraphInterface):
     def __repr__(self):
         return self.__str__()
 
-    def __del__(self):
+    def _unload(self):
         """Unload this graph from graphscope engine."""
         if self._session.info["status"] != "active" or self._key is None:
             return

--- a/python/graphscope/nx/tests/test_transformation.py
+++ b/python/graphscope/nx/tests/test_transformation.py
@@ -161,9 +161,9 @@ class TestGraphTransformation(object):
 
     @classmethod
     def teardown_class(cls):
-        cls.single_label_g.unload()
-        cls.multi_label_g.unload()
-        cls.str_oid_g.unload()
+        del cls.single_label_g
+        del cls.multi_label_g
+        del cls.str_oid_g
 
     def assert_convert_success(self, gs_g, nx_g):
         assert gs_g.is_directed() == nx_g.is_directed()
@@ -642,9 +642,9 @@ class TestDigraphTransformation(TestGraphTransformation):
 
     @classmethod
     def teardown_class(cls):
-        cls.single_label_g.unload()
-        cls.multi_label_g.unload()
-        cls.str_oid_g.unload()
+        del cls.single_label_g
+        del cls.multi_label_g
+        del cls.str_oid_g
 
     def test_error_on_wrong_nx_type(self):
         g = self.single_label_g

--- a/python/graphscope/tests/conftest.py
+++ b/python/graphscope/tests/conftest.py
@@ -54,7 +54,7 @@ def arrow_modern_graph(graphscope_session):
         graphscope_session, prefix="{}/modern_graph".format(test_repo_dir)
     )
     yield graph
-    graph.unload()
+    del graph
 
 
 @pytest.fixture(scope="module")
@@ -233,7 +233,7 @@ def arrow_property_graph(graphscope_session):
         generate_eid=False,
     )
     yield g
-    g.unload()
+    del g
 
 
 @pytest.fixture(scope="module")
@@ -328,7 +328,7 @@ def arrow_property_graph_only_from_efile(graphscope_session):
         generate_eid=False,
     )
     yield g
-    g.unload()
+    del g
 
 
 # @pytest.fixture(scope="module")
@@ -346,7 +346,7 @@ def arrow_property_graph_only_from_efile(graphscope_session):
 # g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_1", "e1", ["weight"], "v1", "v1")
 
 # yield g
-# g.unload()
+# del g
 
 
 # @pytest.fixture(scope="module")
@@ -362,7 +362,7 @@ def arrow_property_graph_only_from_efile(graphscope_session):
 # g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_1", "e1", ["weight"], "v1", "v1")
 
 # yield g
-# g.unload()
+# del g
 
 
 @pytest.fixture(scope="module")
@@ -380,7 +380,7 @@ def arrow_property_graph_undirected(graphscope_session):
     g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_1", "e1", ["weight"], "v1", "v1")
 
     yield g
-    g.unload()
+    del g
 
 
 @pytest.fixture(scope="module")
@@ -392,7 +392,7 @@ def arrow_property_graph_lpa_u2i(graphscope_session):
         f"{property_dir}/lpa_dataset/lpa_3000_e_0", "e0", ["weight"], "v0", "v1"
     )
     yield g
-    g.unload()
+    del g
 
 
 @pytest.fixture(scope="module")
@@ -420,7 +420,7 @@ def p2p_property_graph(graphscope_session):
         dst_label="person",
     )
     yield g
-    g.unload()
+    del g
 
 
 @pytest.fixture(scope="module")
@@ -433,7 +433,7 @@ def p2p_graph_from_pandas(graphscope_session):
     g = g.add_vertices(df_v, "person")
     g = g.add_edges(df_e, label="knows", src_label="person", dst_label="person")
     yield g
-    g.unload()
+    del g
 
 
 @pytest.fixture(scope="module")
@@ -447,7 +447,7 @@ def p2p_property_graph_string(graphscope_session):
         dst_label="person",
     )
     yield g
-    g.unload()
+    del g
 
 
 @pytest.fixture(scope="module")
@@ -461,7 +461,7 @@ def p2p_property_graph_undirected(graphscope_session):
         dst_label="person",
     )
     yield g
-    g.unload()
+    del g
 
 
 @pytest.fixture(scope="module")
@@ -649,7 +649,7 @@ def simple_context(arrow_property_graph):
 def ldbc_graph(graphscope_session):
     graph = load_ldbc(graphscope_session, prefix="{}/ldbc_sample".format(test_repo_dir))
     yield graph
-    graph.unload()
+    del graph
 
 
 @pytest.fixture(scope="module")
@@ -660,7 +660,7 @@ def ldbc_graph_undirected(graphscope_session):
         directed=False,
     )
     yield graph
-    graph.unload()
+    del graph
 
 
 @pytest.fixture(scope="module")

--- a/python/graphscope/tests/unittest/test_download.py
+++ b/python/graphscope/tests/unittest/test_download.py
@@ -26,25 +26,25 @@ from graphscope.dataset import *
 @pytest.mark.skipif("FULL_TEST_SUITE" not in os.environ, reason="Run in nightly CI")
 def test_download_dataset(graphscope_session):
     g1 = load_modern_graph(graphscope_session)
-    g1.unload()
+    del g1
     g2 = load_ldbc(graphscope_session)
-    g2.unload()
+    del g2
     g3 = load_ogbn_mag(graphscope_session)
-    g3.unload()
+    del g3
     g4 = load_ogbn_arxiv(graphscope_session)
-    g4.unload()
+    del g4
     # Unable to fit in the memory of the CI environment
     # g5 = load_ogbn_proteins(graphscope_session)
-    # g5.unload()
+    # del g5
     g6 = load_ogbl_collab(graphscope_session)
-    g6.unload()
+    del g6
     g7 = load_ogbl_ddi(graphscope_session)
-    g7.unload()
+    del g7
     g8 = load_p2p_network(graphscope_session)
-    g8.unload()
+    del g8
     g9 = load_cora(graphscope_session)
-    g9.unload()
+    del g9
     g10 = load_ppi(graphscope_session)
-    g10.unload()
+    del g10
     g11 = load_u2i(graphscope_session)
-    g11.unload()
+    del g11

--- a/python/graphscope/tests/unittest/test_graph.py
+++ b/python/graphscope/tests/unittest/test_graph.py
@@ -55,7 +55,6 @@ def test_load_graph_copy(graphscope_session, arrow_property_graph):
     assert str(g.schema) == str(g2.schema)
     assert np.all(g.to_numpy("v:v0.id") == g2.to_numpy("v:v0.id"))
     del g2
-    assert not g2.loaded()
     # test load from vineyard's graph
     g3 = graphscope_session.g(vineyard.ObjectID(g.vineyard_id))
     assert g3.loaded()

--- a/python/graphscope/tests/unittest/test_graph.py
+++ b/python/graphscope/tests/unittest/test_graph.py
@@ -54,7 +54,7 @@ def test_load_graph_copy(graphscope_session, arrow_property_graph):
     assert g.vineyard_id != g2.vineyard_id
     assert str(g.schema) == str(g2.schema)
     assert np.all(g.to_numpy("v:v0.id") == g2.to_numpy("v:v0.id"))
-    g2.unload()
+    del g2
     assert not g2.loaded()
     # test load from vineyard's graph
     g3 = graphscope_session.g(vineyard.ObjectID(g.vineyard_id))
@@ -130,18 +130,7 @@ def test_unload(graphscope_session):
     g = load_p2p_network(graphscope_session)
     assert g.loaded()
     assert g.vineyard_id is not None
-    g.unload()
-
-    assert not g.loaded()
-
-    # unload twice
-    g.unload()
-
-    with pytest.raises(RuntimeError, match="The graph is not loaded"):
-        pg = g.project(vertices={"host": []}, edges={"connect": []})
-        pg._project_to_simple()
-    with pytest.raises(AssertionError):
-        g2 = graphscope_session.g(g)
+    del g
 
 
 def test_error_on_project_to_simple_wrong_graph_type(arrow_property_graph):
@@ -531,3 +520,11 @@ def test_add_column(ldbc_graph, arrow_modern_graph):
     with pytest.raises(AnalyticalEngineInternalError):
         g5 = sub_graph_4.add_column(ret, selector={"cc": "r"})
         print(g4.schema)
+
+
+def test_graph_lifecycle(graphscope_session):
+    graph = load_modern_graph(graphscope_session)
+    c = graphscope.wcc(graph)
+    del graph
+    assert c.to_numpy("v.id") is not None
+    del c  # should delete c and graph in c++

--- a/python/graphscope/tests/unittest/test_java_app.py
+++ b/python/graphscope/tests/unittest/test_java_app.py
@@ -165,4 +165,4 @@ def test_giraph_app(
 
     giraph_sssp = load_app(algo="giraph:com.alibaba.graphscope.example.giraph.SSSP")
     giraph_sssp(g, sourceId=6)
-    g.unload()
+    del g

--- a/python/graphscope/tests/unittest/test_lazy.py
+++ b/python/graphscope/tests/unittest/test_lazy.py
@@ -98,10 +98,7 @@ def test_construct_graph_step_by_step(sess):
     g1 = sess.run(_g1)
     _g2 = g1.add_vertices(f"{new_property_dir}/twitter_v_1", "v1")
     g2 = sess.run(_g2)
-    ug = g._unload()
-    ug1 = g1._unload()
-    ug2 = g2._unload()
-    sess.run([ug, ug1, ug2])
+    del g, g1, g2
 
 
 def test_unload_graph(sess, student_v, teacher_v, student_group_e):
@@ -109,17 +106,14 @@ def test_unload_graph(sess, student_v, teacher_v, student_group_e):
     # 1. load empty g
     # 2. unload g
     g = sess.g()
-    ug = g._unload()
-    assert sess.run(ug) is None
+    g = sess.run(g)
+    del g
 
     # case 2
     g = sess.g()
     g1 = g.add_vertices(student_v, "student")
     g2 = g.add_vertices(teacher_v, "teacher")
-    ug1 = g1._unload()
-    ug2 = g2._unload()
-    assert sess.run(ug1) is None
-    assert sess.run(ug2) is None
+    del g1, g2
 
     # case 3
     g = sess.g()
@@ -128,26 +122,13 @@ def test_unload_graph(sess, student_v, teacher_v, student_group_e):
     g3 = g2.add_edges(
         student_group_e, "group", src_label="student", dst_label="student"
     )
-    ug = g._unload()
-    ug1 = g1._unload()
-    ug2 = g2._unload()
-    ug3 = g3._unload()
-    sess.run([ug, ug1, ug2, ug3])
+
+    del g, g1, g2, g3
 
     # case 4
     # test unload twice
     g = sess.g()
-    ug = g._unload()
-    assert sess.run(ug) is None
-    assert sess.run(ug) is None
-
-
-def test_error_using_unload_graph(sess, student_v):
-    with pytest.raises(AnalyticalEngineInternalError):
-        g = sess.g()
-        ug = g._unload()
-        g1 = g.add_vertices(student_v, "student")
-        sess.run([ug, g1])
+    del g
 
 
 def test_unload_app(sess, arrow_property_graph_lpa_u2i):
@@ -156,30 +137,8 @@ def test_unload_app(sess, arrow_property_graph_lpa_u2i):
         arrow_property_graph_lpa_u2i,
         AppAssets(algo="lpau2i", context="labeled_vertex_property"),
     )
-    ua1 = a1._unload()
-    assert sess.run(ua1) is None
-
-    # case 2
-    # unload app twice
-    a1 = AppDAGNode(
-        arrow_property_graph_lpa_u2i,
-        AppAssets(algo="lpau2i", context="labeled_vertex_property"),
-    )
-    ua1 = a1._unload()
-    assert sess.run(ua1) is None
-    assert sess.run(ua1) is None
-
-    # case 3
-    # load app after unload
-    a1 = AppDAGNode(
-        arrow_property_graph_lpa_u2i,
-        AppAssets(algo="lpau2i", context="labeled_vertex_property"),
-    )
-    ua1 = a1._unload()
-    assert sess.run(ua1) is None
-    c1 = a1(max_round=10)
-    r1 = c1.to_numpy("r:v0.label_0")
-    r = sess.run(r1)
+    a1 = sess.run(a1)
+    del a1
 
 
 def test_graph_to_numpy(sess):

--- a/python/graphscope/tests/unittest/test_lazy.py
+++ b/python/graphscope/tests/unittest/test_lazy.py
@@ -98,9 +98,9 @@ def test_construct_graph_step_by_step(sess):
     g1 = sess.run(_g1)
     _g2 = g1.add_vertices(f"{new_property_dir}/twitter_v_1", "v1")
     g2 = sess.run(_g2)
-    ug = g.unload()
-    ug1 = g1.unload()
-    ug2 = g2.unload()
+    ug = g._unload()
+    ug1 = g1._unload()
+    ug2 = g2._unload()
     sess.run([ug, ug1, ug2])
 
 
@@ -109,15 +109,15 @@ def test_unload_graph(sess, student_v, teacher_v, student_group_e):
     # 1. load empty g
     # 2. unload g
     g = sess.g()
-    ug = g.unload()
+    ug = g._unload()
     assert sess.run(ug) is None
 
     # case 2
     g = sess.g()
     g1 = g.add_vertices(student_v, "student")
     g2 = g.add_vertices(teacher_v, "teacher")
-    ug1 = g1.unload()
-    ug2 = g2.unload()
+    ug1 = g1._unload()
+    ug2 = g2._unload()
     assert sess.run(ug1) is None
     assert sess.run(ug2) is None
 
@@ -128,16 +128,16 @@ def test_unload_graph(sess, student_v, teacher_v, student_group_e):
     g3 = g2.add_edges(
         student_group_e, "group", src_label="student", dst_label="student"
     )
-    ug = g.unload()
-    ug1 = g1.unload()
-    ug2 = g2.unload()
-    ug3 = g3.unload()
+    ug = g._unload()
+    ug1 = g1._unload()
+    ug2 = g2._unload()
+    ug3 = g3._unload()
     sess.run([ug, ug1, ug2, ug3])
 
     # case 4
     # test unload twice
     g = sess.g()
-    ug = g.unload()
+    ug = g._unload()
     assert sess.run(ug) is None
     assert sess.run(ug) is None
 
@@ -145,7 +145,7 @@ def test_unload_graph(sess, student_v, teacher_v, student_group_e):
 def test_error_using_unload_graph(sess, student_v):
     with pytest.raises(AnalyticalEngineInternalError):
         g = sess.g()
-        ug = g.unload()
+        ug = g._unload()
         g1 = g.add_vertices(student_v, "student")
         sess.run([ug, g1])
 
@@ -156,7 +156,7 @@ def test_unload_app(sess, arrow_property_graph_lpa_u2i):
         arrow_property_graph_lpa_u2i,
         AppAssets(algo="lpau2i", context="labeled_vertex_property"),
     )
-    ua1 = a1.unload()
+    ua1 = a1._unload()
     assert sess.run(ua1) is None
 
     # case 2
@@ -165,7 +165,7 @@ def test_unload_app(sess, arrow_property_graph_lpa_u2i):
         arrow_property_graph_lpa_u2i,
         AppAssets(algo="lpau2i", context="labeled_vertex_property"),
     )
-    ua1 = a1.unload()
+    ua1 = a1._unload()
     assert sess.run(ua1) is None
     assert sess.run(ua1) is None
 
@@ -175,7 +175,7 @@ def test_unload_app(sess, arrow_property_graph_lpa_u2i):
         arrow_property_graph_lpa_u2i,
         AppAssets(algo="lpau2i", context="labeled_vertex_property"),
     )
-    ua1 = a1.unload()
+    ua1 = a1._unload()
     assert sess.run(ua1) is None
     c1 = a1(max_round=10)
     r1 = c1.to_numpy("r:v0.label_0")

--- a/python/graphscope/tests/unittest/test_lazy.py
+++ b/python/graphscope/tests/unittest/test_lazy.py
@@ -131,16 +131,6 @@ def test_unload_graph(sess, student_v, teacher_v, student_group_e):
     del g
 
 
-def test_unload_app(sess, arrow_property_graph_lpa_u2i):
-    # case 1
-    a1 = AppDAGNode(
-        arrow_property_graph_lpa_u2i,
-        AppAssets(algo="lpau2i", context="labeled_vertex_property"),
-    )
-    a1 = sess.run(a1)
-    del a1
-
-
 def test_graph_to_numpy(sess):
     g = load_p2p_network(sess)
     pg = g.project(vertices={"host": ["id"]}, edges={"connect": ["dist"]})


### PR DESCRIPTION
- Use del rather than unload
- Projected graph now hold a reference to the base graph

Fixes #1394 