### PR TITLE
Optimize the clustering algorithm by replacing the complex `vertex_array_t` with `unordered_map`

### DIFF
--- a/analytical_engine/apps/clustering/avg_clustering.h
+++ b/analytical_engine/apps/clustering/avg_clustering.h
@@ -25,7 +25,7 @@ limitations under the License.
 
 namespace gs {
 /**
- * @brief Compute the average clustering coefficient for the graph.
+ * @brief Compute the average clustering coefficient for the directed graph.
  * @tparam FRAG_T
  */
 template <typename FRAG_T>
@@ -48,13 +48,12 @@ class AvgClustering
 
     messages.InitChannels(thread_num());
     ctx.stage = 0;
-    ForEach(inner_vertices.begin(), inner_vertices.end(),
-            [&messages, &frag, &ctx](int tid, vertex_t v) {
-              ctx.global_degree[v] =
-                  frag.GetLocalOutDegree(v) + frag.GetLocalInDegree(v);
-              messages.SendMsgThroughEdges<fragment_t, int>(
-                  frag, v, ctx.global_degree[v], tid);
-            });
+    ForEach(inner_vertices, [&messages, &frag, &ctx](int tid, vertex_t v) {
+      ctx.global_degree[v] =
+          frag.GetLocalOutDegree(v) + frag.GetLocalInDegree(v);
+      messages.SendMsgThroughEdges<fragment_t, int>(frag, v,
+                                                    ctx.global_degree[v], tid);
+    });
     messages.ForceContinue();
   }
 
@@ -70,94 +69,93 @@ class AvgClustering
           thread_num(), frag,
           [&ctx](int tid, vertex_t u, int msg) { ctx.global_degree[u] = msg; });
 
-      ForEach(inner_vertices.begin(), inner_vertices.end(),
-              [this, &frag, &ctx, &messages, &vertices](int tid, vertex_t v) {
-                if (filterByDegree(frag, ctx, v)) {
-                  return;
-                }
-                vid_t u_gid, v_gid;
-                auto& nbr_vec = ctx.complete_neighbor[v];
-                int degree = ctx.global_degree[v];
-                nbr_vec.reserve(degree);
-                std::vector<std::pair<vid_t, uint32_t>> msg_vec;
-                msg_vec.reserve(degree);
+      ForEach(inner_vertices, [this, &frag, &ctx, &messages](int tid,
+                                                             vertex_t v) {
+        if (filterByDegree(frag, ctx, v)) {
+          return;
+        }
+        vid_t u_gid, v_gid;
+        auto& nbr_vec = ctx.complete_neighbor[v];
+        int degree = ctx.global_degree[v];
+        nbr_vec.reserve(degree);
+        std::vector<std::pair<vid_t, uint32_t>> msg_vec;
+        msg_vec.reserve(degree);
 
-                typename FRAG_T::template vertex_array_t<uint32_t> is_rec;
-                is_rec.Init(vertices, 0);
-                auto es = frag.GetOutgoingAdjList(v);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  is_rec[u]++;
-                }
-                es = frag.GetIncomingAdjList(v);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  is_rec[u]++;
-                  if (is_rec[u] == 2) {
-                    ctx.rec_degree[v]++;
-                  }
-                }
+        std::unordered_map<vid_t, uint32_t> is_rec;
+        auto es = frag.GetOutgoingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          is_rec[u.GetValue()]++;
+        }
+        es = frag.GetIncomingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          is_rec[u.GetValue()]++;
+          if (is_rec[u.GetValue()] == 2) {
+            ctx.rec_degree[v]++;
+          }
+        }
 
-                es = frag.GetOutgoingAdjList(v);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  if (ctx.global_degree[u] < ctx.global_degree[v]) {
-                    std::pair<vid_t, uint32_t> msg;
-                    msg.first = frag.Vertex2Gid(u);
-                    if (is_rec[u] == 2) {
-                      msg.second = 2;
-                    } else {
-                      msg.second = 1;
-                    }
-                    msg_vec.push_back(msg);
-                    nbr_vec.push_back(std::make_pair(u, msg.second));
-                  } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
-                    u_gid = frag.Vertex2Gid(u);
-                    v_gid = frag.GetInnerVertexGid(v);
-                    if (v_gid > u_gid) {
-                      std::pair<vid_t, uint32_t> msg;
-                      msg.first = frag.Vertex2Gid(u);
-                      if (is_rec[u] == 2) {
-                        msg.second = 2;
-                      } else {
-                        msg.second = 1;
-                      }
-                      nbr_vec.push_back(std::make_pair(u, msg.second));
-                      msg_vec.push_back(msg);
-                    }
-                  }
-                }
+        es = frag.GetOutgoingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          if (ctx.global_degree[u] < ctx.global_degree[v]) {
+            std::pair<vid_t, uint32_t> msg;
+            msg.first = frag.Vertex2Gid(u);
+            if (is_rec[u.GetValue()] == 2) {
+              msg.second = 2;
+            } else {
+              msg.second = 1;
+            }
+            msg_vec.push_back(msg);
+            nbr_vec.push_back(std::make_pair(u, msg.second));
+          } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
+            u_gid = frag.Vertex2Gid(u);
+            v_gid = frag.GetInnerVertexGid(v);
+            if (v_gid > u_gid) {
+              std::pair<vid_t, uint32_t> msg;
+              msg.first = frag.Vertex2Gid(u);
+              if (is_rec[u.GetValue()] == 2) {
+                msg.second = 2;
+              } else {
+                msg.second = 1;
+              }
+              nbr_vec.push_back(std::make_pair(u, msg.second));
+              msg_vec.push_back(msg);
+            }
+          }
+        }
 
-                es = frag.GetIncomingAdjList(v);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  if (ctx.global_degree[u] < ctx.global_degree[v]) {
-                    std::pair<vid_t, uint32_t> msg;
-                    msg.first = frag.Vertex2Gid(u);
-                    if (is_rec[u] == 1) {
-                      msg.second = 1;
-                      msg_vec.push_back(msg);
-                      nbr_vec.push_back(std::make_pair(u, 1));
-                    }
-                  } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
-                    u_gid = frag.Vertex2Gid(u);
-                    v_gid = frag.GetInnerVertexGid(v);
-                    if (v_gid > u_gid) {
-                      std::pair<vid_t, uint32_t> msg;
-                      msg.first = frag.Vertex2Gid(u);
-                      if (is_rec[u] == 1) {
-                        msg.second = 1;
-                        msg_vec.push_back(msg);
-                        nbr_vec.push_back(std::make_pair(u, 1));
-                      }
-                    }
-                  }
-                }
+        es = frag.GetIncomingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          if (ctx.global_degree[u] < ctx.global_degree[v]) {
+            std::pair<vid_t, uint32_t> msg;
+            msg.first = frag.Vertex2Gid(u);
+            if (is_rec[u.GetValue()] == 1) {
+              msg.second = 1;
+              msg_vec.push_back(msg);
+              nbr_vec.push_back(std::make_pair(u, 1));
+            }
+          } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
+            u_gid = frag.Vertex2Gid(u);
+            v_gid = frag.GetInnerVertexGid(v);
+            if (v_gid > u_gid) {
+              std::pair<vid_t, uint32_t> msg;
+              msg.first = frag.Vertex2Gid(u);
+              if (is_rec[u.GetValue()] == 1) {
+                msg.second = 1;
+                msg_vec.push_back(msg);
+                nbr_vec.push_back(std::make_pair(u, 1));
+              }
+            }
+          }
+        }
 
-                messages.SendMsgThroughEdges<
-                    fragment_t, std::vector<std::pair<vid_t, uint32_t>>>(
-                    frag, v, msg_vec, tid);
-              });
+        messages.SendMsgThroughEdges<fragment_t,
+                                     std::vector<std::pair<vid_t, uint32_t>>>(
+            frag, v, msg_vec, tid);
+      });
       messages.ForceContinue();
     } else if (ctx.stage == 1) {
       ctx.stage = 2;
@@ -202,13 +200,12 @@ class AvgClustering
         }
       }
 
-      ForEach(outer_vertices.begin(), outer_vertices.end(),
-              [&messages, &frag, &ctx](int tid, vertex_t v) {
-                if (ctx.tricnt[v] != 0) {
-                  messages.SyncStateOnOuterVertex<fragment_t, int>(
-                      frag, v, ctx.tricnt[v], tid);
-                }
-              });
+      ForEach(outer_vertices, [&messages, &frag, &ctx](int tid, vertex_t v) {
+        if (ctx.tricnt[v] != 0) {
+          messages.SyncStateOnOuterVertex<fragment_t, int>(frag, v,
+                                                           ctx.tricnt[v], tid);
+        }
+      });
       messages.ForceContinue();
     } else if (ctx.stage == 2) {
       ctx.stage = 3;

--- a/analytical_engine/apps/clustering/clustering.h
+++ b/analytical_engine/apps/clustering/clustering.h
@@ -79,8 +79,8 @@ class Clustering
           thread_num(), frag,
           [&ctx](int tid, vertex_t u, int msg) { ctx.global_degree[u] = msg; });
 
-      ForEach(inner_vertices, [this, &frag, &ctx, &messages, &vertices](
-                                  int tid, vertex_t v) {
+      ForEach(inner_vertices, [this, &frag, &ctx, &messages](int tid,
+                                                             vertex_t v) {
         if (filterByDegree(frag, ctx, v)) {
           return;
         }

--- a/analytical_engine/apps/clustering/clustering.h
+++ b/analytical_engine/apps/clustering/clustering.h
@@ -79,7 +79,7 @@ class Clustering
           thread_num(), frag,
           [&ctx](int tid, vertex_t u, int msg) { ctx.global_degree[u] = msg; });
 
-      ForEach(inner_vertices
+      ForEach(inner_vertices,
               [this, &frag, &ctx, &messages, &vertices](int tid, vertex_t v) {
                 if (filterByDegree(frag, ctx, v)) {
                   return;

--- a/analytical_engine/apps/clustering/clustering.h
+++ b/analytical_engine/apps/clustering/clustering.h
@@ -79,7 +79,7 @@ class Clustering
           thread_num(), frag,
           [&ctx](int tid, vertex_t u, int msg) { ctx.global_degree[u] = msg; });
 
-      ForEach(inner_vertices.begin(), inner_vertices.end(),
+      ForEach(inner_vertices
               [this, &frag, &ctx, &messages, &vertices](int tid, vertex_t v) {
                 if (filterByDegree(frag, ctx, v)) {
                   return;
@@ -92,18 +92,17 @@ class Clustering
                   std::vector<std::pair<vid_t, uint32_t>> msg_vec;
                   msg_vec.reserve(degree);
 
-                  typename FRAG_T::template vertex_array_t<uint32_t> is_rec;
-                  is_rec.Init(vertices, 0);
+                  std::unordered_map<vid_t, uint32_t> is_rec;
                   auto es = frag.GetOutgoingAdjList(v);
                   for (auto& e : es) {
                     auto u = e.get_neighbor();
-                    is_rec[u]++;
+                    is_rec[u.GetValue()]++;
                   }
                   es = frag.GetIncomingAdjList(v);
                   for (auto& e : es) {
                     auto u = e.get_neighbor();
-                    is_rec[u]++;
-                    if (is_rec[u] == 2) {
+                    is_rec[u.GetValue()]++;
+                    if (is_rec[u.GetValue()] == 2) {
                       ctx.rec_degree[v]++;
                     }
                   }
@@ -114,7 +113,7 @@ class Clustering
                     if (ctx.global_degree[u] < ctx.global_degree[v]) {
                       std::pair<vid_t, uint32_t> msg;
                       msg.first = frag.Vertex2Gid(u);
-                      if (is_rec[u] == 2) {
+                      if (is_rec[u.GetValue()] == 2) {
                         msg.second = 2;
                       } else {
                         msg.second = 1;
@@ -127,7 +126,7 @@ class Clustering
                       if (v_gid > u_gid) {
                         std::pair<vid_t, uint32_t> msg;
                         msg.first = frag.Vertex2Gid(u);
-                        if (is_rec[u] == 2) {
+                        if (is_rec[u.GetValue()] == 2) {
                           msg.second = 2;
                         } else {
                           msg.second = 1;
@@ -144,7 +143,7 @@ class Clustering
                     if (ctx.global_degree[u] < ctx.global_degree[v]) {
                       std::pair<vid_t, uint32_t> msg;
                       msg.first = frag.Vertex2Gid(u);
-                      if (is_rec[u] == 1) {
+                      if (is_rec[u.GetValue()] == 1) {
                         msg.second = 1;
                         msg_vec.push_back(msg);
                         nbr_vec.push_back(std::make_pair(u, 1));
@@ -155,7 +154,7 @@ class Clustering
                       if (v_gid > u_gid) {
                         std::pair<vid_t, uint32_t> msg;
                         msg.first = frag.Vertex2Gid(u);
-                        if (is_rec[u] == 1) {
+                        if (is_rec[u.GetValue()] == 1) {
                           msg.second = 1;
                           msg_vec.push_back(msg);
                           nbr_vec.push_back(std::make_pair(u, 1));

--- a/analytical_engine/apps/clustering/clustering.h
+++ b/analytical_engine/apps/clustering/clustering.h
@@ -79,95 +79,95 @@ class Clustering
           thread_num(), frag,
           [&ctx](int tid, vertex_t u, int msg) { ctx.global_degree[u] = msg; });
 
-      ForEach(inner_vertices,
-              [this, &frag, &ctx, &messages, &vertices](int tid, vertex_t v) {
-                if (filterByDegree(frag, ctx, v)) {
-                  return;
+      ForEach(inner_vertices, [this, &frag, &ctx, &messages, &vertices](
+                                  int tid, vertex_t v) {
+        if (filterByDegree(frag, ctx, v)) {
+          return;
+        }
+        int degree = ctx.global_degree[v];
+        if (degree > 1) {
+          vid_t u_gid, v_gid;
+          auto& nbr_vec = ctx.complete_neighbor[v];
+          nbr_vec.reserve(degree);
+          std::vector<std::pair<vid_t, uint32_t>> msg_vec;
+          msg_vec.reserve(degree);
+
+          std::unordered_map<vid_t, uint32_t> is_rec;
+          auto es = frag.GetOutgoingAdjList(v);
+          for (auto& e : es) {
+            auto u = e.get_neighbor();
+            is_rec[u.GetValue()]++;
+          }
+          es = frag.GetIncomingAdjList(v);
+          for (auto& e : es) {
+            auto u = e.get_neighbor();
+            is_rec[u.GetValue()]++;
+            if (is_rec[u.GetValue()] == 2) {
+              ctx.rec_degree[v]++;
+            }
+          }
+
+          es = frag.GetOutgoingAdjList(v);
+          for (auto& e : es) {
+            auto u = e.get_neighbor();
+            if (ctx.global_degree[u] < ctx.global_degree[v]) {
+              std::pair<vid_t, uint32_t> msg;
+              msg.first = frag.Vertex2Gid(u);
+              if (is_rec[u.GetValue()] == 2) {
+                msg.second = 2;
+              } else {
+                msg.second = 1;
+              }
+              msg_vec.push_back(msg);
+              nbr_vec.push_back(std::make_pair(u, msg.second));
+            } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
+              u_gid = frag.Vertex2Gid(u);
+              v_gid = frag.GetInnerVertexGid(v);
+              if (v_gid > u_gid) {
+                std::pair<vid_t, uint32_t> msg;
+                msg.first = frag.Vertex2Gid(u);
+                if (is_rec[u.GetValue()] == 2) {
+                  msg.second = 2;
+                } else {
+                  msg.second = 1;
                 }
-                int degree = ctx.global_degree[v];
-                if (degree > 1) {
-                  vid_t u_gid, v_gid;
-                  auto& nbr_vec = ctx.complete_neighbor[v];
-                  nbr_vec.reserve(degree);
-                  std::vector<std::pair<vid_t, uint32_t>> msg_vec;
-                  msg_vec.reserve(degree);
+                nbr_vec.push_back(std::make_pair(u, msg.second));
+                msg_vec.push_back(msg);
+              }
+            }
+          }
 
-                  std::unordered_map<vid_t, uint32_t> is_rec;
-                  auto es = frag.GetOutgoingAdjList(v);
-                  for (auto& e : es) {
-                    auto u = e.get_neighbor();
-                    is_rec[u.GetValue()]++;
-                  }
-                  es = frag.GetIncomingAdjList(v);
-                  for (auto& e : es) {
-                    auto u = e.get_neighbor();
-                    is_rec[u.GetValue()]++;
-                    if (is_rec[u.GetValue()] == 2) {
-                      ctx.rec_degree[v]++;
-                    }
-                  }
-
-                  es = frag.GetOutgoingAdjList(v);
-                  for (auto& e : es) {
-                    auto u = e.get_neighbor();
-                    if (ctx.global_degree[u] < ctx.global_degree[v]) {
-                      std::pair<vid_t, uint32_t> msg;
-                      msg.first = frag.Vertex2Gid(u);
-                      if (is_rec[u.GetValue()] == 2) {
-                        msg.second = 2;
-                      } else {
-                        msg.second = 1;
-                      }
-                      msg_vec.push_back(msg);
-                      nbr_vec.push_back(std::make_pair(u, msg.second));
-                    } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
-                      u_gid = frag.Vertex2Gid(u);
-                      v_gid = frag.GetInnerVertexGid(v);
-                      if (v_gid > u_gid) {
-                        std::pair<vid_t, uint32_t> msg;
-                        msg.first = frag.Vertex2Gid(u);
-                        if (is_rec[u.GetValue()] == 2) {
-                          msg.second = 2;
-                        } else {
-                          msg.second = 1;
-                        }
-                        nbr_vec.push_back(std::make_pair(u, msg.second));
-                        msg_vec.push_back(msg);
-                      }
-                    }
-                  }
-
-                  es = frag.GetIncomingAdjList(v);
-                  for (auto& e : es) {
-                    auto u = e.get_neighbor();
-                    if (ctx.global_degree[u] < ctx.global_degree[v]) {
-                      std::pair<vid_t, uint32_t> msg;
-                      msg.first = frag.Vertex2Gid(u);
-                      if (is_rec[u.GetValue()] == 1) {
-                        msg.second = 1;
-                        msg_vec.push_back(msg);
-                        nbr_vec.push_back(std::make_pair(u, 1));
-                      }
-                    } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
-                      u_gid = frag.Vertex2Gid(u);
-                      v_gid = frag.GetInnerVertexGid(v);
-                      if (v_gid > u_gid) {
-                        std::pair<vid_t, uint32_t> msg;
-                        msg.first = frag.Vertex2Gid(u);
-                        if (is_rec[u.GetValue()] == 1) {
-                          msg.second = 1;
-                          msg_vec.push_back(msg);
-                          nbr_vec.push_back(std::make_pair(u, 1));
-                        }
-                      }
-                    }
-                  }
-
-                  messages.SendMsgThroughEdges<
-                      fragment_t, std::vector<std::pair<vid_t, uint32_t>>>(
-                      frag, v, msg_vec, tid);
+          es = frag.GetIncomingAdjList(v);
+          for (auto& e : es) {
+            auto u = e.get_neighbor();
+            if (ctx.global_degree[u] < ctx.global_degree[v]) {
+              std::pair<vid_t, uint32_t> msg;
+              msg.first = frag.Vertex2Gid(u);
+              if (is_rec[u.GetValue()] == 1) {
+                msg.second = 1;
+                msg_vec.push_back(msg);
+                nbr_vec.push_back(std::make_pair(u, 1));
+              }
+            } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
+              u_gid = frag.Vertex2Gid(u);
+              v_gid = frag.GetInnerVertexGid(v);
+              if (v_gid > u_gid) {
+                std::pair<vid_t, uint32_t> msg;
+                msg.first = frag.Vertex2Gid(u);
+                if (is_rec[u.GetValue()] == 1) {
+                  msg.second = 1;
+                  msg_vec.push_back(msg);
+                  nbr_vec.push_back(std::make_pair(u, 1));
                 }
-              });
+              }
+            }
+          }
+
+          messages.SendMsgThroughEdges<fragment_t,
+                                       std::vector<std::pair<vid_t, uint32_t>>>(
+              frag, v, msg_vec, tid);
+        }
+      });
       messages.ForceContinue();
     } else if (ctx.stage == 1) {
       ctx.stage = 2;

--- a/analytical_engine/apps/clustering/clustering.h
+++ b/analytical_engine/apps/clustering/clustering.h
@@ -54,15 +54,14 @@ class Clustering
 
     messages.InitChannels(thread_num());
     ctx.stage = 0;
-    ForEach(inner_vertices.begin(), inner_vertices.end(),
-            [&messages, &frag, &ctx](int tid, vertex_t v) {
-              ctx.global_degree[v] =
-                  frag.GetLocalOutDegree(v) + frag.GetLocalInDegree(v);
-              if (ctx.global_degree[v] > 1) {
-                messages.SendMsgThroughEdges<fragment_t, int>(
-                    frag, v, ctx.global_degree[v], tid);
-              }
-            });
+    ForEach(inner_vertices, [&messages, &frag, &ctx](int tid, vertex_t v) {
+      ctx.global_degree[v] =
+          frag.GetLocalOutDegree(v) + frag.GetLocalInDegree(v);
+      if (ctx.global_degree[v] > 1) {
+        messages.SendMsgThroughEdges<fragment_t, int>(
+            frag, v, ctx.global_degree[v], tid);
+      }
+    });
     messages.ForceContinue();
   }
 
@@ -227,13 +226,12 @@ class Clustering
           },
           [](int tid) {});
 
-      ForEach(outer_vertices.begin(), outer_vertices.end(),
-              [&messages, &frag, &ctx](int tid, vertex_t v) {
-                if (ctx.tricnt[v] != 0) {
-                  messages.SyncStateOnOuterVertex<fragment_t, int>(
-                      frag, v, ctx.tricnt[v], tid);
-                }
-              });
+      ForEach(outer_vertices, [&messages, &frag, &ctx](int tid, vertex_t v) {
+        if (ctx.tricnt[v] != 0) {
+          messages.SyncStateOnOuterVertex<fragment_t, int>(frag, v,
+                                                           ctx.tricnt[v], tid);
+        }
+      });
       messages.ForceContinue();
     } else if (ctx.stage == 2) {
       ctx.stage = 3;

--- a/analytical_engine/apps/clustering/transitivity.h
+++ b/analytical_engine/apps/clustering/transitivity.h
@@ -25,7 +25,7 @@ limitations under the License.
 
 namespace gs {
 /**
- * Compute the fraction of triangles in the graph.
+ * Compute the fraction of triangles in the directed graph.
  * @tparam FRAG_T
  */
 template <typename FRAG_T>
@@ -48,13 +48,12 @@ class Transitivity
 
     messages.InitChannels(thread_num());
     ctx.stage = 0;
-    ForEach(inner_vertices.begin(), inner_vertices.end(),
-            [&messages, &frag, &ctx](int tid, vertex_t v) {
-              ctx.global_degree[v] =
-                  frag.GetLocalOutDegree(v) + frag.GetLocalInDegree(v);
-              messages.SendMsgThroughEdges<fragment_t, int>(
-                  frag, v, ctx.global_degree[v], tid);
-            });
+    ForEach(inner_vertices, [&messages, &frag, &ctx](int tid, vertex_t v) {
+      ctx.global_degree[v] =
+          frag.GetLocalOutDegree(v) + frag.GetLocalInDegree(v);
+      messages.SendMsgThroughEdges<fragment_t, int>(frag, v,
+                                                    ctx.global_degree[v], tid);
+    });
     messages.ForceContinue();
   }
 
@@ -70,91 +69,89 @@ class Transitivity
           thread_num(), frag,
           [&ctx](int tid, vertex_t u, int msg) { ctx.global_degree[u] = msg; });
 
-      ForEach(inner_vertices.begin(), inner_vertices.end(),
-              [&frag, &ctx, &messages, &vertices](int tid, vertex_t v) {
-                vid_t u_gid, v_gid;
-                auto& nbr_vec = ctx.complete_neighbor[v];
-                int degree = ctx.global_degree[v];
-                nbr_vec.reserve(degree);
-                std::vector<std::pair<vid_t, uint32_t>> msg_vec;
-                msg_vec.reserve(degree);
+      ForEach(inner_vertices, [&frag, &ctx, &messages](int tid, vertex_t v) {
+        vid_t u_gid, v_gid;
+        auto& nbr_vec = ctx.complete_neighbor[v];
+        int degree = ctx.global_degree[v];
+        nbr_vec.reserve(degree);
+        std::vector<std::pair<vid_t, uint32_t>> msg_vec;
+        msg_vec.reserve(degree);
 
-                typename FRAG_T::template vertex_array_t<uint32_t> is_rec;
-                is_rec.Init(vertices, 0);
-                auto es = frag.GetOutgoingAdjList(v);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  is_rec[u]++;
-                }
-                es = frag.GetIncomingAdjList(v);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  is_rec[u]++;
-                  if (is_rec[u] == 2) {
-                    ctx.rec_degree[v]++;
-                  }
-                }
+        std::unordered_map<vid_t, uint32_t> is_rec;
+        auto es = frag.GetOutgoingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          is_rec[u.GetValue()]++;
+        }
+        es = frag.GetIncomingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          is_rec[u.GetValue()]++;
+          if (is_rec[u.GetValue()] == 2) {
+            ctx.rec_degree[v]++;
+          }
+        }
 
-                es = frag.GetOutgoingAdjList(v);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  if (ctx.global_degree[u] < ctx.global_degree[v]) {
-                    std::pair<vid_t, uint32_t> msg;
-                    msg.first = frag.Vertex2Gid(u);
-                    if (is_rec[u] == 2) {
-                      msg.second = 2;
-                    } else {
-                      msg.second = 1;
-                    }
-                    msg_vec.push_back(msg);
-                    nbr_vec.push_back(std::make_pair(u, msg.second));
-                  } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
-                    u_gid = frag.Vertex2Gid(u);
-                    v_gid = frag.GetInnerVertexGid(v);
-                    if (v_gid > u_gid) {
-                      std::pair<vid_t, uint32_t> msg;
-                      msg.first = frag.Vertex2Gid(u);
-                      if (is_rec[u] == 2) {
-                        msg.second = 2;
-                      } else {
-                        msg.second = 1;
-                      }
-                      nbr_vec.push_back(std::make_pair(u, msg.second));
-                      msg_vec.push_back(msg);
-                    }
-                  }
-                }
+        es = frag.GetOutgoingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          if (ctx.global_degree[u] < ctx.global_degree[v]) {
+            std::pair<vid_t, uint32_t> msg;
+            msg.first = frag.Vertex2Gid(u);
+            if (is_rec[u.GetValue()] == 2) {
+              msg.second = 2;
+            } else {
+              msg.second = 1;
+            }
+            msg_vec.push_back(msg);
+            nbr_vec.push_back(std::make_pair(u, msg.second));
+          } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
+            u_gid = frag.Vertex2Gid(u);
+            v_gid = frag.GetInnerVertexGid(v);
+            if (v_gid > u_gid) {
+              std::pair<vid_t, uint32_t> msg;
+              msg.first = frag.Vertex2Gid(u);
+              if (is_rec[u.GetValue()] == 2) {
+                msg.second = 2;
+              } else {
+                msg.second = 1;
+              }
+              nbr_vec.push_back(std::make_pair(u, msg.second));
+              msg_vec.push_back(msg);
+            }
+          }
+        }
 
-                es = frag.GetIncomingAdjList(v);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  if (ctx.global_degree[u] < ctx.global_degree[v]) {
-                    std::pair<vid_t, uint32_t> msg;
-                    msg.first = frag.Vertex2Gid(u);
-                    if (is_rec[u] == 1) {
-                      msg.second = 1;
-                      msg_vec.push_back(msg);
-                      nbr_vec.push_back(std::make_pair(u, 1));
-                    }
-                  } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
-                    u_gid = frag.Vertex2Gid(u);
-                    v_gid = frag.GetInnerVertexGid(v);
-                    if (v_gid > u_gid) {
-                      std::pair<vid_t, uint32_t> msg;
-                      msg.first = frag.Vertex2Gid(u);
-                      if (is_rec[u] == 1) {
-                        msg.second = 1;
-                        msg_vec.push_back(msg);
-                        nbr_vec.push_back(std::make_pair(u, 1));
-                      }
-                    }
-                  }
-                }
+        es = frag.GetIncomingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          if (ctx.global_degree[u] < ctx.global_degree[v]) {
+            std::pair<vid_t, uint32_t> msg;
+            msg.first = frag.Vertex2Gid(u);
+            if (is_rec[u.GetValue()] == 1) {
+              msg.second = 1;
+              msg_vec.push_back(msg);
+              nbr_vec.push_back(std::make_pair(u, 1));
+            }
+          } else if (ctx.global_degree[u] == ctx.global_degree[v]) {
+            u_gid = frag.Vertex2Gid(u);
+            v_gid = frag.GetInnerVertexGid(v);
+            if (v_gid > u_gid) {
+              std::pair<vid_t, uint32_t> msg;
+              msg.first = frag.Vertex2Gid(u);
+              if (is_rec[u.GetValue()] == 1) {
+                msg.second = 1;
+                msg_vec.push_back(msg);
+                nbr_vec.push_back(std::make_pair(u, 1));
+              }
+            }
+          }
+        }
 
-                messages.SendMsgThroughEdges<
-                    fragment_t, std::vector<std::pair<vid_t, uint32_t>>>(
-                    frag, v, msg_vec, tid);
-              });
+        messages.SendMsgThroughEdges<fragment_t,
+                                     std::vector<std::pair<vid_t, uint32_t>>>(
+            frag, v, msg_vec, tid);
+      });
       messages.ForceContinue();
     } else if (ctx.stage == 1) {
       ctx.stage = 2;
@@ -174,22 +171,21 @@ class Transitivity
                 }
               });
 
-      ForEach(inner_vertices.begin(), inner_vertices.end(),
-              [&frag, &ctx, &messages](int tid, vertex_t v) {
-                auto& outer_nbr_vec = ctx.complete_outer_neighbor[v];
-                int degree = frag.GetLocalOutDegree(v);
-                outer_nbr_vec.reserve(degree);
-                auto es = frag.GetOutgoingAdjList(v);
-                std::vector<vid_t> msg_vec;
-                msg_vec.reserve(degree);
-                for (auto& e : es) {
-                  auto u = e.get_neighbor();
-                  outer_nbr_vec.push_back(u);
-                  msg_vec.push_back(frag.Vertex2Gid(u));
-                }
-                messages.SendMsgThroughEdges<fragment_t, std::vector<vid_t>>(
-                    frag, v, msg_vec, tid);
-              });
+      ForEach(inner_vertices, [&frag, &ctx, &messages](int tid, vertex_t v) {
+        auto& outer_nbr_vec = ctx.complete_outer_neighbor[v];
+        int degree = frag.GetLocalOutDegree(v);
+        outer_nbr_vec.reserve(degree);
+        auto es = frag.GetOutgoingAdjList(v);
+        std::vector<vid_t> msg_vec;
+        msg_vec.reserve(degree);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          outer_nbr_vec.push_back(u);
+          msg_vec.push_back(frag.Vertex2Gid(u));
+        }
+        messages.SendMsgThroughEdges<fragment_t, std::vector<vid_t>>(
+            frag, v, msg_vec, tid);
+      });
       messages.ForceContinue();
     } else if (ctx.stage == 2) {
       ctx.stage = 3;
@@ -266,13 +262,12 @@ class Transitivity
         }
       }
 
-      ForEach(outer_vertices.begin(), outer_vertices.end(),
-              [&messages, &frag, &ctx](int tid, vertex_t v) {
-                if (ctx.tricnt[v] != 0) {
-                  messages.SyncStateOnOuterVertex<fragment_t, int>(
-                      frag, v, ctx.tricnt[v], tid);
-                }
-              });
+      ForEach(outer_vertices, [&messages, &frag, &ctx](int tid, vertex_t v) {
+        if (ctx.tricnt[v] != 0) {
+          messages.SyncStateOnOuterVertex<fragment_t, int>(frag, v,
+                                                           ctx.tricnt[v], tid);
+        }
+      });
       messages.ForceContinue();
     } else if (ctx.stage == 3) {
       ctx.stage = 4;


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
The `is_rec` is construct/destroy with every vertex, no need to use `vertex_array_t`.  Optimize the clustering algorithm by replacing the complex `vertex_array_t` with `unordered_map`

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1850 

