### PR TITLE
[GAIA] Make input data as generic data types in `JobAssembly` interface

### DIFF
--- a/research/engine/pegasus/server/examples/echo_service.rs
+++ b/research/engine/pegasus/server/examples/echo_service.rs
@@ -27,7 +27,7 @@ struct Config {
 
 struct EchoJobParser;
 
-impl JobAssembly<Vec<u8>, Vec<u8>> for EchoJobParser {
+impl JobAssembly<Vec<u8>> for EchoJobParser {
     fn assemble(&self, job: &JobDesc, worker: &mut Worker<Vec<u8>, Vec<u8>>) -> Result<(), BuildJobError> {
         worker.dataflow(|input, output| {
             input

--- a/research/engine/pegasus/server/examples/echo_service.rs
+++ b/research/engine/pegasus/server/examples/echo_service.rs
@@ -27,7 +27,7 @@ struct Config {
 
 struct EchoJobParser;
 
-impl JobAssembly for EchoJobParser {
+impl JobAssembly<Vec<u8>, Vec<u8>> for EchoJobParser {
     fn assemble(&self, job: &JobDesc, worker: &mut Worker<Vec<u8>, Vec<u8>>) -> Result<(), BuildJobError> {
         worker.dataflow(|input, output| {
             input

--- a/research/engine/pegasus/server/src/cluster/standalone.rs
+++ b/research/engine/pegasus/server/src/cluster/standalone.rs
@@ -22,7 +22,7 @@ pub async fn start<I: Data, P>(
     rpc_config: RPCServerConfig, server_config: pegasus::Configuration, assemble: P,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    P: JobAssembly<I, Vec<u8>>,
+    P: JobAssembly<I>,
 {
     let detect = if let Some(net_conf) = server_config.network_config() {
         net_conf.get_servers()?.unwrap_or(vec![])

--- a/research/engine/pegasus/server/src/cluster/standalone.rs
+++ b/research/engine/pegasus/server/src/cluster/standalone.rs
@@ -2,6 +2,7 @@ use std::net::SocketAddr;
 
 use crate::job::JobAssembly;
 use crate::rpc::{RPCServerConfig, ServiceStartListener};
+use pegasus::Data;
 
 struct StandaloneServiceListener;
 
@@ -17,11 +18,11 @@ impl ServiceStartListener for StandaloneServiceListener {
     }
 }
 
-pub async fn start<P>(
+pub async fn start<I: Data, P>(
     rpc_config: RPCServerConfig, server_config: pegasus::Configuration, assemble: P,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    P: JobAssembly,
+    P: JobAssembly<I, Vec<u8>>,
 {
     let detect = if let Some(net_conf) = server_config.network_config() {
         net_conf.get_servers()?.unwrap_or(vec![])

--- a/research/engine/pegasus/server/src/job.rs
+++ b/research/engine/pegasus/server/src/job.rs
@@ -1,6 +1,5 @@
 use libloading::{Library, Symbol};
 use pegasus::{BuildJobError, Data, Worker};
-use std::fmt::Debug;
 
 #[derive(Default)]
 pub struct JobDesc {
@@ -26,13 +25,13 @@ impl JobDesc {
     }
 }
 
-pub trait JobAssembly<I: Data, O: Debug + Send + 'static>: Send + Sync + 'static {
-    fn assemble(&self, job: &JobDesc, worker: &mut Worker<I, O>) -> Result<(), BuildJobError>;
+pub trait JobAssembly<I: Data>: Send + Sync + 'static {
+    fn assemble(&self, job: &JobDesc, worker: &mut Worker<I, Vec<u8>>) -> Result<(), BuildJobError>;
 }
 
 pub struct DynLibraryAssembly;
 
-impl JobAssembly<Vec<u8>, Vec<u8>> for DynLibraryAssembly {
+impl JobAssembly<Vec<u8>> for DynLibraryAssembly {
     fn assemble(&self, job: &JobDesc, worker: &mut Worker<Vec<u8>, Vec<u8>>) -> Result<(), BuildJobError> {
         if let Ok(resource) = String::from_utf8(job.resource.clone()) {
             if let Some(lib) = pegasus::resource::get_global_resource::<Library>(&resource) {

--- a/research/engine/pegasus/server/src/job.rs
+++ b/research/engine/pegasus/server/src/job.rs
@@ -1,5 +1,6 @@
 use libloading::{Library, Symbol};
-use pegasus::{BuildJobError, Worker};
+use pegasus::{BuildJobError, Data, Worker};
+use std::fmt::Debug;
 
 #[derive(Default)]
 pub struct JobDesc {
@@ -25,13 +26,13 @@ impl JobDesc {
     }
 }
 
-pub trait JobAssembly: Send + Sync + 'static {
-    fn assemble(&self, job: &JobDesc, worker: &mut Worker<Vec<u8>, Vec<u8>>) -> Result<(), BuildJobError>;
+pub trait JobAssembly<I: Data, O: Debug + Send + 'static>: Send + Sync + 'static {
+    fn assemble(&self, job: &JobDesc, worker: &mut Worker<I, O>) -> Result<(), BuildJobError>;
 }
 
 pub struct DynLibraryAssembly;
 
-impl JobAssembly for DynLibraryAssembly {
+impl JobAssembly<Vec<u8>, Vec<u8>> for DynLibraryAssembly {
     fn assemble(&self, job: &JobDesc, worker: &mut Worker<Vec<u8>, Vec<u8>>) -> Result<(), BuildJobError> {
         if let Ok(resource) = String::from_utf8(job.resource.clone()) {
             if let Some(lib) = pegasus::resource::get_global_resource::<Library>(&resource) {

--- a/research/engine/pegasus/server/src/rpc.rs
+++ b/research/engine/pegasus/server/src/rpc.rs
@@ -104,7 +104,7 @@ impl Drop for RpcSink {
 
 #[derive(Clone)]
 pub struct JobServiceImpl<I> {
-    inner: Arc<dyn JobAssembly<I, Vec<u8>>>,
+    inner: Arc<dyn JobAssembly<I>>,
     report: bool,
 }
 
@@ -232,7 +232,7 @@ pub async fn start_all<I: Data, P, D, E>(
     mut listener: E,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    P: JobAssembly<I, Vec<u8>>,
+    P: JobAssembly<I>,
     D: ServerDetect + 'static,
     E: ServiceStartListener,
 {
@@ -249,7 +249,7 @@ pub async fn start_rpc_server<I: Data, P, E>(
     server_id: u64, rpc_config: RPCServerConfig, assemble: P, listener: E,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    P: JobAssembly<I, Vec<u8>>,
+    P: JobAssembly<I>,
     E: ServiceStartListener,
 {
     let service = JobServiceImpl { inner: Arc::new(assemble), report: true };

--- a/research/engine/pegasus/server/src/rpc.rs
+++ b/research/engine/pegasus/server/src/rpc.rs
@@ -30,7 +30,7 @@ use hyper::server::conn::{AddrIncoming, AddrStream};
 use pegasus::api::function::FnResult;
 use pegasus::api::FromStream;
 use pegasus::result::{FromStreamExt, ResultSink};
-use pegasus::{Configuration, JobConf, ServerConf};
+use pegasus::{Configuration, Data, JobConf, ServerConf};
 use pegasus_network::config::ServerAddr;
 use pegasus_network::ServerDetect;
 use serde::Deserialize;
@@ -103,15 +103,15 @@ impl Drop for RpcSink {
 }
 
 #[derive(Clone)]
-pub struct JobServiceImpl<P> {
-    inner: Arc<P>,
+pub struct JobServiceImpl<I> {
+    inner: Arc<dyn JobAssembly<I, Vec<u8>>>,
     report: bool,
 }
 
 #[tonic::async_trait]
-impl<P: JobAssembly> pb::job_service_server::JobService for JobServiceImpl<P>
+impl<I> pb::job_service_server::JobService for JobServiceImpl<I>
 where
-    P: JobAssembly,
+    I: Data,
 {
     async fn add_library(&self, request: Request<BinaryResource>) -> Result<Response<Empty>, Status> {
         let BinaryResource { name, resource } = request.into_inner();
@@ -227,12 +227,12 @@ pub struct RPCJobServer<S: pb::job_service_server::JobService> {
 }
 
 /// start both rpc server and pegasus server
-pub async fn start_all<P, D, E>(
+pub async fn start_all<I: Data, P, D, E>(
     rpc_config: RPCServerConfig, server_config: Configuration, assemble: P, server_detector: D,
     mut listener: E,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    P: JobAssembly,
+    P: JobAssembly<I, Vec<u8>>,
     D: ServerDetect + 'static,
     E: ServiceStartListener,
 {
@@ -245,11 +245,11 @@ where
 }
 
 /// startup rpc server
-pub async fn start_rpc_server<P, E>(
+pub async fn start_rpc_server<I: Data, P, E>(
     server_id: u64, rpc_config: RPCServerConfig, assemble: P, listener: E,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    P: JobAssembly,
+    P: JobAssembly<I, Vec<u8>>,
     E: ServiceStartListener,
 {
     let service = JobServiceImpl { inner: Arc::new(assemble), report: true };

--- a/research/query_service/ir/runtime/src/assembly.rs
+++ b/research/query_service/ir/runtime/src/assembly.rs
@@ -467,7 +467,7 @@ impl IRJobAssembly {
     }
 }
 
-impl JobAssembly<Record, Vec<u8>> for IRJobAssembly {
+impl JobAssembly<Record> for IRJobAssembly {
     fn assemble(&self, plan: &JobDesc, worker: &mut Worker<Record, Vec<u8>>) -> Result<(), BuildJobError> {
         worker.dataflow(move |input, output| {
             let source = decode::<server_pb::Source>(&plan.input)?;

--- a/research/query_service/ir/runtime/src/assembly.rs
+++ b/research/query_service/ir/runtime/src/assembly.rs
@@ -26,7 +26,6 @@ use pegasus::api::{
     Collect, CorrelatedSubTask, Count, Dedup, EmitKind, Filter, Fold, FoldByKey, HasAny, IterCondition,
     Iteration, Join, KeyBy, Limit, Map, Merge, PartitionByKey, Sink, SortBy, SortLimitBy,
 };
-use pegasus::codec::{Decode, Encode};
 use pegasus::stream::Stream;
 use pegasus::{BuildJobError, Worker};
 use pegasus_server::job::{JobAssembly, JobDesc};
@@ -468,23 +467,14 @@ impl IRJobAssembly {
     }
 }
 
-impl JobAssembly for IRJobAssembly {
-    fn assemble(&self, plan: &JobDesc, worker: &mut Worker<Vec<u8>, Vec<u8>>) -> Result<(), BuildJobError> {
+impl JobAssembly<Record, Vec<u8>> for IRJobAssembly {
+    fn assemble(&self, plan: &JobDesc, worker: &mut Worker<Record, Vec<u8>>) -> Result<(), BuildJobError> {
         worker.dataflow(move |input, output| {
             let source = decode::<server_pb::Source>(&plan.input)?;
             let source_iter = self
                 .udf_gen
                 .gen_source(self.parse(&source.resource)?)?;
-            let source = input
-                .input_from(source_iter.map(|record| {
-                    let mut buf: Vec<u8> = vec![];
-                    record.write_to(&mut buf).unwrap();
-                    buf
-                }))?
-                .map(|buf| {
-                    let record = Record::read_from(&mut buf.as_slice()).unwrap();
-                    Ok(record)
-                })?;
+            let source = input.input_from(source_iter)?;
             let task = decode::<server_pb::TaskPlan>(&plan.plan)?;
             let stream = self.install(source, &task.plan)?;
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Make input data as generic data types in `JobAssembly`, so that in `IRJobAssembly`, we do not need to serialize/deserialize records when input data for pegasus. This will accelerate the query.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1860 

