### PR TITLE
Disable brew update when installing dependencies as it is super slow.

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -715,6 +715,8 @@ install_dependencies() {
       export HOMEBREW_BOTTLE_DOMAIN="https://mirrors.tuna.tsinghua.edu.cn/homebrew-bottles"
     fi
     log "Installing packages ${BASIC_PACKGES_TO_INSTALL[*]}"
+    export HOMEBREW_NO_INSTALL_CLEANUP=1
+    export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
     brew install ${BASIC_PACKGES_TO_INSTALL[*]}
 
     if [[ ${CN_MIRROR} == true && "${packages_to_install[*]}" =~ "openjdk@11" ]]; then


### PR DESCRIPTION

## What do these changes do?

As titled, to accelerate the macos CI.

## Related issue number

N/A
