### PR TITLE
Drop from vineyard when unloading a arrow projected fragment

### DIFF
--- a/analytical_engine/core/fragment/arrow_projected_fragment.h
+++ b/analytical_engine/core/fragment/arrow_projected_fragment.h
@@ -467,6 +467,8 @@ class ArrowProjectedFragment
 
     meta.AddMember("arrow_fragment", fragment->meta());
     meta.AddMember("arrow_projected_vertex_map", vm->meta());
+    meta.AddKeyValue("vertex_label_num_", 1);
+    meta.AddKeyValue("edge_label_num_", 1);
 
     std::shared_ptr<vineyard::NumericArray<int64_t>> ie_offsets_begin,
         ie_offsets_end;

--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -239,6 +239,83 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::projectGraph(
   return new_frag_wrapper->graph_def();
 }
 
+namespace detail {
+
+// a patched version for vineyard::ConstructFragmentGroup, will be dropped
+// after upgrade to vineyard>=0.7.2
+//
+static boost::leaf::result<vineyard::ObjectID> ConstructFragmentGroup(
+    vineyard::Client& client, vineyard::ObjectID frag_id,
+    const grape::CommSpec& comm_spec) {
+  vineyard::ObjectID group_object_id;
+  uint64_t instance_id = client.instance_id();
+
+  MPI_Barrier(comm_spec.comm());
+  VINEYARD_DISCARD(client.SyncMetaData());
+
+  if (comm_spec.worker_id() == 0) {
+    std::vector<uint64_t> gathered_instance_ids(comm_spec.worker_num());
+    std::vector<vineyard::ObjectID> gathered_object_ids(comm_spec.worker_num());
+
+    MPI_Gather(&instance_id, sizeof(uint64_t), MPI_CHAR,
+               &gathered_instance_ids[0], sizeof(uint64_t), MPI_CHAR, 0,
+               comm_spec.comm());
+
+    MPI_Gather(&frag_id, sizeof(vineyard::ObjectID), MPI_CHAR,
+               &gathered_object_ids[0], sizeof(vineyard::ObjectID), MPI_CHAR, 0,
+               comm_spec.comm());
+
+    vineyard::ArrowFragmentGroupBuilder builder;
+    builder.set_total_frag_num(comm_spec.fnum());
+    typename vineyard::ArrowFragmentBase::label_id_t vertex_label_num = 0,
+                                                     edge_label_num = 0;
+
+    vineyard::ObjectMeta meta;
+    if (client.GetMetaData(frag_id, meta).ok()) {
+      if (meta.Haskey("vertex_label_num_")) {
+        vertex_label_num =
+            meta.GetKeyValue<typename vineyard::ArrowFragmentBase::label_id_t>(
+                "vertex_label_num_");
+      }
+      if (meta.Haskey("edge_label_num_")) {
+        edge_label_num =
+            meta.GetKeyValue<typename vineyard::ArrowFragmentBase::label_id_t>(
+                "edge_label_num_");
+      }
+    }
+
+    builder.set_vertex_label_num(vertex_label_num);
+    builder.set_edge_label_num(edge_label_num);
+    for (fid_t i = 0; i < comm_spec.fnum(); ++i) {
+      builder.AddFragmentObject(
+          i, gathered_object_ids[comm_spec.FragToWorker(i)],
+          gathered_instance_ids[comm_spec.FragToWorker(i)]);
+    }
+
+    auto group_object = std::dynamic_pointer_cast<vineyard::ArrowFragmentGroup>(
+        builder.Seal(client));
+    group_object_id = group_object->id();
+    VY_OK_OR_RAISE(client.Persist(group_object_id));
+
+    MPI_Bcast(&group_object_id, sizeof(vineyard::ObjectID), MPI_CHAR, 0,
+              comm_spec.comm());
+  } else {
+    MPI_Gather(&instance_id, sizeof(uint64_t), MPI_CHAR, NULL, sizeof(uint64_t),
+               MPI_CHAR, 0, comm_spec.comm());
+    MPI_Gather(&frag_id, sizeof(vineyard::ObjectID), MPI_CHAR, NULL,
+               sizeof(vineyard::ObjectID), MPI_CHAR, 0, comm_spec.comm());
+
+    MPI_Bcast(&group_object_id, sizeof(vineyard::ObjectID), MPI_CHAR, 0,
+              comm_spec.comm());
+  }
+
+  MPI_Barrier(comm_spec.comm());
+  VINEYARD_DISCARD(client.SyncMetaData());
+  return group_object_id;
+}
+
+}  // namespace detail
+
 bl::result<rpc::graph::GraphDefPb> GrapeInstance::projectToSimple(
     const rpc::GSParams& params) {
   std::string projected_graph_name = "graph_projected_" + generateId();
@@ -269,7 +346,7 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::projectToSimple(
   VY_OK_OR_RAISE(client_->Persist(vy_info.vineyard_id()));
   // contruct fragment group
   BOOST_LEAF_AUTO(frag_group_id,
-                  vineyard::ConstructFragmentGroup(
+                  detail::ConstructFragmentGroup(
                       *client_, vy_info.vineyard_id(), comm_spec_));
   // return graph def with vineyard id attached
   gs::rpc::graph::VineyardInfoPb new_vy_info = vy_info;

--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -184,13 +184,14 @@ bl::result<void> GrapeInstance::unloadGraph(const rpc::GSParams& params) {
           client_->GetObject(frag_group_id));
       auto fid = comm_spec_.WorkerToFrag(comm_spec_.worker_id());
       auto frag_id = fg->Fragments().at(fid);
-      VY_OK_OR_RAISE(client_->DelData(frag_id, false, true));
-    }
-    MPI_Barrier(comm_spec_.comm());
-    if (exists) {
+
+      // delete the fragment group first
       if (comm_spec_.worker_id() == 0) {
         VINEYARD_SUPPRESS(client_->DelData(frag_group_id, false, true));
       }
+      // ensure all fragments get deleted
+      MPI_Barrier(comm_spec_.comm());
+      VINEYARD_SUPPRESS(client_->DelData(frag_id, false, true));
     }
   }
   VLOG(1) << "Unloading Graph " << graph_name;
@@ -255,7 +256,26 @@ bl::result<rpc::graph::GraphDefPb> GrapeInstance::projectToSimple(
                   projector->Project(wrapper, projected_graph_name, params));
   BOOST_LEAF_CHECK(object_manager_.PutObject(projected_wrapper));
 
-  return projected_wrapper->graph_def();
+  auto graph_def = projected_wrapper->graph_def();
+  if (!graph_def.has_extension()) {
+    return graph_def;
+  }
+  gs::rpc::graph::VineyardInfoPb vy_info;
+  // gather fragment id
+  graph_def.extension().UnpackTo(&vy_info);
+  if (vy_info.vineyard_id() == 0) {
+    return graph_def;
+  }
+  VY_OK_OR_RAISE(client_->Persist(vy_info.vineyard_id()));
+  // contruct fragment group
+  BOOST_LEAF_AUTO(frag_group_id,
+                  vineyard::ConstructFragmentGroup(
+                      *client_, vy_info.vineyard_id(), comm_spec_));
+  // return graph def with vineyard id attached
+  gs::rpc::graph::VineyardInfoPb new_vy_info = vy_info;
+  new_vy_info.set_vineyard_id(frag_group_id);
+  graph_def.mutable_extension()->PackFrom(new_vy_info);
+  return graph_def;
 }
 
 bl::result<std::string> GrapeInstance::query(const rpc::GSParams& params,

--- a/analytical_engine/frame/project_frame.cc
+++ b/analytical_engine/frame/project_frame.cc
@@ -81,6 +81,12 @@ class ProjectSimpleFrame<
     rpc::graph::GraphDefPb graph_def;
     graph_def.set_key(projected_graph_name);
     graph_def.set_graph_type(rpc::graph::ARROW_PROJECTED);
+    gs::rpc::graph::VineyardInfoPb vy_info;
+    if (graph_def.has_extension()) {
+      graph_def.extension().UnpackTo(&vy_info);
+    }
+    vy_info.set_vineyard_id(projected_frag->id());
+    graph_def.mutable_extension()->PackFrom(vy_info);
 
     setGraphDef(projected_frag, v_label_id, e_label_id, v_prop_id, e_prop_id,
                 graph_def);

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -460,6 +460,8 @@ class CoordinatorServiceServicer(
             if op.op in (
                 types_pb2.CREATE_GRAPH,
                 types_pb2.PROJECT_GRAPH,
+                types_pb2.PROJECT_TO_SIMPLE,
+                types_pb2.TRANSFORM_GRAPH,
                 types_pb2.ADD_LABELS,
                 types_pb2.ADD_COLUMN,
             ):


### PR DESCRIPTION
## What do these changes do?

The `ArrowProjectedFragment` holds `ArrowFragment` as a member and should be drop from vineyard when been unloaded otherwise the `ArrowFragment` itself cannot be dropped and leading to memory leak.

## Related issue number

Fixes #1737
