### PR TITLE
Fixed ingestor high CPU usage when empty buffer

### DIFF
--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/ingestor/BatchSender.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/ingestor/BatchSender.java
@@ -189,8 +189,16 @@ public class BatchSender implements MetricsAgent {
             int operationCount = 0;
             int batchCount = 0;
             while (operationCount < this.sendOperationLimit
-                    && batchCount < this.receiverQueueSize
-                    && (dataBatch = buffer.poll()) != null) {
+                    && batchCount < this.receiverQueueSize) {
+                try {
+                    dataBatch = buffer.poll(1000L, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    dataBatch = null;
+                    logger.warn("polling send buffer interrupted", e);
+                }
+                if (dataBatch == null) {
+                    break;
+                }
                 dataToSend.add(dataBatch);
                 operationCount += dataBatch.getSize();
                 batchCount++;


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Fixed ingestor high CPU usage when empty buffer, because no wait loop happened.
I don't know, maybe has a other better way.