### PR TITLE
support valueMap() to fetch all properties of vertices

### DIFF
--- a/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
+++ b/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
@@ -173,10 +173,10 @@ traversalMethod_limit
 	: 'limit' LPAREN integerLiteral RPAREN
 	;
 
+// valueMap()
 // valueMap('s1', ...)
-// valueMap() is unsupported
 traversalMethod_valueMap
-    : 'valueMap' LPAREN stringLiteralExpr RPAREN
+    : 'valueMap' LPAREN stringLiteralList RPAREN
     ;
 
 // order()
@@ -191,7 +191,7 @@ traversalMethod_order
 // by(values(..), 'asc' | 'desc')
 // by(select("a"), 'asc' | 'desc')
 // by(select("a").by("name"), 'asc' | 'desc')
-// by(select("a").by(valueMap("name")), 'asc' | 'desc')
+// by(select("a").by(values("name")), 'asc' | 'desc')
 // by(out().count()), by(out().count(), desc)
 traversalMethod_orderby
     : 'by' LPAREN RPAREN

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgUtils.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgUtils.java
@@ -25,6 +25,7 @@ public class ArgUtils {
     private static String LABEL = "~label";
     private static String ID = "~id";
     private static String LEN = "~len";
+    public static String PROPERTY_ALL = "~all";
 
     public static FfiConst.ByValue asFfiConst(int id) {
         return irCoreLib.int32AsConst(id);

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
@@ -259,7 +259,7 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     public Traversal visitTraversalMethod_valueMap(
             GremlinGSParser.TraversalMethod_valueMapContext ctx) {
         return graphTraversal.valueMap(
-                GenericLiteralVisitor.getStringLiteralExpr(ctx.stringLiteralExpr()));
+                GenericLiteralVisitor.getStringLiteralList(ctx.stringLiteralList()));
     }
 
     @Override

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/graph/RemoteTestGraph.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/graph/RemoteTestGraph.java
@@ -463,10 +463,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         method =
                 "g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectXprojectXX_groupCount_byXnameX",
         reason = "unsupported")
-//@Graph.OptOut(
-//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-//        method = "g_V_valueMap_selectXlast_a_bX",
-//        reason = "unsupported")
+@Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+        method = "g_V_valueMap_selectXlast_a_bX",
+        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_hasLabelXpersonX_asXpX_mapXbothE_label_groupCountX_asXrX_selectXp_rX",
@@ -492,10 +492,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_outE_weight_groupCount_unfold_selectXkeysX_unfold",
         reason = "unsupported")
-//@Graph.OptOut(
-//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-//        method = "g_V_valueMap_selectXlast_aX",
-//        reason = "unsupported")
+@Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+        method = "g_V_valueMap_selectXlast_aX",
+        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_selectXall_aX",
@@ -563,10 +563,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_valueMap_selectXall_a_bX",
         reason = "unsupported")
-//@Graph.OptOut(
-//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-//        method = "g_V_valueMap_selectXa_bX",
-//        reason = "unsupported")
+@Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+        method = "g_V_valueMap_selectXa_bX",
+        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method =
@@ -592,10 +592,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_outE_weight_groupCount_selectXvaluesX_unfold",
         reason = "unsupported")
-//@Graph.OptOut(
-//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-//        method = "g_V_valueMap_selectXaX",
-//        reason = "unsupported")
+@Graph.OptOut(
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+        method = "g_V_valueMap_selectXaX",
+        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest",
         method = "g_VX4X_bothE_hasXweight_lt_1X_otherV",
@@ -1293,14 +1293,14 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 // @Graph.OptOut(method="g_V_valueMapXname_ageX" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest", reason = "will be
 // supported")
-//@Graph.OptOut(
-//        method = "g_VX1X_outXcreatedX_valueMap",
-//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest",
-//        reason = "will be supported")
-//@Graph.OptOut(
-//        method = "g_V_valueMap",
-//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest",
-//        reason = "will be supported")
+@Graph.OptOut(
+        method = "g_VX1X_outXcreatedX_valueMap",
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest",
+        reason = "will be supported")
+@Graph.OptOut(
+        method = "g_V_valueMap",
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest",
+        reason = "will be supported")
 @Graph.OptOut(
         method = "g_V_group_byXlabelX_byXlabel_countX",
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/graph/RemoteTestGraph.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/graph/RemoteTestGraph.java
@@ -463,10 +463,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         method =
                 "g_V_outXcreatedX_unionXasXprojectX_inXcreatedX_hasXname_markoX_selectXprojectX__asXprojectX_inXcreatedX_inXknowsX_hasXname_markoX_selectXprojectXX_groupCount_byXnameX",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_valueMap_selectXlast_a_bX",
-        reason = "unsupported")
+//@Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_valueMap_selectXlast_a_bX",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_hasLabelXpersonX_asXpX_mapXbothE_label_groupCountX_asXrX_selectXp_rX",
@@ -492,10 +492,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_outE_weight_groupCount_unfold_selectXkeysX_unfold",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_valueMap_selectXlast_aX",
-        reason = "unsupported")
+//@Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_valueMap_selectXlast_aX",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_selectXall_aX",
@@ -563,10 +563,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_valueMap_selectXall_a_bX",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_valueMap_selectXa_bX",
-        reason = "unsupported")
+//@Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_valueMap_selectXa_bX",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method =
@@ -592,10 +592,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_outE_weight_groupCount_selectXvaluesX_unfold",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_valueMap_selectXaX",
-        reason = "unsupported")
+//@Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_valueMap_selectXaX",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest",
         method = "g_VX4X_bothE_hasXweight_lt_1X_otherV",
@@ -1293,14 +1293,14 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 // @Graph.OptOut(method="g_V_valueMapXname_ageX" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest", reason = "will be
 // supported")
-@Graph.OptOut(
-        method = "g_VX1X_outXcreatedX_valueMap",
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest",
-        reason = "will be supported")
-@Graph.OptOut(
-        method = "g_V_valueMap",
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest",
-        reason = "will be supported")
+//@Graph.OptOut(
+//        method = "g_VX1X_outXcreatedX_valueMap",
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest",
+//        reason = "will be supported")
+//@Graph.OptOut(
+//        method = "g_V_valueMap",
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ValueMapTest",
+//        reason = "will be supported")
 @Graph.OptOut(
         method = "g_V_group_byXlabelX_byXlabel_countX",
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.GroupTest",

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultParserFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultParserFactory.java
@@ -76,11 +76,19 @@ public enum GremlinResultParserFactory implements GremlinResultParser {
                                             (k, v) -> {
                                                 if (!(v instanceof EmptyValue)) {
                                                     String nameOrId = null;
-                                                    if(k instanceof List) { // valueMap("name") -> Map<["", "name"], value>
-                                                        nameOrId = (String) ((List)k).get(1);
-                                                    } else if (k instanceof String) { // valueMap() -> Map<"name", value>
+                                                    if (k
+                                                            instanceof
+                                                            List) { // valueMap("name") -> Map<["",
+                                                        // "name"], value>
+                                                        nameOrId = (String) ((List) k).get(1);
+                                                    } else if (k
+                                                            instanceof
+                                                            String) { // valueMap() -> Map<"name",
+                                                        // value>
                                                         nameOrId = (String) k;
-                                                    } else if(k instanceof Number) { // valueMap() -> Map<1, value>
+                                                    } else if (k
+                                                            instanceof
+                                                            Number) { // valueMap() -> Map<1, value>
                                                         nameOrId = String.valueOf(k);
                                                     }
                                                     if (nameOrId == null || nameOrId.isEmpty()) {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultParserFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultParserFactory.java
@@ -71,13 +71,19 @@ public enum GremlinResultParserFactory implements GremlinResultParser {
                                 Object parseElement =
                                         ParserUtils.parseElement(column.getEntry().getElement());
                                 if (parseElement instanceof Map) {
-                                    Map<List, Object> projectTags =
-                                            (Map<List, Object>) parseElement;
+                                    Map projectTags = (Map) parseElement;
                                     projectTags.forEach(
                                             (k, v) -> {
                                                 if (!(v instanceof EmptyValue)) {
-                                                    String nameOrId = (String) k.get(1);
-                                                    if (nameOrId.isEmpty()) {
+                                                    String nameOrId = null;
+                                                    if(k instanceof List) { // valueMap("name") -> Map<["", "name"], value>
+                                                        nameOrId = (String) ((List)k).get(1);
+                                                    } else if (k instanceof String) { // valueMap() -> Map<"name", value>
+                                                        nameOrId = (String) k;
+                                                    } else if(k instanceof Number) { // valueMap() -> Map<1, value>
+                                                        nameOrId = String.valueOf(k);
+                                                    }
+                                                    if (nameOrId == null || nameOrId.isEmpty()) {
                                                         throw new GremlinResultParserException(
                                                                 "map value should have property"
                                                                         + " key");

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/TraversalParentTransform.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/TraversalParentTransform.java
@@ -62,9 +62,8 @@ public interface TraversalParentTransform extends Function<TraversalParent, List
                         stringBuilder.append("}");
                         return (new ExprResult(true)).addTagExpr("", stringBuilder.toString());
                     } else {
-                        throw new OpArgIllegalException(
-                                OpArgIllegalException.Cause.UNSUPPORTED_TYPE,
-                                "valueMap() is unsupported");
+                        // valueMap() -> @.~all
+                        return (new ExprResult(true)).addTagExpr("", "@." + ArgUtils.PROPERTY_ALL);
                     }
                 } else if (step instanceof PropertiesStep) { // values(..)
                     String[] mapKeys = ((PropertiesStep) step).getPropertyKeys();

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/ValueMapTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/ValueMapTest.java
@@ -36,6 +36,17 @@ public class ValueMapTest {
     private GraphTraversalSource g = graph.traversal();
 
     @Test
+    public void g_V_valueMap_test() {
+        Traversal traversal = g.V().valueMap();
+        Step valueMapStep = traversal.asAdmin().getEndStep();
+        ProjectOp op = (ProjectOp) StepTransformFactory.VALUE_MAP_STEP.apply(valueMapStep);
+
+        List<Pair> exprWithAlias = (List<Pair>) op.getExprWithAlias().get().applyArg();
+        Assert.assertEquals("@.~all", exprWithAlias.get(0).getValue0());
+        Assert.assertEquals(ArgUtils.asFfiNoneAlias(), exprWithAlias.get(0).getValue1());
+    }
+
+    @Test
     public void g_V_valueMap_strs_test() {
         Traversal traversal = g.V().valueMap("name", "id");
         Step valueMapStep = traversal.asAdmin().getEndStep();

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/NegativeEvalTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/NegativeEvalTest.java
@@ -180,17 +180,6 @@ public class NegativeEvalTest {
     }
 
     @Test
-    public void g_V_valueMap_none_test() {
-        try {
-            scriptEngine.eval("g.V().valueMap()", context);
-        } catch (InvalidGremlinScriptException e) {
-            // expected error
-            return;
-        }
-        Assert.fail();
-    }
-
-    @Test
     public void g_V_as_invalid_test() {
         try {
             scriptEngine.eval("g.V().as('a', 'b')", context);

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
@@ -258,6 +258,11 @@ public class PositiveEvalTest {
     }
 
     @Test
+    public void g_V_valueMap() {
+        Assert.assertEquals(g.V().valueMap(), eval("g.V().valueMap()"));
+    }
+
+    @Test
     public void g_V_valueMap_str_test() {
         Assert.assertEquals(g.V().valueMap("name"), eval("g.V().valueMap('name')"));
     }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. support valueMap() in gremlin grammar
2. translate valueMap() to expression '@.~all', and select('a').by(valueMap()) to '@a.~all'

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1622
