### PR TITLE
Some improvements about dep installation and rust builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,9 +116,9 @@ gie:
 	cd $(WORKING_DIR)/interactive_engine/executor && \
 	rustup component add rustfmt && \
 	if [ x"release" = x"${BUILD_TYPE}" ]; then \
-		cargo build --all --release; \
+		cargo build --workspace --release; \
 	else \
-		cargo build --all; \
+		cargo build --workspace; \
 	fi
 	# install
 	mkdir -p $(WORKING_DIR)/.install_prefix && \

--- a/interactive_engine/executor/README.md
+++ b/interactive_engine/executor/README.md
@@ -8,11 +8,11 @@ This project contains all `rust` modules of MaxGraph, including:
 This crate act as the parent of all the sub-crates. To compile all sub-crates, run:
 
 ```bash
-cargo build --all
+cargo build --workspace
 ```
 
 To test all sub-crates, run:
 
 ```bash
-cargo test --all
+cargo test --workspace
 ```

--- a/interactive_engine/executor/build.sh
+++ b/interactive_engine/executor/build.sh
@@ -9,9 +9,9 @@ if [ "$SKIP" = "true" ]; then
 fi
 
 if [ "$MODE" = "debug" ]; then
-    ./exec.sh cargo build --all
+    ./exec.sh cargo build --workspace
 elif [ "$MODE" = "release" ]; then
-    ./exec.sh cargo build --all --release
+    ./exec.sh cargo build --workspace --release
 else
     exit 1
 fi

--- a/interactive_engine/executor/cov.sh
+++ b/interactive_engine/executor/cov.sh
@@ -144,7 +144,7 @@ install_kcov() {
 
 run() {
     rm -fr target/cov
-    RUSTFLAGS='-C link-dead-code' cargo test --all --no-run
+    RUSTFLAGS='-C link-dead-code' cargo test --workspace --no-run
     if [[ $? -ne 0 ]]; then
         echo "Compile failed"
         exit 1

--- a/interactive_engine/executor/update_proto.sh
+++ b/interactive_engine/executor/update_proto.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 echo "Deprecated!! "
-echo "Just run 'cargo build --all' which will generate proto files."
+echo "Just run 'cargo build --workspace' which will generate proto files."
 exit 1
 
 source_root="$(dirname "$0")"

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -552,7 +552,7 @@ install_dependencies() {
         -P /tmp/
       sudo apt install -y -V /tmp/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
       sudo apt update -y
-      sudo apt install -y libarrow-dev=3.0.0-1 libarrow-python-dev=3.0.0-1
+      sudo apt install -y libarrow-dev libarrow-python-dev
       # remove apache-arrow from packages_to_install
       packages_to_install=("${packages_to_install[@]/apache-arrow}")
     fi


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Some improvements about dep installation and rust build

<!-- Please give a short brief about these changes. -->
- the default version of `apache-arrow` on ubuntu20.04 is not 3 any more
- update deprecated `--all` to `--workspace` 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

None

