### PR TITLE
Fixes the long standing empty column name issue in subgraph

### DIFF
--- a/coordinator/gscoordinator/template/CMakeLists.template
+++ b/coordinator/gscoordinator/template/CMakeLists.template
@@ -211,10 +211,17 @@ set(ANALYTICAL_ENGINE_FRAME_DIR "${ANALYTICAL_ENGINE_HOME}/include/graphscope/fr
 set(FRAME_NAME $_frame_name)
 
 # set javasdk.cc--------------------------------------------------------------
-set(ANALYTICAL_JAVASDK_CC "${ANALYTICAL_ENGINE_HOME}/include/graphscope/core/java/javasdk.cc")
+if(EXISTS "${ANALYTICAL_ENGINE_HOME}/core/java/javasdk.cc")
+    set(ANALYTICAL_JAVASDK_CC "${ANALYTICAL_ENGINE_HOME}/core/java/javasdk.cc")
+else()
+    set(ANALYTICAL_JAVASDK_CC "${ANALYTICAL_ENGINE_HOME}/include/graphscope/core/java/javasdk.cc")
+endif()
 # set dynamic.cc
-set(DYNAMIC_CC "${ANALYTICAL_ENGINE_HOME}/include/graphscope/core/object/dynamic.cc")
-
+if(EXISTS "${ANALYTICAL_ENGINE_HOME}/core/object/dynamic.cc")
+    set(DYNAMIC_CC "${ANALYTICAL_ENGINE_HOME}/core/object/dynamic.cc")
+else()
+    set(DYNAMIC_CC "${ANALYTICAL_ENGINE_HOME}/include/graphscope/core/object/dynamic.cc")
+endif()
 
 # find Glog---------------------------------------------------------------------
 if(GRAPHSCOPE_ANALYTICAL_HOME)

--- a/research/query_service/ir/v6d_ffi/src/native/global_store_ffi.cc
+++ b/research/query_service/ir/v6d_ffi/src/native/global_store_ffi.cc
@@ -116,7 +116,12 @@ OuterId v6d_get_outer_id(GraphHandle graph, Vertex v) {
   OuterId ret;
   auto casted_graph = static_cast<htap_impl::GraphHandleImpl*>(graph);
   if (casted_graph->use_int64_oid) {
-    ret = casted_graph->vertex_map->GetOid((htap_impl::VID_TYPE)v, ret);
+    if (casted_graph->vertex_map->GetOid((htap_impl::VID_TYPE)v, ret)) {
+      return ret;
+    } else {
+      LOG(INFO) << "Unable to find the gid for vertex " << v;
+      return -1; // NOT FOUND
+    }
   } else {
     LOG(FATAL) << "get_outer_id is not supported on string fragment";
   }

--- a/research/query_service/ir/v6d_ffi/src/native/graph_builder_ffi.cc
+++ b/research/query_service/ir/v6d_ffi/src/native/graph_builder_ffi.cc
@@ -400,7 +400,7 @@ int v6d_build_vertex_primary_keys(VertexTypeBuilder vertex, size_t key_count,
   auto entry_ptr = static_cast<entry_t *>(vertex);
   std::vector<std::string> names(key_count);
   for (size_t i = 0; i < key_count; ++i) {
-    names.emplace_back(key_name_list[i]);
+    names[i] = key_name_list[i];
   }
   entry_ptr->AddPrimaryKeys(key_count, names);
   return 0;


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

- Fixes the issue about an empty property name in subgraph's schema.
- Addresses a bug about resolving primary key (OID) in subgraph builder as well.
- Tweak the `CMakeLists.template` to ensure graphscope can be run using the inplace build.
- Using `kDefaultBufferSize` as the default buffer size for subgraph.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #225

