### PR TITLE
Add another write path that uses the C++ IO adaptor

### DIFF
--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -353,21 +353,11 @@ bl::result<void> GrapeInstance::modifyEdges(const rpc::GSParams& params) {
 
 bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::contextToNumpy(
     const rpc::GSParams& params) {
-  std::pair<std::string, std::string> range;
   std::string s_selector;
-
-  if (params.HasKey(rpc::VERTEX_RANGE)) {
-    BOOST_LEAF_AUTO(range_in_json, params.Get<std::string>(rpc::VERTEX_RANGE));
-    range = parseRange(range_in_json);
-  }
-
-  if (params.HasKey(rpc::SELECTOR)) {
-    BOOST_LEAF_ASSIGN(s_selector, params.Get<std::string>(rpc::SELECTOR));
-  }
-
-  BOOST_LEAF_AUTO(context_key, params.Get<std::string>(rpc::CONTEXT_KEY));
-  BOOST_LEAF_AUTO(base_ctx_wrapper,
-                  object_manager_.GetObject<IContextWrapper>(context_key));
+  std::pair<std::string, std::string> range;
+  std::shared_ptr<IContextWrapper> base_ctx_wrapper;
+  BOOST_LEAF_CHECK(
+      getContextDetails(params, &s_selector, &range, &base_ctx_wrapper));
 
   auto ctx_type = base_ctx_wrapper->context_type();
 
@@ -448,21 +438,11 @@ bl::result<std::string> GrapeInstance::getContextData(
 
 bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::contextToDataframe(
     const rpc::GSParams& params) {
+  std::string s_selector;
   std::pair<std::string, std::string> range;
-  std::string s_selectors;
-
-  if (params.HasKey(rpc::VERTEX_RANGE)) {
-    BOOST_LEAF_AUTO(range_in_json, params.Get<std::string>(rpc::VERTEX_RANGE));
-    range = parseRange(range_in_json);
-  }
-
-  if (params.HasKey(rpc::SELECTOR)) {
-    BOOST_LEAF_ASSIGN(s_selectors, params.Get<std::string>(rpc::SELECTOR));
-  }
-
-  BOOST_LEAF_AUTO(context_key, params.Get<std::string>(rpc::CONTEXT_KEY));
-  BOOST_LEAF_AUTO(base_ctx_wrapper,
-                  object_manager_.GetObject<IContextWrapper>(context_key));
+  std::shared_ptr<IContextWrapper> base_ctx_wrapper;
+  BOOST_LEAF_CHECK(
+      getContextDetails(params, &s_selector, &range, &base_ctx_wrapper));
 
   auto ctx_type = base_ctx_wrapper->context_type();
 
@@ -475,26 +455,26 @@ bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::contextToDataframe(
     auto wrapper =
         std::dynamic_pointer_cast<IVertexDataContextWrapper>(base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
     return wrapper->ToDataframe(comm_spec_, selectors, range);
   } else if (ctx_type == CONTEXT_TYPE_LABELED_VERTEX_DATA) {
     auto wrapper = std::dynamic_pointer_cast<ILabeledVertexDataContextWrapper>(
         base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
     return wrapper->ToDataframe(comm_spec_, selectors, range);
   } else if (ctx_type == CONTEXT_TYPE_VERTEX_PROPERTY) {
     auto wrapper = std::dynamic_pointer_cast<IVertexPropertyContextWrapper>(
         base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
     return wrapper->ToDataframe(comm_spec_, selectors, range);
   } else if (ctx_type == CONTEXT_TYPE_LABELED_VERTEX_PROPERTY) {
     auto wrapper =
         std::dynamic_pointer_cast<ILabeledVertexPropertyContextWrapper>(
             base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
     return wrapper->ToDataframe(comm_spec_, selectors, range);
 #ifdef ENABLE_JAVA_SDK
   } else if (ctx_type.find(CONTEXT_TYPE_JAVA_PIE_PROPERTY) !=
@@ -508,7 +488,7 @@ bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::contextToDataframe(
     }
     auto wrapper = std::dynamic_pointer_cast<IJavaPIEPropertyContextWrapper>(
         base_ctx_wrapper);
-    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
     return wrapper->ToDataframe(comm_spec_, selectors, range);
   } else if (ctx_type.find(CONTEXT_TYPE_JAVA_PIE_PROJECTED) !=
              std::string::npos) {
@@ -521,7 +501,7 @@ bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::contextToDataframe(
     }
     auto wrapper = std::dynamic_pointer_cast<IJavaPIEProjectedContextWrapper>(
         base_ctx_wrapper);
-    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
     return wrapper->ToDataframe(comm_spec_, selectors, range);
 #endif
   }
@@ -531,17 +511,13 @@ bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::contextToDataframe(
 
 bl::result<std::string> GrapeInstance::contextToVineyardTensor(
     const rpc::GSParams& params) {
-  BOOST_LEAF_AUTO(context_key, params.Get<std::string>(rpc::CONTEXT_KEY));
-  BOOST_LEAF_AUTO(base_ctx_wrapper,
-                  object_manager_.GetObject<IContextWrapper>(context_key));
-  auto ctx_type = base_ctx_wrapper->context_type();
+  std::string s_selector;
   std::pair<std::string, std::string> range;
+  std::shared_ptr<IContextWrapper> base_ctx_wrapper;
+  BOOST_LEAF_CHECK(
+      getContextDetails(params, &s_selector, &range, &base_ctx_wrapper));
 
-  if (params.HasKey(rpc::VERTEX_RANGE)) {
-    BOOST_LEAF_AUTO(range_in_json, params.Get<std::string>(rpc::VERTEX_RANGE));
-    range = parseRange(range_in_json);
-  }
-
+  auto ctx_type = base_ctx_wrapper->context_type();
   vineyard::ObjectID id;
 
   if (ctx_type == CONTEXT_TYPE_TENSOR) {
@@ -554,7 +530,6 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
     auto wrapper =
         std::dynamic_pointer_cast<IVertexDataContextWrapper>(base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(s_selector, params.Get<std::string>(rpc::SELECTOR));
     BOOST_LEAF_AUTO(selector, Selector::parse(s_selector));
     BOOST_LEAF_ASSIGN(
         id, wrapper->ToVineyardTensor(comm_spec_, *client_, selector, range));
@@ -562,7 +537,6 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
     auto wrapper = std::dynamic_pointer_cast<ILabeledVertexDataContextWrapper>(
         base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(s_selector, params.Get<std::string>(rpc::SELECTOR));
     BOOST_LEAF_AUTO(selector, LabeledSelector::parse(s_selector));
     BOOST_LEAF_ASSIGN(
         id, wrapper->ToVineyardTensor(comm_spec_, *client_, selector, range));
@@ -570,7 +544,6 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
     auto wrapper = std::dynamic_pointer_cast<IVertexPropertyContextWrapper>(
         base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(s_selector, params.Get<std::string>(rpc::SELECTOR));
     BOOST_LEAF_AUTO(selector, Selector::parse(s_selector));
     BOOST_LEAF_ASSIGN(
         id, wrapper->ToVineyardTensor(comm_spec_, *client_, selector, range));
@@ -579,7 +552,6 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
         std::dynamic_pointer_cast<ILabeledVertexPropertyContextWrapper>(
             base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(s_selector, params.Get<std::string>(rpc::SELECTOR));
     BOOST_LEAF_AUTO(selector, LabeledSelector::parse(s_selector));
     BOOST_LEAF_ASSIGN(
         id, wrapper->ToVineyardTensor(comm_spec_, *client_, selector, range));
@@ -595,7 +567,6 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
     }
     auto wrapper = std::dynamic_pointer_cast<IJavaPIEPropertyContextWrapper>(
         base_ctx_wrapper);
-    BOOST_LEAF_AUTO(s_selector, params.Get<std::string>(rpc::SELECTOR));
     BOOST_LEAF_AUTO(selector, LabeledSelector::parse(s_selector));
     BOOST_LEAF_ASSIGN(
         id, wrapper->ToVineyardTensor(comm_spec_, *client_, selector, range));
@@ -610,7 +581,6 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
     }
     auto wrapper = std::dynamic_pointer_cast<IJavaPIEProjectedContextWrapper>(
         base_ctx_wrapper);
-    BOOST_LEAF_AUTO(s_selector, params.Get<std::string>(rpc::SELECTOR));
     BOOST_LEAF_AUTO(selector, Selector::parse(s_selector));
     BOOST_LEAF_ASSIGN(
         id, wrapper->ToVineyardTensor(comm_spec_, *client_, selector, range));
@@ -629,15 +599,11 @@ bl::result<std::string> GrapeInstance::contextToVineyardTensor(
 
 bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
     const rpc::GSParams& params) {
+  std::string s_selector;
   std::pair<std::string, std::string> range;
-
-  BOOST_LEAF_AUTO(context_key, params.Get<std::string>(rpc::CONTEXT_KEY));
-  BOOST_LEAF_AUTO(base_ctx_wrapper,
-                  object_manager_.GetObject<IContextWrapper>(context_key));
-  if (params.HasKey(rpc::VERTEX_RANGE)) {
-    BOOST_LEAF_AUTO(range_in_json, params.Get<std::string>(rpc::VERTEX_RANGE));
-    range = parseRange(range_in_json);
-  }
+  std::shared_ptr<IContextWrapper> base_ctx_wrapper;
+  BOOST_LEAF_CHECK(
+      getContextDetails(params, &s_selector, &range, &base_ctx_wrapper));
 
   vineyard::ObjectID id;
   auto ctx_type = base_ctx_wrapper->context_type();
@@ -651,8 +617,7 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
     auto vd_ctx_wrapper =
         std::dynamic_pointer_cast<IVertexDataContextWrapper>(base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(s_selectors, params.Get<std::string>(rpc::SELECTOR));
-    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
     BOOST_LEAF_ASSIGN(id, vd_ctx_wrapper->ToVineyardDataframe(
                               comm_spec_, *client_, selectors, range));
   } else if (ctx_type == CONTEXT_TYPE_LABELED_VERTEX_DATA) {
@@ -660,8 +625,7 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
         std::dynamic_pointer_cast<ILabeledVertexDataContextWrapper>(
             base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(s_selectors, params.Get<std::string>(rpc::SELECTOR));
-    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
     BOOST_LEAF_ASSIGN(id, vd_ctx_wrapper->ToVineyardDataframe(
                               comm_spec_, *client_, selectors, range));
   } else if (ctx_type == CONTEXT_TYPE_VERTEX_PROPERTY) {
@@ -669,8 +633,7 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
         std::dynamic_pointer_cast<IVertexPropertyContextWrapper>(
             base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(s_selectors, params.Get<std::string>(rpc::SELECTOR));
-    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
     BOOST_LEAF_ASSIGN(id, vd_ctx_wrapper->ToVineyardDataframe(
                               comm_spec_, *client_, selectors, range));
   } else if (ctx_type == CONTEXT_TYPE_LABELED_VERTEX_PROPERTY) {
@@ -678,8 +641,7 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
         std::dynamic_pointer_cast<ILabeledVertexPropertyContextWrapper>(
             base_ctx_wrapper);
 
-    BOOST_LEAF_AUTO(s_selectors, params.Get<std::string>(rpc::SELECTOR));
-    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
     BOOST_LEAF_ASSIGN(id, vd_ctx_wrapper->ToVineyardDataframe(
                               comm_spec_, *client_, selectors, range));
 #ifdef ENABLE_JAVA_SDK
@@ -695,8 +657,7 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
     auto vd_ctx_wrapper =
         std::dynamic_pointer_cast<IJavaPIEPropertyContextWrapper>(
             base_ctx_wrapper);
-    BOOST_LEAF_AUTO(s_selectors, params.Get<std::string>(rpc::SELECTOR));
-    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
     BOOST_LEAF_ASSIGN(id, vd_ctx_wrapper->ToVineyardDataframe(
                               comm_spec_, *client_, selectors, range));
   } else if (ctx_type.find(CONTEXT_TYPE_JAVA_PIE_PROJECTED) !=
@@ -711,8 +672,7 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
     auto vd_ctx_wrapper =
         std::dynamic_pointer_cast<IJavaPIEProjectedContextWrapper>(
             base_ctx_wrapper);
-    BOOST_LEAF_AUTO(s_selectors, params.Get<std::string>(rpc::SELECTOR));
-    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selectors));
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
     BOOST_LEAF_ASSIGN(id, vd_ctx_wrapper->ToVineyardDataframe(
                               comm_spec_, *client_, selectors, range));
 #endif
@@ -728,11 +688,114 @@ bl::result<std::string> GrapeInstance::contextToVineyardDataFrame(
   return toJson({{"object_id", s_id}});
 }
 
+bl::result<void> GrapeInstance::outputContext(const rpc::GSParams& params) {
+  std::string s_selector;
+  std::pair<std::string, std::string> range;
+  std::shared_ptr<IContextWrapper> base_ctx_wrapper;
+  BOOST_LEAF_CHECK(
+      getContextDetails(params, &s_selector, &range, &base_ctx_wrapper));
+
+  if (!range.first.empty() && !range.second.empty()) {
+    LOG(WARNING)
+        << "Specifing vertex range for output is not supported and ignored";
+  }
+
+  BOOST_LEAF_AUTO(location, params.Get<std::string>(rpc::FD));
+
+  auto ctx_type = base_ctx_wrapper->context_type();
+  std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>> arrays;
+  if (ctx_type == CONTEXT_TYPE_VERTEX_DATA) {
+    auto wrapper =
+        std::dynamic_pointer_cast<IVertexDataContextWrapper>(base_ctx_wrapper);
+
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
+    BOOST_LEAF_ASSIGN(arrays, wrapper->ToArrowArrays(comm_spec_, selectors));
+  } else if (ctx_type == CONTEXT_TYPE_LABELED_VERTEX_DATA) {
+    auto wrapper = std::dynamic_pointer_cast<ILabeledVertexDataContextWrapper>(
+        base_ctx_wrapper);
+
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
+    BOOST_LEAF_AUTO(arrays_map, wrapper->ToArrowArrays(comm_spec_, selectors));
+    for (auto& pair : arrays_map) {
+      arrays.insert(arrays.end(), pair.second.begin(), pair.second.end());
+    }
+  } else if (ctx_type == CONTEXT_TYPE_VERTEX_PROPERTY) {
+    auto wrapper = std::dynamic_pointer_cast<IVertexPropertyContextWrapper>(
+        base_ctx_wrapper);
+
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
+    BOOST_LEAF_ASSIGN(arrays, wrapper->ToArrowArrays(comm_spec_, selectors));
+  } else if (ctx_type == CONTEXT_TYPE_LABELED_VERTEX_PROPERTY) {
+    auto wrapper =
+        std::dynamic_pointer_cast<ILabeledVertexPropertyContextWrapper>(
+            base_ctx_wrapper);
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
+    BOOST_LEAF_AUTO(arrays_map, wrapper->ToArrowArrays(comm_spec_, selectors));
+    for (auto& pair : arrays_map) {
+      arrays.insert(arrays.end(), pair.second.begin(), pair.second.end());
+    }
+#ifdef ENABLE_JAVA_SDK
+  } else if (ctx_type.find(CONTEXT_TYPE_JAVA_PIE_PROPERTY) !=
+             std::string::npos) {
+    std::vector<std::string> outer_and_inner;
+    boost::split(outer_and_inner, ctx_type, boost::is_any_of(":"));
+    if (outer_and_inner.size() != 2) {
+      RETURN_GS_ERROR(
+          vineyard::ErrorCode::kIllegalStateError,
+          "Unsupported java property context type: " + std::string(ctx_type));
+    }
+    auto wrapper = std::dynamic_pointer_cast<IJavaPIEPropertyContextWrapper>(
+        base_ctx_wrapper);
+    BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
+    BOOST_LEAF_AUTO(arrays_map, wrapper->ToArrowArrays(comm_spec_, selectors));
+    for (auto& pair : arrays_map) {
+      arrays.insert(arrays.end(), pair.second.begin(), pair.second.end());
+    }
+  } else if (ctx_type.find(CONTEXT_TYPE_JAVA_PIE_PROJECTED) !=
+             std::string::npos) {
+    std::vector<std::string> outer_and_inner;
+    boost::split(outer_and_inner, ctx_type, boost::is_any_of(":"));
+    if (outer_and_inner.size() != 2) {
+      RETURN_GS_ERROR(
+          vineyard::ErrorCode::kInvalidValueError,
+          "Unsupported java projected context type: " + std::string(ctx_type));
+    }
+    auto wrapper = std::dynamic_pointer_cast<IJavaPIEProjectedContextWrapper>(
+        base_ctx_wrapper);
+    BOOST_LEAF_AUTO(selectors, Selector::ParseSelectors(s_selector));
+    BOOST_LEAF_ASSIGN(arrays, wrapper->ToArrowArrays(comm_spec_, selectors));
+#endif
+  } else {
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
+                    "Unsupported context type: " + std::string(ctx_type));
+  }
+  std::vector<std::shared_ptr<arrow::Array>> arrays_vec;
+  std::vector<std::shared_ptr<arrow::Field>> fields_vec;
+  for (auto& pair : arrays) {
+    arrays_vec.push_back(pair.second);
+    auto field =
+        std::make_shared<arrow::Field>(pair.first, pair.second->type());
+    fields_vec.push_back(field);
+  }
+  auto schema = std::make_shared<arrow::Schema>(fields_vec);
+  auto table = arrow::Table::Make(schema, arrays_vec);
+  VLOG(2) << "Output table schema: " << table->schema()->ToString();
+  auto io_adaptor = vineyard::IOFactory::CreateIOAdaptor(location);
+  if (io_adaptor == nullptr) {
+    RETURN_GS_ERROR(vineyard::ErrorCode::kIOError,
+                    "Cannot find a supported adaptor for " + location);
+  }
+  ARROW_OK_OR_RAISE(io_adaptor->Open("w"));
+  ARROW_OK_OR_RAISE(io_adaptor->WriteTable(table));
+  ARROW_OK_OR_RAISE(io_adaptor->Close());
+  return {};
+}
+
 bl::result<rpc::graph::GraphDefPb> GrapeInstance::addColumn(
     const rpc::GSParams& params) {
   BOOST_LEAF_AUTO(graph_name, params.Get<std::string>(rpc::GRAPH_NAME));
   BOOST_LEAF_AUTO(context_key, params.Get<std::string>(rpc::CONTEXT_KEY));
-  BOOST_LEAF_AUTO(s_selectors, params.Get<std::string>(rpc::SELECTOR));
+  BOOST_LEAF_AUTO(s_selector, params.Get<std::string>(rpc::SELECTOR));
   BOOST_LEAF_AUTO(
       frag_wrapper,
       object_manager_.GetObject<ILabeledFragmentWrapper>(graph_name));
@@ -747,7 +810,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::addColumn(
 
   BOOST_LEAF_AUTO(new_frag_wrapper,
                   frag_wrapper->AddColumn(comm_spec_, dst_graph_name,
-                                          ctx_wrapper, s_selectors));
+                                          ctx_wrapper, s_selector));
   BOOST_LEAF_CHECK(object_manager_.PutObject(new_frag_wrapper));
   return new_frag_wrapper->graph_def();
 }
@@ -1055,8 +1118,8 @@ bl::result<std::shared_ptr<grape::InArchive>> GrapeInstance::graphToDataframe(
     range = parseRange(range_in_json);
   }
 
-  BOOST_LEAF_AUTO(s_selectors, params.Get<std::string>(rpc::SELECTOR));
-  BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selectors));
+  BOOST_LEAF_AUTO(s_selector, params.Get<std::string>(rpc::SELECTOR));
+  BOOST_LEAF_AUTO(selectors, LabeledSelector::ParseSelectors(s_selector));
 
   return wrapper->ToDataframe(comm_spec_, selectors, range);
 }
@@ -1269,6 +1332,10 @@ bl::result<std::shared_ptr<DispatchResult>> GrapeInstance::OnReceive(
   case rpc::TO_VINEYARD_DATAFRAME: {
     BOOST_LEAF_AUTO(vy_obj_id_in_json, contextToVineyardDataFrame(params));
     r->set_data(vy_obj_id_in_json);
+    break;
+  }
+  case rpc::OUTPUT: {
+    BOOST_LEAF_CHECK(outputContext(params));
     break;
   }
   case rpc::GET_CONTEXT_DATA: {

--- a/analytical_engine/core/grape_instance.h
+++ b/analytical_engine/core/grape_instance.h
@@ -122,6 +122,10 @@ class GrapeInstance : public Subscriber {
   bl::result<std::string> contextToVineyardDataFrame(
       const rpc::GSParams& params);
 
+  bl::result<void> outputContext(const rpc::GSParams& params);
+
+  bl::result<std::string> output(const rpc::GSParams& params);
+
   bl::result<rpc::graph::GraphDefPb> addColumn(const rpc::GSParams& params);
 
   bl::result<rpc::graph::GraphDefPb> convertGraph(const rpc::GSParams& params);
@@ -151,6 +155,24 @@ class GrapeInstance : public Subscriber {
       const rpc::GSParams& params);
 
   bl::result<void> registerGraphType(const rpc::GSParams& params);
+
+  bl::result<void> getContextDetails(
+      const rpc::GSParams& params, std::string* s_selector,
+      std::pair<std::string, std::string>* range,
+      std::shared_ptr<IContextWrapper>* wrapper) {
+    if (params.HasKey(rpc::SELECTOR)) {
+      BOOST_LEAF_ASSIGN(*s_selector, params.Get<std::string>(rpc::SELECTOR));
+    }
+    if (params.HasKey(rpc::VERTEX_RANGE)) {
+      BOOST_LEAF_AUTO(range_in_json,
+                      params.Get<std::string>(rpc::VERTEX_RANGE));
+      *range = parseRange(range_in_json);
+    }
+    BOOST_LEAF_AUTO(context_key, params.Get<std::string>(rpc::CONTEXT_KEY));
+    BOOST_LEAF_ASSIGN(*wrapper,
+                      object_manager_.GetObject<IContextWrapper>(context_key));
+    return {};
+  }
 
   static std::string toJson(const std::map<std::string, std::string>& map) {
     boost::property_tree::ptree pt;

--- a/analytical_engine/core/object/fragment_wrapper.h
+++ b/analytical_engine/core/object/fragment_wrapper.h
@@ -750,6 +750,71 @@ class FragmentWrapper<ArrowProjectedFragment<OID_T, VID_T, VDATA_T, EDATA_T>>
   std::shared_ptr<fragment_t> fragment_;
 };
 
+/**
+ * @brief A specialized FragmentWrapper for ArrowFlattenedFragment.
+ */
+template <typename OID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
+class FragmentWrapper<ArrowFlattenedFragment<OID_T, VID_T, VDATA_T, EDATA_T>>
+    : public IFragmentWrapper {
+  using fragment_t = ArrowFlattenedFragment<OID_T, VID_T, VDATA_T, EDATA_T>;
+
+ public:
+  FragmentWrapper(const std::string& id, rpc::graph::GraphDefPb graph_def,
+                  std::shared_ptr<fragment_t> fragment)
+      : IFragmentWrapper(id),
+        graph_def_(std::move(graph_def)),
+        fragment_(std::move(fragment)) {
+    CHECK_EQ(graph_def_.graph_type(), rpc::graph::ARROW_FLATTENED);
+  }
+
+  std::shared_ptr<void> fragment() const override {
+    return std::static_pointer_cast<void>(fragment_);
+  }
+
+  const rpc::graph::GraphDefPb& graph_def() const override {
+    return graph_def_;
+  }
+
+  bl::result<std::unique_ptr<grape::InArchive>> ReportGraph(
+      const grape::CommSpec& comm_spec, const rpc::GSParams& params) override {
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
+                    "Not implemented.");
+  }
+
+  bl::result<std::shared_ptr<IFragmentWrapper>> CopyGraph(
+      const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
+      const std::string& copy_type) override {
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
+                    "Cannot copy the ArrowFlattenedFragment");
+  }
+
+  bl::result<std::shared_ptr<IFragmentWrapper>> ToDirected(
+      const grape::CommSpec& comm_spec,
+      const std::string& dst_graph_name) override {
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
+                    "Cannot convert to the directed ArrowFlattenedFragment");
+  }
+
+  bl::result<std::shared_ptr<IFragmentWrapper>> ToUndirected(
+      const grape::CommSpec& comm_spec,
+      const std::string& dst_graph_name) override {
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
+                    "Cannot convert to the undirected ArrowFlattenedFragment");
+  }
+
+  bl::result<std::shared_ptr<IFragmentWrapper>> CreateGraphView(
+      const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
+      const std::string& copy_type) override {
+    RETURN_GS_ERROR(
+        vineyard::ErrorCode::kInvalidOperationError,
+        "Cannot generate a graph view over the ArrowFlattenedFragment.");
+  }
+
+ private:
+  rpc::graph::GraphDefPb graph_def_;
+  std::shared_ptr<fragment_t> fragment_;
+};
+
 #ifdef NETWORKX
 /**
  * @brief A specialized FragmentWrapper for DynamicFragment.
@@ -979,71 +1044,6 @@ class FragmentWrapper<DynamicProjectedFragment<VDATA_T, EDATA_T>>
   std::shared_ptr<fragment_t> fragment_;
 };
 
-/**
- * @brief A specialized FragmentWrapper for ArrowFlattenedFragment.
- */
-template <typename OID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
-class FragmentWrapper<ArrowFlattenedFragment<OID_T, VID_T, VDATA_T, EDATA_T>>
-    : public IFragmentWrapper {
-  using fragment_t = ArrowFlattenedFragment<OID_T, VID_T, VDATA_T, EDATA_T>;
-
- public:
-  FragmentWrapper(const std::string& id, rpc::graph::GraphDefPb graph_def,
-                  std::shared_ptr<fragment_t> fragment)
-      : IFragmentWrapper(id),
-        graph_def_(std::move(graph_def)),
-        fragment_(std::move(fragment)) {
-    CHECK_EQ(graph_def_.graph_type(), rpc::graph::ARROW_FLATTENED);
-  }
-
-  std::shared_ptr<void> fragment() const override {
-    return std::static_pointer_cast<void>(fragment_);
-  }
-
-  const rpc::graph::GraphDefPb& graph_def() const override {
-    return graph_def_;
-  }
-
-  bl::result<std::unique_ptr<grape::InArchive>> ReportGraph(
-      const grape::CommSpec& comm_spec, const rpc::GSParams& params) override {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Not implemented.");
-  }
-
-  bl::result<std::shared_ptr<IFragmentWrapper>> CopyGraph(
-      const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
-      const std::string& copy_type) override {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Cannot copy the ArrowFlattenedFragment");
-  }
-
-  bl::result<std::shared_ptr<IFragmentWrapper>> ToDirected(
-      const grape::CommSpec& comm_spec,
-      const std::string& dst_graph_name) override {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Cannot convert to the directed ArrowFlattenedFragment");
-  }
-
-  bl::result<std::shared_ptr<IFragmentWrapper>> ToUndirected(
-      const grape::CommSpec& comm_spec,
-      const std::string& dst_graph_name) override {
-    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
-                    "Cannot convert to the undirected ArrowFlattenedFragment");
-  }
-
-  bl::result<std::shared_ptr<IFragmentWrapper>> CreateGraphView(
-      const grape::CommSpec& comm_spec, const std::string& dst_graph_name,
-      const std::string& copy_type) override {
-    RETURN_GS_ERROR(
-        vineyard::ErrorCode::kInvalidOperationError,
-        "Cannot generate a graph view over the ArrowFlattenedFragment.");
-  }
-
- private:
-  rpc::graph::GraphDefPb graph_def_;
-  std::shared_ptr<fragment_t> fragment_;
-};
 #endif
-
 }  // namespace gs
 #endif  // ANALYTICAL_ENGINE_CORE_OBJECT_FRAGMENT_WRAPPER_H_

--- a/analytical_engine/frame/project_frame.cc
+++ b/analytical_engine/frame/project_frame.cc
@@ -130,52 +130,6 @@ class ProjectSimpleFrame<
   }
 };
 
-#ifdef NETWORKX
-template <typename VDATA_T, typename EDATA_T>
-class ProjectSimpleFrame<gs::DynamicProjectedFragment<VDATA_T, EDATA_T>> {
-  using fragment_t = DynamicFragment;
-  using projected_fragment_t = gs::DynamicProjectedFragment<VDATA_T, EDATA_T>;
-
- public:
-  static bl::result<std::shared_ptr<IFragmentWrapper>> Project(
-      std::shared_ptr<IFragmentWrapper>& input_wrapper,
-      const std::string& projected_graph_name, const rpc::GSParams& params) {
-    auto graph_type = input_wrapper->graph_def().graph_type();
-    if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
-      RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
-                      "graph_type should be DYNAMIC_PROPERTY, got " +
-                          rpc::graph::GraphTypePb_Name(graph_type));
-    }
-    BOOST_LEAF_AUTO(v_prop_key, params.Get<std::string>(rpc::V_PROP_KEY));
-    BOOST_LEAF_AUTO(e_prop_key, params.Get<std::string>(rpc::E_PROP_KEY));
-    auto input_frag =
-        std::static_pointer_cast<fragment_t>(input_wrapper->fragment());
-    auto projected_frag =
-        projected_fragment_t::Project(input_frag, v_prop_key, e_prop_key);
-
-    rpc::graph::GraphDefPb graph_def;
-
-    graph_def.set_key(projected_graph_name);
-    graph_def.set_graph_type(rpc::graph::DYNAMIC_PROJECTED);
-    gs::rpc::graph::VineyardInfoPb vy_info;
-    if (graph_def.has_extension()) {
-      graph_def.extension().UnpackTo(&vy_info);
-    }
-    vy_info.set_oid_type(PropertyTypeToPb(vineyard::normalize_datatype(
-        vineyard::TypeName<typename projected_fragment_t::oid_t>::Get())));
-    vy_info.set_vid_type(PropertyTypeToPb(vineyard::normalize_datatype(
-        vineyard::TypeName<typename projected_fragment_t::vid_t>::Get())));
-    vy_info.set_vdata_type(PropertyTypeToPb(vineyard::normalize_datatype(
-        vineyard::TypeName<typename projected_fragment_t::vdata_t>::Get())));
-    vy_info.set_edata_type(PropertyTypeToPb(vineyard::normalize_datatype(
-        vineyard::TypeName<typename projected_fragment_t::edata_t>::Get())));
-    graph_def.mutable_extension()->PackFrom(vy_info);
-    auto wrapper = std::make_shared<FragmentWrapper<projected_fragment_t>>(
-        projected_graph_name, graph_def, projected_frag);
-    return std::dynamic_pointer_cast<IFragmentWrapper>(wrapper);
-  }
-};
-
 template <typename OID_T, typename VID_T, typename VDATA_T, typename EDATA_T>
 class ProjectSimpleFrame<
     gs::ArrowFlattenedFragment<OID_T, VID_T, VDATA_T, EDATA_T>> {
@@ -205,6 +159,52 @@ class ProjectSimpleFrame<
 
     graph_def.set_key(projected_graph_name);
     graph_def.set_graph_type(rpc::graph::ARROW_FLATTENED);
+    gs::rpc::graph::VineyardInfoPb vy_info;
+    if (graph_def.has_extension()) {
+      graph_def.extension().UnpackTo(&vy_info);
+    }
+    vy_info.set_oid_type(PropertyTypeToPb(vineyard::normalize_datatype(
+        vineyard::TypeName<typename projected_fragment_t::oid_t>::Get())));
+    vy_info.set_vid_type(PropertyTypeToPb(vineyard::normalize_datatype(
+        vineyard::TypeName<typename projected_fragment_t::vid_t>::Get())));
+    vy_info.set_vdata_type(PropertyTypeToPb(vineyard::normalize_datatype(
+        vineyard::TypeName<typename projected_fragment_t::vdata_t>::Get())));
+    vy_info.set_edata_type(PropertyTypeToPb(vineyard::normalize_datatype(
+        vineyard::TypeName<typename projected_fragment_t::edata_t>::Get())));
+    graph_def.mutable_extension()->PackFrom(vy_info);
+    auto wrapper = std::make_shared<FragmentWrapper<projected_fragment_t>>(
+        projected_graph_name, graph_def, projected_frag);
+    return std::dynamic_pointer_cast<IFragmentWrapper>(wrapper);
+  }
+};
+
+#ifdef NETWORKX
+template <typename VDATA_T, typename EDATA_T>
+class ProjectSimpleFrame<gs::DynamicProjectedFragment<VDATA_T, EDATA_T>> {
+  using fragment_t = DynamicFragment;
+  using projected_fragment_t = gs::DynamicProjectedFragment<VDATA_T, EDATA_T>;
+
+ public:
+  static bl::result<std::shared_ptr<IFragmentWrapper>> Project(
+      std::shared_ptr<IFragmentWrapper>& input_wrapper,
+      const std::string& projected_graph_name, const rpc::GSParams& params) {
+    auto graph_type = input_wrapper->graph_def().graph_type();
+    if (graph_type != rpc::graph::DYNAMIC_PROPERTY) {
+      RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidValueError,
+                      "graph_type should be DYNAMIC_PROPERTY, got " +
+                          rpc::graph::GraphTypePb_Name(graph_type));
+    }
+    BOOST_LEAF_AUTO(v_prop_key, params.Get<std::string>(rpc::V_PROP_KEY));
+    BOOST_LEAF_AUTO(e_prop_key, params.Get<std::string>(rpc::E_PROP_KEY));
+    auto input_frag =
+        std::static_pointer_cast<fragment_t>(input_wrapper->fragment());
+    auto projected_frag =
+        projected_fragment_t::Project(input_frag, v_prop_key, e_prop_key);
+
+    rpc::graph::GraphDefPb graph_def;
+
+    graph_def.set_key(projected_graph_name);
+    graph_def.set_graph_type(rpc::graph::DYNAMIC_PROJECTED);
     gs::rpc::graph::VineyardInfoPb vy_info;
     if (graph_def.has_extension()) {
       graph_def.extension().UnpackTo(&vy_info);

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -587,8 +587,8 @@ class CoordinatorServiceServicer(
             )
             if op.op == types_pb2.DATA_SOURCE:
                 op_result = self._process_data_source(op, dag_bodies, loader_op_bodies)
-            elif op.op == types_pb2.OUTPUT:
-                op_result = self._output(op)
+            elif op.op == types_pb2.DATA_SINK:
+                op_result = self._process_data_sink(op)
             else:
                 raise RuntimeError("Unsupport op type: " + str(op.op))
             response_head.head.results.append(op_result)
@@ -926,7 +926,7 @@ class CoordinatorServiceServicer(
             result=pickle.dumps(rlt),
         )
 
-    def _output(self, op: op_def_pb2.OpDef):
+    def _process_data_sink(self, op: op_def_pb2.OpDef):
         import vineyard
         import vineyard.io
 

--- a/coordinator/gscoordinator/dag_manager.py
+++ b/coordinator/gscoordinator/dag_manager.py
@@ -53,6 +53,7 @@ class DAGManager(object):
         types_pb2.GRAPH_TO_DATAFRAME,  # need loaded graph to transform selector
         types_pb2.TO_VINEYARD_TENSOR,  # need loaded graph to transform selector
         types_pb2.TO_VINEYARD_DATAFRAME,  # need loaded graph to transform selector
+        types_pb2.OUTPUT,  # need loaded graph to transform selector
         types_pb2.PROJECT_GRAPH,  # need loaded graph to transform selector
         types_pb2.PROJECT_TO_SIMPLE,  # need loaded graph schema information
         types_pb2.ADD_COLUMN,  # need ctx result
@@ -75,7 +76,7 @@ class DAGManager(object):
 
     _coordinator_split_op = [
         types_pb2.DATA_SOURCE,  # spawn an io stream to read/write data from/to vineyard
-        types_pb2.OUTPUT,  # spawn an io stream to read/write data from/to vineyard
+        types_pb2.DATA_SINK,  # spawn an io stream to read/write data from/to vineyard
     ]
 
     def __init__(self, request_iterator: Sequence[message_pb2.RunStepRequest]):

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -508,6 +508,7 @@ def op_pre_process(op, op_result_pool, key_to_op, **kwargs):  # noqa: C901
         types_pb2.CONTEXT_TO_DATAFRAME,
         types_pb2.TO_VINEYARD_TENSOR,
         types_pb2.TO_VINEYARD_DATAFRAME,
+        types_pb2.OUTPUT,
     ):
         _pre_process_for_context_op(op, op_result_pool, key_to_op, **kwargs)
     if op.op in (types_pb2.GRAPH_TO_NUMPY, types_pb2.GRAPH_TO_DATAFRAME):
@@ -538,8 +539,8 @@ def op_pre_process(op, op_result_pool, key_to_op, **kwargs):  # noqa: C901
         _pre_process_for_close_learning_instance_op(
             op, op_result_pool, key_to_op, **kwargs
         )
-    if op.op == types_pb2.OUTPUT:
-        _pre_process_for_output_op(op, op_result_pool, key_to_op, **kwargs)
+    if op.op == types_pb2.DATA_SINK:
+        _pre_process_for_data_sink_op(op, op_result_pool, key_to_op, **kwargs)
     if op.op in (types_pb2.TO_DIRECTED, types_pb2.TO_UNDIRECTED):
         _pre_process_for_transform_op(op, op_result_pool, key_to_op, **kwargs)
 
@@ -857,7 +858,11 @@ def _pre_process_for_context_op(op, op_result_pool, key_to_op, **kwargs):
     schema = GraphSchema()
     schema.from_graph_def(r.graph_def)
     selector = op.attr[types_pb2.SELECTOR].s.decode("utf-8")
-    if op.op in (types_pb2.CONTEXT_TO_DATAFRAME, types_pb2.TO_VINEYARD_DATAFRAME):
+    if op.op in (
+        types_pb2.CONTEXT_TO_DATAFRAME,
+        types_pb2.TO_VINEYARD_DATAFRAME,
+        types_pb2.OUTPUT,
+    ):
         selector = _tranform_dataframe_selector(context_type, schema, selector)
     else:
         # to numpy
@@ -868,7 +873,7 @@ def _pre_process_for_context_op(op, op_result_pool, key_to_op, **kwargs):
         )
 
 
-def _pre_process_for_output_op(op, op_result_pool, key_to_op, **kwargs):
+def _pre_process_for_data_sink_op(op, op_result_pool, key_to_op, **kwargs):
     assert len(op.parents) == 1
     key_of_parent_op = op.parents[0]
     parent_op = key_to_op[key_of_parent_op]

--- a/proto/graphscope/proto/types.proto
+++ b/proto/graphscope/proto/types.proto
@@ -111,6 +111,7 @@ enum OperationType {
   CLOSE_LEARNING_INSTANCE = 42;
 
   DATA_SOURCE = 46;  // loader
+  DATA_SINK = 47;
 
   // data
   CONTEXT_TO_NUMPY = 50;

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -254,8 +254,20 @@ class BaseContextDAGNode(DAGNode):
         Returns:
             :class:`graphscope.framework.context.ResultDAGNode`, evaluated in eager mode.
         """
-        df = self.to_vineyard_dataframe(selector, vertex_range)
-        op = dag_utils.output(df, fd, **kwargs)
+        protocol = fd.split("://")[0]
+        if protocol in ("hdfs", "hive", "oss", "s3"):
+            df = self.to_vineyard_dataframe(selector, vertex_range)
+            op = dag_utils.to_data_sink(df, fd, **kwargs)
+        else:
+            check_argument(
+                isinstance(selector, Mapping), "selector of to_dataframe must be a dict"
+            )
+            for _, value in selector.items():
+                self._check_selector(value)
+            _ensure_consistent_label(self.context_type, selector)
+            selector = json.dumps(selector)
+            vertex_range = utils.transform_vertex_range(vertex_range)
+            op = dag_utils.output(self, fd, selector, vertex_range, **kwargs)
         return ResultDAGNode(self, op)
 
     def __del__(self):

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -255,7 +255,9 @@ class BaseContextDAGNode(DAGNode):
             :class:`graphscope.framework.context.ResultDAGNode`, evaluated in eager mode.
         """
         protocol = fd.split("://")[0]
-        if protocol in ("hdfs", "hive", "oss", "s3"):
+        # Still use the stream to write to file,
+        # as the C++ adaptor in Vineyard requires arrow >= 4.0.0
+        if protocol in ("file", "hdfs", "hive", "oss", "s3"):
             df = self.to_vineyard_dataframe(selector, vertex_range)
             op = dag_utils.to_data_sink(df, fd, **kwargs)
         else:

--- a/python/graphscope/framework/dag_utils.py
+++ b/python/graphscope/framework/dag_utils.py
@@ -891,13 +891,13 @@ def to_vineyard_dataframe(context, selector=None, vertex_range=None):
     return op
 
 
-def output(result, fd, **kwargs):
-    """Dump result to `fd`
+def to_data_sink(result, fd, **kwargs):
+    """Dump result to `fd` by drivers in vineyard.
 
     Parameters:
         result (:class:`graphscope.framework.context.ResultDAGNode`):
             Dataframe or numpy or result hold the object id of vineyard dataframe.
-        fd (str): Such as `file:///tmp/result_path`
+        fd (str): Such as `hdfs:///tmp/result_path`
         kwargs (dict, optional): Storage options with respect to output storage type
 
     Returns:
@@ -909,9 +909,37 @@ def output(result, fd, **kwargs):
     }
     op = Operation(
         result.session_id,
-        types_pb2.OUTPUT,
+        types_pb2.DATA_SINK,
         config=config,
         inputs=[result.op],
+        output_types=types_pb2.NULL_OUTPUT,
+    )
+    return op
+
+
+def output(context, fd, selector, vertex_range, **kwargs):
+    """Output result to `fd`, this will be handled by registered vineyard C++ adaptor.
+
+    Args:
+        results (:class:`Context`): Results return by `run_app` operation, store the query results.
+        fd (str): Such as `file:///tmp/result_path`
+        selector (str): Select the type of data to retrieve.
+        vertex_range (str): Specify a range to retrieve.
+    Returns:
+        An op to output results to `fd`.
+    """
+    config = {}
+    config[types_pb2.FD] = utils.s_to_attr(fd)
+    config[types_pb2.SELECTOR] = utils.s_to_attr(selector)
+    config[types_pb2.STORAGE_OPTIONS] = utils.s_to_attr(json.dumps(kwargs))
+    if vertex_range is not None:
+        config[types_pb2.VERTEX_RANGE] = utils.s_to_attr(vertex_range)
+
+    op = Operation(
+        context.sess_id,
+        types_pb2.OUTPUT,
+        config=None,
+        inputs=[context.op],
         output_types=types_pb2.NULL_OUTPUT,
     )
     return op

--- a/python/graphscope/framework/dag_utils.py
+++ b/python/graphscope/framework/dag_utils.py
@@ -936,9 +936,9 @@ def output(context, fd, selector, vertex_range, **kwargs):
         config[types_pb2.VERTEX_RANGE] = utils.s_to_attr(vertex_range)
 
     op = Operation(
-        context.sess_id,
+        context.session_id,
         types_pb2.OUTPUT,
-        config=None,
+        config=config,
         inputs=[context.op],
         output_types=types_pb2.NULL_OUTPUT,
     )


### PR DESCRIPTION
- Add another write path that uses the C++ IO adaptor
- Reduce some code duplication in `grape_instance.cc`
- Move ArrowFlattenProject related stuff out of the NETWORKX guard.

Fixes #1468 