### PR TITLE
[IR Compiler] support hasNot in ir compiler

### DIFF
--- a/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraph.java
+++ b/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraph.java
@@ -1214,11 +1214,11 @@ import java.util.Map;
 @Graph.OptOut(
         method = "g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV",
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        reason = "will be supported")
+        reason = "range is unsupported, use limit instead")
 @Graph.OptOut(
         method = "g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X",
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        reason = "will be supported")
+        reason = "range is unsupported, use limit instead")
 // @Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXeqXaXX_name" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be
 // supported")

--- a/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraph.java
+++ b/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraph.java
@@ -74,10 +74,10 @@ import java.util.Map;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
         method = "g_V_hasIdXwithoutXemptyXX_count",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
-        method = "g_V_hasNotXageX_name",
-        reason = "unsupported")
+// @Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
+//        method = "g_V_hasNotXageX_name",
+//        reason = "unsupported")
 // @Graph.OptOut(
 //        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
 //        method = "g_V_hasXname_containingXarkXX",
@@ -1211,12 +1211,14 @@ import java.util.Map;
 // @Graph.OptOut(method="g_VX1X_out_limitX2X" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
 // supported")
-// @Graph.OptOut(method="g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV" ,
-// test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
-// supported")
-// @Graph.OptOut(method="g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X" ,
-// test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
-// supported")
+@Graph.OptOut(
+        method = "g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV",
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
+        reason = "will be supported")
+@Graph.OptOut(
+        method = "g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X",
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
+        reason = "will be supported")
 // @Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXeqXaXX_name" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be
 // supported")

--- a/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraphProvider.java
+++ b/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraphProvider.java
@@ -71,8 +71,8 @@ public class MaxTestGraphProvider extends AbstractGraphProvider implements AutoC
     @Override
     public void loadGraphData(
             Graph graph, LoadGraphWith loadGraphWith, Class testClass, String testName) {
-        LoadGraphWith.GraphData graphData =
-                null == loadGraphWith ? LoadGraphWith.GraphData.CLASSIC : loadGraphWith.value();
+        // other graph data is unsupported for ir on groot
+        LoadGraphWith.GraphData graphData = LoadGraphWith.GraphData.MODERN;
         if (loadedGraphs.contains(graphData)) return;
         try {
             ((MaxTestGraph) graph).loadSchema(graphData);

--- a/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraphProvider.java
+++ b/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraphProvider.java
@@ -36,6 +36,8 @@ public class MaxTestGraphProvider extends AbstractGraphProvider implements AutoC
     private MaxTestGraph graph;
     private String storeDataPath;
 
+    private Set<LoadGraphWith.GraphData> loadedGraphs = new HashSet<>();
+
     @Override
     public Map<String, Object> getBaseConfiguration(
             String graphName,
@@ -71,13 +73,11 @@ public class MaxTestGraphProvider extends AbstractGraphProvider implements AutoC
             Graph graph, LoadGraphWith loadGraphWith, Class testClass, String testName) {
         LoadGraphWith.GraphData graphData =
                 null == loadGraphWith ? LoadGraphWith.GraphData.CLASSIC : loadGraphWith.value();
-        if ((new File(this.storeDataPath)).exists()) {
-            logger.debug("{}", "data has existed, skip ddl");
-            return;
-        }
+        if (loadedGraphs.contains(graphData)) return;
         try {
             ((MaxTestGraph) graph).loadSchema(graphData);
             ((MaxTestGraph) graph).loadData(graphData);
+            loadedGraphs.add(graphData);
         } catch (URISyntaxException | IOException e) {
             logger.error("load schema failed", e);
             throw new MaxGraphException(e);

--- a/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraphProvider.java
+++ b/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraphProvider.java
@@ -36,8 +36,6 @@ public class MaxTestGraphProvider extends AbstractGraphProvider implements AutoC
     private MaxTestGraph graph;
     private String storeDataPath;
 
-    private Set<LoadGraphWith.GraphData> loadedGraphs = new HashSet<>();
-
     @Override
     public Map<String, Object> getBaseConfiguration(
             String graphName,
@@ -73,11 +71,13 @@ public class MaxTestGraphProvider extends AbstractGraphProvider implements AutoC
             Graph graph, LoadGraphWith loadGraphWith, Class testClass, String testName) {
         LoadGraphWith.GraphData graphData =
                 null == loadGraphWith ? LoadGraphWith.GraphData.CLASSIC : loadGraphWith.value();
-        if (loadedGraphs.contains(graphData)) return;
+        if ((new File(this.storeDataPath)).exists()) {
+            logger.debug("{}", "data has existed, skip ddl");
+            return;
+        }
         try {
             ((MaxTestGraph) graph).loadSchema(graphData);
             ((MaxTestGraph) graph).loadData(graphData);
-            loadedGraphs.add(graphData);
         } catch (URISyntaxException | IOException e) {
             logger.error("load schema failed", e);
             throw new MaxGraphException(e);

--- a/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraphProvider.java
+++ b/interactive_engine/groot-server/src/test/java/com/alibaba/maxgraph/tests/gremlin/MaxTestGraphProvider.java
@@ -71,7 +71,7 @@ public class MaxTestGraphProvider extends AbstractGraphProvider implements AutoC
     @Override
     public void loadGraphData(
             Graph graph, LoadGraphWith loadGraphWith, Class testClass, String testName) {
-        // other graph data is unsupported for ir on groot
+        // other graph data excluding modern is unsupported for ir on groot
         LoadGraphWith.GraphData graphData = LoadGraphWith.GraphData.MODERN;
         if (loadedGraphs.contains(graphData)) return;
         try {

--- a/interactive_engine/tests/src/main/java/com/alibaba/maxgraph/function/test/RemoteTestGraph.java
+++ b/interactive_engine/tests/src/main/java/com/alibaba/maxgraph/function/test/RemoteTestGraph.java
@@ -54,10 +54,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
         method = "g_V_hasIdXwithoutXemptyXX_count",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
-        method = "g_V_hasNotXageX_name",
-        reason = "unsupported")
+// @Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
+//        method = "g_V_hasNotXageX_name",
+//        reason = "unsupported")
 // @Graph.OptOut(
 //        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
 //        method = "g_V_hasXname_containingXarkXX",
@@ -1191,12 +1191,14 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 // @Graph.OptOut(method="g_VX1X_out_limitX2X" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
 // supported")
-// @Graph.OptOut(method="g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV" ,
-// test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
-// supported")
-// @Graph.OptOut(method="g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X" ,
-// test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
-// supported")
+@Graph.OptOut(
+        method = "g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV",
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
+        reason = "will be supported")
+@Graph.OptOut(
+        method = "g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X",
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
+        reason = "will be supported")
 // @Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXeqXaXX_name" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be
 // supported")

--- a/interactive_engine/tests/src/main/java/com/alibaba/maxgraph/function/test/RemoteTestGraph.java
+++ b/interactive_engine/tests/src/main/java/com/alibaba/maxgraph/function/test/RemoteTestGraph.java
@@ -1194,11 +1194,11 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 @Graph.OptOut(
         method = "g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV",
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        reason = "will be supported")
+        reason = "range is unsupported, use limit instead")
 @Graph.OptOut(
         method = "g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X",
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
-        reason = "will be supported")
+        reason = "range is unsupported, use limit instead")
 // @Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXeqXaXX_name" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be
 // supported")

--- a/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
+++ b/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
@@ -77,10 +77,10 @@ traversalMethod
     | traversalMethod_otherV  // otherV()
     | traversalMethod_not  // not()
     | traversalMethod_union // union()
-    | traversalMethod_range // range()
     | traversalMethod_match // match()
     | traversalMethod_subgraph // subgraph()
     | traversalMethod_bothV // bothV()
+    | traversalMethod_hasNot // hasNot()
     ;
 
 traversalSourceSpawnMethod_V
@@ -115,6 +115,11 @@ traversalMethod_has
     | 'has' LPAREN stringLiteral COMMA stringLiteral COMMA genericLiteral RPAREN
     | 'has' LPAREN stringLiteral COMMA stringLiteral COMMA traversalPredicate RPAREN
     | 'has' LPAREN stringLiteral RPAREN
+    ;
+
+// hasNot("age")
+traversalMethod_hasNot
+    : 'hasNot' LPAREN stringLiteral RPAREN
     ;
 
 // out('str1', ...)
@@ -336,10 +341,6 @@ traversalMethod_union
 
 nestedTraversalExpr
     : nestedTraversal (COMMA nestedTraversal)*
-    ;
-
-traversalMethod_range
-    : 'range' LPAREN integerLiteral COMMA integerLiteral RPAREN
     ;
 
 traversalMethod_match

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
@@ -116,6 +116,14 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
     }
 
     @Override
+    public Traversal visitTraversalMethod_hasNot(
+            GremlinGSParser.TraversalMethod_hasNotContext ctx) {
+        P neqAny = P.neq(AnyValue.INSTANCE);
+        return graphTraversal.has(
+                GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral()), neqAny);
+    }
+
+    @Override
     public Traversal visitTraversalMethod_is(GremlinGSParser.TraversalMethod_isContext ctx) {
         if (ctx.genericLiteral() != null) {
             return graphTraversal.is(
@@ -600,20 +608,6 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
         } else {
             throw new UnsupportedEvalException(
                     ctx.getClass(), "supported pattern is [union(__.out(), ...)]");
-        }
-    }
-
-    @Override
-    public Traversal visitTraversalMethod_range(GremlinGSParser.TraversalMethod_rangeContext ctx) {
-        if (ctx.integerLiteral() != null && ctx.integerLiteral().size() == 2) {
-            Object lower =
-                    GenericLiteralVisitor.getInstance().visitIntegerLiteral(ctx.integerLiteral(0));
-            Object upper =
-                    GenericLiteralVisitor.getInstance().visitIntegerLiteral(ctx.integerLiteral(1));
-            return graphTraversal.range(((Number) lower).longValue(), ((Number) upper).longValue());
-        } else {
-            throw new UnsupportedEvalException(
-                    ctx.getClass(), "supported pattern is [range(1, 2)]");
         }
     }
 

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/graph/RemoteTestGraph.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/graph/RemoteTestGraph.java
@@ -48,10 +48,10 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
         test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
         method = "g_V_hasIdXwithoutXemptyXX_count",
         reason = "unsupported")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
-        method = "g_V_hasNotXageX_name",
-        reason = "unsupported")
+// @Graph.OptOut(
+//        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
+//        method = "g_V_hasNotXageX_name",
+//        reason = "unsupported")
 // @Graph.OptOut(
 //        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasTest",
 //        method = "g_V_hasXname_containingXarkXX",
@@ -1185,12 +1185,14 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 // @Graph.OptOut(method="g_VX1X_out_limitX2X" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
 // supported")
-// @Graph.OptOut(method="g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV" ,
-// test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
-// supported")
-// @Graph.OptOut(method="g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X" ,
-// test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest", reason = "will be
-// supported")
+@Graph.OptOut(
+        method = "g_VX1X_outXknowsX_outEXcreatedX_rangeX0_1X_inV",
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
+        reason = "range is unsupported, use limit instead")
+@Graph.OptOut(
+        method = "g_VX1X_outXknowsX_outXcreatedX_rangeX0_1X",
+        test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeTest",
+        reason = "range is unsupported, use limit instead")
 // @Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXeqXaXX_name" ,
 // test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be
 // supported")

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransform.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransform.java
@@ -56,10 +56,21 @@ public interface PredicateExprTransform extends Function<Step, String> {
             }
         } else {
             Object predicateValue = predicate.getValue();
-            if (predicateValue instanceof AnyValue) {
-                expr = getExprIfPropertyExist(subject);
+            BiPredicate biPredicate = predicate.getBiPredicate();
+            if (predicateValue instanceof AnyValue) { // has("age") or hasNot("age")
+                // @.age
+                String propertyExist = subject;
+                if (biPredicate == Compare.eq) { // has("age")
+                    expr = propertyExist;
+                } else if (biPredicate == Compare.neq) { // hasNot("age")
+                    expr = "!" + propertyExist;
+                } else {
+                    throw new OpArgIllegalException(
+                            OpArgIllegalException.Cause.INVALID_TYPE,
+                            "property type is invalid in checking property existence, "
+                                    + biPredicate.toString());
+                }
             } else {
-                BiPredicate biPredicate = predicate.getBiPredicate();
                 // format as (subject predicate value), i.e "@a.name within [...]"
                 Function<Triple, String> defaultFormat =
                         (Triple t) ->


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. hasNot("age") -> !@.age
2. lower bound of the limit operator should start from 0, range(1, 2) with a lower bound greater than 0 is unsupported in ir runtime, currently remove `traversalMethod_range` from the grammar
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#1802 

