### PR TITLE
[GAIA-IR] Make v6d_ffi build as features in IR

### DIFF
--- a/interactive_engine/executor/gaia_runtime/Cargo.toml
+++ b/interactive_engine/executor/gaia_runtime/Cargo.toml
@@ -43,10 +43,11 @@ gaia_pegasus = { path = "../../../research/engine/pegasus/pegasus", package = "p
 pegasus_network = { path = "../../../research/engine/pegasus/network" }
 pegasus_server = { path = "../../../research/engine/pegasus/server" }
 runtime_integration =  { path = "../../../research/query_service/ir/integrated" }
-v6d_ffi = { path = "../../../research/query_service/ir/v6d_ffi" }
+v6d_ffi = { path = "../../../research/query_service/ir/v6d_ffi", features = ["with_v6d"] }
 
 [dev-dependencies]
 env_logger = "0.6"
 
 [build-dependencies]
 cmake = "0.1"
+

--- a/interactive_engine/executor/runtime/Cargo.toml
+++ b/interactive_engine/executor/runtime/Cargo.toml
@@ -42,3 +42,7 @@ env_logger = "0.6"
 
 [build-dependencies]
 cmake = "0.1"
+
+[features]
+default = []
+with_native = []

--- a/interactive_engine/executor/runtime/build.rs
+++ b/interactive_engine/executor/runtime/build.rs
@@ -1,12 +1,12 @@
 //
 //! Copyright 2020 Alibaba Group Holding Limited.
-//! 
+//!
 //! Licensed under the Apache License, Version 2.0 (the "License");
 //! you may not use this file except in compliance with the License.
 //! You may obtain a copy of the License at
-//! 
+//!
 //!     http://www.apache.org/licenses/LICENSE-2.0
-//! 
+//!
 //! Unless required by applicable law or agreed to in writing, software
 //! distributed under the License is distributed on an "AS IS" BASIS,
 //! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,14 +15,21 @@
 
 extern crate cmake;
 
-use std::path::Path;
-use cmake::Config;
 use std::env;
+use std::path::Path;
 
-fn main() {
-    let dst = Config::new("native")
-        .build_target("native_store")
-        .build();
+use cmake::Config;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    codegen_inplace()
+}
+
+#[cfg(feature = "with_native")]
+const NATIVE_DIR: &'static str = "src/native";
+
+#[cfg(feature = "with_native")]
+fn codegen_inplace() -> Result<(), Box<dyn std::error::Error>> {
+    let dst = Config::new(NATIVE_DIR).build_target("native_store").build();
 
     println!("cargo:rustc-link-search=/usr/local/lib");
     println!("cargo:rustc-link-search=/usr/local/lib64");
@@ -32,7 +39,7 @@ fn main() {
             println!("cargo:rustc-link-search={}/lib", val);
             println!("cargo:rustc-link-search={}/lib64", val);
         }
-        Err(_) => ()
+        Err(_) => (),
     }
     println!("cargo:rustc-link-search={}/build", dst.display());
     println!("cargo:rustc-link-lib=native_store");
@@ -50,7 +57,15 @@ fn main() {
         if Path::new("/usr/ali/alicpp/built/gcc-4.9.2").exists() {
             println!("cargo:cfg=tunnel");
         }
-    } else if cfg!(target_os = "macos") {} else {
+    } else if cfg!(target_os = "macos") {
+    } else {
         unimplemented!()
     }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "with_native"))]
+fn codegen_inplace() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
 }

--- a/research/query_service/ir/integrated/build.rs
+++ b/research/query_service/ir/integrated/build.rs
@@ -1,0 +1,26 @@
+//
+//! Copyright 2020-2022 Alibaba Group Holding Limited.
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//!     http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if cfg!(target_os = "linux") {
+        println!("cargo:rustc-link-arg=-Wl,--unresolved-symbols=ignore-all");
+    } else if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-arg=-Wl,-undefined");
+        println!("cargo:rustc-link-arg=-Wl,dynamic_lookup");
+    } else {
+        unimplemented!()
+    }
+    Ok(())
+}

--- a/research/query_service/ir/v6d_ffi/Cargo.toml
+++ b/research/query_service/ir/v6d_ffi/Cargo.toml
@@ -17,3 +17,7 @@ maxgraph-runtime = {path = "../../../../interactive_engine/executor/runtime"}
 
 [build-dependencies]
 cmake = "0.1"
+
+[features]
+default = []
+with_v6d = []

--- a/research/query_service/ir/v6d_ffi/build.rs
+++ b/research/query_service/ir/v6d_ffi/build.rs
@@ -20,8 +20,16 @@ use std::path::Path;
 
 use cmake::Config;
 
-fn main() {
-    let dst = Config::new("src/native")
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    codegen_inplace()
+}
+
+#[cfg(feature = "with_v6d")]
+const NATIVE_DIR: &'static str = "src/native";
+
+#[cfg(feature = "with_v6d")]
+fn codegen_inplace() -> Result<(), Box<dyn std::error::Error>> {
+    let dst = Config::new(NATIVE_DIR)
         .build_target("v6d_native_store")
         .build();
 
@@ -55,4 +63,11 @@ fn main() {
     } else {
         unimplemented!()
     }
+
+    Ok(())
+}
+
+#[cfg(not(feature = "with_v6d"))]
+fn codegen_inplace() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Make v6d_ffi build as features.
When compiling IR (e.g., on exp_store) with cargo build, v6d_ffi is not needed and will not be compiled.
If we do want to query with IR on vineyard, build IR with cargo build --features with_v6d. BTW, on the case of starting query service on vineyard, v6d_ffi will be compiled as a default choice (i.e., in interactive_engine/executor/gaia_runtime/Cargo.toml).

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1772

