### PR TITLE
Upgrade vineyard version to fixes some build failures on Mac.

### DIFF
--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.5.0
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.5.3
       options:
         --shm-size 4096m
     steps:

--- a/.github/workflows/networkx-forward-algo-nightly.yml
+++ b/.github/workflows/networkx-forward-algo-nightly.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.5.0
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.5.3
       options:
         --shm-size 4096m
 

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -188,7 +188,7 @@ endif ()
 find_package(libgrapelite REQUIRED)
 include_directories(${LIBGRAPELITE_INCLUDE_DIRS})
 
-find_package(vineyard 0.5.0 REQUIRED)
+find_package(vineyard 0.5.3 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/coordinator/gscoordinator/template/CMakeLists.template
+++ b/coordinator/gscoordinator/template/CMakeLists.template
@@ -136,6 +136,7 @@ include_directories("${ANALYTICAL_ENGINE_HOME}/openmpi/include"
                     "${ANALYTICAL_ENGINE_HOME}/open-mpi/include"
                     "${ANALYTICAL_ENGINE_HOME}/include"
                     "${ANALYTICAL_ENGINE_HOME}/include/vineyard"
+                    "${ANALYTICAL_ENGINE_HOME}/include/vineyard/contrib"
                     "${ANALYTICAL_ENGINE_HOME}/include/graphscope"
                     "${ANALYTICAL_ENGINE_HOME}/include/graphscope/apps"
                     "${ANALYTICAL_ENGINE_HOME}/include/grape/analytical_apps")
@@ -164,7 +165,7 @@ if (libgrapelite_FOUND)
 endif()
 
 # find vineyard-----------------------------------------
-find_package(vineyard 0.5.0 QUIET)
+find_package(vineyard 0.5.3 QUIET)
 if (vineyard_FOUND)
   include_directories(AFTER SYSTEM ${VINEYARD_INCLUDE_DIRS})
 endif()

--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -5,5 +5,5 @@ grpcio
 kubernetes
 protobuf>=3.15.0,<3.19.0
 PyYAML
-vineyard>=0.5.0; sys_platform != "win32"
-vineyard-io>=0.5.0; sys_platform != "win32"
+vineyard>=0.5.2; sys_platform != "win32"
+vineyard-io>=0.5.2; sys_platform != "win32"

--- a/interactive_engine/executor/runtime/native/CMakeLists.txt
+++ b/interactive_engine/executor/runtime/native/CMakeLists.txt
@@ -50,7 +50,7 @@ find_package(Threads REQUIRED)
 #  we need edge src/dst ids in etable.
 add_definitions(-DENDPOINT_LISTS)
 
-find_package(vineyard 0.5.0 REQUIRED)
+find_package(vineyard 0.5.3 REQUIRED)
 add_library(native_store global_store_ffi.cc
                          htap_ds_impl.cc
                          graph_builder_ffi.cc

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -30,7 +30,7 @@ else
 endif
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.5.0
+VINEYARD_VERSION ?= v0.5.3
 PROFILE ?= release
 
 

--- a/k8s/actions-runner-controller/manylinux/Dockerfile
+++ b/k8s/actions-runner-controller/manylinux/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.5.0
+FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:v0.5.3
 
 ARG TARGETPLATFORM
 ARG RUNNER_VERSION=2.287.1

--- a/k8s/graphscope-dev.Dockerfile
+++ b/k8s/graphscope-dev.Dockerfile
@@ -4,7 +4,7 @@
 # the result image includes all runtime stuffs of graphscope, with analytical engine,
 # learning engine and interactive engine installed.
 
-ARG BASE_VERSION=v0.5.0
+ARG BASE_VERSION=v0.5.3
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG NETWORKX=ON

--- a/k8s/graphscope-store.Dockerfile
+++ b/k8s/graphscope-store.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=v0.5.0
+ARG BASE_VERSION=v0.5.3
 FROM registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-vineyard:$BASE_VERSION as builder
 
 ARG CI=true

--- a/k8s/gsvineyard.Dockerfile
+++ b/k8s/gsvineyard.Dockerfile
@@ -27,7 +27,7 @@ RUN sudo mkdir -p /opt/vineyard && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.5.0 https://github.com/v6d-io/v6d.git --depth=1 && \
+    git clone -b v0.5.3 https://github.com/v6d-io/v6d.git --depth=1 && \
     cd v6d && \
     git submodule update --init && \
     mkdir -p /tmp/v6d/build && \

--- a/k8s/ubuntu/gsvineyard.Dockerfile
+++ b/k8s/ubuntu/gsvineyard.Dockerfile
@@ -14,7 +14,7 @@ RUN cd /tmp && \
     make -j`nproc` && \
     make install && \
     cd /tmp && \
-    git clone -b v0.5.0 https://github.com/v6d-io/v6d.git --depth=1 && \
+    git clone -b v0.5.3 https://github.com/v6d-io/v6d.git --depth=1 && \
     cd v6d && \
     git submodule update --init && \
     mkdir -p /tmp/v6d/build && \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,5 +18,5 @@ pysimdjson
 PyYAML
 scipy
 tqdm
-vineyard>=0.5.0; sys_platform != "win32"
-vineyard-io>=0.5.0; sys_platform != "win32"
+vineyard>=0.5.2; sys_platform != "win32"
+vineyard-io>=0.5.2; sys_platform != "win32"

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.5.2"  # vineyard version
-readonly V6D_BRANCH="v0.5.2" # vineyard branch
+readonly V6D_VERSION="0.5.3"  # vineyard version
+readonly V6D_BRANCH="v0.5.3" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true


### PR DESCRIPTION

## What do these changes do?

Fixes the build failure on Mac and header not found issue after upgrading vineyard when compiling frames.

## Related issue number

N/A
