### PR TITLE
Add auth for Python Groot SDK

### DIFF
--- a/python/graphscope/client/connection.py
+++ b/python/graphscope/client/connection.py
@@ -157,4 +157,4 @@ class Connection:
 
 
 def conn(addr, gremlin_endpoint=None):
-    return Connection(addr, gremlin_endpoint)
+    return Connection(addr, gremlin_endpoint, username=None, password=None)

--- a/python/graphscope/client/connection.py
+++ b/python/graphscope/client/connection.py
@@ -19,8 +19,9 @@
 """ Manage connections of the GraphScope store service.
 """
 
-import grpc
 import base64
+
+import grpc
 from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
 from gremlin_python.process.anonymous_traversal import traversal
 


### PR DESCRIPTION
Encode username and password in metadata, which will be carried on every GRPC call.
Fixes #1678 