### PR TITLE
Fixes the nx.compat for name conflicts

### DIFF
--- a/python/graphscope/nx/utils/compat.py
+++ b/python/graphscope/nx/utils/compat.py
@@ -126,9 +126,23 @@ def load_the_module(module_or_name):
     try:
         for name in names[1:]:
             module_path = imp.find_module(name, [module_path[1]])
-    except Exception:
+    except ImportError:
         return module_or_name
-    return imp.load_module(module_or_name, *module_path)
+    module = imp.load_module(module_or_name, *module_path)
+    return apply_networkx_patches(module)
+
+
+def apply_networkx_patches(module):
+    # there'a some name conflicts in networkx and we need to be careful
+    # e.g.,
+    #
+    #     networkx.algorithms.approximation.connectivity
+    # vs. networkx.algorithms.connectivity
+    #
+    if module.__name__ == "networkx.algorithms":
+        mod_connectivity = load_the_module("networkx.algorithms.connectivity")
+        setattr(module, "connectivity", mod_connectivity)
+    return module
 
 
 def replace_module_context(  # noqa: C901

--- a/python/graphscope/nx/utils/contextmanagers.py
+++ b/python/graphscope/nx/utils/contextmanagers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Alibaba Group Holding Limited. All Rights Reserved.
+# Copyright 2020-2022 Alibaba Group Holding Limited. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,8 @@
 # limitations under the License.
 #
 
-from graphscope.nx.utils.contextmanagers import *
-from graphscope.nx.utils.decorators import *
-from graphscope.nx.utils.heaps import *
-from graphscope.nx.utils.mapped_queue import *
-from graphscope.nx.utils.misc import *
-from graphscope.nx.utils.random_sequence import *
-from graphscope.nx.utils.rcm import *
-from graphscope.nx.utils.union_find import *
+import networkx.utils.contextmanagers
+
+from graphscope.nx.utils.compat import import_as_graphscope_nx
+
+import_as_graphscope_nx(networkx.utils.contextmanagers)

--- a/python/graphscope/nx/utils/heaps.py
+++ b/python/graphscope/nx/utils/heaps.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Alibaba Group Holding Limited. All Rights Reserved.
+# Copyright 2020-2022 Alibaba Group Holding Limited. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,8 @@
 # limitations under the License.
 #
 
-from graphscope.nx.utils.contextmanagers import *
-from graphscope.nx.utils.decorators import *
-from graphscope.nx.utils.heaps import *
-from graphscope.nx.utils.mapped_queue import *
-from graphscope.nx.utils.misc import *
-from graphscope.nx.utils.random_sequence import *
-from graphscope.nx.utils.rcm import *
-from graphscope.nx.utils.union_find import *
+import networkx.utils.heaps
+
+from graphscope.nx.utils.compat import import_as_graphscope_nx
+
+import_as_graphscope_nx(networkx.utils.heaps)

--- a/python/graphscope/nx/utils/mapped_queue.py
+++ b/python/graphscope/nx/utils/mapped_queue.py
@@ -16,11 +16,8 @@
 # limitations under the License.
 #
 
-from graphscope.nx.utils.contextmanagers import *
-from graphscope.nx.utils.decorators import *
-from graphscope.nx.utils.heaps import *
-from graphscope.nx.utils.mapped_queue import *
-from graphscope.nx.utils.misc import *
-from graphscope.nx.utils.random_sequence import *
-from graphscope.nx.utils.rcm import *
-from graphscope.nx.utils.union_find import *
+import networkx.utils.mapped_queue
+
+from graphscope.nx.utils.compat import import_as_graphscope_nx
+
+import_as_graphscope_nx(networkx.utils.mapped_queue)

--- a/python/graphscope/nx/utils/random_sequence.py
+++ b/python/graphscope/nx/utils/random_sequence.py
@@ -1,3 +1,21 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright 2020-2022 Alibaba Group Holding Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import networkx.utils.random_sequence
 
 from graphscope.nx.utils.compat import import_as_graphscope_nx

--- a/python/graphscope/nx/utils/rcm.py
+++ b/python/graphscope/nx/utils/rcm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Alibaba Group Holding Limited. All Rights Reserved.
+# Copyright 2020-2022 Alibaba Group Holding Limited. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,8 @@
 # limitations under the License.
 #
 
-from graphscope.nx.utils.contextmanagers import *
-from graphscope.nx.utils.decorators import *
-from graphscope.nx.utils.heaps import *
-from graphscope.nx.utils.mapped_queue import *
-from graphscope.nx.utils.misc import *
-from graphscope.nx.utils.random_sequence import *
-from graphscope.nx.utils.rcm import *
-from graphscope.nx.utils.union_find import *
+import networkx.utils.rcm
+
+from graphscope.nx.utils.compat import import_as_graphscope_nx
+
+import_as_graphscope_nx(networkx.utils.rcm)

--- a/python/graphscope/nx/utils/union_find.py
+++ b/python/graphscope/nx/utils/union_find.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2020 Alibaba Group Holding Limited. All Rights Reserved.
+# Copyright 2020-2022 Alibaba Group Holding Limited. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,8 @@
 # limitations under the License.
 #
 
-from graphscope.nx.utils.contextmanagers import *
-from graphscope.nx.utils.decorators import *
-from graphscope.nx.utils.heaps import *
-from graphscope.nx.utils.mapped_queue import *
-from graphscope.nx.utils.misc import *
-from graphscope.nx.utils.random_sequence import *
-from graphscope.nx.utils.rcm import *
-from graphscope.nx.utils.union_find import *
+import networkx.utils.union_find
+
+from graphscope.nx.utils.compat import import_as_graphscope_nx
+
+import_as_graphscope_nx(networkx.utils.union_find)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools_scm", "grpcio", "grpcio-tools", "numpy", "wheel"]
 
 [tool.black]
 line-length = 88
-exclude = '.*\/(forward|node_modules|\.eggs|build)\/.*'
+exclude = '.*\/(forward|node_modules|\.eggs|build|_pb2\.py)\/.*'


### PR DESCRIPTION
## What do these changes do?

There are name conflicts in networkx, e.g.,

- `networkx.algorithms.approximation.connectivity` vs. `networkx.algorithms.connectivity`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

N/A

