### PR TITLE
AndPredicate in IndexPredicate should be joined use or.

### DIFF
--- a/research/query_service/ir/graph_proxy/src/utils/expr/eval_pred.rs
+++ b/research/query_service/ir/graph_proxy/src/utils/expr/eval_pred.rs
@@ -207,7 +207,7 @@ impl TryFrom<pb::IndexPredicate> for Predicates {
                 is_first = false;
             } else {
                 let new_pred = and_triplet.try_into()?;
-                predicates = predicates.map(|pred| pred.and(new_pred));
+                predicates = predicates.map(|pred| pred.or(new_pred));
             }
         }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
fix bug, or_predicates is a collection of `AndPredicate` that forms a logical **OR** of all `AndPredicate`s
## Related issue number
None


