### PR TITLE
Support return a dict for graph schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ env:
 
 jobs:
   release-gss-image:
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope' }}
+    # See issue: https://github.com/alibaba/GraphScope/issues/1645
+    if: false
+    # if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2.3.2

--- a/docs/frequently_asked_questions.rst
+++ b/docs/frequently_asked_questions.rst
@@ -98,7 +98,7 @@ If you don't find an answer to your question here, feel free to file a `Issues`_
 12. why ``Timeout Exception`` raised during launching GraphScope instance on kubernetes cluster?
 
     It will take a few minutes for pulling image during the first time for launching GraphScope instance. Thus, the ``Timeout Exception`` may caused by a poor network connection.
-    You can increase the ``timeeout_seconds`` parameter as your expect by ``graphscope.set_option(timeout_seconds=600))``.
+    You can increase the value of ``timeeout_seconds`` parameter as your expectation by ``graphscope.set_option(timeout_seconds=600))``.
 
 
 **I do have many other questions...**

--- a/docs/frequently_asked_questions.rst
+++ b/docs/frequently_asked_questions.rst
@@ -95,6 +95,12 @@ If you don't find an answer to your question here, feel free to file a `Issues`_
 
         The elegant one is creating ``graphscope`` user and user group first, and then grant the access permission on ``graphscope`` to the related NFS directories.
 
+12. why ``Timeout Exception`` raised during launching GraphScope instance on kubernetes cluster?
+
+    It will take a few minutes for pulling image during the first time for launching GraphScope instance. Thus, the ``Timeout Exception`` may caused by a poor network connection.
+    You can increase the ``timeeout_seconds`` parameter as your expect by ``graphscope.set_option(timeout_seconds=600))``.
+
+
 **I do have many other questions...**
 
     Please feel free to contact us. You may reach us by `Issues`_, ask questions in `Discussions`_, or drop a message in `Slack`_ or `DingTalk`_. We are happy to answer your questions responsively.

--- a/docs/frequently_asked_questions.rst
+++ b/docs/frequently_asked_questions.rst
@@ -98,7 +98,7 @@ If you don't find an answer to your question here, feel free to file a `Issues`_
 12. why ``Timeout Exception`` raised during launching GraphScope instance on kubernetes cluster?
 
     It will take a few minutes for pulling image during the first time for launching GraphScope instance. Thus, the ``Timeout Exception`` may caused by a poor network connection.
-    You can increase the value of ``timeeout_seconds`` parameter as your expectation by ``graphscope.set_option(timeout_seconds=600))``.
+    You can increase the value of ``timeout_seconds`` parameter as your expectation by ``graphscope.set_option(timeout_seconds=600))``.
 
 
 **I do have many other questions...**

--- a/docs/zh/frequently_asked_questions.rst
+++ b/docs/zh/frequently_asked_questions.rst
@@ -76,6 +76,21 @@
     - 编译 ``grpcio`` 失败: 你可以通过 ``export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=True`` 来尝试使用系统安装的 ``openssl`` 编译 grpcio。详情可参考 `grpc issue <https://github.com/grpc/grpc/issues/25082>`_
 
     - 编译 ``scipy`` 失败: 你可以根据 `此教程 <https://stackoverflow.com/questions/65745683/how-to-install-scipy-on-apple-silicon-arm-m1>`_ 来源码编译，或尝试通过 ``pip3 install --pre -i https://pypi.anaconda.org/scipy-wheels-nightly/simple scipy`` 来解决这个问题。
+
+11. 在 NFS 上分配 PV 时遇到了 ``Permission denied`` 问题，如何解决？
+
+    - Appearance: 通常当使用 helm 的方式安装 graphscope-store 时，Pod ``graphscope-store-kafka-0`` , ``graphscope-store-zookeeper-0`` 会报 ``CrashLoopBackOff`` 错误
+
+    - Check: 我们通过 ``kubectl logs graphscope-store-zookeeper-0`` 来查看日志，此时日志显示 ``mkdir: cannot create directory '/bitnami/zookeeper/data': Permission denied``
+
+    - Solution: 通常有两种解决方式:
+
+      1. 快速的方式是在所有相关的 PV 目录上使用 ``chmod 777`` ，但不建议在生产环境中使用。
+      2. 优雅的方法是首先创建 ``graphscope`` 用户和用户组，然后将 ``graphscope`` 上的访问权限授予相关NFS目录。
+
+12. 为什么在 Kubernetes 集群上拉起 GraphScope 实例时，产生超时异常？
+
+    大多数情况下，超时的原因是因为在 Kubernetes 集群拉起 GraphScope 实例时需要下载对应镜像，这一步通常需要几分钟的时间，你可以通过 ``graphscope.set_option(timeout_seconds=600)`` 适当的增加超时等待时间来解决该问题。
     
 
 **其他问题**

--- a/python/graphscope/framework/graph_schema.py
+++ b/python/graphscope/framework/graph_schema.py
@@ -64,6 +64,13 @@ class Property:
     def __str__(self) -> str:
         return self.__repr__()
 
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "id": self.id,
+            "type": graph_def_pb2.DataTypePb.Name(self.data_type),
+        }
+
 
 Relation = namedtuple("Relation", "source destination")
 
@@ -124,6 +131,12 @@ class Label:
 
     def __str__(self) -> str:
         return self.__repr__()
+
+    def to_dict(self) -> dict:
+        properties = []
+        for p in self.properties:
+            properties.append(p.to_dict())
+        return {"label": self.label, "properties": properties}
 
     @property
     def type_enum(self):
@@ -189,6 +202,15 @@ class EdgeLabel(Label):
         if self._relations:
             s += f"Relations: {self.relations}"
         return s
+
+    def to_dict(self) -> dict:
+        # super dict
+        sd = super().to_dict()
+        relations = []
+        for r in self._relations:
+            relations.append({"src_label": r.source, "dst_label": r.destination})
+        sd.update({"relations": relations})
+        return sd
 
 
 class GraphSchema:
@@ -345,6 +367,15 @@ class GraphSchema:
 
     def __str__(self):
         return self.__repr__()
+
+    def to_dict(self) -> dict:
+        vertices = []
+        for entry in self._valid_vertex_labels():
+            vertices.append(entry.to_dict())
+        edges = []
+        for entry in self._valid_edge_labels():
+            edges.append(entry.to_dict())
+        return {"vertices": vertices, "edges": edges}
 
     @property
     def oid_type(self):

--- a/python/graphscope/tests/unittest/test_graph.py
+++ b/python/graphscope/tests/unittest/test_graph.py
@@ -47,6 +47,32 @@ def test_graph_schema(arrow_property_graph):
     assert schema.edge_labels == ["e0", "e1"]
 
 
+def test_graph_schema_todict(p2p_property_graph):
+    rlt = {
+        "vertices": [
+            {
+                "label": "person",
+                "properties": [
+                    {"name": "weight", "id": 0, "type": "LONG"},
+                    {"name": "id", "id": 1, "type": "LONG"},
+                ],
+            }
+        ],
+        "edges": [
+            {
+                "label": "knows",
+                "properties": [
+                    {"name": "src_label_id", "id": 0, "type": "LONG"},
+                    {"name": "dst_label_id", "id": 1, "type": "LONG"},
+                    {"name": "dist", "id": 2, "type": "LONG"},
+                ],
+                "relations": [{"src_label": "person", "dst_label": "person"}],
+            }
+        ],
+    }
+    assert p2p_property_graph.schema.to_dict() == rlt
+
+
 def test_load_graph_copy(graphscope_session, arrow_property_graph):
     g = arrow_property_graph
     g2 = graphscope_session.g(g)


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

This is a requirement of `GraphInsight` for graph schema visualization.

This pr also:

- [x] Add FAQ for `timeout exception` during launching GraphScope on the Kubernetes cluster.
- [x] Disable release `graphscope-store` image because the disk is out of space. Will reopen after #1645 

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1646 

