### PR TITLE
Bump karma from 3.0.0 to 6.3.16 in /python/jupyter

### DIFF
--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -60,7 +60,6 @@
     <dep.kryo.version>4.0.0</dep.kryo.version>
     <dep.json.version>20160810</dep.json.version>
     <dep.kryo-serializers.version>0.42</dep.kryo-serializers.version>
-    <dep.zookeeper.version>3.4.5</dep.zookeeper.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -140,33 +139,6 @@
         <groupId>de.javakaffee</groupId>
         <artifactId>kryo-serializers</artifactId>
         <version>${dep.kryo-serializers.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.zookeeper</groupId>
-        <artifactId>zookeeper</artifactId>
-        <version>${dep.zookeeper.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.sun.jmx</groupId>
-            <artifactId>jmxri</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.jdmk</groupId>
-            <artifactId>jmxtools</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.jboss.netty</groupId>
-            <artifactId>netty</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.jms</groupId>
-            <artifactId>jms</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/python/jupyter/graphscope/package.json
+++ b/python/jupyter/graphscope/package.json
@@ -75,7 +75,7 @@
     "expect.js": "^0.3.1",
     "fs-extra": "^7.0.0",
     "husky": "^4.2.5",
-    "karma": "^3.0.0",
+    "karma": "^6.3.16",
     "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^1.1.0",
     "karma-ie-launcher": "^1.0.0",


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

- Fix dependabot alert caused by crossbeam in npm package
- Remove zookeeper dependency in analytical engine

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

