### PR TITLE
[GAIA-IR] fix gaia-test ci caused by invalid group type used in compiler

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/StepTransformFactory.java
@@ -28,6 +28,8 @@ import com.alibaba.graphscope.common.jna.type.*;
 import com.alibaba.graphscope.gremlin.InterOpCollectionBuilder;
 import com.alibaba.graphscope.gremlin.antlr4.GremlinAntlrToJava;
 import com.alibaba.graphscope.gremlin.plugin.step.ExprStep;
+import com.alibaba.graphscope.gremlin.plugin.step.GroupCountStep;
+import com.alibaba.graphscope.gremlin.plugin.step.GroupStep;
 import com.alibaba.graphscope.gremlin.plugin.step.PathExpandStep;
 import com.alibaba.graphscope.gremlin.plugin.step.ScanFusionStep;
 import com.alibaba.graphscope.gremlin.transform.alias.AliasArg;


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
as titled
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

