### PR TITLE
Implement `createGraph` on coordinator, add API to initialize builder using schema

### DIFF
--- a/interactive_engine/executor/runtime/native/graph_builder_ffi.cc
+++ b/interactive_engine/executor/runtime/native/graph_builder_ffi.cc
@@ -170,6 +170,12 @@ GraphBuilder get_graph_builder(const char *graph_name, const int index) {
   return new std::shared_ptr<vineyard::PropertyGraphOutStream>(builder);
 }
 
+void initialize_graph_builder(GraphBuilder builder, Schema schema) {
+  auto stream =
+      static_cast<std::shared_ptr<vineyard::PropertyGraphOutStream> *>(builder);
+  return (*stream)->Initialize(schema);
+}
+
 void add_vertex(GraphBuilder builder, VertexId id, LabelId labelid,
                 size_t property_size, Property *properties) {
   auto stream =

--- a/interactive_engine/executor/runtime/native/graph_builder_ffi.h
+++ b/interactive_engine/executor/runtime/native/graph_builder_ffi.h
@@ -87,6 +87,13 @@ ObjectId build_global_graph_stream(const char* graph_name, size_t size,
 GraphBuilder get_graph_builder(const char* graph_name, const int index);
 
 /**
+ * Initialize the builder using schema.
+ *
+ * See also `finish_build_schema`
+ */
+void initialize_graph_builder(GraphBuilder builder, Schema schema);
+
+/**
  * 多个property用array的方式给出，property_size指定property array的size。
  */
 void add_vertex(GraphBuilder builder, VertexId id, LabelId labelid,

--- a/interactive_engine/executor/runtime/native/property_graph_stream.cc
+++ b/interactive_engine/executor/runtime/native/property_graph_stream.cc
@@ -227,6 +227,14 @@ void PropertyTableAppender::Flush(
 
 }  // namespace detail
 
+void PropertyGraphOutStream::Initialize(Schema schema) {
+  auto schema_ptr = static_cast<vineyard::MGPropertyGraphSchema *>(schema);
+  *graph_schema_ = *schema_ptr;
+
+  LOG(INFO) << "Initialize the graph builder using schema ...";
+  this->initialTables();
+}
+
 void PropertyGraphOutStream::AddVertex(VertexId id, LabelId labelid,
                                        size_t property_size,
                                        Property* properties) {

--- a/interactive_engine/executor/runtime/native/property_graph_stream.h
+++ b/interactive_engine/executor/runtime/native/property_graph_stream.h
@@ -254,8 +254,11 @@ class PropertyGraphOutStream : public Registered<PropertyGraphOutStream> {
       std::dynamic_pointer_cast<vineyard::RecordBatchStream>(meta.GetMember("edge_stream"));
 
     this->graph_schema_ = std::make_shared<MGPropertyGraphSchema>();
-    graph_schema_->FromJSONString(meta.GetKeyValue("graph_schema"));
-    this->initialTables();
+    auto graph_schema_json = vineyard::json::parse(meta.GetKeyValue("graph_schema"));
+    if (graph_schema_json.contains("types")) {
+      graph_schema_->FromJSON(graph_schema_json);
+      this->initialTables();
+    }
   }
 
   Status Open(std::shared_ptr<vineyard::RecordBatchStream> &output_stream) {
@@ -266,6 +269,8 @@ class PropertyGraphOutStream : public Registered<PropertyGraphOutStream> {
     }
     return status;
   }
+
+  void Initialize(Schema schema);
 
   void AddVertex(VertexId id, LabelId labelid, size_t property_size,
                  Property* properties);

--- a/interactive_engine/executor/runtime/src/store/graph_builder_ffi.rs
+++ b/interactive_engine/executor/runtime/src/store/graph_builder_ffi.rs
@@ -36,6 +36,7 @@ extern {
 
     fn build_global_graph_stream(graph_name: *const ::libc::c_char, size: usize, object_ids: *const GraphId, instance_ids: *const InstanceId) -> GraphId;
     fn get_graph_builder(graph_name: *const ::libc::c_char, index: i32) -> GraphBuilder;
+    fn initialize_graph_builder(builder: GraphBuilder, schema: SchemaHandle);
 
     fn add_vertex(graph_builder: GraphBuilder, id: VertexId, labelId: LabelId,
                   property_size: usize, properties: *const WriteNativeProperty);


### PR DESCRIPTION

## What do these changes do?

Implemented the logic of `create_graph_builder` in the coordinator to reduce the complexity of the GIE ffi wrapper.

A `initialize_graph_builder` API has been added to initialize the builder using created schema.

## Related issue number

Fixes #1604

