### PR TITLE
[IR Compiler] fix error when creating json file

### DIFF
--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
@@ -46,8 +46,8 @@ import java.util.function.Function;
 // represent ir plan as a chain of operators
 public class IrPlan implements Closeable {
     private static IrCoreLibrary irCoreLib = IrCoreLibrary.INSTANCE;
-    // write to '/tmp' which is accessible from common users
-    private static String JSON_PLAN_DIR = "/tmp";
+    // get tmp directory from system properties, which is accessible from common users
+    private static String JSON_PLAN_DIR = System.getProperty("java.io.tmpdir");
     private Pointer ptrPlan;
     private IrMeta meta;
     // to identify a unique json file which contains the logic plan from ir_core

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
@@ -46,9 +46,12 @@ import java.util.function.Function;
 // represent ir plan as a chain of operators
 public class IrPlan implements Closeable {
     private static IrCoreLibrary irCoreLib = IrCoreLibrary.INSTANCE;
-    private static String PLAN_JSON_FILE = "plan.json";
+    // write to '/tmp' which is accessible from common users
+    private static String JSON_PLAN_DIR = "/tmp";
     private Pointer ptrPlan;
     private IrMeta meta;
+    // to identify a unique json file which contains the logic plan from ir_core
+    private String planName;
 
     // call libc to transform from InterOpBase to c structure
     private enum TransformFactory implements Function<InterOpBase, Pointer> {
@@ -542,8 +545,9 @@ public class IrPlan implements Closeable {
         }
     }
 
-    public IrPlan(IrMeta meta, InterOpCollection opCollection) {
+    public IrPlan(IrMeta meta, InterOpCollection opCollection, String planName) {
         this.meta = meta;
+        this.planName = planName;
         irCoreLib.setSchema(meta.getSchema());
         this.ptrPlan = irCoreLib.initLogicalPlan();
         // add snapshot to QueryParams
@@ -585,11 +589,12 @@ public class IrPlan implements Closeable {
     public String getPlanAsJson() throws IOException {
         String json = "";
         if (ptrPlan != null) {
-            File file = new File(PLAN_JSON_FILE);
+            String fileName = JSON_PLAN_DIR + File.separator + planName + ".json";
+            File file = new File(fileName);
             if (file.exists()) {
                 file.delete();
             }
-            irCoreLib.writePlanToJson(ptrPlan, PLAN_JSON_FILE);
+            irCoreLib.writePlanToJson(ptrPlan, fileName);
             json = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
             if (file.exists()) {
                 file.delete();

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -292,14 +292,14 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
         // add sink operator
         InterOpCollection.process(opCollection);
 
-        IrPlan irPlan = new IrPlan(irMeta, opCollection);
+        long jobId = JOB_ID_COUNTER.incrementAndGet();
+        String jobName = "ir_plan_" + jobId;
+
+        IrPlan irPlan = new IrPlan(irMeta, opCollection, jobName);
         logger.info("{}", irPlan.getPlanAsJson());
 
         byte[] physicalPlanBytes = irPlan.toPhysicalBytes(configs);
         irPlan.close();
-
-        long jobId = JOB_ID_COUNTER.incrementAndGet();
-        String jobName = "ir_plan_" + jobId;
 
         PegasusClient.JobRequest request = PegasusClient.JobRequest.parseFrom(physicalPlanBytes);
         PegasusClient.JobConfig jobConfig =

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
@@ -59,6 +59,6 @@ public class DedupOpTest {
                 opCollection.appendInterOp(op1);
             }
         }
-        return new IrPlan(new IrMeta(""), opCollection);
+        return new IrPlan(new IrMeta(""), opCollection, "");
     }
 }


### PR DESCRIPTION
… to /tmp instead of current to have access to

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. write json file to /tmp instead of the current directory to solve the problem of file privilege
2. attach job id to each json file name to avoid conflicts in concurrent scenarios

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1729

