### PR TITLE
[GAIA-IR] Filter the data when selecting a non-exist tag

### DIFF
--- a/research/query_service/ir/compiler/conf/ir.compiler.properties
+++ b/research/query_service/ir/compiler/conf/ir.compiler.properties
@@ -7,7 +7,7 @@ pegasus.hosts: localhost:1234
 pegasus.server.num: 1
 
 # graph.schema
-graph.schema: ../core/resource/modern_schema.json
+graph.schema: ../core/resource/modern_schema_nopk.json
 
 # disable the authentication if username or password not set
 #auth.username: default

--- a/research/query_service/ir/compiler/conf/ir.compiler.properties
+++ b/research/query_service/ir/compiler/conf/ir.compiler.properties
@@ -7,7 +7,7 @@ pegasus.hosts: localhost:1234
 pegasus.server.num: 1
 
 # graph.schema
-graph.schema: ../core/resource/modern_schema_nopk.json
+graph.schema: ../core/resource/modern_schema.json
 
 # disable the authentication if username or password not set
 #auth.username: default

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/graph/RemoteTestGraph.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/graph/RemoteTestGraph.java
@@ -517,10 +517,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_asXaX_outXknowsX_asXbX_localXselectXa_bX_byXnameXX",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_selectXa_bX",
-        reason = "unsupported")
+// @Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_selectXa_bX",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method =
@@ -542,10 +542,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_VX1X_groupXaX_byXconstantXaXX_byXnameX_selectXaX_selectXaX",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_selectXaX_count",
-        reason = "unsupported")
+// @Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_selectXaX_count",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_asXaX_outXknowsX_asXaX_selectXall_constantXaXX",
@@ -555,18 +555,18 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         method =
                 "g_V_outE_weight_groupCount_selectXvaluesX_unfold_groupCount_selectXvaluesX_unfold",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_selectXaX",
-        reason = "unsupported")
+// @Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_selectXaX",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_valueMap_selectXall_a_bX",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_valueMap_selectXa_bX",
-        reason = "unsupported")
+// @Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_valueMap_selectXa_bX",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method =
@@ -592,10 +592,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
         method = "g_V_outE_weight_groupCount_selectXvaluesX_unfold",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
-        method = "g_V_valueMap_selectXaX",
-        reason = "unsupported")
+// @Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest",
+//        method = "g_V_valueMap_selectXaX",
+//        reason = "unsupported")
 @Graph.OptOut(
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest",
         method = "g_VX4X_bothE_hasXweight_lt_1X_otherV",

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransform.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransform.java
@@ -17,7 +17,6 @@
 package com.alibaba.graphscope.gremlin.transform;
 
 import com.alibaba.graphscope.common.exception.OpArgIllegalException;
-import com.alibaba.graphscope.common.jna.type.FfiVariable;
 import com.alibaba.graphscope.gremlin.antlr4.AnyValue;
 
 import org.apache.commons.lang3.tuple.Triple;
@@ -158,19 +157,6 @@ public interface PredicateExprTransform extends Function<Step, String> {
 
     default String getPredicateExpr(
             String subject, String predicate, Object value, Function<Triple, String> format) {
-        String subjectKeyExist = getExprIfPropertyExist(subject);
-        String valueKeyExist = "";
-        if (value instanceof FfiVariable.ByValue) {
-            valueKeyExist = getExprIfPropertyExist(value.toString());
-        }
-        String predicateExpr = format.apply(Triple.of(subject, predicate, value));
-        StringBuilder builder = new StringBuilder(predicateExpr);
-        if (!valueKeyExist.isEmpty()) {
-            builder.insert(0, String.format("%s && ", valueKeyExist));
-        }
-        if (!subjectKeyExist.isEmpty()) {
-            builder.insert(0, String.format("%s && ", subjectKeyExist));
-        }
-        return builder.toString();
+        return format.apply(Triple.of(subject, predicate, value));
     }
 }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GraphStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GraphStepTest.java
@@ -82,7 +82,7 @@ public class GraphStepTest {
         Step graphStep = traversal.asAdmin().getStartStep();
         ScanFusionOp op = (ScanFusionOp) StepTransformFactory.SCAN_FUSION_STEP.apply(graphStep);
         String expr = op.getParams().get().getPredicate().get();
-        Assert.assertEquals("@.name && @.name == \"marko\"", expr);
+        Assert.assertEquals("@.name == \"marko\"", expr);
     }
 
     @Test

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/HasStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/HasStepTest.java
@@ -38,7 +38,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("name", "marko");
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.name && @.name == \"marko\"", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -46,7 +46,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("name", P.eq("marko"));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.name && @.name == \"marko\"", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("name", P.neq("marko"));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.name && @.name != \"marko\"", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name != \"marko\"", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.lt(10));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.age && @.age < 10", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age < 10", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.lte(10));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.age && @.age <= 10", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age <= 10", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.gt(10));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.age && @.age > 10", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age > 10", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.gte(10));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.age && @.age >= 10", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age >= 10", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.within(10));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.age && @.age within [10]", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age within [10]", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -102,7 +102,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.within(10, 11));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.age && @.age within [10, 11]", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age within [10, 11]", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.without(10));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.age && @.age without [10]", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age without [10]", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.without(10, 11));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals("@.age && @.age without [10, 11]", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age without [10, 11]", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -127,8 +127,7 @@ public class HasStepTest {
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
         Assert.assertEquals(
-                "@.name && @.name within [\"marko\", \"josh\"]",
-                op.getPredicate().get().applyArg());
+                "@.name within [\"marko\", \"josh\"]", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -137,8 +136,7 @@ public class HasStepTest {
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
         Assert.assertEquals(
-                "@.name && @.name without [\"marko\", \"josh\"]",
-                op.getPredicate().get().applyArg());
+                "@.name without [\"marko\", \"josh\"]", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -146,8 +144,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.gt(27).and(P.lt(32)));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals(
-                "@.age && @.age > 27 && (@.age && @.age < 32)", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age > 27 && (@.age < 32)", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -155,8 +152,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("age", P.lt(27).or(P.gt(32)));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals(
-                "@.age && @.age < 27 || (@.age && @.age > 32)", op.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age < 27 || (@.age > 32)", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -181,8 +177,7 @@ public class HasStepTest {
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
         Assert.assertEquals(
-                "@.name && @.name == \"marko\" && (@.id && @.id == 1)",
-                op.getPredicate().get().applyArg());
+                "@.name == \"marko\" && (@.id == 1)", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -190,8 +185,7 @@ public class HasStepTest {
         Traversal traversal = g.V().has("name", TextP.containing("marko"));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals(
-                "@.name && \"marko\" within @.name", op.getPredicate().get().applyArg());
+        Assert.assertEquals("\"marko\" within @.name", op.getPredicate().get().applyArg());
     }
 
     @Test
@@ -199,7 +193,6 @@ public class HasStepTest {
         Traversal traversal = g.V().has("name", TextP.notContaining("marko"));
         Step hasStep = traversal.asAdmin().getEndStep();
         SelectOp op = (SelectOp) StepTransformFactory.HAS_STEP.apply(hasStep);
-        Assert.assertEquals(
-                "@.name && \"marko\" without @.name", op.getPredicate().get().applyArg());
+        Assert.assertEquals("\"marko\" without @.name", op.getPredicate().get().applyArg());
     }
 }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/MatchStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/MatchStepTest.java
@@ -78,8 +78,7 @@ public class MatchStepTest {
         Assert.assertEquals(false, op.getIsEdge().get().applyArg());
 
         SelectOp selectOp = (SelectOp) sentence.getBinders().unmodifiableCollection().get(1);
-        Assert.assertEquals(
-                "@.~label && @.~label == \"person\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.~label == \"person\"", selectOp.getPredicate().get().applyArg());
     }
 
     // out + has("name", "marko") -> expand + filter
@@ -93,8 +92,7 @@ public class MatchStepTest {
         Assert.assertEquals(false, op.getIsEdge().get().applyArg());
 
         SelectOp selectOp = (SelectOp) sentence.getBinders().unmodifiableCollection().get(1);
-        Assert.assertEquals(
-                "@.name && @.name == \"marko\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", selectOp.getPredicate().get().applyArg());
     }
 
     // fuse outE + hasLabel("knows")
@@ -117,8 +115,7 @@ public class MatchStepTest {
         MatchSentence sentence = getSentences(traversal).get(0);
         Assert.assertTrue(isEqualWith(sentence, "a", "b", FfiJoinKind.Inner, 1));
         ExpandOp op = (ExpandOp) sentence.getBinders().unmodifiableCollection().get(0);
-        Assert.assertEquals(
-                "@.weight && @.weight == 1.0", op.getParams().get().getPredicate().get());
+        Assert.assertEquals("@.weight == 1.0", op.getParams().get().getPredicate().get());
         Assert.assertEquals(true, op.getIsEdge().get().applyArg());
     }
 
@@ -133,8 +130,7 @@ public class MatchStepTest {
         Assert.assertEquals(FfiVOpt.Start, op.getGetVOpt().get().applyArg());
 
         SelectOp selectOp = (SelectOp) sentence.getBinders().unmodifiableCollection().get(2);
-        Assert.assertEquals(
-                "@.~label && @.~label == \"person\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.~label == \"person\"", selectOp.getPredicate().get().applyArg());
     }
 
     // outV + has("name", "marko") -> getV + filter
@@ -148,8 +144,7 @@ public class MatchStepTest {
         Assert.assertEquals(FfiVOpt.Start, op.getGetVOpt().get().applyArg());
 
         SelectOp selectOp = (SelectOp) sentence.getBinders().unmodifiableCollection().get(2);
-        Assert.assertEquals(
-                "@.name && @.name == \"marko\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", selectOp.getPredicate().get().applyArg());
     }
 
     // fuse outE + hasLabel("knows") + inV()
@@ -168,8 +163,7 @@ public class MatchStepTest {
         Assert.assertEquals("knows", op.getParams().get().getTables().get(0).name);
 
         SelectOp selectOp = (SelectOp) sentence.getBinders().unmodifiableCollection().get(1);
-        Assert.assertEquals(
-                "@.name && @.name == \"marko\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", selectOp.getPredicate().get().applyArg());
     }
 
     // fuse outE + has("weight", 1.0) + inV()
@@ -189,13 +183,11 @@ public class MatchStepTest {
         Assert.assertTrue(isEqualWith(sentence, "a", "b", FfiJoinKind.Inner, 2));
 
         ExpandOp expandOp = (ExpandOp) sentence.getBinders().unmodifiableCollection().get(0);
-        Assert.assertEquals(
-                "@.weight && @.weight == 1.0", expandOp.getParams().get().getPredicate().get());
+        Assert.assertEquals("@.weight == 1.0", expandOp.getParams().get().getPredicate().get());
         Assert.assertEquals(false, expandOp.getIsEdge().get().applyArg());
 
         SelectOp selectOp = (SelectOp) sentence.getBinders().unmodifiableCollection().get(1);
-        Assert.assertEquals(
-                "@.name && @.name == \"marko\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", selectOp.getPredicate().get().applyArg());
     }
 
     @Test

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/VertexStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/VertexStepTest.java
@@ -80,8 +80,7 @@ public class VertexStepTest {
         Assert.assertEquals(2, ops.size() - 1);
         ExpandOp expandOp = (ExpandOp) ops.get(1);
         Assert.assertEquals(true, expandOp.getIsEdge().get().applyArg());
-        Assert.assertEquals(
-                "@.weight && @.weight == 1.0", expandOp.getParams().get().getPredicate().get());
+        Assert.assertEquals("@.weight == 1.0", expandOp.getParams().get().getPredicate().get());
     }
 
     // fuse outE + has("name", ...) + inV
@@ -92,8 +91,7 @@ public class VertexStepTest {
         Assert.assertEquals(2, ops.size() - 1);
         ExpandOp expandOp = (ExpandOp) ops.get(1);
         Assert.assertEquals(false, expandOp.getIsEdge().get().applyArg());
-        Assert.assertEquals(
-                "@.weight && @.weight == 1.0", expandOp.getParams().get().getPredicate().get());
+        Assert.assertEquals("@.weight == 1.0", expandOp.getParams().get().getPredicate().get());
     }
 
     // fuse outE + has("name", ...) + inV
@@ -105,12 +103,10 @@ public class VertexStepTest {
 
         ExpandOp expandOp = (ExpandOp) ops.get(1);
         Assert.assertEquals(false, expandOp.getIsEdge().get().applyArg());
-        Assert.assertEquals(
-                "@.weight && @.weight == 1.0", expandOp.getParams().get().getPredicate().get());
+        Assert.assertEquals("@.weight == 1.0", expandOp.getParams().get().getPredicate().get());
 
         SelectOp selectOp = (SelectOp) ops.get(2);
-        Assert.assertEquals(
-                "@.name && @.name == \"marko\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", selectOp.getPredicate().get().applyArg());
     }
 
     // fuse outE + has("name", ...)
@@ -123,8 +119,7 @@ public class VertexStepTest {
 
         ExpandOp expandOp = (ExpandOp) ops.get(1);
         Assert.assertEquals(true, expandOp.getIsEdge().get().applyArg());
-        Assert.assertEquals(
-                "@.weight && @.weight == 1.0", expandOp.getParams().get().getPredicate().get());
+        Assert.assertEquals("@.weight == 1.0", expandOp.getParams().get().getPredicate().get());
         Assert.assertEquals(ArgUtils.asFfiAlias("a", true), expandOp.getAlias().get().applyArg());
 
         GetVOp getVOp = (GetVOp) ops.get(2);
@@ -142,16 +137,14 @@ public class VertexStepTest {
 
         ExpandOp expandOp = (ExpandOp) ops.get(1);
         Assert.assertEquals(true, expandOp.getIsEdge().get().applyArg());
-        Assert.assertEquals(
-                "@.weight && @.weight == 1.0", expandOp.getParams().get().getPredicate().get());
+        Assert.assertEquals("@.weight == 1.0", expandOp.getParams().get().getPredicate().get());
         Assert.assertEquals(ArgUtils.asFfiAlias("a", true), expandOp.getAlias().get().applyArg());
 
         GetVOp op = (GetVOp) ops.get(2);
         Assert.assertEquals(FfiVOpt.End, op.getGetVOpt().get().applyArg());
 
         SelectOp selectOp = (SelectOp) ops.get(3);
-        Assert.assertEquals(
-                "@.name && @.name == \"marko\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", selectOp.getPredicate().get().applyArg());
     }
 
     // out + hasLabel -> expand + filter
@@ -165,8 +158,7 @@ public class VertexStepTest {
         Assert.assertEquals(false, expandOp.getIsEdge().get().applyArg());
 
         SelectOp selectOp = (SelectOp) ops.get(2);
-        Assert.assertEquals(
-                "@.~label && @.~label == \"person\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.~label == \"person\"", selectOp.getPredicate().get().applyArg());
     }
 
     // out + has("name", ...) -> expand + filter
@@ -180,8 +172,7 @@ public class VertexStepTest {
         Assert.assertEquals(false, expandOp.getIsEdge().get().applyArg());
 
         SelectOp selectOp = (SelectOp) ops.get(2);
-        Assert.assertEquals(
-                "@.name && @.name == \"marko\"", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.name == \"marko\"", selectOp.getPredicate().get().applyArg());
     }
 
     public static List<InterOpBase> getOps(Traversal traversal) {

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/subtask/WherePredicateTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/subtask/WherePredicateTest.java
@@ -75,8 +75,7 @@ public class WherePredicateTest {
         Traversal traversal = g.V().as("a").out().where(P.eq("a")).by("age");
         SelectOp selectOp = (SelectOp) getApplyWithSelect(traversal).get(0);
 
-        Assert.assertEquals(
-                "@.age && @a.age && @.age == @a.age", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age == @a.age", selectOp.getPredicate().get().applyArg());
     }
 
     @Test
@@ -84,8 +83,7 @@ public class WherePredicateTest {
         Traversal traversal = g.V().as("a").out().where(P.eq("a")).by(__.values("age"));
         SelectOp selectOp = (SelectOp) getApplyWithSelect(traversal).get(0);
 
-        Assert.assertEquals(
-                "@.age && @a.age && @.age == @a.age", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@.age == @a.age", selectOp.getPredicate().get().applyArg());
     }
 
     @Test
@@ -93,8 +91,7 @@ public class WherePredicateTest {
         Traversal traversal = g.V().as("a").out().as("b").where("a", P.eq("b")).by("id").by("age");
         SelectOp selectOp = (SelectOp) getApplyWithSelect(traversal).get(0);
 
-        Assert.assertEquals(
-                "@a.id && @b.age && @a.id == @b.age", selectOp.getPredicate().get().applyArg());
+        Assert.assertEquals("@a.id == @b.age", selectOp.getPredicate().get().applyArg());
     }
 
     @Test
@@ -112,8 +109,7 @@ public class WherePredicateTest {
         SelectOp selectOp = (SelectOp) getApplyWithSelect(traversal).get(0);
 
         Assert.assertEquals(
-                "@a.id && @b.age && @a.id == @b.age || (@a.id && @c.id && @a.id == @c.id)",
-                selectOp.getPredicate().get().applyArg());
+                "@a.id == @b.age || (@a.id == @c.id)", selectOp.getPredicate().get().applyArg());
     }
 
     @Test

--- a/research/query_service/ir/core/resource/ldbc_schema_pk.json
+++ b/research/query_service/ir/core/resource/ldbc_schema_pk.json
@@ -12,7 +12,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -84,7 +84,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -156,7 +156,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -188,7 +188,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -220,7 +220,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -252,7 +252,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -284,7 +284,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -316,7 +316,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -388,7 +388,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -420,7 +420,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -452,7 +452,7 @@
             "name": "id"
           },
           "data_type": 2,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {

--- a/research/query_service/ir/core/resource/modern_schema.json
+++ b/research/query_service/ir/core/resource/modern_schema.json
@@ -12,7 +12,7 @@
             "name": "name"
           },
           "data_type": 4,
-          "is_primary_key": true
+          "is_primary_key": false
         },
         {
           "key": {
@@ -36,7 +36,7 @@
             "name": "name"
           },
           "data_type": 4,
-          "is_primary_key": true
+          "is_primary_key": false
         },
         {
           "key": {

--- a/research/query_service/ir/core/resource/modern_schema_nopk.json
+++ b/research/query_service/ir/core/resource/modern_schema_nopk.json
@@ -1,0 +1,112 @@
+{
+  "entities": [
+    {
+      "label": {
+        "id": 1,
+        "name": "software"
+      },
+      "columns": [
+        {
+          "key": {
+            "id": 0,
+            "name": "name"
+          },
+          "data_type": 4,
+          "is_primary_key": false
+        },
+        {
+          "key": {
+            "id": 2,
+            "name": "lang"
+          },
+          "data_type": 4,
+          "is_primary_key": false
+        }
+      ]
+    },
+    {
+      "label": {
+        "id": 0,
+        "name": "person"
+      },
+      "columns": [
+        {
+          "key": {
+            "id": 0,
+            "name": "name"
+          },
+          "data_type": 4,
+          "is_primary_key": false
+        },
+        {
+          "key": {
+            "id": 1,
+            "name": "age"
+          },
+          "data_type": 1,
+          "is_primary_key": false
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {
+      "label": {
+        "id": 0,
+        "name": "knows"
+      },
+      "entity_pairs": [
+        {
+          "src": {
+            "id": 0,
+            "name": "person"
+          },
+          "dst": {
+            "id": 0,
+            "name": "person"
+          }
+        }
+      ],
+      "columns": [
+        {
+          "key": {
+            "id": 3,
+            "name": "weight"
+          },
+          "data_type": 3,
+          "is_primary_key": false
+        }
+      ]
+    },
+    {
+      "label": {
+        "id": 1,
+        "name": "created"
+      },
+      "entity_pairs": [
+        {
+          "src": {
+            "id": 0,
+            "name": "person"
+          },
+          "dst": {
+            "id": 0,
+            "name": "software"
+          }
+        }
+      ],
+      "columns": [
+        {
+          "key": {
+            "id": 3,
+            "name": "weight"
+          },
+          "data_type": 3,
+          "is_primary_key": false
+        }
+      ]
+    }
+  ],
+  "is_table_id": true,
+  "is_column_id": false
+}

--- a/research/query_service/ir/core/resource/modern_schema_pk.json
+++ b/research/query_service/ir/core/resource/modern_schema_pk.json
@@ -12,7 +12,7 @@
             "name": "name"
           },
           "data_type": 4,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {
@@ -36,7 +36,7 @@
             "name": "name"
           },
           "data_type": 4,
-          "is_primary_key": false
+          "is_primary_key": true
         },
         {
           "key": {

--- a/research/query_service/ir/core/src/plan/logical.rs
+++ b/research/query_service/ir/core/src/plan/logical.rs
@@ -730,11 +730,8 @@ fn get_column_id_from_pb(schema: &Schema, name: &common_pb::NameOrId) -> Option<
 fn preprocess_var(
     var: &mut common_pb::Variable, meta: &StoreMeta, plan_meta: &mut PlanMeta, is_predicate: bool,
 ) -> IrResult<()> {
-    let tag = if let Some(tag) = var.tag.as_mut() {
-        Some(get_or_set_tag_id(tag, true, plan_meta)?)
-    } else {
-        None
-    };
+    let tag =
+        if let Some(tag) = var.tag.as_mut() { Some(get_or_set_tag_id(tag, plan_meta)?) } else { None };
     let mut node_meta = plan_meta.curr_node_meta_mut();
     if let Some(property) = var.property.as_mut() {
         if let Some(key) = property.item.as_mut() {
@@ -895,18 +892,13 @@ fn preprocess_params(
     Ok(())
 }
 
-fn get_or_set_tag_id(
-    tag_pb: &mut common_pb::NameOrId, should_exist: bool, plan_meta: &mut PlanMeta,
-) -> IrResult<TagId> {
+fn get_or_set_tag_id(tag_pb: &mut common_pb::NameOrId, plan_meta: &mut PlanMeta) -> IrResult<TagId> {
     use common_pb::name_or_id::Item;
     if let Some(tag_item) = tag_pb.item.as_mut() {
-        let (is_exist, tag_id) = match tag_item {
+        let (_, tag_id) = match tag_item {
             Item::Name(tag) => plan_meta.get_or_set_tag_id(tag),
             Item::Id(id) => (true, *id as TagId),
         };
-        if should_exist && !is_exist {
-            return Err(IrError::TagNotExist((tag_id as i32).into()));
-        }
         *tag_pb = (tag_id as i32).into();
 
         Ok(tag_id)
@@ -948,7 +940,7 @@ impl AsLogical for pb::Project {
         let len = self.mappings.len();
         for mapping in self.mappings.iter_mut() {
             if let Some(alias) = mapping.alias.as_mut() {
-                let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+                let tag_id = get_or_set_tag_id(alias, plan_meta)?;
                 plan_meta.insert_tag_nodes(tag_id, vec![plan_meta.get_curr_node()]);
             }
             if let Some(expr) = &mut mapping.expr {
@@ -960,15 +952,14 @@ impl AsLogical for pb::Project {
                         expr.operators.get_mut(0).unwrap()
                     {
                         if let Some(tag) = var.tag.as_mut() {
-                            let tag_id = get_or_set_tag_id(tag, true, plan_meta)?;
+                            let tag_id = get_or_set_tag_id(tag, plan_meta)?;
                             if var.property.is_none() {
                                 let nodes = plan_meta.get_tag_nodes(tag_id).to_vec();
-                                if nodes.is_empty() {
-                                    return Err(IrError::TagNotExist((tag_id as i32).into()));
+                                if !nodes.is_empty() {
+                                    // the case of `project("@a")`, must refer to the nodes referred by the tag,
+                                    plan_meta.refer_to_nodes(curr_node, nodes);
+                                    is_project_as_head = true;
                                 }
-                                // the case of `project("@a")`, must refer to the nodes referred by the tag,
-                                plan_meta.refer_to_nodes(curr_node, nodes);
-                                is_project_as_head = true;
                             }
                         }
                     }
@@ -1003,7 +994,7 @@ impl AsLogical for pb::Scan {
         let curr_node = plan_meta.get_curr_node();
         plan_meta.refer_to_nodes(curr_node, vec![curr_node]);
         if let Some(alias) = self.alias.as_mut() {
-            let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+            let tag_id = get_or_set_tag_id(alias, plan_meta)?;
             plan_meta.insert_tag_nodes(tag_id, vec![plan_meta.get_curr_node()]);
         }
         if let Some(params) = self.params.as_mut() {
@@ -1045,7 +1036,7 @@ impl AsLogical for pb::EdgeExpand {
             preprocess_params(params, meta, plan_meta)?;
         }
         if let Some(alias) = self.alias.as_mut() {
-            let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+            let tag_id = get_or_set_tag_id(alias, plan_meta)?;
             plan_meta.insert_tag_nodes(tag_id, vec![plan_meta.get_curr_node()]);
         }
 
@@ -1065,7 +1056,7 @@ impl AsLogical for pb::PathExpand {
             base.preprocess(meta, plan_meta)?;
         }
         if let Some(alias) = self.alias.as_mut() {
-            let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+            let tag_id = get_or_set_tag_id(alias, plan_meta)?;
             plan_meta.insert_tag_nodes(tag_id, vec![plan_meta.get_curr_node()]);
         }
         // PathExpand would never require adding columns
@@ -1085,7 +1076,7 @@ impl AsLogical for pb::GetV {
             preprocess_params(params, meta, plan_meta)?;
         }
         if let Some(alias) = self.alias.as_mut() {
-            let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+            let tag_id = get_or_set_tag_id(alias, plan_meta)?;
             plan_meta.insert_tag_nodes(tag_id, vec![plan_meta.get_curr_node()]);
         }
 
@@ -1113,21 +1104,17 @@ impl AsLogical for pb::GroupBy {
                 preprocess_var(key, meta, plan_meta, false)?;
                 let mut tag_id = 0;
                 if let Some(alias) = mapping.alias.as_mut() {
-                    tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+                    tag_id = get_or_set_tag_id(alias, plan_meta)?;
                 }
                 // TODO() check the logic again
                 if key.property.is_none() {
                     let node_ids = if let Some(tag_pb) = key.tag.as_mut() {
-                        let tag_id = get_or_set_tag_id(tag_pb, false, plan_meta)?;
-                        let nodes = plan_meta.get_tag_nodes(tag_id);
-                        if nodes.is_empty() {
-                            return Err(IrError::TagNotExist((tag_id as i32).into()));
-                        }
-                        nodes.to_vec()
+                        let tag_id = get_or_set_tag_id(tag_pb, plan_meta)?;
+                        plan_meta.get_tag_nodes(tag_id).to_vec()
                     } else {
                         plan_meta.get_curr_referred_nodes().to_vec()
                     };
-                    if mapping.alias.is_some() {
+                    if mapping.alias.is_some() && !node_ids.is_empty() {
                         plan_meta.insert_tag_nodes(tag_id, node_ids);
                     }
                 }
@@ -1138,7 +1125,7 @@ impl AsLogical for pb::GroupBy {
                 preprocess_var(var, meta, plan_meta, false)?;
             }
             if let Some(alias) = agg_fn.alias.as_mut() {
-                let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+                let tag_id = get_or_set_tag_id(alias, plan_meta)?;
                 plan_meta.insert_tag_nodes(tag_id, vec![plan_meta.get_curr_node()]);
             }
         }
@@ -1205,7 +1192,7 @@ impl AsLogical for pb::Limit {
 impl AsLogical for pb::As {
     fn preprocess(&mut self, _meta: &StoreMeta, plan_meta: &mut PlanMeta) -> IrResult<()> {
         if let Some(alias) = self.alias.as_mut() {
-            let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+            let tag_id = get_or_set_tag_id(alias, plan_meta)?;
             plan_meta.insert_tag_nodes(tag_id, plan_meta.get_curr_referred_nodes().to_vec());
         }
         Ok(())
@@ -1231,7 +1218,7 @@ impl AsLogical for pb::Sink {
     fn preprocess(&mut self, _meta: &StoreMeta, plan_meta: &mut PlanMeta) -> IrResult<()> {
         for tag_key in self.tags.iter_mut() {
             if let Some(tag) = tag_key.key.as_mut() {
-                get_or_set_tag_id(tag, true, plan_meta)?;
+                get_or_set_tag_id(tag, plan_meta)?;
             }
         }
         Ok(())
@@ -1245,7 +1232,7 @@ impl AsLogical for pb::Apply {
             plan_meta.refer_to_nodes(curr_node, vec![curr_node]);
         }
         if let Some(alias) = self.alias.as_mut() {
-            let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+            let tag_id = get_or_set_tag_id(alias, plan_meta)?;
             plan_meta.insert_tag_nodes(tag_id, vec![plan_meta.get_curr_node()]);
         }
         Ok(())
@@ -1256,7 +1243,7 @@ impl AsLogical for pb::Pattern {
     fn preprocess(&mut self, meta: &StoreMeta, plan_meta: &mut PlanMeta) -> IrResult<()> {
         for sentence in self.sentences.iter_mut() {
             if let Some(alias) = sentence.start.as_mut() {
-                let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+                let tag_id = get_or_set_tag_id(alias, plan_meta)?;
                 if plan_meta.has_tag(tag_id) {
                     return Err(IrError::InvalidPattern(format!(
                         "`pb::Pattern` cannot reference existing tag: {:?}",
@@ -1269,7 +1256,7 @@ impl AsLogical for pb::Pattern {
                 ));
             }
             if let Some(alias) = sentence.end.as_mut() {
-                let tag_id = get_or_set_tag_id(alias, false, plan_meta)?;
+                let tag_id = get_or_set_tag_id(alias, plan_meta)?;
                 if plan_meta.has_tag(tag_id) {
                     return Err(IrError::InvalidPattern(format!(
                         "`pb::Pattern` cannot reference existing tag: {:?}",
@@ -2558,11 +2545,10 @@ mod test {
             }],
             is_append: false,
         };
+        // visiting a non-existing tag does not return error
         let result = plan.append_operator_as_node(project.into(), vec![0]);
-        match result.err() {
-            Some(IrError::TagNotExist(_)) => {}
-            _ => panic!("should produce `IrError::TagNotExist`"),
-        }
+        println!("{:?}", result);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/research/query_service/ir/core/src/plan/logical.rs
+++ b/research/query_service/ir/core/src/plan/logical.rs
@@ -1803,7 +1803,7 @@ mod test {
         plan_meta.refer_to_nodes(0, vec![0]);
         let meta = StoreMeta {
             schema: Some(
-                Schema::from_json(std::fs::File::open("resource/modern_schema.json").unwrap()).unwrap(),
+                Schema::from_json(std::fs::File::open("resource/modern_schema_pk.json").unwrap()).unwrap(),
             ),
         };
         let mut scan = pb::Scan {

--- a/research/query_service/ir/core/src/plan/meta.rs
+++ b/research/query_service/ir/core/src/plan/meta.rs
@@ -801,7 +801,7 @@ impl PlanMeta {
             if let Some(nodes) = self.tag_nodes.get(&tag).cloned() {
                 Ok(self.get_or_insert_nodes_meta(&nodes))
             } else {
-                Err(IrError::TagNotExist((tag as KeyId).into()))
+                Ok(self.get_or_insert_nodes_meta(&[]))
             }
         } else {
             let ref_curr_nodes = self.get_curr_referred_nodes().to_vec();

--- a/research/query_service/ir/graph_proxy/src/utils/expr/mod.rs
+++ b/research/query_service/ir/graph_proxy/src/utils/expr/mod.rs
@@ -40,6 +40,8 @@ pub enum ExprEvalError {
     NoneOperand(OperatorDesc),
     /// Meant to evaluate a certain operator, but obtain a different one
     UnmatchedOperator(OperatorDesc),
+    /// Meant to evaluate a variable, but the data type is unexpected (e.g., not a graph-element)
+    UnexpectedDataType(OperatorDesc),
     /// Unsupported
     Unsupported(String),
     /// Other unknown errors that is converted from a error description
@@ -56,7 +58,10 @@ impl Display for ExprEvalError {
             EmptyExpression => write!(f, "try to evaluate an empty expression"),
             NoneOperand(opr) => write!(f, "try to evaluate {:?} but obtain `None` value", opr),
             UnmatchedOperator(opr) => {
-                write!(f, "meant to evaluate a certain operator, but obtain a different one： {:?}", opr)
+                write!(f, "meant to evaluate a certain operator, but obtain a different one: {:?}", opr)
+            }
+            UnexpectedDataType(opr) => {
+                write!(f, "meant to evaluate a variable, but with unexpected data type: {:?}", opr)
             }
             Unsupported(e) => write!(f, "unsupported: {}", e),
             OtherErr(e) => write!(f, "parse error {}", e),

--- a/research/query_service/ir/graph_proxy/src/utils/expr/mod.rs
+++ b/research/query_service/ir/graph_proxy/src/utils/expr/mod.rs
@@ -42,6 +42,8 @@ pub enum ExprEvalError {
     UnmatchedOperator(OperatorDesc),
     /// Meant to evaluate a variable, but the data type is unexpected (e.g., not a graph-element)
     UnexpectedDataType(OperatorDesc),
+    /// Get ``None` from `Context`
+    GetNoneFromContext,
     /// Unsupported
     Unsupported(String),
     /// Other unknown errors that is converted from a error description
@@ -63,6 +65,7 @@ impl Display for ExprEvalError {
             UnexpectedDataType(opr) => {
                 write!(f, "meant to evaluate a variable, but with unexpected data type: {:?}", opr)
             }
+            GetNoneFromContext => write!(f, "get `None` from `Context`"),
             Unsupported(e) => write!(f, "unsupported: {}", e),
             OtherErr(e) => write!(f, "parse error {}", e),
         }

--- a/research/query_service/ir/integrated/tests/expand_test.rs
+++ b/research/query_service/ir/integrated/tests/expand_test.rs
@@ -32,7 +32,7 @@ mod test {
     use pegasus::result::ResultStream;
     use pegasus::JobConf;
     use runtime::process::operator::flatmap::FlatMapFuncGen;
-    use runtime::process::operator::map::{FilterMapFuncGen, MapFuncGen};
+    use runtime::process::operator::map::FilterMapFuncGen;
     use runtime::process::operator::source::SourceOperator;
     use runtime::process::record::Record;
 
@@ -267,8 +267,8 @@ mod test {
             let expand = expand.clone();
             |input, output| {
                 let mut stream = input.input_from(source_gen(Some(TAG_A.into())))?;
-                let map_func = project.gen_map().unwrap();
-                stream = stream.map(move |input| map_func.exec(input))?;
+                let filter_map_func = project.gen_filter_map().unwrap();
+                stream = stream.filter_map(move |input| filter_map_func.exec(input))?;
                 let flatmap_func = expand.gen_flat_map().unwrap();
                 stream = stream.flat_map(move |input| flatmap_func.exec(input))?;
                 stream.sink_into(output)
@@ -380,8 +380,8 @@ mod test {
                 let mut stream = input.input_from(source_gen(None))?;
                 let flatmap_func = expand.gen_flat_map().unwrap();
                 stream = stream.flat_map(move |input| flatmap_func.exec(input))?;
-                let map_func = getv.gen_map().unwrap();
-                stream = stream.map(move |input| map_func.exec(input))?;
+                let filter_map_func = getv.gen_filter_map().unwrap();
+                stream = stream.filter_map(move |input| filter_map_func.exec(input))?;
                 stream.sink_into(output)
             }
         })
@@ -429,8 +429,8 @@ mod test {
                 let mut stream = input.input_from(source_gen(None))?;
                 let flatmap_func = expand.gen_flat_map().unwrap();
                 stream = stream.flat_map(move |input| flatmap_func.exec(input))?;
-                let map_func = getv.gen_map().unwrap();
-                stream = stream.map(move |input| map_func.exec(input))?;
+                let filter_map_func = getv.gen_filter_map().unwrap();
+                stream = stream.filter_map(move |input| filter_map_func.exec(input))?;
                 stream.sink_into(output)
             }
         })
@@ -478,8 +478,8 @@ mod test {
                 let mut stream = input.input_from(source_gen(None))?;
                 let flatmap_func = expand.gen_flat_map().unwrap();
                 stream = stream.flat_map(move |input| flatmap_func.exec(input))?;
-                let map_func = getv.gen_map().unwrap();
-                stream = stream.map(move |input| map_func.exec(input))?;
+                let filter_map_func = getv.gen_filter_map().unwrap();
+                stream = stream.filter_map(move |input| filter_map_func.exec(input))?;
                 stream.sink_into(output)
             }
         })

--- a/research/query_service/ir/integrated/tests/graph_query_test.rs
+++ b/research/query_service/ir/integrated/tests/graph_query_test.rs
@@ -121,7 +121,7 @@ mod test {
 
         let mut job_builder = JobBuilder::default();
         job_builder.add_source(source_opr_bytes);
-        job_builder.map(project_opr_bytes);
+        job_builder.filter_map(project_opr_bytes);
         job_builder.sink(sink_opr_bytes);
         job_builder.build().unwrap()
     }
@@ -161,7 +161,7 @@ mod test {
         job_builder.add_source(source_opr_bytes);
         job_builder.repartition(shuffle_opr_bytes);
         job_builder.flat_map(expand_opr_bytes);
-        job_builder.map(project_opr_bytes);
+        job_builder.filter_map(project_opr_bytes);
         job_builder.sink(sink_opr_bytes);
         job_builder.build().unwrap()
     }

--- a/research/query_service/ir/integrated/tests/pathxd_test.rs
+++ b/research/query_service/ir/integrated/tests/pathxd_test.rs
@@ -54,7 +54,7 @@ mod test {
 
         let mut job_builder = JobBuilder::default();
         job_builder.add_source(source_opr.encode_to_vec());
-        job_builder.map(path_start_opr.encode_to_vec());
+        job_builder.filter_map(path_start_opr.encode_to_vec());
         job_builder.iterate_emit(2, |plan| {
             plan.repartition(shuffle_opr.clone().encode_to_vec());
             plan.flat_map(expand_opr.clone().encode_to_vec());
@@ -91,7 +91,7 @@ mod test {
 
         let mut job_builder = JobBuilder::default();
         job_builder.add_source(source_opr.encode_to_vec());
-        job_builder.map(path_start_opr.encode_to_vec());
+        job_builder.filter_map(path_start_opr.encode_to_vec());
         job_builder.repartition(shuffle_opr.clone().encode_to_vec());
         job_builder.flat_map(expand_opr.clone().encode_to_vec());
         job_builder.iterate_emit(1, |plan| {

--- a/research/query_service/ir/runtime/src/process/operator/filter/select.rs
+++ b/research/query_service/ir/runtime/src/process/operator/filter/select.rs
@@ -123,6 +123,89 @@ mod tests {
         assert_eq!(count, 1);
     }
 
+    // g.V().has("code11")
+    #[test]
+    fn select_property_none_exist_test() {
+        let select_opr_pb = pb::Select { predicate: Some(str_to_expr_pb("@.code11".to_string()).unwrap()) };
+        let mut result = select_test(init_source(), select_opr_pb);
+        let mut count = 0;
+        while let Some(res) = result.next() {
+            match res {
+                Ok(_) => {
+                    count += 1;
+                }
+                Err(_) => {
+                    assert!(false)
+                }
+            }
+        }
+
+        assert_eq!(count, 0);
+    }
+
+    // g.V().has("code11").or(has("code"))
+    #[test]
+    fn select_property_none_exist_or_exist_test() {
+        let select_opr_pb =
+            pb::Select { predicate: Some(str_to_expr_pb("@.code11||@.code".to_string()).unwrap()) };
+        let mut result = select_test(init_source(), select_opr_pb);
+        let mut count = 0;
+        while let Some(res) = result.next() {
+            match res {
+                Ok(_) => {
+                    count += 1;
+                }
+                Err(_) => {
+                    assert!(false)
+                }
+            }
+        }
+
+        assert_eq!(count, 1);
+    }
+
+    // g.V().has("code11").and(has("age",27))
+    #[test]
+    fn select_property_none_exist_and_predicate_test() {
+        let select_opr_pb =
+            pb::Select { predicate: Some(str_to_expr_pb("@.code11&&@.age==27".to_string()).unwrap()) };
+        let mut result = select_test(init_source(), select_opr_pb);
+        let mut count = 0;
+        while let Some(res) = result.next() {
+            match res {
+                Ok(_) => {
+                    count += 1;
+                }
+                Err(_) => {
+                    assert!(false)
+                }
+            }
+        }
+
+        assert_eq!(count, 0);
+    }
+
+    // g.V().has("code11").or(has("age",27))
+    #[test]
+    fn select_property_none_exist_or_predicate_test() {
+        let select_opr_pb =
+            pb::Select { predicate: Some(str_to_expr_pb("@.code11||@.age==27".to_string()).unwrap()) };
+        let mut result = select_test(init_source(), select_opr_pb);
+        let mut count = 0;
+        while let Some(res) = result.next() {
+            match res {
+                Ok(_) => {
+                    count += 1;
+                }
+                Err(_) => {
+                    assert!(false)
+                }
+            }
+        }
+
+        assert_eq!(count, 1);
+    }
+
     // g.V().has("id",gt(1))
     #[test]
     fn select_gt_test() {

--- a/research/query_service/ir/runtime/src/process/operator/map/auxilia.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/auxilia.rs
@@ -36,60 +36,61 @@ struct AuxiliaOperator {
 
 impl FilterMapFunction<Record, Record> for AuxiliaOperator {
     fn exec(&self, mut input: Record) -> FnResult<Option<Record>> {
-        let entry = input
-            .get(self.tag)
-            .ok_or(FnExecError::get_tag_error("get current entry failed in AuxiliaOperator"))?
-            .clone();
-        // Make sure there is anything to query with
-        // Note that we need to guarantee the requested column if it has any alias,
-        // e.g., for g.V().out().as("a").has("name", "marko"), we should compile as:
-        // g.V().out().auxilia(as("a"))... where we give alias in auxilia,
-        //     then we set tag=None and alias="a" in auxilia
-        // TODO: it seems that we do not really care about getting head from curr or "a", we only need to save the updated entry with expected alias "a"
-        if self.query_params.is_queryable() {
-            // If queryable, then turn into graph element and do the query
-            let graph = get_graph().ok_or(FnExecError::NullGraphError)?;
-            let new_entry: Option<Entry> = if let Some(v) = entry.as_graph_vertex() {
-                let mut result_iter = graph.get_vertex(&[v.id()], &self.query_params)?;
-                result_iter.next().map(|mut vertex| {
-                    if let Some(details) = v.details() {
-                        if let Some(properties) = details.get_all_properties() {
-                            for (key, val) in properties {
-                                vertex
-                                    .get_details_mut()
-                                    .insert_property(key, val);
+        if let Some(entry) = input.get(self.tag) {
+            let entry = entry.clone();
+            // Make sure there is anything to query with
+            // Note that we need to guarantee the requested column if it has any alias,
+            // e.g., for g.V().out().as("a").has("name", "marko"), we should compile as:
+            // g.V().out().auxilia(as("a"))... where we give alias in auxilia,
+            //     then we set tag=None and alias="a" in auxilia
+            // TODO: it seems that we do not really care about getting head from curr or "a", we only need to save the updated entry with expected alias "a"
+            if self.query_params.is_queryable() {
+                // If queryable, then turn into graph element and do the query
+                let graph = get_graph().ok_or(FnExecError::NullGraphError)?;
+                let new_entry: Option<Entry> = if let Some(v) = entry.as_graph_vertex() {
+                    let mut result_iter = graph.get_vertex(&[v.id()], &self.query_params)?;
+                    result_iter.next().map(|mut vertex| {
+                        if let Some(details) = v.details() {
+                            if let Some(properties) = details.get_all_properties() {
+                                for (key, val) in properties {
+                                    vertex
+                                        .get_details_mut()
+                                        .insert_property(key, val);
+                                }
                             }
                         }
-                    }
-                    vertex.into()
-                })
-            } else if let Some(e) = entry.as_graph_edge() {
-                let mut result_iter = graph.get_edge(&[e.id()], &self.query_params)?;
-                result_iter.next().map(|mut edge| {
-                    if let Some(details) = e.details() {
-                        if let Some(properties) = details.get_all_properties() {
-                            for (key, val) in properties {
-                                edge.get_details_mut().insert_property(key, val);
+                        vertex.into()
+                    })
+                } else if let Some(e) = entry.as_graph_edge() {
+                    let mut result_iter = graph.get_edge(&[e.id()], &self.query_params)?;
+                    result_iter.next().map(|mut edge| {
+                        if let Some(details) = e.details() {
+                            if let Some(properties) = details.get_all_properties() {
+                                for (key, val) in properties {
+                                    edge.get_details_mut().insert_property(key, val);
+                                }
                             }
                         }
-                    }
-                    edge.into()
-                })
+                        edge.into()
+                    })
+                } else {
+                    Err(FnExecError::unexpected_data_error("should be vertex or edge in AuxiliaOperator"))?
+                };
+                if new_entry.is_some() {
+                    input.append(new_entry.unwrap(), self.alias.clone());
+                } else {
+                    return Ok(None);
+                }
             } else {
-                Err(FnExecError::unexpected_data_error("should be vertex or edge in AuxiliaOperator"))?
-            };
-            if new_entry.is_some() {
-                input.append(new_entry.unwrap(), self.alias.clone());
-            } else {
-                return Ok(None);
+                if self.alias.is_some() {
+                    input.append_arc_entry(entry, self.alias.clone());
+                }
             }
-        } else {
-            if self.alias.is_some() {
-                input.append_arc_entry(entry, self.alias.clone());
-            }
-        }
 
-        Ok(Some(input))
+            Ok(Some(input))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/research/query_service/ir/runtime/src/process/operator/map/mod.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/mod.rs
@@ -32,9 +32,6 @@ pub trait MapFuncGen {
 impl MapFuncGen for algebra_pb::logical_plan::operator::Opr {
     fn gen_map(self) -> FnGenResult<Box<dyn MapFunction<Record, Record>>> {
         match self {
-            algebra_pb::logical_plan::operator::Opr::Project(project) => project.gen_map(),
-            algebra_pb::logical_plan::operator::Opr::Vertex(get_vertex) => get_vertex.gen_map(),
-            algebra_pb::logical_plan::operator::Opr::PathStart(path_start) => path_start.gen_map(),
             algebra_pb::logical_plan::operator::Opr::PathEnd(path_end) => path_end.gen_map(),
             _ => Err(ParsePbError::from("algebra_pb op is not a map"))?,
         }
@@ -48,7 +45,11 @@ pub trait FilterMapFuncGen {
 impl FilterMapFuncGen for algebra_pb::logical_plan::operator::Opr {
     fn gen_filter_map(self) -> FnGenResult<Box<dyn FilterMapFunction<Record, Record>>> {
         match self {
+            algebra_pb::logical_plan::operator::Opr::Vertex(get_vertex) => get_vertex.gen_filter_map(),
+            algebra_pb::logical_plan::operator::Opr::PathStart(path_start) => path_start.gen_filter_map(),
+            algebra_pb::logical_plan::operator::Opr::Project(project) => project.gen_filter_map(),
             algebra_pb::logical_plan::operator::Opr::Auxilia(auxilia) => auxilia.gen_filter_map(),
+
             _ => Err(ParsePbError::from("algebra_pb op is not a map"))?,
         }
     }

--- a/research/query_service/ir/runtime/src/process/operator/mod.rs
+++ b/research/query_service/ir/runtime/src/process/operator/mod.rs
@@ -130,9 +130,10 @@ impl TagKey {
                 _ => Ok(CommonObject::Prop(prop_obj).into()),
             }
         } else {
-            Err(FnExecError::unexpected_data_error(
-                "Get key failed when attempt to get prop_key from a non-graph element",
-            ))
+            Err(FnExecError::unexpected_data_error(&format!(
+                "Get key failed when attempt to get prop_key from a non-graph element {:?}",
+                entry
+            )))
         }
     }
 }

--- a/research/query_service/ir/runtime/src/process/record.rs
+++ b/research/query_service/ir/runtime/src/process/record.rs
@@ -33,7 +33,10 @@ use vec_map::VecMap;
 
 #[derive(Debug, Clone, Hash, PartialEq, PartialOrd)]
 pub enum CommonObject {
-    // TODO: common-used object elements
+    /// a None value used when:
+    /// 1) project a non-exist tag of the record;
+    /// 2) project a non-exist label/property of the record of graph_element;
+    /// 3) the property value returned from store is Object::None (TODO: may need to distinguish this case)
     None,
     /// projected property
     Prop(Object),
@@ -123,6 +126,13 @@ impl Entry {
         match self {
             Entry::Element(record_element) => record_element.as_mut_graph_path(),
             _ => None,
+        }
+    }
+
+    pub fn is_none(&self) -> bool {
+        match self {
+            Entry::Element(RecordElement::OffGraph(CommonObject::None)) => true,
+            _ => false,
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. In IR-Runtime, filter the record rather than throw error when the specified start_tag does not exist for `GetV`, `PathStart`, `Project` and `EdgeExpand`.
2. In IR-Core, build `GetV`, `PathStart` and `Project` as a `FilterMap` operator.
3. In IR-Runtime accumulation, only accumulate the not-none-entry (i.e., entry/column that is not a `None`) in Record. Also, this makes consistency of e.g., `g.V().group().by(select('a'))` and `g.V().select('a').group().by()`. 
4. In IR-Compiler, remove property checking in predicate expression.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1835

