### PR TITLE
Workaround for pip failure to perform editable install with `--user`

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -17,6 +17,7 @@
 #
 
 import os
+import site
 import subprocess
 import sys
 from distutils.cmd import Command
@@ -32,7 +33,6 @@ from wheel.bdist_wheel import bdist_wheel
 
 # Enables --editable install with --user
 # https://github.com/pypa/pip/issues/7953
-import site
 site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
 repo_root = os.path.dirname(os.path.abspath(__file__))

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,6 +30,11 @@ from setuptools.command.develop import develop
 from setuptools.command.sdist import sdist
 from wheel.bdist_wheel import bdist_wheel
 
+# Enables --editable install with --user
+# https://github.com/pypa/pip/issues/7953
+import site
+site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
+
 repo_root = os.path.dirname(os.path.abspath(__file__))
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
PEP517 implemented recently in pip does not allow editable install in user site-packages.  Add a workaround to support install with editable mode with `--user`


<!-- Please give a short brief about these changes. -->

## Related issue number
See discussion here https://github.com/pypa/pip/issues/7953


