### PR TITLE
Decrease the make job numbers when building gae.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ gae:
 	mkdir -p $(WORKING_DIR)/analytical_engine/build
 	cd $(WORKING_DIR)/analytical_engine/build && \
 	cmake -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX) -DNETWORKX=$(NETWORKX) -DBUILD_TESTS=${BUILD_TEST} -DENABLE_JAVA_SDK=${ENABLE_JAVA_SDK} .. && \
-	make -j`nproc` && \
+	make -j2 && \
 	sudo make install && \
 	sudo cp -r $(WORKING_DIR)/k8s/kube_ssh $(INSTALL_PREFIX)/bin/
 ifneq ($(INSTALL_PREFIX), /usr/local)

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ gae:
 	mkdir -p $(WORKING_DIR)/analytical_engine/build
 	cd $(WORKING_DIR)/analytical_engine/build && \
 	cmake -DCMAKE_INSTALL_PREFIX=$(INSTALL_PREFIX) -DNETWORKX=$(NETWORKX) -DBUILD_TESTS=${BUILD_TEST} -DENABLE_JAVA_SDK=${ENABLE_JAVA_SDK} .. && \
-	make -j2 && \
+	make -j1 && \
 	sudo make install && \
 	sudo cp -r $(WORKING_DIR)/k8s/kube_ssh $(INSTALL_PREFIX)/bin/
 ifneq ($(INSTALL_PREFIX), /usr/local)

--- a/analytical_engine/apps/sssp/sssp_path.h
+++ b/analytical_engine/apps/sssp/sssp_path.h
@@ -15,6 +15,7 @@ limitations under the License.
 
 #ifndef ANALYTICAL_ENGINE_APPS_SSSP_SSSP_PATH_H_
 #define ANALYTICAL_ENGINE_APPS_SSSP_SSSP_PATH_H_
+
 #include <limits>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
This is a temporary solution to make the CI pass.
Change this back when #1864 is merged.