### PR TITLE
[IR Compiler] create FfiNameOrId from java side to fix k8s test error

### DIFF
--- a/interactive_engine/executor/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/IrCoreLibrary.java
+++ b/interactive_engine/executor/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/IrCoreLibrary.java
@@ -182,7 +182,12 @@ public interface IrCoreLibrary extends Library {
 
     FfiNameOrId.ByValue noneNameOrId();
 
-    FfiNameOrId.ByValue cstrAsNameOrId(String name);
+    default FfiNameOrId.ByValue cstrAsNameOrId(String name) {
+        FfiNameOrId.ByValue ffiName = new FfiNameOrId.ByValue();
+        ffiName.opt = FfiNameIdOpt.Name;
+        ffiName.name = name;
+        return ffiName;
+    }
 
     FfiConst.ByValue cstrAsConst(String value);
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
create FfiNameOrId from java side to avoid memory leak problems @siyuan0322 @sighingnow 
<!-- Please give a short brief about these changes. -->

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #1896 


