### PR TITLE
fuse expand/getV with the following filters to support more patterns in match

### DIFF
--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/InterOpCollection.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/InterOpCollection.java
@@ -22,6 +22,7 @@ import com.alibaba.graphscope.common.intermediate.operator.InterOpBase;
 import com.alibaba.graphscope.common.intermediate.operator.OpArg;
 import com.alibaba.graphscope.common.intermediate.process.InterOpProcessor;
 import com.alibaba.graphscope.common.intermediate.process.SinkOutputProcessor;
+import com.alibaba.graphscope.common.intermediate.strategy.ElementFusionStrategy;
 import com.alibaba.graphscope.common.intermediate.strategy.InterOpStrategy;
 import com.alibaba.graphscope.common.intermediate.strategy.TopKStrategy;
 
@@ -35,7 +36,7 @@ import java.util.Optional;
 // collection of intermediate operators
 public class InterOpCollection {
     private List<InterOpBase> opCollection;
-    private static List<InterOpStrategy> strategies = Arrays.asList(TopKStrategy.INSTANCE);
+    private static List<InterOpStrategy> strategies = Arrays.asList(TopKStrategy.INSTANCE, ElementFusionStrategy.INSTANCE);
     private static List<InterOpProcessor> processors = Arrays.asList(SinkOutputProcessor.INSTANCE);
 
     public InterOpCollection() {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/InterOpCollection.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/InterOpCollection.java
@@ -36,7 +36,8 @@ import java.util.Optional;
 // collection of intermediate operators
 public class InterOpCollection {
     private List<InterOpBase> opCollection;
-    private static List<InterOpStrategy> strategies = Arrays.asList(TopKStrategy.INSTANCE, ElementFusionStrategy.INSTANCE);
+    private static List<InterOpStrategy> strategies =
+            Arrays.asList(TopKStrategy.INSTANCE, ElementFusionStrategy.INSTANCE);
     private static List<InterOpProcessor> processors = Arrays.asList(SinkOutputProcessor.INSTANCE);
 
     public InterOpCollection() {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/SelectOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/SelectOp.java
@@ -41,7 +41,6 @@ public class SelectOp extends InterOpBase {
         this.type = type;
     }
 
-
     public FilterType getType() {
         return type;
     }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/SelectOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/SelectOp.java
@@ -22,7 +22,10 @@ public class SelectOp extends InterOpBase {
     public SelectOp() {
         super();
         this.predicate = Optional.empty();
+        this.type = FilterType.NONE;
     }
+
+    private FilterType type;
 
     private Optional<OpArg> predicate;
 
@@ -32,5 +35,20 @@ public class SelectOp extends InterOpBase {
 
     public void setPredicate(OpArg predicate) {
         this.predicate = Optional.of(predicate);
+    }
+
+    public void setType(FilterType type) {
+        this.type = type;
+    }
+
+
+    public FilterType getType() {
+        return type;
+    }
+
+    public enum FilterType {
+        NONE,
+        HAS,
+        WHERE,
     }
 }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/strategy/ElementFusionStrategy.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/strategy/ElementFusionStrategy.java
@@ -1,0 +1,44 @@
+package com.alibaba.graphscope.common.intermediate.strategy;
+
+import com.alibaba.graphscope.common.intermediate.InterOpCollection;
+import com.alibaba.graphscope.common.intermediate.operator.*;
+
+import java.util.List;
+
+// fuse out + has, inV + has
+public class ElementFusionStrategy implements InterOpStrategy {
+    public static ElementFusionStrategy INSTANCE = new ElementFusionStrategy();
+
+    private ElementFusionStrategy() {
+    }
+
+    @Override
+    public void apply(InterOpCollection opCollection) {
+        List<InterOpBase> original = opCollection.unmodifiableCollection();
+        for (int i = original.size() - 2; i >= 0; --i) {
+            InterOpBase cur = original.get(i), next = original.get(i + 1);
+            if (next instanceof SelectOp &&
+                    (cur instanceof ExpandOp || cur instanceof GetVOp)) {
+                QueryParams params = (cur instanceof ExpandOp) ?
+                        ((ExpandOp) cur).getParams().get() : ((GetVOp) cur).getParams().get();
+                String fuse = fusePredicates(params, (SelectOp) next);
+                if (fuse != null && !fuse.isEmpty()) {
+                    params.setPredicate(fuse);
+                }
+                opCollection.removeInterOp(i + 1);
+            }
+        }
+    }
+
+    private String fusePredicates(QueryParams params, SelectOp selectOp) {
+        String p1 = params.getPredicate().isPresent() ? params.getPredicate().get() : null;
+        String p2 = selectOp.getPredicate().isPresent() ? (String) selectOp.getPredicate().get().applyArg() : null;
+        if (p2 == null || p2.isEmpty()) {
+            return p1;
+        } else if (p1 == null || p1.isEmpty()) {
+            return p2;
+        } else {
+            return String.format("%s&&(%s)", p1, p2);
+        }
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/strategy/ElementFusionStrategy.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/strategy/ElementFusionStrategy.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.intermediate.strategy;
 
 import com.alibaba.graphscope.common.intermediate.InterOpCollection;
@@ -5,7 +21,7 @@ import com.alibaba.graphscope.common.intermediate.operator.*;
 
 import java.util.List;
 
-// fuse out + has, inV + has
+// fuse ExpandOp + SelectOp, GetVOp + SelectOp
 public class ElementFusionStrategy implements InterOpStrategy {
     public static ElementFusionStrategy INSTANCE = new ElementFusionStrategy();
 

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/strategy/ElementFusionStrategy.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/strategy/ElementFusionStrategy.java
@@ -25,8 +25,7 @@ import java.util.List;
 public class ElementFusionStrategy implements InterOpStrategy {
     public static ElementFusionStrategy INSTANCE = new ElementFusionStrategy();
 
-    private ElementFusionStrategy() {
-    }
+    private ElementFusionStrategy() {}
 
     @Override
     public void apply(InterOpCollection opCollection) {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/strategy/ElementFusionStrategy.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/strategy/ElementFusionStrategy.java
@@ -9,18 +9,18 @@ import java.util.List;
 public class ElementFusionStrategy implements InterOpStrategy {
     public static ElementFusionStrategy INSTANCE = new ElementFusionStrategy();
 
-    private ElementFusionStrategy() {
-    }
+    private ElementFusionStrategy() {}
 
     @Override
     public void apply(InterOpCollection opCollection) {
         List<InterOpBase> original = opCollection.unmodifiableCollection();
         for (int i = original.size() - 2; i >= 0; --i) {
             InterOpBase cur = original.get(i), next = original.get(i + 1);
-            if (next instanceof SelectOp &&
-                    (cur instanceof ExpandOp || cur instanceof GetVOp)) {
-                QueryParams params = (cur instanceof ExpandOp) ?
-                        ((ExpandOp) cur).getParams().get() : ((GetVOp) cur).getParams().get();
+            if (next instanceof SelectOp && (cur instanceof ExpandOp || cur instanceof GetVOp)) {
+                QueryParams params =
+                        (cur instanceof ExpandOp)
+                                ? ((ExpandOp) cur).getParams().get()
+                                : ((GetVOp) cur).getParams().get();
                 String fuse = fusePredicates(params, (SelectOp) next);
                 if (fuse != null && !fuse.isEmpty()) {
                     params.setPredicate(fuse);
@@ -32,7 +32,10 @@ public class ElementFusionStrategy implements InterOpStrategy {
 
     private String fusePredicates(QueryParams params, SelectOp selectOp) {
         String p1 = params.getPredicate().isPresent() ? params.getPredicate().get() : null;
-        String p2 = selectOp.getPredicate().isPresent() ? (String) selectOp.getPredicate().get().applyArg() : null;
+        String p2 =
+                selectOp.getPredicate().isPresent()
+                        ? (String) selectOp.getPredicate().get().applyArg()
+                        : null;
         if (p2 == null || p2.isEmpty()) {
             return p1;
         } else if (p1 == null || p1.isEmpty()) {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
@@ -499,11 +499,11 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                                             Set<String> scopeKeys;
                                             if (!startTag.isPresent()
                                                     && !(scopeKeys =
-                                                    ((WhereTraversalStep
-                                                            .WhereStartStep)
-                                                            s1)
-                                                            .getScopeKeys())
-                                                    .isEmpty()) {
+                                                                    ((WhereTraversalStep
+                                                                                            .WhereStartStep)
+                                                                                    s1)
+                                                                            .getScopeKeys())
+                                                            .isEmpty()) {
                                                 startTag = Optional.of(scopeKeys.iterator().next());
                                             }
                                         } else if (s1
@@ -513,11 +513,11 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                                             Set<String> scopeKeys;
                                             if (!endTag.isPresent()
                                                     && !(scopeKeys =
-                                                    ((WhereTraversalStep
-                                                            .WhereEndStep)
-                                                            s1)
-                                                            .getScopeKeys())
-                                                    .isEmpty()) {
+                                                                    ((WhereTraversalStep
+                                                                                            .WhereEndStep)
+                                                                                    s1)
+                                                                            .getScopeKeys())
+                                                            .isEmpty()) {
                                                 endTag = Optional.of(scopeKeys.iterator().next());
                                             }
                                         } else if (isValidBinderStep(s1)) {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
@@ -548,12 +548,14 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                                 });
                         InterOpCollection ops =
                                 (new InterOpCollectionBuilder(binderTraversal)).build();
+                        // apply fusion strategy
                         ElementFusionStrategy.INSTANCE.apply(ops);
+                        // all of the SelectOps should have been fused with Expand/GetV, otherwise invalid
                         for (InterOpBase opBase : ops.unmodifiableCollection()) {
                             if (opBase instanceof SelectOp) {
                                 throw new OpArgIllegalException(
                                         OpArgIllegalException.Cause.INVALID_TYPE,
-                                        "the filter should be fused with GetV or Expand");
+                                        "the filter should have been fused with GetV or Expand");
                             }
                         }
                         sentences.add(
@@ -567,7 +569,7 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                     || step instanceof PathExpandStep // out/in/both('1..5', 'knows')
                     || step instanceof EdgeOtherVertexStep // otherV()
                     || step instanceof EdgeVertexStep // inV()/outV()/endV()(todo)
-                    || step instanceof HasStep;
+                    || step instanceof HasStep; // permit has() nested in match step
         }
     },
 

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
@@ -99,6 +99,7 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
         @Override
         public InterOpBase apply(Step step) {
             SelectOp op = new SelectOp();
+            op.setType(SelectOp.FilterType.HAS);
             List containers = ((HasStep) step).getHasContainers();
             // add corner judgement
             if (!containers.isEmpty()) {
@@ -498,11 +499,11 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                                             Set<String> scopeKeys;
                                             if (!startTag.isPresent()
                                                     && !(scopeKeys =
-                                                                    ((WhereTraversalStep
-                                                                                            .WhereStartStep)
-                                                                                    s1)
-                                                                            .getScopeKeys())
-                                                            .isEmpty()) {
+                                                    ((WhereTraversalStep
+                                                            .WhereStartStep)
+                                                            s1)
+                                                            .getScopeKeys())
+                                                    .isEmpty()) {
                                                 startTag = Optional.of(scopeKeys.iterator().next());
                                             }
                                         } else if (s1
@@ -512,11 +513,11 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                                             Set<String> scopeKeys;
                                             if (!endTag.isPresent()
                                                     && !(scopeKeys =
-                                                                    ((WhereTraversalStep
-                                                                                            .WhereEndStep)
-                                                                                    s1)
-                                                                            .getScopeKeys())
-                                                            .isEmpty()) {
+                                                    ((WhereTraversalStep
+                                                            .WhereEndStep)
+                                                            s1)
+                                                            .getScopeKeys())
+                                                    .isEmpty()) {
                                                 endTag = Optional.of(scopeKeys.iterator().next());
                                             }
                                         } else if (isValidBinderStep(s1)) {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
@@ -550,7 +550,8 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                                 (new InterOpCollectionBuilder(binderTraversal)).build();
                         // apply fusion strategy
                         ElementFusionStrategy.INSTANCE.apply(ops);
-                        // all of the SelectOps should have been fused with Expand/GetV, otherwise invalid
+                        // all of the SelectOps should have been fused with Expand/GetV, otherwise
+                        // invalid
                         for (InterOpBase opBase : ops.unmodifiableCollection()) {
                             if (opBase instanceof SelectOp) {
                                 throw new OpArgIllegalException(

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
@@ -498,11 +498,11 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                                             Set<String> scopeKeys;
                                             if (!startTag.isPresent()
                                                     && !(scopeKeys =
-                                                    ((WhereTraversalStep
-                                                            .WhereStartStep)
-                                                            s1)
-                                                            .getScopeKeys())
-                                                    .isEmpty()) {
+                                                                    ((WhereTraversalStep
+                                                                                            .WhereStartStep)
+                                                                                    s1)
+                                                                            .getScopeKeys())
+                                                            .isEmpty()) {
                                                 startTag = Optional.of(scopeKeys.iterator().next());
                                             }
                                         } else if (s1
@@ -512,11 +512,11 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                                             Set<String> scopeKeys;
                                             if (!endTag.isPresent()
                                                     && !(scopeKeys =
-                                                    ((WhereTraversalStep
-                                                            .WhereEndStep)
-                                                            s1)
-                                                            .getScopeKeys())
-                                                    .isEmpty()) {
+                                                                    ((WhereTraversalStep
+                                                                                            .WhereEndStep)
+                                                                                    s1)
+                                                                            .getScopeKeys())
+                                                            .isEmpty()) {
                                                 endTag = Optional.of(scopeKeys.iterator().next());
                                             }
                                         } else if (isValidBinderStep(s1)) {
@@ -552,7 +552,8 @@ public enum StepTransformFactory implements Function<Step, InterOpBase> {
                         for (InterOpBase opBase : ops.unmodifiableCollection()) {
                             if (opBase instanceof SelectOp) {
                                 throw new OpArgIllegalException(
-                                        OpArgIllegalException.Cause.INVALID_TYPE, "the filter should be fused with GetV or Expand");
+                                        OpArgIllegalException.Cause.INVALID_TYPE,
+                                        "the filter should be fused with GetV or Expand");
                             }
                         }
                         sentences.add(

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/MatchStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/MatchStepTest.java
@@ -18,6 +18,8 @@ package com.alibaba.graphscope.gremlin;
 
 import com.alibaba.graphscope.common.intermediate.ArgUtils;
 import com.alibaba.graphscope.common.intermediate.MatchSentence;
+import com.alibaba.graphscope.common.intermediate.operator.ExpandOp;
+import com.alibaba.graphscope.common.intermediate.operator.GetVOp;
 import com.alibaba.graphscope.common.intermediate.operator.MatchOp;
 import com.alibaba.graphscope.common.jna.type.FfiJoinKind;
 import com.alibaba.graphscope.gremlin.transform.StepTransformFactory;
@@ -60,6 +62,41 @@ public class MatchStepTest {
         Traversal traversal = g.V().match(__.as("a").out().as("b"));
         MatchSentence sentence = getSentences(traversal).get(0);
         Assert.assertTrue(isEqualWith(sentence, "a", "b", FfiJoinKind.Inner, 1));
+    }
+
+    // fuse out + has
+    @Test
+    public void g_V_match_as_a_out_has_as_b_test() {
+        Traversal traversal = g.V().match(__.as("a").out().has("name", "marko").as("b"));
+        MatchSentence sentence = getSentences(traversal).get(0);
+        Assert.assertTrue(isEqualWith(sentence, "a", "b", FfiJoinKind.Inner, 1));
+        ExpandOp op = (ExpandOp) sentence.getBinders().unmodifiableCollection().get(0);
+        Assert.assertEquals(
+                "@.name && @.name == \"marko\"", op.getParams().get().getPredicate().get());
+        Assert.assertEquals(false, op.getIsEdge().get().applyArg());
+    }
+
+    // fuse outE + has
+    @Test
+    public void g_V_match_as_a_outE_has_as_b_test() {
+        Traversal traversal = g.V().match(__.as("a").outE().has("name", "marko").as("b"));
+        MatchSentence sentence = getSentences(traversal).get(0);
+        Assert.assertTrue(isEqualWith(sentence, "a", "b", FfiJoinKind.Inner, 1));
+        ExpandOp op = (ExpandOp) sentence.getBinders().unmodifiableCollection().get(0);
+        Assert.assertEquals(
+                "@.name && @.name == \"marko\"", op.getParams().get().getPredicate().get());
+        Assert.assertEquals(true, op.getIsEdge().get().applyArg());
+    }
+
+    // fuse outV + has
+    @Test
+    public void g_V_match_as_a_outE_outV_has_as_b_test() {
+        Traversal traversal = g.V().match(__.as("a").outE().outV().has("name", "marko").as("b"));
+        MatchSentence sentence = getSentences(traversal).get(0);
+        Assert.assertTrue(isEqualWith(sentence, "a", "b", FfiJoinKind.Inner, 2));
+        GetVOp op = (GetVOp) sentence.getBinders().unmodifiableCollection().get(1);
+        Assert.assertEquals(
+                "@.name && @.name == \"marko\"", op.getParams().get().getPredicate().get());
     }
 
     @Test

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/integration/ldbc/LdbcQueryTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/integration/ldbc/LdbcQueryTest.java
@@ -708,8 +708,6 @@ public abstract class LdbcQueryTest extends AbstractGremlinProcessTest {
                     .limit(20);
         }
 
-        
-
         @Override
         public Traversal<Vertex, Map<String, Object>> get_ldbc_6_test() {
             return g.V().hasId(72088380363511554L)

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/integration/ldbc/LdbcQueryTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/integration/ldbc/LdbcQueryTest.java
@@ -708,6 +708,8 @@ public abstract class LdbcQueryTest extends AbstractGremlinProcessTest {
                     .limit(20);
         }
 
+        
+
         @Override
         public Traversal<Vertex, Map<String, Object>> get_ldbc_6_test() {
             return g.V().hasId(72088380363511554L)


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

fuse expand/getV with the following filters, i.e. out().has("name", "marko"), to support more nested patterns in match which are requirements from scope & insight

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1669

