### PR TITLE
Upgrade graph learn version and force pyarrow<=6.0.0.

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,7 +12,7 @@ packaging
 pandas
 protobuf>=3.15.0,<3.19.0
 psutil
-pyarrow
+pyarrow<=6.0.0
 pysimdjson
 PyYAML
 scipy


### PR DESCRIPTION
## What do these changes do?

+ Sync some improvements from graph learn upstream
+ Force pyarrow to version `<=6.0.0` as pyarrow starts to depends on protobuf (C++ library dependency) from 7.0.0, which makes `pywrap_graphlearn.so` un-importable on Mac for inplace built artifacts.

## Related issue number

N/A
