### PR TITLE
Restrict protobuf version

### DIFF
--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -3,7 +3,7 @@ etcd-distro>=3.5.1
 graphscope-client>=0.11.0
 grpcio
 kubernetes
-protobuf
+protobuf>=3.15.0,<3.19.0
 PyYAML
 vineyard>=0.4.0; sys_platform != "win32"
 vineyard-io>=0.4.0; sys_platform != "win32"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -10,7 +10,7 @@ numpy
 orjson
 packaging
 pandas
-protobuf
+protobuf>=3.15.0,<3.19.0
 psutil
 pyarrow<=6.0.0
 pysimdjson


### PR DESCRIPTION
latest protobuf 3.20 not compatible with GraphScope:
```python
t = 'int64_t'

    def _unify_str_type(t):
        t = t.lower()
        if t in ("b", "bool"):
            return graph_def_pb2.DataTypePb.BOOL
        elif t in ("c", "char"):
            return graph_def_pb2.DataTypePb.CHAR
        elif t in ("s", "short"):
            return graph_def_pb2.DataTypePb.SHORT
        elif t in ("i", "int", "int32", "int32_t"):
            return graph_def_pb2.DataTypePb.INT
        elif t in ("l", "long", "int64_t", "int64"):
>           return graph_def_pb2.DataTypePb.LONG
E           AttributeError: 'EnumTypeWrapper' object has no attribute 'LONG'
```
