### PR TITLE
Optimize clustering by ignoring computation of vertices that degree less than 2

### DIFF
--- a/analytical_engine/apps/clustering/clustering_context.h
+++ b/analytical_engine/apps/clustering/clustering_context.h
@@ -72,7 +72,7 @@ class ClusteringContext : public grape::VertexDataContext<FRAG_T, double> {
   typename FRAG_T::template vertex_array_t<
       std::vector<std::pair<vertex_t, uint32_t>>>
       complete_neighbor;
-  typename FRAG_T::template vertex_array_t<int> tricnt;
+  typename FRAG_T::template vertex_array_t<uint32_t> tricnt;
 
   int stage = 0;
 };

--- a/python/graphscope/nx/utils/compat.py
+++ b/python/graphscope/nx/utils/compat.py
@@ -126,7 +126,7 @@ def load_the_module(module_or_name):
     try:
         for name in names[1:]:
             module_path = imp.find_module(name, [module_path[1]])
-    except ImportError:
+    except Exception:
         return module_or_name
     module = imp.load_module(module_or_name, *module_path)
     return apply_networkx_patches(module)


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Since vertices which degree < 2 its clustering coefficient is 0 , we can optimize clustering by ignoring the computation of this kind of vertices.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1586 

