### PR TITLE
Attempt backoff and retry during download dataset

### DIFF
--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -1352,6 +1352,7 @@ def set_option(**kwargs):
         - engine_params
         - initializing_interactive_engine
         - timeout_seconds
+        - dataset_download_retries
 
     Args:
         kwargs: dict
@@ -1406,6 +1407,7 @@ def get_option(key):
         - engine_params
         - initializing_interactive_engine
         - timeout_seconds
+        - dataset_download_retries
 
     Args:
         key: str

--- a/python/graphscope/config.py
+++ b/python/graphscope/config.py
@@ -104,3 +104,6 @@ class GSConfig(object):
     k8s_dataset_image = (
         f"registry.cn-hongkong.aliyuncs.com/graphscope/dataset:{__version__}"
     )
+
+    # download_retries
+    dataset_download_retries = 3


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Add backoff and retry mechanism with `urllib.request` rather than use [urllib3](https://github.com/urllib3/urllib3/blob/main/src/urllib3/util/retry.py), as compared with [urllib3](https://urllib3.readthedocs.io/en/stable/), The `urllib` we used has the following advantages:
-  The `urlretrieve` in [urllib.request](https://docs.python.org/3/library/urllib.request.html) is a wrapper to copy a network object denoted by a URL to a local file, which doesn't have in `urllib3 (just a HTTP client)`
- support `reporthook` to display ProgressBar

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1391 

