### PR TITLE
Fixes bugs while building on macOS 12 wiht apple silicon

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.5.0"  # vineyard version
-readonly V6D_BRANCH="v0.5.0" # vineyard branch
+readonly V6D_VERSION="0.5.2"  # vineyard version
+readonly V6D_BRANCH="v0.5.2" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true
@@ -385,12 +385,7 @@ write_envs_config() {
   fi
 
   if [[ "${PLATFORM}" == *"Darwin"* ]]; then
-    if [[ "$(uname -m)" == *"x86_64"* ]]; then
-      declare -r homebrew_prefix=/usr/local
-    else
-      # Apple Silicon: packages are installed under /opt/homebrew by default
-      declare -r homebrew_prefix=/opt/homebrew
-    fi
+    declare -r homebrew_prefix=$(brew --prefix)
     {
       echo "export CC=${homebrew_prefix}/opt/llvm/bin/clang"
       echo "export CXX=${homebrew_prefix}/opt/llvm/bin/clang++"
@@ -507,8 +502,9 @@ install_cppkafka() {
   fi
 
   if [[ "${PLATFORM}" == *"Darwin"* ]]; then
-    export LDFLAGS="-L/usr/local/opt/openssl@3/lib"
-    export CPPFLAGS="-I/usr/local/opt/openssl@3/include"
+    declare -r homebrew_prefix=$(brew --prefix)
+    export LDFLAGS="-L${homebrew_prefix}/opt/openssl@3/lib"
+    export CPPFLAGS="-I${homebrew_prefix}/opt/openssl@3/include"
   fi
 
   check_and_remove_dir "/tmp/cppkafka"
@@ -517,7 +513,7 @@ install_cppkafka() {
   pushd /tmp/cppkafka
   git submodule update --init
   mkdir -p build && pushd build
-  cmake .. && make -j$(nproc)
+  cmake -DCPPKAFKA_DISABLE_TESTS=ON  -DCPPKAFKA_DISABLE_EXAMPLES=ON .. && make -j$(nproc)
   sudo make install && popd
   popd
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
add new vineyard version which can build on MacOS with LLVM<=14, find `homebrew_prefix` in `install_cppkafka()`, disable build tests and examples in `install_cppkafka()`, which can not compile on macOS.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Resolves #1734 

