### PR TITLE
Fixes the bug in AddColumn to graphs with `string` oid type.

### DIFF
--- a/analytical_engine/core/object/fragment_wrapper.h
+++ b/analytical_engine/core/object/fragment_wrapper.h
@@ -488,23 +488,26 @@ class FragmentWrapper<vineyard::ArrowFragment<OID_T, VID_T>>
       for (fid_t i = 0; i < cur_fnum; ++i) {
         auto name =
             "o2g_" + std::to_string(i) + "_" + std::to_string(pair.first);
+        if (ctx_meta.Haskey(name) && cur_meta.Haskey(name)) {
+          auto id_in_ctx = ctx_meta.GetMemberMeta(name).GetId();
+          auto id_in_cur = cur_meta.GetMemberMeta(name).GetId();
+          if (id_in_ctx != id_in_cur) {
+            RETURN_GS_ERROR(vineyard::ErrorCode::kIllegalStateError,
+                            "OID to GID mapping '" + name +
+                                "' in context differ from vertex map of the "
+                                "destination fragment");
+          }
+        }
+
+        name = "oid_arrays_" + std::to_string(i) + "_" +
+               std::to_string(pair.first);
         auto id_in_ctx = ctx_meta.GetMemberMeta(name).GetId();
         auto id_in_cur = cur_meta.GetMemberMeta(name).GetId();
         if (id_in_ctx != id_in_cur) {
           RETURN_GS_ERROR(vineyard::ErrorCode::kIllegalStateError,
-                          "Vertex datastructure " + name +
-                              "in context differ from vertex map of the "
+                          "OID array '" + name +
+                              "' in context differs from vertex map of the "
                               "destination fragment");
-        }
-        name = "oid_arrays_" + std::to_string(i) + "_" +
-               std::to_string(pair.first);
-        id_in_ctx = ctx_meta.GetMemberMeta(name).GetId();
-        id_in_cur = cur_meta.GetMemberMeta(name).GetId();
-        if (id_in_ctx != id_in_cur) {
-          RETURN_GS_ERROR(vineyard::ErrorCode::kIllegalStateError,
-                          "Vertex datastructure " + name +
-                              "in context differ from vertex map of the "
-                              "destionation fragment");
         }
       }
     }

--- a/python/graphscope/tests/unittest/test_graph.py
+++ b/python/graphscope/tests/unittest/test_graph.py
@@ -521,6 +521,22 @@ def test_add_column(ldbc_graph, arrow_modern_graph):
         print(g4.schema)
 
 
+def test_add_column_string_oid(
+    p2p_property_graph_string, p2p_project_directed_graph_string
+):
+    g1 = p2p_property_graph_string
+    g2 = p2p_project_directed_graph_string
+
+    property_names = [p.name for p in g1.schema.get_vertex_properties("person")]
+    assert "pagerank" not in property_names
+
+    ctx = graphscope.pagerank(g2)
+    g3 = g1.add_column(ctx, selector={"pagerank": "r"})
+
+    property_names = [p.name for p in g3.schema.get_vertex_properties("person")]
+    assert "pagerank" in property_names
+
+
 def test_graph_lifecycle(graphscope_session):
     graph = load_modern_graph(graphscope_session)
     c = graphscope.wcc(graph)


### PR DESCRIPTION

## What do these changes do?

Vertex maps `string` OID type doesn't have the `o2g_*` keys.

Add a test case to prevent it from being broken in the future as well.

## Related issue number

Fixes #1626 

