### PR TITLE
GraphScope for Spark-GraphX

### DIFF
--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -417,7 +417,7 @@ if(ENABLE_JAVA_SDK)
         "${GRAPHSCOPE_ANALYTICAL_VERSION}"
     )
     set(GAE_JAVA_RUNTIME_JAR "${GAE_JAVA_RUNTIME_DIR}/target/grape-runtime-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
-    set(GAE_JAVA_GRAPHX_JAR "${GAE_JAVA_RUNTIME_DIR}/target/graphx-on-graphscope-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
+    set(GAE_JAVA_GRAPHX_JAR "${GAE_JAVA_DIR}/graphx-on-graphscope/target/graphx-on-graphscope-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
     add_custom_command(
         OUTPUT "${GAE_JAVA_RUNTIME_DIR}/target/native/libgrape-jni.so"
         COMMAND mvn clean install -DskipTests --quiet

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -275,6 +275,19 @@ if (${LIBUNWIND_FOUND})
     target_link_libraries(grape_engine PRIVATE ${LIBUNWIND_LIBRARIES})
 endif ()
 
+# An executable to work around for graphx pregel.
+if (ENABLE_JAVA_SDK)
+    add_executable(graphx_runner core/java/graphx_runner.cc core/java/javasdk.cc)
+    target_include_directories(graphx_runner PRIVATE core utils apps)
+    target_compile_definitions(graphx_runner PUBLIC ENABLE_JAVA_SDK)
+    target_link_libraries(graphx_runner PRIVATE ${CMAKE_DL_LIBS} gs_proto ${VINEYARD_LIBRARIES} ${Boost_LIBRARIES} ${GFLAGS_LIBRARIES} ${JNI_LIBRARIES})
+
+    if (${LIBUNWIND_FOUND})
+        target_link_libraries(graphx_runner PRIVATE ${LIBUNWIND_LIBRARIES})
+    endif()
+endif()
+
+
 # Test targets
 if (BUILD_TESTS)
     add_executable(run_app test/run_app.cc core/object/dynamic.cc)
@@ -301,11 +314,22 @@ if (BUILD_TESTS)
         target_compile_definitions(giraph_runner PUBLIC ENABLE_JAVA_SDK)
         target_link_libraries(giraph_runner ${CMAKE_DL_LIBS} gs_proto ${VINEYARD_LIBRARIES} ${Boost_LIBRARIES} ${GFLAGS_LIBRARIES}  ${JNI_LIBRARIES})
 
+        # graphx related test
+        add_executable(graphx_test test/graphx_test.cc)
+        target_include_directories(graphx_test PRIVATE core utils apps)
+        target_compile_definitions(graphx_test PUBLIC ENABLE_JAVA_SDK)
+        target_link_libraries(graphx_test ${CMAKE_DL_LIBS} ${VINEYARD_LIBRARIES} ${Boost_LIBRARIES} ${GLOG_LIBRARIES})
+
+        add_executable(projected_fragment_mapper_test test/projected_fragment_mapper_test.cc)
+        target_include_directories(projected_fragment_mapper_test PRIVATE core utils apps)
+        target_link_libraries(projected_fragment_mapper_test ${CMAKE_DL_LIBS} ${VINEYARD_LIBRARIES} ${Boost_LIBRARIES} ${GLOG_LIBRARIES} ${GFLAGS_LIBRARIES})
 
         if (${LIBUNWIND_FOUND})
             target_link_libraries(run_java_app ${LIBUNWIND_LIBRARIES})
             target_link_libraries(property_graph_java_app_benchmarks ${LIBUNWIND_LIBRARIES})
             target_link_libraries(giraph_runner ${LIBUNWIND_LIBRARIES})
+            target_link_libraries(graphx_test ${LIBUNWIND_LIBRARIES})
+            target_link_libraries(projected_fragment_mapper_test ${LIBUNWIND_LIBRARIES})
         endif ()
     endif()
 
@@ -393,6 +417,7 @@ if(ENABLE_JAVA_SDK)
         "${GRAPHSCOPE_ANALYTICAL_VERSION}"
     )
     set(GAE_JAVA_RUNTIME_JAR "${GAE_JAVA_RUNTIME_DIR}/target/grape-runtime-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
+    set(GAE_JAVA_GRAPHX_JAR "${GAE_JAVA_RUNTIME_DIR}/target/graphx-on-graphscope-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
     add_custom_command(
         OUTPUT "${GAE_JAVA_RUNTIME_DIR}/target/native/libgrape-jni.so"
         COMMAND mvn clean install -DskipTests --quiet
@@ -407,6 +432,7 @@ if(ENABLE_JAVA_SDK)
     install(FILES DESTINATION lib)
     install(FILES "${GAE_JAVA_RUNTIME_DIR}/target/native/libgrape-jni.so" DESTINATION lib)
     install(FILES "${GAE_JAVA_RUNTIME_JAR}" DESTINATION lib)
+    install(FILES "${GAE_JAVA_GRAPHX_JAR}" DESTINATION lib)
     install(FILES "${GAE_JAVA_DIR}/grape_jvm_opts" DESTINATION conf)
 endif()
 
@@ -457,6 +483,7 @@ endmacro()
 install_gsa_binary(grape_engine)
 install_gsa_binary(gs_proto)
 install_gsa_binary(gs_util)
+install_gsa_binary(graphx_runner)
 
 install_gsa_headers("${PROJECT_SOURCE_DIR}/apps")
 install_gsa_headers("${PROJECT_SOURCE_DIR}/benchmarks")

--- a/analytical_engine/core/fragment/arrow_projected_fragment.h
+++ b/analytical_engine/core/fragment/arrow_projected_fragment.h
@@ -363,6 +363,10 @@ class AdjList<VID_T, EID_T, grape::EmptyType> {
 
 }  // namespace arrow_projected_fragment_impl
 
+template <typename OID_T, typename VID_T, typename OLD_VDATA_T,
+          typename NEW_VDATA_T, typename OLD_EDATA_T, typename NEW_EDATA_T>
+class ArrowProjectedFragmentMapper;
+
 /**
  * @brief This class represents the fragment projected from ArrowFragment which
  * contains only one vertex label and edge label. The fragment has no label and
@@ -1225,6 +1229,10 @@ class ArrowProjectedFragment
 
   std::vector<vid_t> outer_vertex_offsets_;
   std::vector<std::vector<vertex_t>> mirrors_of_frag_;
+
+  template <typename _OID_T, typename _VID_T, typename _OLD_VDATA_T,
+            typename _NEW_VDATA_T, typename _OLD_EDATA_T, typename _NEW_EDATA_T>
+  friend class ArrowProjectedFragmentMapper;
 };
 
 }  // namespace gs

--- a/analytical_engine/core/fragment/arrow_projected_fragment_mapper.h
+++ b/analytical_engine/core/fragment/arrow_projected_fragment_mapper.h
@@ -1,0 +1,174 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANALYTICAL_ENGINE_CORE_FRAGMENT_ARROW_PROJECTED_FRAGMENT_MAPPER_H_
+#define ANALYTICAL_ENGINE_CORE_FRAGMENT_ARROW_PROJECTED_FRAGMENT_MAPPER_H_
+
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <boost/asio.hpp>
+#include "arrow/array.h"
+#include "boost/lexical_cast.hpp"
+
+#include "grape/fragment/fragment_base.h"
+#include "vineyard/basic/ds/arrow_utils.h"
+#include "vineyard/common/util/version.h"
+#include "vineyard/graph/fragment/property_graph_types.h"
+
+#include "core/fragment/arrow_projected_fragment.h"
+
+namespace gs {
+
+/**
+ * @brief Create a new arrowProjectedFragment with new vdata and new edata.
+ *
+ * @tparam OID_T OID type
+ * @tparam VID_T VID type
+ */
+template <typename OID_T, typename VID_T, typename OLD_VDATA_T,
+          typename NEW_VDATA_T, typename OLD_EDATA_T, typename NEW_EDATA_T>
+class ArrowProjectedFragmentMapper {
+ public:
+  using label_id_t = vineyard::property_graph_types::LABEL_ID_TYPE;
+  using prop_id_t = vineyard::property_graph_types::PROP_ID_TYPE;
+  using vid_t = VID_T;
+  using oid_t = OID_T;
+  using old_vdata_t = OLD_VDATA_T;
+  using new_vdata_t = NEW_VDATA_T;
+  using old_edata_t = OLD_EDATA_T;
+  using new_edata_t = NEW_EDATA_T;
+
+  using edata_array_builder_t =
+      typename vineyard::ConvertToArrowType<new_edata_t>::BuilderType;
+  using edata_array_t =
+      typename vineyard::ConvertToArrowType<new_edata_t>::ArrayType;
+  using vineyard_edata_array_builder_t =
+      typename vineyard::InternalType<new_edata_t>::vineyard_builder_type;
+
+  using vdata_array_builder_t =
+      typename vineyard::ConvertToArrowType<new_vdata_t>::BuilderType;
+  using vdata_array_t =
+      typename vineyard::ConvertToArrowType<new_vdata_t>::ArrayType;
+  using vineyard_vdata_array_builder_t =
+      typename vineyard::InternalType<new_vdata_t>::vineyard_builder_type;
+
+  using old_frag_t =
+      ArrowProjectedFragment<oid_t, vid_t, old_vdata_t, old_edata_t>;
+  using new_frag_t =
+      ArrowProjectedFragment<oid_t, vid_t, new_vdata_t, new_edata_t>;
+
+  ArrowProjectedFragmentMapper() {}
+  ~ArrowProjectedFragmentMapper() {}
+
+  std::shared_ptr<new_frag_t> Map(old_frag_t& old_fragment,
+                                  vdata_array_builder_t& vdata_array_builder,
+                                  edata_array_builder_t& edata_array_builder,
+                                  vineyard::Client& client) {
+    const vineyard::ObjectMeta& old_meta = old_fragment.meta();
+    std::shared_ptr<vineyard::ArrowFragment<oid_t, vid_t>> old_arrow_fragment =
+        old_fragment.fragment_;
+    auto v_label = old_meta.GetKeyValue<int>("projected_v_label");
+    auto e_label = old_meta.GetKeyValue<int>("projected_e_label");
+    auto old_vprop_num = old_arrow_fragment->vertex_property_num(v_label);
+    auto old_eprop_num = old_arrow_fragment->edge_property_num(e_label);
+    LOG(INFO) << "Old arrow fragment has " << old_vprop_num
+              << " vertex properties and " << old_eprop_num
+              << " edge properties";
+    auto new_vprop_name = "VPROP_" + std::to_string(old_vprop_num);
+    auto new_eprop_name = "EPROP_" + std::to_string(old_eprop_num);
+
+    std::shared_ptr<edata_array_t> arrow_edata_array;
+    edata_array_builder.Finish(&arrow_edata_array);
+    std::shared_ptr<vdata_array_t> arrow_vdata_array;
+    vdata_array_builder.Finish(&arrow_vdata_array);
+    std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>
+        vertex_columns_map;
+    std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>
+        edge_columns_map;
+    vertex_columns_map.push_back(
+        std::make_pair(new_vprop_name, arrow_vdata_array));
+    edge_columns_map.push_back(
+        std::make_pair(new_eprop_name, arrow_edata_array));
+
+    vineyard::ObjectID new_frag_id;
+
+    // Add new data to original ArrowFragment's table.
+    {
+      std::map<
+          label_id_t,
+          std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>>
+          v_map;
+      v_map[v_label] = vertex_columns_map;
+      vineyard::ObjectID new_arrow_fragment_id = bl::try_handle_all(
+          [&]() { return old_arrow_fragment->AddVertexColumns(client, v_map); },
+          [](const vineyard::GSError& e) {
+            LOG(ERROR) << e.error_msg;
+            return 0;
+          },
+          [](const bl::error_info& unmatched) {
+            LOG(ERROR) << "Unmatched error " << unmatched;
+            return 0;
+          });
+      LOG(INFO) << "Build First fragment: " << new_arrow_fragment_id;
+      std::shared_ptr<vineyard::ArrowFragment<oid_t, vid_t>>
+          new_arrow_fragment =
+              std::dynamic_pointer_cast<vineyard::ArrowFragment<oid_t, vid_t>>(
+                  client.GetObject(new_arrow_fragment_id));
+
+      std::map<
+          label_id_t,
+          std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>>
+          e_map;
+      e_map[e_label] = edge_columns_map;
+      vineyard::ObjectID new_new_arrow_fragment_id = bl::try_handle_all(
+          [&]() { return new_arrow_fragment->AddEdgeColumns(client, e_map); },
+          [](const vineyard::GSError& e) {
+            LOG(ERROR) << e.error_msg;
+            return 0;
+          },
+          [](const bl::error_info& unmatched) {
+            LOG(ERROR) << "Unmatched error " << unmatched;
+            return 0;
+          });
+
+      LOG(INFO) << "Build Second fragment: " << new_new_arrow_fragment_id;
+      std::shared_ptr<vineyard::ArrowFragment<oid_t, vid_t>>
+          new_new_arrow_fragment =
+              std::dynamic_pointer_cast<vineyard::ArrowFragment<oid_t, vid_t>>(
+                  client.GetObject(new_new_arrow_fragment_id));
+      auto schema = new_new_arrow_fragment->schema();
+      auto v_prop_id = schema.GetVertexPropertyId(v_label, new_vprop_name);
+      auto e_prop_id = schema.GetEdgePropertyId(e_label, new_eprop_name);
+      std::shared_ptr<new_frag_t> res = new_frag_t::Project(
+          new_new_arrow_fragment, 0, v_prop_id, 0, e_prop_id);
+      new_frag_id = res->id();
+    }
+
+    LOG(INFO) << "Got projected fragment: " << new_frag_id;
+    auto new_frag =
+        std::dynamic_pointer_cast<new_frag_t>(client.GetObject(new_frag_id));
+    return new_frag;
+  }
+};
+}  // namespace gs
+
+#endif  // ANALYTICAL_ENGINE_CORE_FRAGMENT_ARROW_PROJECTED_FRAGMENT_MAPPER_H_

--- a/analytical_engine/core/java/graphx/edge_data.h
+++ b/analytical_engine/core/java/graphx/edge_data.h
@@ -1,0 +1,266 @@
+
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_EDGE_DATA_H_
+#define ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_EDGE_DATA_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/array/builder_binary.h"
+
+#include "grape/grape.h"
+#include "grape/utils/vertex_array.h"
+#include "grape/worker/comm_spec.h"
+#include "vineyard/basic/ds/array.h"
+#include "vineyard/basic/ds/arrow.h"
+#include "vineyard/basic/ds/arrow_utils.h"
+#include "vineyard/client/client.h"
+#include "vineyard/common/util/functions.h"
+#include "vineyard/common/util/typename.h"
+#include "vineyard/graph/fragment/property_graph_types.h"
+#include "vineyard/graph/fragment/property_graph_utils.h"
+#include "vineyard/graph/utils/error.h"
+
+#include "core/error.h"
+#include "core/fragment/arrow_projected_fragment.h"
+#include "core/io/property_parser.h"
+#include "core/java/graphx/local_vertex_map.h"
+
+namespace gs {
+template <typename VID_T, typename ED_T>
+class EdgeData : public vineyard::Registered<EdgeData<VID_T, ED_T>> {
+  using vid_t = VID_T;
+  using edata_t = ED_T;
+  using eid_t = uint64_t;
+  using edata_array_t = typename vineyard::Array<edata_t>;
+  using vertex_t = grape::Vertex<VID_T>;
+
+ public:
+  EdgeData() {}
+  ~EdgeData() {}
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<EdgeData<VID_T, ED_T>>{new EdgeData<VID_T, ED_T>()});
+  }
+
+  void Construct(const vineyard::ObjectMeta& meta) override {
+    this->meta_ = meta;
+    this->id_ = meta.GetId();
+    this->edge_num_ = meta.GetKeyValue<eid_t>("edge_num");
+    edatas_.Construct(meta.GetMemberMeta("edatas"));
+
+    edatas_accessor_.Init(edatas_);
+    VLOG(10) << "Finish construct edge data, edge num: " << edge_num_;
+  }
+
+  ED_T GetEdgeDataByEid(const eid_t& eid) { return edatas_accessor_[eid]; }
+
+  eid_t GetEdgeNum() { return edge_num_; }
+
+  gs::arrow_projected_fragment_impl::TypedArray<edata_t>& GetEdataArray() {
+    return edatas_accessor_;
+  }
+
+ private:
+  eid_t edge_num_;
+  edata_array_t edatas_;
+  gs::arrow_projected_fragment_impl::TypedArray<edata_t> edatas_accessor_;
+
+  template <typename _VID_T, typename _ED_T>
+  friend class EdgeDataBuilder;
+};
+
+template <typename VID_T>
+class EdgeData<VID_T, std::string>
+    : public vineyard::Registered<EdgeData<VID_T, std::string>> {
+  using vid_t = VID_T;
+  using edata_t = std::string;
+  using eid_t = uint64_t;
+  using edata_array_t = arrow::LargeStringArray;
+  using vertex_t = grape::Vertex<VID_T>;
+
+ public:
+  EdgeData() {}
+  ~EdgeData() {}
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<EdgeData<VID_T, std::string>>{
+            new EdgeData<VID_T, std::string>()});
+  }
+
+  void Construct(const vineyard::ObjectMeta& meta) override {
+    this->meta_ = meta;
+    this->id_ = meta.GetId();
+    this->edge_num_ = meta.GetKeyValue<eid_t>("edge_num");
+    vineyard::LargeStringArray vineyard_array;
+    vineyard_array.Construct(meta.GetMemberMeta("edatas"));
+    edatas_ = vineyard_array.GetArray();
+
+    edatas_accessor_.Init(edatas_);
+    VLOG(10) << "Finish construct edge data, edge nums: " << edge_num_;
+  }
+
+  arrow::util::string_view GetEdgeDataByEid(const eid_t& eid) {
+    return edatas_->GetView(eid);
+  }
+
+  eid_t GetEdgeNum() { return edge_num_; }
+
+  gs::arrow_projected_fragment_impl::TypedArray<edata_t>& GetEdataArray() {
+    return edatas_accessor_;
+  }
+
+ private:
+  eid_t edge_num_;
+  std::shared_ptr<edata_array_t> edatas_;
+  gs::arrow_projected_fragment_impl::TypedArray<std::string> edatas_accessor_;
+
+  template <typename _VID_T, typename _ED_T>
+  friend class EdgeDataBuilder;
+};
+
+template <typename VID_T, typename ED_T>
+class EdgeDataBuilder : public vineyard::ObjectBuilder {
+  using vid_t = VID_T;
+  using edata_t = ED_T;
+  using eid_t = uint64_t;
+  using edata_array_builder_t = vineyard::ArrayBuilder<edata_t>;
+  using edata_array_t = vineyard::Array<edata_t>;
+
+ public:
+  EdgeDataBuilder(vineyard::Client& client, std::vector<ED_T>& edata_array)
+      : edata_builder_(client, edata_array) {
+    edge_num_ = edata_array.size();
+  }
+  EdgeDataBuilder(vineyard::Client& client, size_t size)
+      : edata_builder_(client, size) {
+    edge_num_ = edata_builder_.size();
+  }
+
+  ~EdgeDataBuilder() {}
+
+  edata_array_builder_t& GetArrayBuilder() { return edata_builder_; }
+
+  std::shared_ptr<EdgeData<vid_t, edata_t>> MySeal(vineyard::Client& client) {
+    return std::dynamic_pointer_cast<EdgeData<vid_t, edata_t>>(
+        this->Seal(client));
+  }
+
+  std::shared_ptr<vineyard::Object> _Seal(vineyard::Client& client) override {
+    // ensure the builder hasn't been sealed yet.
+    ENSURE_NOT_SEALED(this);
+    VINEYARD_CHECK_OK(this->Build(client));
+    auto edge_data = std::make_shared<EdgeData<vid_t, edata_t>>();
+    edge_data->meta_.SetTypeName(type_name<EdgeData<vid_t, edata_t>>());
+
+    size_t nBytes = 0;
+    edge_data->edatas_ = *edata_array_.get();
+    edge_data->edge_num_ = edge_num_;
+    edge_data->edatas_accessor_.Init(edge_data->edatas_);
+    edge_data->meta_.AddKeyValue("edge_num", edge_num_);
+    edge_data->meta_.AddMember("edatas", edata_array_->meta());
+    nBytes += edata_array_->nbytes();
+    edge_data->meta_.SetNBytes(nBytes);
+    VINEYARD_CHECK_OK(client.CreateMetaData(edge_data->meta_, edge_data->id_));
+    // mark the builder as sealed
+    this->set_sealed(true);
+    return std::static_pointer_cast<vineyard::Object>(edge_data);
+  }
+
+  vineyard::Status Build(vineyard::Client& client) override {
+    edata_array_ =
+        std::dynamic_pointer_cast<edata_array_t>(edata_builder_.Seal(client));
+    VLOG(10) << "Finish building edge data;";
+    return vineyard::Status::OK();
+  }
+
+ private:
+  eid_t edge_num_;
+  edata_array_builder_t edata_builder_;
+  std::shared_ptr<edata_array_t> edata_array_;
+};  // namespace gs
+
+template <typename VID_T>
+class EdgeDataBuilder<VID_T, std::string> : public vineyard::ObjectBuilder {
+  using vid_t = VID_T;
+  using eid_t = uint64_t;
+  using edata_array_builder_t = arrow::LargeStringBuilder;
+  using edata_array_t = arrow::LargeStringArray;
+
+ public:
+  EdgeDataBuilder() {}
+  ~EdgeDataBuilder() {}
+
+  void Init(eid_t edge_num, std::vector<char>& edata_buffer,
+            std::vector<int32_t>& lengths) {
+    this->edge_num_ = edge_num;
+    edata_array_builder_t builder;
+    builder.Reserve(edge_num_);
+    builder.ReserveData(edata_buffer.size());
+    const char* ptr = edata_buffer.data();
+    for (auto len : lengths) {
+      builder.UnsafeAppend(ptr, len);
+      ptr += len;
+    }
+    builder.Finish(&edata_array_);
+    VLOG(10) << "Init edge data, num edges: " << edge_num_;
+  }
+
+  std::shared_ptr<EdgeData<vid_t, std::string>> MySeal(
+      vineyard::Client& client) {
+    return std::dynamic_pointer_cast<EdgeData<vid_t, std::string>>(
+        this->Seal(client));
+  }
+
+  std::shared_ptr<vineyard::Object> _Seal(vineyard::Client& client) override {
+    // ensure the builder hasn't been sealed yet.
+    ENSURE_NOT_SEALED(this);
+    VINEYARD_CHECK_OK(this->Build(client));
+    auto edge_data = std::make_shared<EdgeData<vid_t, std::string>>();
+    edge_data->meta_.SetTypeName(type_name<EdgeData<vid_t, std::string>>());
+
+    size_t nBytes = 0;
+    edge_data->edatas_ = vineyard_array.GetArray();
+    edge_data->edge_num_ = edge_num_;
+    edge_data->edatas_accessor_.Init(edge_data->edatas_);
+    edge_data->meta_.AddKeyValue("edge_num", edge_num_);
+    edge_data->meta_.AddMember("edatas", vineyard_array.meta());
+    nBytes += vineyard_array.nbytes();
+    edge_data->meta_.SetNBytes(nBytes);
+    VINEYARD_CHECK_OK(client.CreateMetaData(edge_data->meta_, edge_data->id_));
+    // mark the builder as sealed
+    this->set_sealed(true);
+    return std::static_pointer_cast<vineyard::Object>(edge_data);
+  }
+
+  vineyard::Status Build(vineyard::Client& client) override {
+    vineyard::LargeStringArrayBuilder edata_builder(client, this->edata_array_);
+    vineyard_array = *std::dynamic_pointer_cast<vineyard::LargeStringArray>(
+        edata_builder.Seal(client));
+    VLOG(10) << "Finish building edge data;";
+    return vineyard::Status::OK();
+  }
+
+ private:
+  eid_t edge_num_;
+  std::shared_ptr<edata_array_t> edata_array_;
+  vineyard::LargeStringArray vineyard_array;
+};
+}  // namespace gs
+#endif  // ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_EDGE_DATA_H_

--- a/analytical_engine/core/java/graphx/fragment_getter.h
+++ b/analytical_engine/core/java/graphx/fragment_getter.h
@@ -1,0 +1,83 @@
+
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_FRAGMENT_GETTER_H_
+#define ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_FRAGMENT_GETTER_H_
+
+#define WITH_PROFILING
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "flat_hash_map/flat_hash_map.hpp"
+
+#include "grape/grape.h"
+#include "grape/util.h"
+#include "grape/worker/comm_spec.h"
+
+#include "core/error.h"
+#include "core/fragment/arrow_projected_fragment.h"
+#include "vineyard/graph/fragment/arrow_fragment_group.h"
+
+/**
+ * @brief This make us easier when obtain fragment from object id in java via
+ * FFI.
+ *
+ */
+namespace gs {
+
+template <typename OID_T, typename VID_T, typename VD_T, typename ED_T>
+class ArrowProjectedFragmentGetter {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using vdata_t = VD_T;
+  using edata_t = ED_T;
+
+ public:
+  ArrowProjectedFragmentGetter() {}
+  ~ArrowProjectedFragmentGetter() {}
+  std::shared_ptr<ArrowProjectedFragment<oid_t, vid_t, vdata_t, edata_t>> Get(
+      vineyard::Client& client, vineyard::ObjectID fragmentID) {
+    auto fragment = std::dynamic_pointer_cast<
+        ArrowProjectedFragment<oid_t, vid_t, vdata_t, edata_t>>(
+        client.GetObject(fragmentID));
+    return fragment;
+  }
+};
+
+class ArrowFragmentGroupGetter {
+ public:
+  ArrowFragmentGroupGetter() {}
+  ~ArrowFragmentGroupGetter() {}
+
+  std::shared_ptr<vineyard::ArrowFragmentGroup> Get(
+      vineyard::Client& client, vineyard::ObjectID groupId) {
+    auto fragment = std::dynamic_pointer_cast<vineyard::ArrowFragmentGroup>(
+        client.GetObject(groupId));
+    return fragment;
+  }
+};
+
+}  // namespace gs
+
+#endif  // ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_FRAGMENT_GETTER_H_

--- a/analytical_engine/core/java/graphx/graphx_csr.h
+++ b/analytical_engine/core/java/graphx/graphx_csr.h
@@ -1,0 +1,686 @@
+
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_CSR_H_
+#define ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_CSR_H_
+
+#define WITH_PROFILING
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "flat_hash_map/flat_hash_map.hpp"
+
+#include "grape/grape.h"
+#include "grape/graph/immutable_csr.h"
+#include "grape/utils/bitset.h"
+#include "grape/worker/comm_spec.h"
+#include "vineyard/basic/ds/arrow_utils.h"
+#include "vineyard/client/client.h"
+#include "vineyard/common/util/functions.h"
+#include "vineyard/graph/fragment/property_graph_utils.h"
+#include "vineyard/graph/utils/error.h"
+#include "vineyard/io/io/i_io_adaptor.h"
+#include "vineyard/io/io/io_factory.h"
+
+#include "core/config.h"
+#include "core/error.h"
+#include "core/fragment/arrow_projected_fragment.h"
+#include "core/io/property_parser.h"
+#include "core/java/graphx/graphx_vertex_map.h"
+/**
+ * @brief Defines the RDD of edges. when data is feed into this, we assume it is
+ * already shuffle and partitioned.
+ *
+ */
+namespace gs {
+struct int64_atomic {
+  std::atomic<int64_t> atomic_{0};
+  int64_atomic() : atomic_{0} {};
+  int64_atomic(const int64_atomic& other) : atomic_(other.atomic_.load()) {}
+  int64_atomic& operator=(const int64_atomic& other) {
+    atomic_.store(other.atomic_.load());
+    return *this;
+  }
+};
+
+template <typename VID_T>
+class GraphXCSR : public vineyard::Registered<GraphXCSR<VID_T>> {
+ public:
+  using eid_t = vineyard::property_graph_types::EID_TYPE;
+  using vid_t = VID_T;
+  using vineyard_offset_array_t =
+      typename vineyard::InternalType<int64_t>::vineyard_array_type;
+  using vid_array_t = typename vineyard::ConvertToArrowType<vid_t>::ArrayType;
+  using nbr_t = vineyard::property_graph_utils::NbrUnit<vid_t, eid_t>;
+  using vineyard_edges_array_t = vineyard::FixedSizeBinaryArray;
+
+  GraphXCSR() {}
+  ~GraphXCSR() {}
+
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<GraphXCSR<VID_T>>{new GraphXCSR<VID_T>()});
+  }
+
+  int64_t GetInDegree(vid_t lid) {
+    return GetIEOffset(lid + 1) - GetIEOffset(lid);
+  }
+
+  int64_t GetOutDegree(vid_t lid) {
+    return GetOEOffset(lid + 1) - GetOEOffset(lid);
+  }
+  bool IsIEEmpty(vid_t lid) { return GetIEOffset(lid + 1) == GetIEOffset(lid); }
+  bool IsOEEmpty(vid_t lid) { return GetOEOffset(lid + 1) == GetOEOffset(lid); }
+
+  nbr_t* GetIEBegin(VID_T i) { return &in_edge_ptr_[GetIEOffset(i)]; }
+  nbr_t* GetOEBegin(VID_T i) { return &out_edge_ptr_[GetOEOffset(i)]; }
+
+  nbr_t* GetIEEnd(VID_T i) { return &in_edge_ptr_[GetIEOffset(i + 1)]; }
+  nbr_t* GetOEEnd(VID_T i) { return &out_edge_ptr_[GetOEOffset(i + 1)]; }
+
+  // inner verticesNum
+  vid_t VertexNum() const { return local_vnum_; }
+
+  int64_t GetInEdgesNum() const { return in_edges_num_; }
+
+  int64_t GetOutEdgesNum() const { return out_edges_num_; }
+
+  int64_t GetTotalEdgesNum() const { return total_edge_num_; }
+
+  int64_t GetPartialInEdgesNum(vid_t from, vid_t end) const {
+    return ie_offsets_->Value(static_cast<int64_t>(end)) -
+           ie_offsets_->Value(static_cast<int64_t>(from));
+  }
+  int64_t GetPartialOutEdgesNum(vid_t from, vid_t end) const {
+    return oe_offsets_->Value(static_cast<int64_t>(end)) -
+           oe_offsets_->Value(static_cast<int64_t>(from));
+  }
+
+  void Construct(const vineyard::ObjectMeta& meta) override {
+    this->meta_ = meta;
+    this->id_ = meta.GetId();
+    this->total_edge_num_ = meta.GetKeyValue<eid_t>("total_edge_num");
+    {
+      vineyard_edges_array_t v6d_edges;
+      v6d_edges.Construct(meta.GetMemberMeta("in_edges"));
+      in_edges_ = v6d_edges.GetArray();
+    }
+    {
+      vineyard_edges_array_t v6d_edges;
+      v6d_edges.Construct(meta.GetMemberMeta("out_edges"));
+      out_edges_ = v6d_edges.GetArray();
+    }
+
+    {
+      vineyard_offset_array_t array;
+      array.Construct(meta.GetMemberMeta("ie_offsets"));
+      ie_offsets_ = array.GetArray();
+      ie_offsets_accessor_.Init(ie_offsets_);
+    }
+    {
+      vineyard_offset_array_t array;
+      array.Construct(meta.GetMemberMeta("oe_offsets"));
+      oe_offsets_ = array.GetArray();
+      oe_offsets_accessor_.Init(oe_offsets_);
+    }
+
+    local_vnum_ = ie_offsets_->length() - 1;
+    CHECK_GT(local_vnum_, 0);
+    VLOG(10) << "In constructing graphx csr, local vnum: " << local_vnum_;
+    out_edge_ptr_ = const_cast<nbr_t*>(
+        reinterpret_cast<const nbr_t*>(out_edges_->GetValue(0)));
+    in_edge_ptr_ = const_cast<nbr_t*>(
+        reinterpret_cast<const nbr_t*>(in_edges_->GetValue(0)));
+    in_edges_num_ = GetIEOffset(local_vnum_);
+    out_edges_num_ = GetOEOffset(local_vnum_);
+    VLOG(10) << "total in edges: " << in_edges_num_
+             << " out edges : " << out_edges_num_;
+    VLOG(10) << "Finish construct GraphXCSR: ";
+  }
+  inline int64_t GetIEOffset(vid_t lid) {
+    return ie_offsets_->Value(static_cast<int64_t>(lid));
+  }
+  inline int64_t GetOEOffset(vid_t lid) {
+    return oe_offsets_->Value(static_cast<int64_t>(lid));
+  }
+
+  inline gs::arrow_projected_fragment_impl::TypedArray<int64_t>&
+  GetIEOffsetArray() {
+    return ie_offsets_accessor_;
+  }
+  inline gs::arrow_projected_fragment_impl::TypedArray<int64_t>&
+  GetOEOffsetArray() {
+    return oe_offsets_accessor_;
+  }
+
+ private:
+  vid_t local_vnum_;
+  eid_t total_edge_num_;
+  int64_t in_edges_num_, out_edges_num_;
+  nbr_t *in_edge_ptr_, *out_edge_ptr_;
+  std::shared_ptr<arrow::FixedSizeBinaryArray> in_edges_, out_edges_;
+  std::shared_ptr<arrow::Int64Array> ie_offsets_, oe_offsets_;
+  gs::arrow_projected_fragment_impl::TypedArray<int64_t> ie_offsets_accessor_,
+      oe_offsets_accessor_;
+
+  template <typename _VID_T>
+  friend class GraphXCSRBuilder;
+};
+
+template <typename VID_T>
+class GraphXCSRBuilder : public vineyard::ObjectBuilder {
+  using eid_t = vineyard::property_graph_types::EID_TYPE;
+  using vid_t = VID_T;
+  using nbr_t = vineyard::property_graph_utils::NbrUnit<vid_t, eid_t>;
+
+ public:
+  explicit GraphXCSRBuilder(vineyard::Client& client) : client_(client) {}
+
+  void SetInEdges(const vineyard::FixedSizeBinaryArray& edges) {
+    this->in_edges = edges;
+  }
+  void SetOutEdges(const vineyard::FixedSizeBinaryArray& edges) {
+    this->out_edges = edges;
+  }
+  void SetIEOffsetArray(const vineyard::NumericArray<int64_t>& array) {
+    this->ie_offsets = array;
+  }
+  void SetOEOffsetArray(const vineyard::NumericArray<int64_t>& array) {
+    this->oe_offsets = array;
+  }
+  void SetTotalEdgesNum(eid_t edge_num) { this->total_edge_num_ = edge_num; }
+
+  std::shared_ptr<vineyard::Object> _Seal(vineyard::Client& client) {
+    // ensure the builder hasn't been sealed yet.
+    ENSURE_NOT_SEALED(this);
+    VINEYARD_CHECK_OK(this->Build(client));
+
+    auto graphx_csr = std::make_shared<GraphXCSR<vid_t>>();
+    graphx_csr->meta_.SetTypeName(type_name<GraphXCSR<vid_t>>());
+
+    size_t nBytes = 0;
+    graphx_csr->total_edge_num_ = total_edge_num_;
+    graphx_csr->ie_offsets_ = ie_offsets.GetArray();
+    graphx_csr->ie_offsets_accessor_.Init(graphx_csr->ie_offsets_);
+    nBytes += ie_offsets.nbytes();
+    graphx_csr->oe_offsets_ = oe_offsets.GetArray();
+    graphx_csr->oe_offsets_accessor_.Init(graphx_csr->oe_offsets_);
+    nBytes += oe_offsets.nbytes();
+    graphx_csr->in_edges_ = in_edges.GetArray();
+    nBytes += in_edges.nbytes();
+    graphx_csr->out_edges_ = out_edges.GetArray();
+    nBytes += out_edges.nbytes();
+    VLOG(10) << "total bytes: " << nBytes;
+
+    graphx_csr->in_edge_ptr_ = const_cast<nbr_t*>(
+        reinterpret_cast<const nbr_t*>(graphx_csr->in_edges_->GetValue(0)));
+    graphx_csr->out_edge_ptr_ = const_cast<nbr_t*>(
+        reinterpret_cast<const nbr_t*>(graphx_csr->out_edges_->GetValue(0)));
+    graphx_csr->local_vnum_ = graphx_csr->ie_offsets_->length() - 1;
+    graphx_csr->in_edges_num_ =
+        graphx_csr->GetIEOffset(graphx_csr->local_vnum_);
+    graphx_csr->out_edges_num_ =
+        graphx_csr->GetOEOffset(graphx_csr->local_vnum_);
+
+    graphx_csr->meta_.AddMember("in_edges", in_edges.meta());
+    graphx_csr->meta_.AddMember("out_edges", out_edges.meta());
+
+    graphx_csr->meta_.AddMember("ie_offsets", ie_offsets.meta());
+    graphx_csr->meta_.AddMember("oe_offsets", oe_offsets.meta());
+    graphx_csr->meta_.AddKeyValue("total_edge_num", total_edge_num_);
+    graphx_csr->meta_.SetNBytes(nBytes);
+
+    VINEYARD_CHECK_OK(
+        client.CreateMetaData(graphx_csr->meta_, graphx_csr->id_));
+    this->set_sealed(true);
+
+    return std::static_pointer_cast<vineyard::Object>(graphx_csr);
+  }
+
+ private:
+  eid_t total_edge_num_;
+  vineyard::Client& client_;
+  vineyard::FixedSizeBinaryArray in_edges, out_edges;
+  vineyard::NumericArray<int64_t> ie_offsets, oe_offsets;
+};
+
+template <typename OID_T, typename VID_T>
+class BasicGraphXCSRBuilder : public GraphXCSRBuilder<VID_T> {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using eid_t = vineyard::property_graph_types::EID_TYPE;
+  using nbr_t = vineyard::property_graph_utils::NbrUnit<vid_t, eid_t>;
+  using offset_array_builder_t =
+      typename vineyard::ConvertToArrowType<int64_t>::BuilderType;
+  using vineyard_offset_array_builder_t =
+      typename vineyard::InternalType<int64_t>::vineyard_builder_type;
+  using offset_array_t =
+      typename vineyard::ConvertToArrowType<int64_t>::ArrayType;
+  using vid_array_t = typename vineyard::ConvertToArrowType<vid_t>::ArrayType;
+  using oid_array_builder_t =
+      typename vineyard::ConvertToArrowType<oid_t>::BuilderType;
+  using vid_array_builder_t =
+      typename vineyard::ConvertToArrowType<vid_t>::BuilderType;
+  using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
+
+ public:
+  explicit BasicGraphXCSRBuilder(vineyard::Client& client)
+      : GraphXCSRBuilder<vid_t>(client) {}
+
+  boost::leaf::result<void> LoadEdges(
+      std::vector<OID_T>& srcOids, std::vector<OID_T>& dstOids,
+      GraphXVertexMap<oid_t, vid_t>& graphx_vertex_map, int local_num) {
+    auto edges_num_ = srcOids.size();
+    return LoadEdgesImpl(srcOids, dstOids, edges_num_, graphx_vertex_map,
+                         local_num);
+  }
+
+  boost::leaf::result<void> LoadEdgesImpl(
+      std::vector<OID_T>& src_oid_ptr, std::vector<OID_T>& dst_oid_ptr,
+      int64_t edges_num_, GraphXVertexMap<oid_t, vid_t>& graphx_vertex_map,
+      int local_num) {
+    this->total_edge_num_ = edges_num_;
+    vnum_ = graphx_vertex_map.GetInnerVertexSize();
+    std::vector<vid_t> srcLids(edges_num_), dstLids(edges_num_);
+
+    int thread_num =
+        (std::thread::hardware_concurrency() + local_num - 1) / local_num;
+    // int thread_num = 1;
+    int64_t chunk_size = 8192;
+    int64_t num_chunks = (edges_num_ + chunk_size - 1) / chunk_size;
+    VLOG(10) << "edges nun: " << edges_num_ << " thread num " << thread_num
+             << ", chunk size: " << chunk_size << "num chunks " << num_chunks;
+#if defined(WITH_PROFILING)
+    auto start_ts = grape::GetCurrentTime();
+#endif
+    {
+      // int thread_num = 1;
+      std::atomic<int> current_chunk(0);
+      std::vector<std::thread> work_threads(thread_num);
+      std::vector<int> cnt(thread_num);
+      for (int i = 0; i < thread_num; ++i) {
+        work_threads[i] = std::thread(
+            [&](int tid) {
+              int got;
+              int64_t begin, end;
+              while (true) {
+                got = current_chunk.fetch_add(1, std::memory_order_relaxed);
+                if (got >= num_chunks) {
+                  break;
+                }
+                begin = std::min(edges_num_, got * chunk_size);
+                end = std::min(edges_num_, begin + chunk_size);
+
+                for (auto cur = begin; cur < end; ++cur) {
+                  auto src_lid = graphx_vertex_map.GetLid(src_oid_ptr[cur]);
+                  srcLids[cur] = src_lid;
+                }
+                for (auto cur = begin; cur < end; ++cur) {
+                  auto dst_lid = graphx_vertex_map.GetLid(dst_oid_ptr[cur]);
+                  dstLids[cur] = dst_lid;
+                }
+                cnt[tid] += (end - begin);
+              }
+            },
+            i);
+      }
+      for (auto& thrd : work_threads) {
+        thrd.join();
+      }
+    }
+#if defined(WITH_PROFILING)
+    auto build_lid_time = grape::GetCurrentTime();
+    VLOG(10) << "Finish building lid arra edges cost"
+             << (build_lid_time - start_ts) << " seconds";
+#endif
+
+    ie_degree_.resize(vnum_);
+    oe_degree_.resize(vnum_);
+    for (vid_t i = 0; i < vnum_; ++i) {
+      ie_degree_[i].atomic_ = 0;
+      oe_degree_[i].atomic_ = 0;
+    }
+
+    grape::Bitset in_edge_active, out_edge_active;
+    build_degree_and_active(in_edge_active, out_edge_active, srcLids, dstLids,
+                            edges_num_, thread_num, chunk_size, num_chunks);
+#if defined(WITH_PROFILING)
+    auto degree_time = grape::GetCurrentTime();
+    VLOG(10) << "Finish building degree time cost"
+             << (degree_time - build_lid_time) << " seconds";
+#endif
+    VLOG(10) << "Loading edges size " << edges_num_
+             << "vertices num: " << vnum_;
+    build_offsets();
+    add_edges(vnum_, graphx_vertex_map.GetVertexSize(), local_num, srcLids,
+              dstLids, in_edge_active, out_edge_active, edges_num_, chunk_size,
+              num_chunks, thread_num);
+    sort(thread_num);
+    return {};
+  }
+
+  void build_degree_and_active(grape::Bitset& in_edge_active,
+                               grape::Bitset& out_edge_active,
+                               std::vector<vid_t>& srcLids,
+                               std::vector<vid_t>& dstLids, int64_t edges_num_,
+                               int thread_num, int64_t chunk_size,
+                               int num_chunks) {
+    in_edge_active.init(edges_num_);
+    out_edge_active.init(edges_num_);
+    std::atomic<int> current_chunk(0);
+    std::vector<std::thread> work_threads(thread_num);
+    for (int i = 0; i < thread_num; ++i) {
+      work_threads[i] = std::thread([&]() {
+        int got;
+        int64_t begin, end;
+        while (true) {
+          got = current_chunk.fetch_add(1, std::memory_order_relaxed);
+          if (got >= num_chunks) {
+            break;
+          }
+          begin = std::min(edges_num_, got * chunk_size);
+          end = std::min(edges_num_, begin + chunk_size);
+          for (auto j = begin; j < end; ++j) {
+            auto src_lid = srcLids[j];
+            if (src_lid < vnum_) {
+              oe_degree_[src_lid].atomic_.fetch_add(1,
+                                                    std::memory_order_relaxed);
+              out_edge_active.set_bit(j);
+            }
+          }
+          for (auto j = begin; j < end; ++j) {
+            auto dst_lid = dstLids[j];
+            if (dst_lid < vnum_) {
+              ie_degree_[dst_lid].atomic_.fetch_add(1,
+                                                    std::memory_order_relaxed);
+              in_edge_active.set_bit(j);
+            }
+          }
+        }
+      });
+    }
+
+    for (auto& thrd : work_threads) {
+      thrd.join();
+    }
+  }
+
+  vineyard::Status Build(vineyard::Client& client) override {
+    this->SetTotalEdgesNum(total_edge_num_);
+#if defined(WITH_PROFILING)
+    auto time00 = grape::GetCurrentTime();
+#endif
+    std::vector<std::thread> threads(4);
+    threads[0] = std::thread([&]() {
+#if defined(WITH_PROFILING)
+      auto time0 = grape::GetCurrentTime();
+#endif
+      std::shared_ptr<arrow::FixedSizeBinaryArray> edges;
+      CHECK(in_edge_builder_.Finish(&edges).ok());
+
+      vineyard::FixedSizeBinaryArrayBuilder edge_builder_v6d(client, edges);
+      auto res = std::dynamic_pointer_cast<vineyard::FixedSizeBinaryArray>(
+          edge_builder_v6d.Seal(client));
+      this->SetInEdges(*res);
+#if defined(WITH_PROFILING)
+      auto time1 = grape::GetCurrentTime();
+      VLOG(10) << "Building in edges cost" << (time1 - time0) << " seconds";
+#endif
+    });
+    threads[1] = std::thread([&]() {
+#if defined(WITH_PROFILING)
+      auto time0 = grape::GetCurrentTime();
+#endif
+      std::shared_ptr<arrow::FixedSizeBinaryArray> edges;
+      CHECK(out_edge_builder_.Finish(&edges).ok());
+
+      vineyard::FixedSizeBinaryArrayBuilder edge_builder_v6d(client, edges);
+      auto res = std::dynamic_pointer_cast<vineyard::FixedSizeBinaryArray>(
+          edge_builder_v6d.Seal(client));
+      this->SetOutEdges(*res);
+#if defined(WITH_PROFILING)
+      auto time1 = grape::GetCurrentTime();
+      VLOG(10) << "Building out edges cost" << (time1 - time0) << " seconds";
+#endif
+    });
+
+    threads[2] = std::thread([&]() {
+#if defined(WITH_PROFILING)
+      auto time0 = grape::GetCurrentTime();
+#endif
+      vineyard_offset_array_builder_t offset_array_builder(client,
+                                                           ie_offset_array_);
+      this->SetIEOffsetArray(
+          *std::dynamic_pointer_cast<vineyard::NumericArray<int64_t>>(
+              offset_array_builder.Seal(client)));
+#if defined(WITH_PROFILING)
+      auto time1 = grape::GetCurrentTime();
+      VLOG(10) << "Building ie offset cost" << (time1 - time0) << " seconds";
+#endif
+    });
+    threads[3] = std::thread([&]() {
+#if defined(WITH_PROFILING)
+      auto time0 = grape::GetCurrentTime();
+#endif
+      vineyard_offset_array_builder_t offset_array_builder(client,
+                                                           oe_offset_array_);
+      this->SetOEOffsetArray(
+          *std::dynamic_pointer_cast<vineyard::NumericArray<int64_t>>(
+              offset_array_builder.Seal(client)));
+#if defined(WITH_PROFILING)
+      auto time1 = grape::GetCurrentTime();
+      VLOG(10) << "Building oe offset cost" << (time1 - time0) << " seconds";
+#endif
+    });
+    for (auto& work_thread : threads) {
+      work_thread.join();
+    }
+#if defined(WITH_PROFILING)
+    auto time11 = grape::GetCurrentTime();
+    VLOG(10) << "Building all cost" << (time11 - time00) << " seconds";
+#endif
+    return vineyard::Status::OK();
+  }
+
+  std::shared_ptr<GraphXCSR<vid_t>> MySeal(vineyard::Client& client) {
+    return std::dynamic_pointer_cast<GraphXCSR<vid_t>>(this->Seal(client));
+  }
+
+ private:
+  boost::leaf::result<void> build_offsets() {
+    in_edges_num_ = 0;
+    for (auto d : ie_degree_) {
+      in_edges_num_ += d.atomic_.load();
+    }
+    ARROW_OK_OR_RAISE(in_edge_builder_.Resize(in_edges_num_));
+
+    out_edges_num_ = 0;
+    for (auto d : oe_degree_) {
+      out_edges_num_ += d.atomic_.load();
+    }
+    ARROW_OK_OR_RAISE(out_edge_builder_.Resize(out_edges_num_));
+
+    {
+      ie_offsets_.resize(vnum_ + 1);
+      ie_offsets_[0] = 0;
+      for (VID_T i = 0; i < vnum_; ++i) {
+        ie_offsets_[i + 1] = ie_offsets_[i] + ie_degree_[i].atomic_.load();
+      }
+      offset_array_builder_t builder;
+      ARROW_OK_OR_RAISE(builder.AppendValues(ie_offsets_));
+      ARROW_OK_OR_RAISE(builder.Finish(&ie_offset_array_));
+    }
+    {
+      oe_offsets_.resize(vnum_ + 1);
+      oe_offsets_[0] = 0;
+      for (VID_T i = 0; i < vnum_; ++i) {
+        oe_offsets_[i + 1] = oe_offsets_[i] + oe_degree_[i].atomic_.load();
+      }
+      offset_array_builder_t builder;
+      ARROW_OK_OR_RAISE(builder.AppendValues(oe_offsets_));
+      ARROW_OK_OR_RAISE(builder.Finish(&oe_offset_array_));
+    }
+
+    return {};
+  }
+
+  void add_edges(int vnum, int tvnum, int local_num,
+                 const std::vector<vid_t>& src_accessor,
+                 const std::vector<vid_t>& dst_accessor,
+                 const grape::Bitset& in_edge_active,
+                 const grape::Bitset& out_edge_active, int64_t edges_num_,
+                 int64_t chunk_size, int64_t num_chunks, int64_t thread_num) {
+#if defined(WITH_PROFILING)
+    auto start_ts = grape::GetCurrentTime();
+#endif
+
+    nbr_t* ie_mutable_ptr_begin = in_edge_builder_.MutablePointer(0);
+    nbr_t* oe_mutable_ptr_begin = out_edge_builder_.MutablePointer(0);
+
+    std::vector<int64_atomic> atomic_oe_offsets, atomic_ie_offsets;
+    atomic_oe_offsets.resize(vnum);
+    atomic_ie_offsets.resize(vnum);
+    for (int i = 0; i < vnum; ++i) {
+      atomic_oe_offsets[i].atomic_ = oe_offsets_[i];
+      atomic_ie_offsets[i].atomic_ = ie_offsets_[i];
+    }
+    {
+      std::atomic<int> current_chunk(0);
+      VLOG(10) << "thread num " << thread_num << ", chunk size: " << chunk_size
+               << "num chunks " << num_chunks;
+      std::vector<std::thread> work_threads(thread_num);
+      for (int i = 0; i < thread_num; ++i) {
+        work_threads[i] = std::thread(
+            [&](int tid) {
+              int got;
+              int64_t begin, end;
+              while (true) {
+                got = current_chunk.fetch_add(1, std::memory_order_relaxed);
+                if (got >= num_chunks) {
+                  break;
+                }
+                begin = std::min(edges_num_, got * chunk_size);
+                end = std::min(edges_num_, begin + chunk_size);
+                for (int64_t j = begin; j < end; ++j) {
+                  vid_t srcLid = src_accessor[j];
+                  vid_t dstLid = dst_accessor[j];
+                  if (out_edge_active.get_bit(j)) {
+                    int dstPos = atomic_oe_offsets[srcLid].atomic_.fetch_add(
+                        1, std::memory_order_relaxed);
+                    nbr_t* ptr = oe_mutable_ptr_begin + dstPos;
+                    ptr->vid = dstLid;
+                    ptr->eid = static_cast<eid_t>(j);
+                  }
+                  if (in_edge_active.get_bit(j)) {
+                    int dstPos = atomic_ie_offsets[dstLid].atomic_.fetch_add(
+                        1, std::memory_order_relaxed);
+                    nbr_t* ptr = ie_mutable_ptr_begin + dstPos;
+                    ptr->vid = srcLid;
+                    ptr->eid = static_cast<eid_t>(j);
+                  }
+                }
+              }
+            },
+            i);
+      }
+      for (auto& thrd : work_threads) {
+        thrd.join();
+      }
+    }
+
+#if defined(WITH_PROFILING)
+    auto finish_seal_ts = grape::GetCurrentTime();
+    VLOG(10) << "Finish adding " << edges_num_ << "edges cost"
+             << (finish_seal_ts - start_ts) << " seconds";
+#endif
+  }
+
+  void sort(int64_t thread_num) {
+#if defined(WITH_PROFILING)
+    auto start_ts = grape::GetCurrentTime();
+#endif
+    int64_t chunk_size = 8192;
+    int64_t num_chunks = (vnum_ + chunk_size - 1) / chunk_size;
+    std::atomic<int> current_chunk(0);
+    VLOG(10) << "thread num " << thread_num << ", chunk size: " << chunk_size
+             << "num chunks " << num_chunks;
+    std::vector<std::thread> work_threads(thread_num);
+    const int64_t* ie_offsets_ptr = ie_offset_array_->raw_values();
+    const int64_t* oe_offsets_ptr = oe_offset_array_->raw_values();
+    for (int i = 0; i < thread_num; ++i) {
+      work_threads[i] = std::thread(
+          [&](int tid) {
+            int got;
+            int64_t start, limit;
+            nbr_t *begin, *end;
+            while (true) {
+              got = current_chunk.fetch_add(1, std::memory_order_relaxed);
+              if (got >= num_chunks) {
+                break;
+              }
+              start = std::min(static_cast<int64_t>(vnum_), got * chunk_size);
+              limit = std::min(static_cast<int64_t>(vnum_), start + chunk_size);
+              for (int64_t j = start; j < limit; ++j) {
+                begin = in_edge_builder_.MutablePointer(ie_offsets_ptr[j]);
+                end = in_edge_builder_.MutablePointer(ie_offsets_ptr[j + 1]);
+                std::sort(begin, end, [](const nbr_t& lhs, const nbr_t& rhs) {
+                  return lhs.vid < rhs.vid;
+                });
+                begin = out_edge_builder_.MutablePointer(oe_offsets_ptr[j]);
+                end = out_edge_builder_.MutablePointer(oe_offsets_ptr[j + 1]);
+                std::sort(begin, end, [](const nbr_t& lhs, const nbr_t& rhs) {
+                  return lhs.vid < rhs.vid;
+                });
+              }
+            }
+          },
+          i);
+    }
+    for (auto& thrd : work_threads) {
+      thrd.join();
+    }
+
+#if defined(WITH_PROFILING)
+    auto finish_seal_ts = grape::GetCurrentTime();
+    VLOG(10) << "Sort edges cost" << (finish_seal_ts - start_ts) << " seconds";
+#endif
+  }
+
+  vid_t vnum_;
+  eid_t total_edge_num_;
+  int64_t in_edges_num_, out_edges_num_;
+
+  std::vector<int64_atomic> ie_degree_, oe_degree_;
+  vineyard::PodArrayBuilder<nbr_t> in_edge_builder_, out_edge_builder_;
+  std::shared_ptr<offset_array_t> ie_offset_array_,
+      oe_offset_array_;  // for output
+  std::vector<int64_t> ie_offsets_,
+      oe_offsets_;  // used for edge iterate in this
+};
+}  // namespace gs
+
+#endif  // ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_CSR_H_

--- a/analytical_engine/core/java/graphx/graphx_fragment.h
+++ b/analytical_engine/core/java/graphx/graphx_fragment.h
@@ -1,0 +1,357 @@
+
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H_
+#define ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H_
+
+#define WITH_PROFILING
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "flat_hash_map/flat_hash_map.hpp"
+
+#include "grape/grape.h"
+#include "grape/utils/vertex_array.h"
+#include "grape/worker/comm_spec.h"
+#include "vineyard/basic/ds/array.h"
+#include "vineyard/basic/ds/arrow.h"
+#include "vineyard/basic/ds/arrow_utils.h"
+#include "vineyard/basic/ds/hashmap.h"
+#include "vineyard/client/client.h"
+#include "vineyard/common/util/functions.h"
+#include "vineyard/common/util/typename.h"
+#include "vineyard/graph/fragment/property_graph_types.h"
+#include "vineyard/graph/fragment/property_graph_utils.h"
+#include "vineyard/graph/utils/error.h"
+#include "vineyard/graph/utils/table_shuffler.h"
+
+#include "core/config.h"
+#include "core/error.h"
+#include "core/fragment/arrow_projected_fragment.h"
+#include "core/io/property_parser.h"
+#include "core/java/graphx/edge_data.h"
+#include "core/java/graphx/graphx_csr.h"
+#include "core/java/graphx/graphx_vertex_map.h"
+#include "core/java/graphx/vertex_data.h"
+
+/**
+ * @brief only stores local vertex mapping, construct global vertex map in mpi
+ *
+ */
+namespace gs {
+
+template <typename OID_T, typename VID_T, typename VD_T, typename ED_T>
+class GraphXFragment
+    : public vineyard::Registered<GraphXFragment<OID_T, VID_T, VD_T, ED_T>> {
+ public:
+  using eid_t = vineyard::property_graph_types::EID_TYPE;
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using vdata_t = VD_T;
+  using edata_t = ED_T;
+  using csr_t = GraphXCSR<VID_T>;
+  using vm_t = GraphXVertexMap<OID_T, VID_T>;
+  using graphx_vdata_t = VertexData<VID_T, VD_T>;
+  using graphx_edata_t = EdgeData<VID_T, ED_T>;
+  using vertices_t = grape::VertexRange<VID_T>;
+  using vertex_t = grape::Vertex<VID_T>;
+  using nbr_t = vineyard::property_graph_utils::NbrUnit<vid_t, eid_t>;
+  using adj_list_t =
+      arrow_projected_fragment_impl::AdjList<vid_t, eid_t, edata_t>;
+
+  static constexpr grape::LoadStrategy load_strategy =
+      grape::LoadStrategy::kBothOutIn;
+
+  template <typename T>
+  using vertex_array_t = grape::VertexArray<vertices_t, T>;
+
+  GraphXFragment() {}
+  ~GraphXFragment() {}
+
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<GraphXFragment<OID_T, VID_T, VD_T, ED_T>>{
+            new GraphXFragment<OID_T, VID_T, VD_T, ED_T>()});
+  }
+
+  void PrepareToRunApp(const grape::CommSpec& comm_spec,
+                       grape::PrepareConf conf) {}
+
+  void Construct(const vineyard::ObjectMeta& meta) override {
+    auto time = -grape::GetCurrentTime();
+    this->meta_ = meta;
+    this->id_ = meta.GetId();
+
+    this->fnum_ = meta.GetKeyValue<fid_t>("fnum");
+    this->fid_ = meta.GetKeyValue<fid_t>("fid");
+
+    this->csr_.Construct(meta.GetMemberMeta("csr"));
+    this->vm_.Construct(meta.GetMemberMeta("vm"));
+    this->vdata_.Construct(meta.GetMemberMeta("vdata"));
+    this->edata_.Construct(meta.GetMemberMeta("edata"));
+    CHECK_EQ(vm_.GetVertexSize(), vdata_.VerticesNum());
+    this->inner_vertices_.SetRange(0, vm_.GetInnerVertexSize());
+    this->outer_vertices_.SetRange(vm_.GetInnerVertexSize(),
+                                   vm_.GetVertexSize());
+    this->vertices_.SetRange(0, vm_.GetVertexSize());
+    time += grape::GetCurrentTime();
+    VLOG(10) << "GraphXFragment finish construction : " << fid_
+             << ", took: " << time << "s";
+  }
+  inline fid_t fid() const { return fid_; }
+  inline fid_t fnum() const { return fnum_; }
+
+  csr_t& GetCSR() { return csr_; }
+
+  vm_t& GetVM() { return vm_; }
+
+  graphx_vdata_t GetVdata() { return vdata_; }
+
+  graphx_edata_t GetEdata() { return edata_; }
+
+  inline int64_t GetEdgeNum() const { return csr_.GetTotalEdgesNum(); }
+  inline int64_t GetInEdgeNum() const { return csr_.GetInEdgesNum(); }
+  inline int64_t GetOutEdgeNum() const { return csr_.GetOutEdgesNum(); }
+
+  inline VID_T GetInnerVerticesNum() const { return vm_.GetInnerVertexSize(); }
+  inline VID_T GetOuterVerticesNum() const { return vm_.GetOuterVertexSize(); }
+  inline VID_T GetVerticesNum() const { return vm_.GetVertexSize(); }
+  inline VID_T GetTotalVerticesNum() const { return vm_.GetTotalVertexSize(); }
+
+  inline vertices_t Vertices() const { return vertices_; }
+  inline vertices_t InnerVertices() const { return inner_vertices_; }
+  inline vertices_t OuterVertices() const { return outer_vertices_; }
+
+  inline bool GetVertex(const oid_t& oid, vertex_t& v) {
+    return vm_.GetVertex(oid, v);
+  }
+
+  inline OID_T GetId(const vertex_t& v) { return vm_.GetId(v); }
+
+  inline fid_t GetFragId(const vertex_t& v) const { return vm_.GetFragId(v); }
+
+  inline int GetLocalInDegree(const vertex_t& v) {
+    assert(IsInnerVertex(v));
+    return csr_.GetInDegree(v.GetValue());
+  }
+  inline int GetLocalOutDegree(const vertex_t& v) {
+    assert(IsInnerVertex(v));
+    return csr_.GetOutDegree(v.GetValue());
+  }
+
+  inline bool Gid2Vertex(const vid_t& gid, vertex_t& v) const {
+    return vm_.Gid2Vertex(gid, v);
+  }
+
+  inline vid_t Vertex2Gid(const vertex_t& v) { return vm_.Vertex2Gid(v); }
+
+  inline bool IsInnerVertex(const vertex_t& v) {
+    return inner_vertices_.Contain(v);
+  }
+  inline bool IsOuterVertex(const vertex_t& v) {
+    return outer_vertices_.Contain(v);
+  }
+
+  // Try to get iv lid from oid
+  inline bool GetInnerVertex(const OID_T& oid, vertex_t& v) {
+    return vm_.GetInnerVertex(oid, v);
+  }
+
+  inline bool GetOuterVertex(const OID_T& oid, vertex_t& v) {
+    return vm_.GetOuterVertex(oid, v);
+  }
+
+  inline OID_T GetInnerVertexId(const vertex_t& v) const {
+    return vm_.GetInnerVertexId(v);
+  }
+
+  inline OID_T GetOuterVertexId(const vertex_t& v) const {
+    return vm_.GetOuterVertexId(v);
+  }
+
+  inline bool InnerVertexGid2Vertex(const vid_t& gid, vertex_t& v) {
+    return vm_.InnerVertexGid2Vertex(gid, v);
+  }
+  inline bool OuterVertexGid2Vertex(const vid_t& gid, vertex_t& v) {
+    return vm_.OuterVertexGid2Vertex(gid, v);
+  }
+
+  inline VID_T GetInnerVertexGid(const vertex_t& v) const {
+    return vm_.GetInnerVertexGid(v);
+  }
+  inline VID_T GetOuterVertexGid(const vertex_t& v) const {
+    return vm_.GetOuterVertexGid(v);
+  }
+
+  inline vdata_t GetData(const vertex_t& v) { return vdata_.GetData(v); }
+
+  inline nbr_t* GetIEBegin(const vertex_t& v) {
+    return csr_.GetIEBegin(v.GetValue());
+  }
+  inline nbr_t* GetOEBegin(const vertex_t& v) {
+    return csr_.GetOEBegin(v.GetValue());
+  }
+  inline nbr_t* GetIEEnd(const vertex_t& v) {
+    return csr_.GetIEEnd(v.GetValue());
+  }
+  inline nbr_t* GetOEEnd(const vertex_t& v) {
+    return csr_.GetOEEnd(v.GetValue());
+  }
+
+  inline adj_list_t GetIncomingAdjList(const vertex_t& v) const {
+    return adj_list_t(GetIEBegin(v), GetIEEnd(v), edata_.GetEdataArray());
+  }
+
+  inline adj_list_t GetOutgoingAdjList(const vertex_t& v) const {
+    return adj_list_t(GetOEBegin(v), GetOEEnd(v), edata_.GetEdataArray());
+  }
+
+  gs::arrow_projected_fragment_impl::TypedArray<edata_t>& GetEdataArray() {
+    return edata_.GetEdataArray();
+  }
+  gs::arrow_projected_fragment_impl::TypedArray<vdata_t>& GetVdataArray() {
+    return vdata_.GetVdataArray();
+  }
+
+ private:
+  grape::fid_t fnum_, fid_;
+  vertices_t inner_vertices_, outer_vertices_, vertices_;
+  csr_t csr_;
+  vm_t vm_;
+  graphx_vdata_t vdata_;
+  graphx_edata_t edata_;
+
+  template <typename _OID_T, typename _VID_T, typename _VD_T, typename _ED_T>
+  friend class GraphXFragmentBuilder;
+};
+
+template <typename OID_T, typename VID_T, typename VD_T, typename ED_T>
+class GraphXFragmentBuilder : public vineyard::ObjectBuilder {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using vdata_t = VD_T;
+  using edata_t = ED_T;
+  using csr_t = GraphXCSR<VID_T>;
+  using vm_t = GraphXVertexMap<OID_T, VID_T>;
+  using graphx_vdata_t = VertexData<VID_T, VD_T>;
+  using graphx_edata_t = EdgeData<VID_T, ED_T>;
+
+ public:
+  explicit GraphXFragmentBuilder(vineyard::Client& client,
+                                 GraphXVertexMap<OID_T, VID_T>& vm,
+                                 GraphXCSR<VID_T>& csr,
+                                 VertexData<VID_T, VD_T>& vdata,
+                                 EdgeData<VID_T, ED_T>& edata)
+      : client_(client) {
+    fid_ = vm.fid();
+    fnum_ = vm.fnum();
+    vm_ = vm;
+    csr_ = csr;
+    vdata_ = vdata;
+    edata_ = edata;
+  }
+
+  explicit GraphXFragmentBuilder(vineyard::Client& client,
+                                 vineyard::ObjectID vm_id,
+                                 vineyard::ObjectID csr_id,
+                                 vineyard::ObjectID vdata_id,
+                                 vineyard::ObjectID edata_id)
+      : client_(client) {
+    vm_ = *std::dynamic_pointer_cast<vm_t>(client.GetObject(vm_id));
+    fid_ = vm_.fid();
+    fnum_ = vm_.fnum();
+    csr_ = *std::dynamic_pointer_cast<csr_t>(client.GetObject(csr_id));
+    vdata_ =
+        *std::dynamic_pointer_cast<graphx_vdata_t>(client.GetObject(vdata_id));
+    edata_ =
+        *std::dynamic_pointer_cast<graphx_edata_t>(client.GetObject(edata_id));
+  }
+
+  std::shared_ptr<GraphXFragment<oid_t, vid_t, vdata_t, edata_t>> MySeal(
+      vineyard::Client& client) {
+    return std::dynamic_pointer_cast<
+        GraphXFragment<oid_t, vid_t, vdata_t, edata_t>>(this->Seal(client));
+  }
+
+  std::shared_ptr<vineyard::Object> _Seal(vineyard::Client& client) override {
+    // ensure the builder hasn't been sealed yet.
+    ENSURE_NOT_SEALED(this);
+    VINEYARD_CHECK_OK(this->Build(client));
+
+    auto fragment =
+        std::make_shared<GraphXFragment<oid_t, vid_t, vdata_t, edata_t>>();
+    fragment->meta_.SetTypeName(
+        type_name<GraphXFragment<oid_t, vid_t, vdata_t, edata_t>>());
+
+    fragment->fid_ = fid_;
+    fragment->fnum_ = fnum_;
+    fragment->csr_ = csr_;
+    fragment->vm_ = vm_;
+    fragment->vdata_ = vdata_;
+    fragment->edata_ = edata_;
+
+    fragment->meta_.AddKeyValue("fid", fid_);
+    fragment->meta_.AddKeyValue("fnum", fnum_);
+    fragment->meta_.AddMember("vdata", vdata_.meta());
+    fragment->meta_.AddMember("csr", csr_.meta());
+    fragment->meta_.AddMember("vm", vm_.meta());
+    fragment->meta_.AddMember("edata", edata_.meta());
+
+    fragment->inner_vertices_.SetRange(0, vm_.GetInnerVertexSize());
+    fragment->outer_vertices_.SetRange(vm_.GetInnerVertexSize(),
+                                       vm_.GetVertexSize());
+    fragment->vertices_.SetRange(0, vm_.GetVertexSize());
+
+    size_t nBytes = 0;
+    nBytes += vdata_.nbytes();
+    nBytes += csr_.nbytes();
+    nBytes += vm_.nbytes();
+    nBytes += edata_.nbytes();
+    LOG(INFO) << "total bytes: " << nBytes;
+    fragment->meta_.SetNBytes(nBytes);
+
+    VINEYARD_CHECK_OK(client.CreateMetaData(fragment->meta_, fragment->id_));
+    // mark the builder as sealed
+    this->set_sealed(true);
+
+    return std::static_pointer_cast<vineyard::Object>(fragment);
+  }
+
+  vineyard::Status Build(vineyard::Client& client) override {
+    LOG(INFO) << "no need for build";
+    return vineyard::Status::OK();
+  }
+
+ private:
+  grape::fid_t fnum_, fid_;
+  csr_t csr_;
+  vm_t vm_;
+  graphx_vdata_t vdata_;
+  graphx_edata_t edata_;
+  vineyard::Client& client_;
+};
+
+}  // namespace gs
+
+#endif  // ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H_

--- a/analytical_engine/core/java/graphx/graphx_runner.h
+++ b/analytical_engine/core/java/graphx/graphx_runner.h
@@ -1,0 +1,288 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_RUNNER_H_
+#define ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_RUNNER_H_
+
+#ifdef ENABLE_JAVA_SDK
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "grape/config.h"
+#include "grape/grape.h"
+#include "grape/util.h"
+
+#include <boost/asio.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include "apps/java_pie/java_pie_projected_default_app.h"
+#include "apps/java_pie/java_pie_projected_parallel_app.h"
+#include "core/io/property_parser.h"
+#include "core/java/graphx/graphx_fragment.h"
+#include "core/java/javasdk.h"
+#include "core/java/utils.h"
+#include "core/loader/arrow_fragment_loader.h"
+
+DECLARE_string(task);
+DECLARE_string(ipc_socket);
+DECLARE_string(local_vm_ids);
+DECLARE_string(user_lib_path);
+DECLARE_string(app_class);      // graphx_driver_class
+DECLARE_string(context_class);  // graphx_driver_class
+DECLARE_string(vd_class);
+DECLARE_string(ed_class);
+DECLARE_string(msg_class);
+DECLARE_string(frag_ids);
+DECLARE_int32(max_iterations);
+DECLARE_string(serial_path);
+DECLARE_string(num_part);
+
+namespace gs {
+
+void Init() {
+  grape::InitMPIComm();
+  grape::CommSpec comm_spec;
+  comm_spec.Init(MPI_COMM_WORLD);
+}
+void Finalize() {
+  grape::FinalizeMPIComm();
+  VLOG(10) << "Workers finalized.";
+}
+std::string getHostName() { return boost::asio::ip::host_name(); }
+
+vineyard::ObjectID splitAndGet(grape::CommSpec& comm_spec,
+                               const std::string& ids) {
+  std::vector<std::string> splited;
+  boost::split(splited, ids, boost::is_any_of(","));
+  CHECK_EQ(splited.size(), comm_spec.worker_num());
+  auto my_host_name = getHostName();
+  std::vector<std::string> pid_vineyard_id;
+  {
+    for (auto str : splited) {
+      if (str.find(my_host_name) != std::string::npos) {
+        auto trimed =
+            str.substr(str.find(my_host_name) + my_host_name.size() + 1);
+        pid_vineyard_id.push_back(trimed);
+      }
+    }
+  }
+  CHECK_EQ(pid_vineyard_id.size(), comm_spec.local_num());
+  vineyard::ObjectID res_id;
+  int graphx_pid;
+
+  {
+    std::vector<std::string> graphx_pid_vm_id;
+    boost::split(graphx_pid_vm_id, pid_vineyard_id[comm_spec.local_id()],
+                 boost::is_any_of(":"));
+    CHECK_EQ(graphx_pid_vm_id.size(), 2);
+    res_id = std::stoull(graphx_pid_vm_id[1]);
+    graphx_pid = std::stoi(graphx_pid_vm_id[0]);
+  }
+
+  LOG(INFO) << "worker [" << comm_spec.worker_id() << "], local id ["
+            << comm_spec.local_id() << "] got pid " << graphx_pid << ", id "
+            << res_id;
+  return res_id;
+}
+template <typename OID_T, typename VID_T>
+void LoadGraphXVertexMapImpl(const std::string local_vm_ids_str,
+                             vineyard::Client& client) {
+  grape::CommSpec comm_spec;
+  comm_spec.Init(MPI_COMM_WORLD);
+
+  std::vector<std::string> splited;
+  boost::split(splited, local_vm_ids_str, boost::is_any_of(","));
+  CHECK_EQ(splited.size(), comm_spec.worker_num());
+
+  vineyard::ObjectID global_vm_id;
+  int graphx_pid;
+  {
+    std::string host_name = getHostName();
+    std::vector<std::string> local_vm_ids;
+    for (auto raw : splited) {
+      if (raw.find(host_name) != std::string::npos) {
+        // shoud find first
+        local_vm_ids.push_back(
+            raw.substr(raw.find(":") + 1, std::string::npos));
+      }
+    }
+    if (local_vm_ids.size() == 0) {
+      LOG(ERROR) << "Worker [" << comm_spec.worker_id() << "](" + host_name
+                 << ") find no suitable ids from" << local_vm_ids_str;
+      return;
+    }
+    CHECK_EQ(local_vm_ids.size(), comm_spec.local_num());
+
+    vineyard::ObjectID partial_map;
+
+    {
+      std::vector<std::string> graphx_pid_vm_id;
+      boost::split(graphx_pid_vm_id, local_vm_ids[comm_spec.local_id()],
+                   boost::is_any_of(":"));
+      CHECK_EQ(graphx_pid_vm_id.size(), 2);
+      partial_map = std::stoull(graphx_pid_vm_id[1]);
+      graphx_pid = std::stoi(graphx_pid_vm_id[0]);
+    }
+
+    gs::BasicGraphXVertexMapBuilder<int64_t, uint64_t> builder(
+        client, comm_spec, graphx_pid, partial_map);
+
+    global_vm_id = builder.Seal(client)->id();
+    VINEYARD_CHECK_OK(client.Persist(global_vm_id));
+  }
+  LOG(INFO) << "GlobalVertexMapID:" << getHostName() << ":" << graphx_pid << ":"
+            << global_vm_id;
+}
+
+template <typename OID_T, typename VID_T>
+void LoadGraphXVertexMap(const std::string local_vm_ids_str,
+                         vineyard::Client& client) {
+  gs::Init();
+  LoadGraphXVertexMapImpl<OID_T, VID_T>(local_vm_ids_str, client);
+  gs::Finalize();
+}
+
+template <typename OID_T, typename VID_T, typename VD_T, typename ED_T>
+vineyard::ObjectID LoadFragment(vineyard::Client& client,
+                                grape::CommSpec& comm_spec,
+                                std::string& frag_ids) {
+  auto cur_frag_id = splitAndGet(comm_spec, frag_ids);
+  LOG(INFO) << "Worker [" << comm_spec.worker_id()
+            << "] got graphx fragment from id: " << cur_frag_id;
+  return cur_frag_id;
+}
+
+template <typename FRAG_T, typename APP_TYPE>
+void Query(grape::CommSpec& comm_spec, std::shared_ptr<FRAG_T> fragment,
+           const std::string& params_str, const std::string& user_lib_path) {
+  auto app = std::make_shared<APP_TYPE>();
+  auto worker = APP_TYPE::CreateWorker(app, fragment);
+  auto spec = grape::DefaultParallelEngineSpec();
+
+  worker->Init(comm_spec, spec);
+
+  MPI_Barrier(comm_spec.comm());
+  double t = -grape::GetCurrentTime();
+  worker->Query(params_str, user_lib_path);
+  t += grape::GetCurrentTime();
+  MPI_Barrier(comm_spec.comm());
+  if (comm_spec.worker_id() == grape::kCoordinatorRank) {
+    VLOG(1) << "Query time cost: " << t;
+  }
+
+  std::ofstream unused_stream;
+  unused_stream.open("empty");
+  worker->Output(unused_stream);
+  unused_stream.close();
+}
+
+template <typename OID_T, typename VID_T, typename VD_T, typename ED_T>
+void CreateAndQuery(std::string params, const std::string& frag_name) {
+  grape::CommSpec comm_spec;
+  comm_spec.Init(MPI_COMM_WORLD);
+  using GraphXFragmentType = gs::GraphXFragment<OID_T, VID_T, VD_T, ED_T>;
+  boost::property_tree::ptree pt;
+  string2ptree(params, pt);
+
+  vineyard::Client client;
+  VINEYARD_CHECK_OK(client.Connect(FLAGS_ipc_socket));
+  // VLOG(1) << "Connected to IPCServer: " << FLAGS_ipc_socket;
+
+  auto fragment_id =
+      LoadFragment<OID_T, VID_T, VD_T, ED_T>(client, comm_spec, FLAGS_frag_ids);
+
+  VLOG(10) << "[worker " << comm_spec.worker_id()
+           << "] loaded frag id: " << fragment_id;
+
+  double t = -grape::GetCurrentTime();
+  std::shared_ptr<GraphXFragmentType> fragment =
+      std::dynamic_pointer_cast<GraphXFragmentType>(
+          client.GetObject(fragment_id));
+  t += grape::GetCurrentTime();
+  VLOG(10) << "Work [" << comm_spec.worker_id() << " load fragment cost: " << t
+           << " second";
+
+  // As the comm_spec world in this mpirun run may differs from the old
+  // fid->comm_spec mapping, we need to know the mapping by gathering info.
+  {
+    std::vector<int32_t> worker_id_to_fid;
+    worker_id_to_fid.resize(comm_spec.fnum());
+    auto fid = fragment->fid();
+    MPI_Allgather(&fid, 1, MPI_INT, worker_id_to_fid.data(), 1, MPI_INT,
+                  comm_spec.comm());
+    std::stringstream ss;
+    for (grape::fid_t i = 0; i < comm_spec.fnum(); ++i) {
+      ss << ";" << i << ":" << worker_id_to_fid[i];
+    }
+    auto worker_id_to_fid_str = ss.str().substr(1);
+    // LOG(INFO) << "worker_id_to_fid_str: " << worker_id_to_fid_str;
+    pt.put("worker_id_to_fid", worker_id_to_fid_str);
+  }
+
+  pt.put("frag_name", frag_name);
+
+  if (getenv("USER_JAR_PATH")) {
+    pt.put("jar_name", getenv("USER_JAR_PATH"));
+  } else {
+    LOG(ERROR) << "USER_JAR_PATH not set";
+    return;
+  }
+
+  std::stringstream ss;
+  boost::property_tree::json_parser::write_json(ss, pt);
+  std::string new_params = ss.str();
+
+  double t0 = grape::GetCurrentTime();
+
+  for (int i = 0; i < 1; ++i) {
+    if (FLAGS_context_class ==
+        "com.alibaba.graphscope.context.GraphXParallelAdaptorContext") {
+      using APP_TYPE = JavaPIEProjectedParallelApp<GraphXFragmentType>;
+      Query<GraphXFragmentType, APP_TYPE>(comm_spec, fragment, new_params,
+                                          FLAGS_user_lib_path);
+    } else {
+      LOG(ERROR) << "Not recegonized context clz" << FLAGS_context_class;
+    }
+  }
+  double t1 = grape::GetCurrentTime();
+  if (comm_spec.worker_id() == grape::kCoordinatorRank) {
+    VLOG(1) << "[Total Query time]: " << (t1 - t0);
+  }
+}
+
+template <typename OID_T, typename VID_T, typename VD_T, typename ED_T>
+void Run(std::string& params) {
+  std::string frag_name = "gs::GraphXFragment<" + gs::TypeName<OID_T>::Get() +
+                          "," + gs::TypeName<VID_T>::Get() + "," +
+                          gs::TypeName<VD_T>::Get() + "," +
+                          gs::TypeName<ED_T>::Get() + ">";
+
+  gs::Init();
+  gs::CreateAndQuery<OID_T, VID_T, VD_T, ED_T>(params, frag_name);
+  gs::Finalize();
+}
+}  // namespace gs
+
+#endif
+#endif  // ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_RUNNER_H_

--- a/analytical_engine/core/java/graphx/graphx_vertex_map.h
+++ b/analytical_engine/core/java/graphx/graphx_vertex_map.h
@@ -1,0 +1,885 @@
+
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_VERTEX_MAP_H_
+#define ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_VERTEX_MAP_H_
+
+#define WITH_PROFILING
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "flat_hash_map/flat_hash_map.hpp"
+
+#include "grape/grape.h"
+#include "grape/util.h"
+#include "grape/worker/comm_spec.h"
+#include "vineyard/basic/ds/array.h"
+#include "vineyard/basic/ds/arrow.h"
+#include "vineyard/basic/ds/arrow_utils.h"
+#include "vineyard/basic/ds/hashmap.h"
+#include "vineyard/client/client.h"
+#include "vineyard/common/util/functions.h"
+#include "vineyard/common/util/typename.h"
+#include "vineyard/graph/fragment/property_graph_types.h"
+#include "vineyard/graph/fragment/property_graph_utils.h"
+#include "vineyard/graph/utils/error.h"
+#include "vineyard/graph/utils/table_shuffler.h"
+
+#include "core/config.h"
+#include "core/error.h"
+#include "core/fragment/arrow_projected_fragment.h"
+#include "core/io/property_parser.h"
+#include "core/java/graphx/local_vertex_map.h"
+
+/**
+ * @brief only stores local vertex mapping, construct global vertex map in mpi
+ *
+ */
+namespace gs {
+
+template <typename OID_T, typename VID_T>
+class GraphXVertexMap
+    : public vineyard::Registered<GraphXVertexMap<OID_T, VID_T>> {
+ public:
+  static constexpr int thread_num = 16;
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
+  using vid_array_t = typename vineyard::ConvertToArrowType<vid_t>::ArrayType;
+  using vineyard_array_t =
+      typename vineyard::InternalType<oid_t>::vineyard_array_type;
+  using vineyard_vid_array_t =
+      typename vineyard::InternalType<vid_t>::vineyard_array_type;
+  using vid_array_builder_t =
+      typename vineyard::ConvertToArrowType<vid_t>::BuilderType;
+  using vertex_t = grape::Vertex<VID_T>;
+
+  GraphXVertexMap() {}
+  ~GraphXVertexMap() {}
+
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<GraphXVertexMap<OID_T, VID_T>>{
+            new GraphXVertexMap<OID_T, VID_T>()});
+  }
+
+  void Construct(const vineyard::ObjectMeta& meta) override {
+    this->meta_ = meta;
+    this->id_ = meta.GetId();
+
+    this->fnum_ = meta.GetKeyValue<fid_t>("fnum");
+    this->fid_ = meta.GetKeyValue<fid_t>("fid");
+    this->graphx_pid_ = meta.GetKeyValue<int>("graphx_pid");
+    this->shuffle_num_ = meta.GetKeyValue<int>("shuffle_num");
+
+    id_parser_.init(fnum_);
+
+    l2o_.resize(fnum_);
+    l2o_accessor_.resize(fnum_);
+    o2l_.resize(fnum_);
+    for (fid_t i = 0; i < fnum_; ++i) {
+      vineyard_array_t array;
+      array.Construct(meta.GetMemberMeta("l2o_" + std::to_string(i)));
+      l2o_[i] = array.GetArray();
+      l2o_accessor_[i].Init(l2o_[i]);
+
+      o2l_[i].Construct(meta.GetMemberMeta("o2l_" + std::to_string(i)));
+    }
+    {
+      vineyard::NumericArray<int32_t> array;
+      array.Construct(meta.GetMemberMeta("fid_to_pid"));
+      fid_to_pid_ = array.GetArray();
+    }
+    {
+      vineyard::NumericArray<int32_t> array;
+      array.Construct(meta.GetMemberMeta("pid_to_fid"));
+      pid_to_fid_ = array.GetArray();
+    }
+    {
+      vineyard::NumericArray<int32_t> array;
+      array.Construct(meta.GetMemberMeta("pid_array"));
+      pid_array_ = array.GetArray();
+    }
+    {
+      vineyard_vid_array_t array;
+      array.Construct(meta.GetMemberMeta("ov_l2g"));
+      ov_l2g_ = array.GetArray();
+      ov_l2g_accessor_.Init(ov_l2g_);
+    }
+
+    this->ivnum_ = l2o_[fid_]->length();
+    this->ovnum_ = ov_l2g_->length();
+    this->tvnum_ = this->ivnum_ + this->ovnum_;
+
+    ov_g2l_.resize(thread_num);
+    for (int i = 0; i < thread_num; ++i) {
+      std::string str = "ov_g2l_" + std::to_string(i);
+      if (meta.Haskey(str)) {
+        ov_g2l_[i].Construct(meta.GetMemberMeta(str));
+      }
+    }
+
+    VLOG(10) << "Finish constructing global vertex map, ivnum: " << ivnum_
+             << "ovnum: " << ovnum_ << " tvnum: " << tvnum_;
+  }
+  fid_t fid() const { return fid_; }
+  fid_t fnum() const { return fnum_; }
+
+  int32_t Fid2GraphxPid(fid_t fid) {
+    CHECK_LT(fid, fnum_);
+    return fid_to_pid_->Value(fid);
+  }
+
+  int32_t GraphXPid2Fid(fid_t pid) {
+    CHECK_LT(pid, fnum_);
+    return pid_to_fid_->Value(pid);
+  }
+
+  inline fid_t Oid2FragId(const oid_t& oid) const {
+    int32_t shuffle_pid = static_cast<uint64_t>(oid) % shuffle_num_;
+    int32_t pid = pid_array_->Value(shuffle_pid);
+    fid_t fid = pid_to_fid_->Value(pid);
+    return fid;
+  }
+
+  inline fid_t GetFragId(const vertex_t& v) const {
+    if (v.GetValue() > ivnum_) {
+      auto gid = ov_l2g_->Value(v.GetValue());
+      return id_parser_.get_fragment_id(gid);
+    }
+    return fid_;
+  }
+
+  inline fid_t GetFragId(vid_t lid) const {
+    if (lid >= ivnum_) {
+      auto gid = ov_l2g_accessor_[lid - ivnum_];
+      return id_parser_.get_fragment_id(gid);
+    }
+    return fid_;
+  }
+
+  inline VID_T GetTotalVertexSize() const {
+    size_t size = 0;
+    for (const auto& v : o2l_) {
+      size += v.size();
+    }
+    return size;
+  }
+
+  VID_T GetInnerVertexSize(fid_t fid) const { return o2l_[fid].size(); }
+
+  VID_T GetInnerVertexSize() const { return ivnum_; }
+
+  VID_T GetOuterVertexSize() const { return ovnum_; }
+
+  VID_T GetVertexSize() const { return tvnum_; }
+
+  bool GetVertex(const oid_t& oid, vertex_t& v) {
+    vid_t gid;
+    if (!GetGid(oid, gid)) {
+      LOG(ERROR) << "worker " << fid_ << "Get gid from oid faild: oid" << oid;
+      return false;
+    }
+    return Gid2Vertex(gid, v);
+  }
+
+  bool GetInnerVertex(const oid_t& oid, vertex_t& v) {
+    auto iter = o2l_[fid_].find(oid);
+    if (iter == o2l_[fid_].end()) {
+      LOG(ERROR) << "No match for oid " << oid << "found in frag: " << fid_;
+      return false;
+    }
+    v.SetValue(iter->second);
+    return true;
+  }
+
+  bool GetOuterVertex(const oid_t& oid, vertex_t& v) {
+    vid_t gid, lid;
+    assert(GetGid(oid, gid));
+    assert(OuterVertexGid2Lid(gid, lid));
+    v.SetValue(lid);
+    return true;
+  }
+
+  bool Gid2Vertex(const vid_t& gid, vertex_t& v) const {
+    return IsInnerVertexGid(gid) ? InnerVertexGid2Vertex(gid, v)
+                                 : OuterVertexGid2Vertex(gid, v);
+  }
+  inline bool IsInnerVertexGid(const VID_T& gid) const {
+    return id_parser_.get_fragment_id(gid) == fid();
+  }
+
+  inline bool InnerVertexGid2Vertex(const VID_T& gid, vertex_t& v) const {
+    v.SetValue(id_parser_.get_local_id(gid));
+    return true;
+  }
+
+  inline bool OuterVertexGid2Vertex(const VID_T& gid, vertex_t& v) const {
+    vid_t lid;
+    if (OuterVertexGid2Lid(gid, lid)) {
+      v.SetValue(lid);
+      return true;
+    }
+    return false;
+  }
+
+  inline bool OuterVertexGid2Lid(const VID_T gid, VID_T& lid) const {
+    int32_t tid = gid % thread_num;
+    auto iter = ov_g2l_[tid].find(gid);
+    if (iter != ov_g2l_[tid].end()) {
+      lid = iter->second;
+      return true;
+    }
+    LOG(ERROR) << "worker [" << fid_ << "find no lid for outer gid" << gid;
+    return false;
+  }
+
+  inline VID_T Vertex2Gid(const vertex_t& v) {
+    return IsInnerVertex(v) ? GetInnerVertexGid(v) : GetOuterVertexGid(v);
+  }
+  inline VID_T GetInnerVertexGid(const vertex_t& v) const {
+    return id_parser_.generate_global_id(fid(), v.GetValue());
+  }
+  inline VID_T GetOuterVertexGid(const vertex_t& v) const {
+    return ov_l2g_->Value(v.GetValue() - ivnum_);
+  }
+  inline VID_T GetOuterVertexGid(const VID_T& lid) const {
+    CHECK_GE(lid, ivnum_);
+    return ov_l2g_accessor_[lid - ivnum_];
+  }
+
+  inline OID_T GetInnerVertexId(const vertex_t& v) const {
+    assert(v.GetValue() < ivnum_);
+    return l2o_accessor_[fid_][v.GetValue()];
+  }
+  inline OID_T GetOuterVertexId(const vertex_t& v) const {
+    assert(v.GetValue() >= ivnum_);
+    return OuterVertexLid2Oid(v.GetValue());
+  }
+
+  inline bool IsInnerVertex(const vertex_t& v) { return v.GetValue() < ivnum_; }
+
+  inline bool InnerVertexGid2Lid(VID_T gid, VID_T& lid) const {
+    lid = id_parser_.get_local_id(gid);
+    return true;
+  }
+
+  inline VID_T GetInnererVertexGid(const vertex_t& v) {
+    assert(v.GetValue() < ivnum_);
+    return id_parser_.generate_global_id(fid_, v.GetValue());
+  }
+
+  OID_T GetId(const vertex_t& v) const {
+    if (v.GetValue() >= ivnum_) {
+      return OuterVertexLid2Oid(v.GetValue());
+    } else {
+      return InnerVertexLid2Oid(v.GetValue());
+    }
+  }
+  OID_T GetId(const vid_t lid) const {
+    if (lid >= ivnum_) {
+      return OuterVertexLid2Oid(lid);
+    } else {
+      return InnerVertexLid2Oid(lid);
+    }
+  }
+
+  inline bool GetOid(const VID_T& gid, OID_T& oid) const {
+    fid_t fid = GetFidFromGid(gid);
+    VID_T lid = id_parser_.get_local_id(gid);
+    return GetOid(fid, lid, oid);
+  }
+
+  bool GetOid(fid_t fid, const VID_T& lid, OID_T& oid) const {
+    if (lid >= l2o_[fid]->length()) {
+      return false;
+    }
+    oid = l2o_accessor_[fid][lid];
+    return true;
+  }
+
+  /**
+   * @brief For a oid, get the lid in this frag.
+   *
+   * @param oid
+   * @return VID_T
+   */
+  inline VID_T GetLid(const OID_T& oid) const {
+    vid_t gid;
+    CHECK(GetGid(oid, gid));
+    if (GetFidFromGid(gid) == fid_) {
+      return id_parser_.get_local_id(gid);
+    } else {
+      vid_t vid;
+      CHECK(OuterVertexGid2Lid(gid, vid));
+      CHECK(vid < tvnum_);
+      return vid;
+    }
+  }
+
+  inline OID_T InnerVertexLid2Oid(const VID_T& lid) const {
+    CHECK_LT(lid, ivnum_);
+    return l2o_accessor_[fid_][lid];
+  }
+  inline OID_T OuterVertexLid2Oid(const VID_T& lid) const {
+    auto gid = ov_l2g_accessor_[lid - ivnum_];
+    oid_t oid;
+    CHECK(GetOid(gid, oid));
+    return oid;
+  }
+
+  inline bool GetGid(fid_t fid, const OID_T& oid, VID_T& gid) const {
+    auto& rm = o2l_[fid];
+    auto iter = rm.find(oid);
+    if (iter == rm.end()) {
+      return false;
+    } else {
+      gid = Lid2Gid(fid, iter->second);
+      return true;
+    }
+  }
+
+  VID_T InnerOid2Gid(const OID_T& oid) const {
+    VID_T gid;
+    CHECK(GetGid(fid_, oid, gid));
+    return gid;
+  }
+
+  inline bool GetGid(const OID_T& oid, VID_T& gid) const {
+    // judge the fid from partition.
+    int32_t shuffle_pid = static_cast<uint64_t>(oid) % shuffle_num_;
+    int32_t pid = pid_array_->Value(shuffle_pid);
+    fid_t fid = pid_to_fid_->Value(pid);
+    bool res = GetGid(fid, oid, gid);
+    if (!res) {
+      LOG(ERROR) << "Fail to get gid for oid " << oid << ", shuffle_pid "
+                 << shuffle_pid << " pid " << pid << " fid " << fid;
+      for (fid_t i = 1; i < fnum_; ++i) {
+        fid_t try_fid = (fid + i) % fnum_;
+        if (GetGid(try_fid, oid, gid)) {
+          LOG(ERROR) << "Found dst fid for " << oid << " at " << try_fid;
+          return true;
+        }
+      }
+      return false;
+    }
+    return res;
+  }
+
+  inline fid_t GetFidFromGid(const VID_T& gid) const {
+    return id_parser_.get_fragment_id(gid);
+  }
+  inline VID_T Lid2Gid(fid_t fid, const VID_T& lid) const {
+    return id_parser_.generate_global_id(fid, lid);
+  }
+
+  inline gs::arrow_projected_fragment_impl::TypedArray<oid_t>&
+  GetLid2OidsAccessor(fid_t fid) {
+    return l2o_accessor_[fid];
+  }
+
+  inline gs::arrow_projected_fragment_impl::TypedArray<vid_t>&
+  GetOuterLid2GidsAccessor() {
+    return ov_l2g_accessor_;
+  }
+
+ private:
+  grape::fid_t fnum_, fid_;
+  int graphx_pid_;
+  int32_t shuffle_num_;
+  vid_t ivnum_, ovnum_, tvnum_;
+  grape::IdParser<vid_t> id_parser_;
+  std::vector<vineyard::Hashmap<oid_t, vid_t>> o2l_;
+  std::vector<std::shared_ptr<oid_array_t>> l2o_;
+  std::vector<gs::arrow_projected_fragment_impl::TypedArray<oid_t>>
+      l2o_accessor_;
+  gs::arrow_projected_fragment_impl::TypedArray<vid_t> ov_l2g_accessor_;
+  std::shared_ptr<vid_array_t> ov_l2g_;
+  std::vector<vineyard::Hashmap<vid_t, vid_t>> ov_g2l_;
+  std::shared_ptr<arrow::Int32Array> fid_to_pid_, pid_to_fid_;
+  std::shared_ptr<arrow::Int32Array> pid_array_;
+
+  template <typename _OID_T, typename _VID_T>
+  friend class GraphXVertexMapBuilder;
+};
+
+template <typename OID_T, typename VID_T>
+class GraphXVertexMapBuilder : public vineyard::ObjectBuilder {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
+  using vid_array_t = typename vineyard::ConvertToArrowType<vid_t>::ArrayType;
+  using vineyard_oid_array_t =
+      typename vineyard::InternalType<oid_t>::vineyard_array_type;
+  using vineyard_vid_array_t =
+      typename vineyard::InternalType<vid_t>::vineyard_array_type;
+  using vid_array_builder_t =
+      typename vineyard::ConvertToArrowType<vid_t>::BuilderType;
+  using oid_array_builder_t =
+      typename vineyard::ConvertToArrowType<oid_t>::BuilderType;
+
+ public:
+  explicit GraphXVertexMapBuilder(vineyard::Client& client, grape::fid_t fnum,
+                                  grape::fid_t fid, int graphx_pid,
+                                  int32_t local_num)
+      : client_(client) {
+    l2o_.resize(fnum);
+    o2l_.resize(fnum);
+    fnum_ = fnum;
+    fid_ = fid;
+    graphx_pid_ = graphx_pid;
+    local_num_ = local_num;
+    id_parser_.init(fnum);
+  }
+
+  void setOuterLid2Oid(std::shared_ptr<oid_array_t> outer_oids) {
+    this->outer_oid_array_ = outer_oids;
+  }
+
+  void setPidArray(vineyard::NumericArray<int32_t>& pid_array) {
+    this->pid_array_ = pid_array;
+    this->pid_array_accessor_ = pid_array.GetArray();
+    this->shuffle_num_ = pid_array_accessor_->length();
+  }
+
+  void SetFid2GraphXPids(
+      const vineyard::NumericArray<int32_t>& graphx_pids_array) {
+    this->fid_to_pid_ = graphx_pids_array;
+  }
+
+  void SetGraphXPid2Fid(const vineyard::NumericArray<int32_t>& pid_to_fid) {
+    this->pid_to_fid_ = pid_to_fid;
+    this->pid_to_fid_accessor_ = pid_to_fid_.GetArray();
+  }
+
+  void SetOidArray(grape::fid_t fid, const vineyard_oid_array_t& oid_arrays) {
+    this->l2o_[fid] = oid_arrays;
+  }
+
+  void SetOid2Lid(grape::fid_t fid, const vineyard::Hashmap<oid_t, vid_t>& rm) {
+    this->o2l_[fid] = rm;
+  }
+
+  std::shared_ptr<vineyard::Object> _Seal(vineyard::Client& client) {
+    // ensure the builder hasn't been sealed yet.
+    ENSURE_NOT_SEALED(this);
+    VINEYARD_CHECK_OK(this->Build(client));
+#if defined(WITH_PROFILING)
+    auto start_ts = grape::GetCurrentTime();
+#endif
+
+    auto vertex_map = std::make_shared<GraphXVertexMap<oid_t, vid_t>>();
+    vertex_map->fnum_ = fnum_;
+    vertex_map->fid_ = fid_;
+    vertex_map->shuffle_num_ = shuffle_num_;
+    vertex_map->id_parser_.init(fnum_);
+    vertex_map->graphx_pid_ = graphx_pid_;
+    vertex_map->ivnum_ = l2o_[fid_].GetArray()->length();
+    vertex_map->ovnum_ = outer_oid_array_->length();
+    vertex_map->tvnum_ = vertex_map->ivnum_ + vertex_map->ovnum_;
+
+    vertex_map->l2o_.resize(fnum_);
+    vertex_map->l2o_accessor_.resize(fnum_);
+    for (grape::fid_t i = 0; i < fnum_; ++i) {
+      auto& array = vertex_map->l2o_[i];
+      array = l2o_[i].GetArray();
+      vertex_map->l2o_accessor_[i].Init(array);
+    }
+
+    vertex_map->o2l_ = o2l_;
+    size_t nbytes = 0;
+    // Builder ovg2l and ovgids
+    int64_t ovnum = vertex_map->ovnum_;
+    VLOG(10) << "ivnum: " << vertex_map->ivnum_ << ", " << ovnum;
+#if defined(WITH_PROFILING)
+    auto time0 = grape::GetCurrentTime();
+#endif
+    {
+      std::atomic<int64_t> current_ind(0);
+      int thread_num =
+          (std::thread::hardware_concurrency() + local_num_ - 1) / local_num_;
+      std::vector<std::thread> threads(thread_num);
+      vid_array_builder_t gid_builder;
+      gid_builder.Resize(ovnum);
+      const oid_t* outer_lid2Oids_accessor_ = outer_oid_array_->raw_values();
+      for (int i = 0; i < thread_num; ++i) {
+        threads[i] = std::thread(
+            [&](int fid) {
+              int64_t begin, end;
+              while (true) {
+                begin = std::min(ovnum, current_ind.fetch_add(
+                                            4096, std::memory_order_relaxed));
+                end = std::min(begin + 4096, ovnum);
+                if (begin >= end) {
+                  break;
+                }
+                for (int64_t j = begin; j < end; ++j) {
+                  CHECK(getGid(outer_lid2Oids_accessor_[j], gid_builder[j]));
+                }
+              }
+            },
+            i);
+      }
+      for (int i = 0; i < thread_num; ++i) {
+        threads[i].join();
+      }
+      gid_builder.Advance(ovnum);
+      gid_builder.Finish(&vertex_map->ov_l2g_);
+      vertex_map->ov_l2g_accessor_.Init(vertex_map->ov_l2g_);
+    }
+#if defined(WITH_PROFILING)
+    auto time1 = grape::GetCurrentTime();
+    VLOG(10) << "Build gid array len: " << vertex_map->ov_l2g_->length()
+             << " cost" << (time1 - time0) << " seconds";
+#endif
+    {
+      typename vineyard::InternalType<vid_t>::vineyard_builder_type
+          array_builder(client, vertex_map->ov_l2g_);
+      auto vineyard_gid_array =
+          *std::dynamic_pointer_cast<vineyard::NumericArray<vid_t>>(
+              array_builder.Seal(client));
+      nbytes += vineyard_gid_array.nbytes();
+      vertex_map->meta_.AddMember("ov_l2g", vineyard_gid_array.meta());
+    }
+    {
+      int thread_num = GraphXVertexMap<oid_t, vid_t>::thread_num;
+      vertex_map->ov_g2l_.resize(thread_num);
+      std::vector<std::thread> threads(thread_num);
+      auto& gid_accessor = vertex_map->ov_l2g_accessor_;
+      int64_t chunk_size = (ovnum + thread_num - 1) / thread_num;
+      int64_t ivnum = static_cast<int64_t>(vertex_map->ivnum_);
+      for (int i = 0; i < thread_num; ++i) {
+        threads[i] = std::thread(
+            [&](int fid) {
+              vineyard::HashmapBuilder<vid_t, vid_t> builder(client);
+              builder.reserve(static_cast<size_t>(chunk_size));
+              for (int j = 0; j < ovnum; ++j) {
+                int pid = gid_accessor[j] % thread_num;
+                if (pid == fid) {
+                  builder.emplace(gid_accessor[j], j + ivnum);
+                }
+              }
+              if (builder.size() > 0) {
+                vertex_map->ov_g2l_[fid] =
+                    *std::dynamic_pointer_cast<vineyard::Hashmap<vid_t, vid_t>>(
+                        builder.Seal(client));
+              }
+            },
+            i);
+      }
+      for (int i = 0; i < thread_num; ++i) {
+        threads[i].join();
+      }
+      for (int i = 0; i < thread_num; ++i) {
+        if (vertex_map->ov_g2l_[i].size() > 0) {
+          nbytes += vertex_map->ov_g2l_[i].nbytes();
+          vertex_map->meta_.AddMember("ov_g2l_" + std::to_string(i),
+                                      vertex_map->ov_g2l_[i].meta());
+        }
+      }
+    }
+#if defined(WITH_PROFILING)
+    auto time2 = grape::GetCurrentTime();
+    VLOG(10) << "building gid2lid cost" << (time2 - time1) << " seconds";
+#endif
+    vertex_map->fid_to_pid_ = fid_to_pid_.GetArray();
+    vertex_map->pid_to_fid_ = pid_to_fid_.GetArray();
+    vertex_map->pid_array_ = pid_array_.GetArray();
+
+    vertex_map->meta_.SetTypeName(type_name<GraphXVertexMap<oid_t, vid_t>>());
+
+    vertex_map->meta_.AddKeyValue("fnum", fnum_);
+    vertex_map->meta_.AddKeyValue("fid", fid_);
+    vertex_map->meta_.AddKeyValue("shuffle_num", shuffle_num_);
+    vertex_map->meta_.AddKeyValue("graphx_pid", graphx_pid_);
+
+    for (grape::fid_t i = 0; i < fnum_; ++i) {
+      vertex_map->meta_.AddMember("o2l_" + std::to_string(i), o2l_[i].meta());
+      nbytes += o2l_[i].nbytes();
+
+      vertex_map->meta_.AddMember("l2o_" + std::to_string(i), l2o_[i].meta());
+      nbytes += l2o_[i].nbytes();
+    }
+    vertex_map->meta_.AddMember("fid_to_pid", fid_to_pid_.meta());
+    nbytes += fid_to_pid_.nbytes();
+    vertex_map->meta_.AddMember("pid_to_fid", pid_to_fid_.meta());
+    nbytes += pid_to_fid_.nbytes();
+    vertex_map->meta_.AddMember("pid_array", pid_array_.meta());
+    nbytes += pid_array_.nbytes();
+
+    vertex_map->meta_.SetNBytes(nbytes);
+
+    VINEYARD_CHECK_OK(
+        client.CreateMetaData(vertex_map->meta_, vertex_map->id_));
+    this->set_sealed(true);
+#if defined(WITH_PROFILING)
+    auto finish_seal_ts = grape::GetCurrentTime();
+    VLOG(10) << "Sealing GraphX vertex map cost" << (finish_seal_ts - start_ts)
+             << " seconds";
+#endif
+
+    return std::static_pointer_cast<vineyard::Object>(vertex_map);
+  }
+
+ protected:
+  int graphx_pid_;
+  vineyard::NumericArray<int32_t> pid_array_;
+  std::shared_ptr<arrow::Int32Array> pid_array_accessor_;
+  int32_t shuffle_num_;  // num part when do graphx shuffling
+
+ private:
+  inline bool getGid(const oid_t& oid, vid_t& gid) const {
+    int32_t shuffle_pid = static_cast<uint64_t>(oid) % shuffle_num_;
+    int32_t pid = pid_array_accessor_->Value(shuffle_pid);
+    fid_t fid = pid_to_fid_accessor_->Value(pid);
+    return getGid(fid, oid, gid);
+  }
+
+  inline bool getGid(fid_t fid, const oid_t& oid, vid_t& gid) const {
+    auto& rm = o2l_[fid];
+    auto iter = rm.find(oid);
+    if (iter == rm.end()) {
+      return false;
+    } else {
+      gid = lid2Gid(fid, iter->second);
+      return true;
+    }
+  }
+  inline vid_t lid2Gid(fid_t fid, const vid_t& lid) const {
+    return id_parser_.generate_global_id(fid, lid);
+  }
+
+  grape::fid_t fnum_, fid_;
+  int32_t local_num_;
+  grape::IdParser<vid_t> id_parser_;
+  vineyard::Client& client_;
+  std::vector<vineyard_oid_array_t> l2o_;
+  std::vector<vineyard::Hashmap<oid_t, vid_t>> o2l_;
+  std::shared_ptr<oid_array_t> outer_oid_array_;
+  vineyard::NumericArray<int32_t> fid_to_pid_, pid_to_fid_;
+  std::shared_ptr<arrow::Int32Array> pid_to_fid_accessor_;
+};
+
+template <typename OID_T, typename VID_T>
+class BasicGraphXVertexMapBuilder
+    : public GraphXVertexMapBuilder<OID_T, VID_T> {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
+  using oid_array_builder_t =
+      typename vineyard::ConvertToArrowType<oid_t>::BuilderType;
+  using base_t = GraphXVertexMapBuilder<oid_t, vid_t>;
+
+ public:
+  BasicGraphXVertexMapBuilder(vineyard::Client& client,
+                              grape::CommSpec& comm_spec, int graphx_pid,
+                              vineyard::ObjectID localVertexMapID)
+      : GraphXVertexMapBuilder<oid_t, vid_t>(client, comm_spec.worker_num(),
+                                             comm_spec.worker_id(), graphx_pid,
+                                             comm_spec.local_num()),
+        comm_spec_(comm_spec) {
+    comm_spec_.Dup();
+    partial_vmap_ = std::dynamic_pointer_cast<LocalVertexMap<oid_t, vid_t>>(
+        client.GetObject(localVertexMapID));
+    VLOG(10) << "Worer [" << comm_spec.worker_id() << " got partial vmap id "
+             << localVertexMapID
+             << ", local vnum: " << partial_vmap_->GetInnerVerticesNum()
+             << ", graphx pid: " << graphx_pid;
+    base_t::setOuterLid2Oid(partial_vmap_->GetOuterLid2Oid().GetArray());
+    base_t::setPidArray(partial_vmap_->GetPidArray());
+  }
+
+  vineyard::Status Build(vineyard::Client& client) override {
+#if defined(WITH_PROFILING)
+    auto start_ts = grape::GetCurrentTime();
+#endif
+    std::vector<std::shared_ptr<oid_array_t>> collected_oids;
+    std::shared_ptr<oid_array_t> our_oids =
+        partial_vmap_->GetInnerLid2Oid().GetArray();
+
+    CHECK(vineyard::FragmentAllGatherArray<oid_t>(comm_spec_, our_oids,
+                                                  collected_oids)
+              .ok());
+    CHECK_EQ(collected_oids.size(), comm_spec_.worker_num());
+#if defined(WITH_PROFILING)
+    auto shuffle_ts = grape::GetCurrentTime();
+    VLOG(10) << "Shuffle inner oids cost " << (shuffle_ts - start_ts)
+             << " seconds";
+#endif
+
+    grape::fid_t curFid = comm_spec_.fid();
+
+    int thread_num =
+        (std::thread::hardware_concurrency() + comm_spec_.local_num() - 1) /
+        comm_spec_.local_num();
+    {
+      std::atomic<grape::fid_t> current_fid(0);
+      std::vector<std::thread> threads(thread_num);
+      for (int i = 0; i < thread_num; ++i) {
+        threads[i] = std::thread(
+            [&](int fid) {
+              grape::fid_t cur_fid;
+              while (true) {
+                cur_fid = current_fid.fetch_add(1, std::memory_order_relaxed);
+                if (cur_fid >= comm_spec_.fnum()) {
+                  break;
+                }
+                if (cur_fid == curFid) {
+                  this->SetOidArray(cur_fid, partial_vmap_->GetInnerLid2Oid());
+                } else {
+                  typename vineyard::InternalType<oid_t>::vineyard_builder_type
+                      array_builder(client, collected_oids[cur_fid]);
+                  this->SetOidArray(
+                      cur_fid,
+                      *std::dynamic_pointer_cast<vineyard::NumericArray<oid_t>>(
+                          array_builder.Seal(client)));
+                }
+              }
+            },
+            i);
+      }
+      for (auto& thrd : threads) {
+        thrd.join();
+      }
+    }
+#if defined(WITH_PROFILING)
+    auto oidArrayTime = grape::GetCurrentTime();
+    VLOG(10) << "Buillding GraphX vertex map oid array"
+             << (oidArrayTime - start_ts) << " seconds";
+#endif
+    {
+      std::atomic<grape::fid_t> current_fid(0);
+      std::vector<std::thread> threads(thread_num);
+      for (int i = 0; i < thread_num; ++i) {
+        threads[i] = std::thread(
+            [&](int fid) {
+              grape::fid_t cur_fid;
+              while (true) {
+                cur_fid = current_fid.fetch_add(1, std::memory_order_relaxed);
+                if (cur_fid >= comm_spec_.fnum()) {
+                  break;
+                }
+                vineyard::HashmapBuilder<oid_t, vid_t> builder(client);
+                auto array = collected_oids[cur_fid]->raw_values();
+                {
+                  int64_t vnum = collected_oids[cur_fid]->length();
+                  builder.reserve(static_cast<size_t>(vnum));
+                  for (int64_t k = 0; k < vnum; ++k) {
+                    builder.emplace(array[k], k);
+                  }
+                }
+                {
+                  this->SetOid2Lid(cur_fid,
+                                   *std::dynamic_pointer_cast<
+                                       vineyard::Hashmap<oid_t, vid_t>>(
+                                       builder.Seal(client)));
+                }
+              }
+            },
+            i);
+      }
+      for (auto& thrd : threads) {
+        thrd.join();
+      }
+    }
+#if defined(WITH_PROFILING)
+    auto oid2LidTime = grape::GetCurrentTime();
+    VLOG(10) << "Buillding oid2Lid cost" << (oid2LidTime - oidArrayTime)
+             << " seconds";
+#endif
+
+    {
+      // gather grape pid <-> graphx pid matching.
+      std::vector<int32_t> fid_to_graphx_pids;
+      fid_to_graphx_pids.resize(comm_spec_.fnum());
+      int32_t tmp_graphx_pid = base_t::graphx_pid_;
+      MPI_Allgather(&tmp_graphx_pid, 1, MPI_INT, fid_to_graphx_pids.data(), 1,
+                    MPI_INT, comm_spec_.comm());
+
+      {
+        arrow::Int32Builder builder;
+        CHECK(builder.AppendValues(fid_to_graphx_pids).ok());
+        std::shared_ptr<arrow::Int32Array> graphx_pids_array;
+        CHECK(builder.Finish(&graphx_pids_array).ok());
+        vineyard::NumericArrayBuilder<int32_t> v6d_graphx_pids_builder(
+            client, graphx_pids_array);
+        this->SetFid2GraphXPids(
+            *std::dynamic_pointer_cast<vineyard::NumericArray<int32_t>>(
+                v6d_graphx_pids_builder.Seal(client)));
+      }
+
+      std::vector<int32_t> graphx_pid_to_fid;
+      graphx_pid_to_fid.resize(comm_spec_.fnum());
+      for (grape::fid_t i = 0; i < comm_spec_.fnum(); ++i) {
+        graphx_pid_to_fid[fid_to_graphx_pids[i]] = i;
+      }
+      {
+        arrow::Int32Builder builder;
+        CHECK(builder.AppendValues(graphx_pid_to_fid).ok());
+        std::shared_ptr<arrow::Int32Array> graphx_pid_to_fid_array;
+        CHECK(builder.Finish(&graphx_pid_to_fid_array).ok());
+        vineyard::NumericArrayBuilder<int32_t> v6d_graphx_pid2fid_builder(
+            client, graphx_pid_to_fid_array);
+        this->SetGraphXPid2Fid(
+            *std::dynamic_pointer_cast<vineyard::NumericArray<int32_t>>(
+                v6d_graphx_pid2fid_builder.Seal(client)));
+      }
+    }
+
+#if defined(WITH_PROFILING)
+    auto finish_seal_ts = grape::GetCurrentTime();
+    VLOG(10) << "Buillding GraphX vertex map cost"
+             << (finish_seal_ts - start_ts) << " seconds";
+#endif
+    return vineyard::Status::OK();
+  }
+
+ private:
+  grape::CommSpec comm_spec_;
+  std::shared_ptr<LocalVertexMap<OID_T, VID_T>> partial_vmap_;
+};
+
+template <typename OID_T, typename VID_T>
+class GraphXVertexMapGetter {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
+  using oid_array_builder_t =
+      typename vineyard::ConvertToArrowType<oid_t>::BuilderType;
+
+ public:
+  GraphXVertexMapGetter() {}
+  ~GraphXVertexMapGetter() {}
+  std::shared_ptr<GraphXVertexMap<oid_t, vid_t>> Get(
+      vineyard::Client& client, vineyard::ObjectID global_vm_id) {
+    auto global_vm = std::dynamic_pointer_cast<GraphXVertexMap<oid_t, vid_t>>(
+        client.GetObject(global_vm_id));
+    VLOG(10) << "Got global vm: " << global_vm_id
+             << " total vnum: " << global_vm->GetTotalVertexSize();
+    return global_vm;
+  }
+};
+}  // namespace gs
+
+#endif  // ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_GRAPHX_VERTEX_MAP_H_

--- a/analytical_engine/core/java/graphx/local_vertex_map.h
+++ b/analytical_engine/core/java/graphx/local_vertex_map.h
@@ -1,0 +1,237 @@
+
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_LOCAL_VERTEX_MAP_H_
+#define ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_LOCAL_VERTEX_MAP_H_
+
+#define WITH_PROFILING
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "flat_hash_map/flat_hash_map.hpp"
+
+#include "grape/grape.h"
+#include "grape/worker/comm_spec.h"
+#include "vineyard/basic/ds/array.h"
+#include "vineyard/basic/ds/arrow.h"
+#include "vineyard/basic/ds/arrow_utils.h"
+#include "vineyard/basic/ds/hashmap.h"
+#include "vineyard/client/client.h"
+#include "vineyard/common/util/functions.h"
+#include "vineyard/common/util/typename.h"
+#include "vineyard/graph/fragment/property_graph_types.h"
+
+#include "core/config.h"
+
+/**
+ * @brief only stores local vertex mapping.
+ *
+ */
+namespace gs {
+
+template <typename OID_T, typename VID_T>
+class LocalVertexMap
+    : public vineyard::Registered<LocalVertexMap<OID_T, VID_T>> {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
+  using vid_array_t = typename vineyard::ConvertToArrowType<vid_t>::ArrayType;
+  using vineyard_array_t =
+      typename vineyard::InternalType<oid_t>::vineyard_array_type;
+  using vineyard_oid_array_t =
+      typename vineyard::InternalType<oid_t>::vineyard_array_type;
+
+ public:
+  LocalVertexMap() {}
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<LocalVertexMap<OID_T, VID_T>>{
+            new LocalVertexMap<OID_T, VID_T>()});
+  }
+
+  void Construct(const vineyard::ObjectMeta& meta) override {
+    this->meta_ = meta;
+    this->id_ = meta.GetId();
+    this->ivnum_ = meta.GetKeyValue<grape::fid_t>("ivnum");
+    this->ovnum_ = meta.GetKeyValue<grape::fid_t>("ovnum");
+    VLOG(10) << "ivnum: " << ivnum_ << "ovnum: " << ovnum_;
+
+    inner_lid2Oid_.Construct(meta.GetMemberMeta("inner_lid2Oid"));
+    outer_lid2Oid_.Construct(meta.GetMemberMeta("outer_lid2Oid"));
+
+    pid_array_.Construct(meta.GetMemberMeta("pid_array"));
+
+    VLOG(10) << "Finish construct local_vertex_map,  ivnum" << ivnum_
+             << "ovnum: " << ovnum_;
+  }
+
+  int64_t GetInnerVerticesNum() { return ivnum_; }
+
+  vineyard_oid_array_t& GetInnerLid2Oid() { return inner_lid2Oid_; }
+
+  vineyard_oid_array_t& GetOuterLid2Oid() { return outer_lid2Oid_; }
+
+  vineyard::NumericArray<int32_t>& GetPidArray() { return pid_array_; }
+
+ private:
+  vid_t ivnum_, ovnum_;
+  vineyard_oid_array_t inner_lid2Oid_, outer_lid2Oid_;
+  vineyard::NumericArray<int32_t> pid_array_;
+
+  template <typename _OID_T, typename _VID_T>
+  friend class LocalVertexMapBuilder;
+};
+
+template <typename OID_T, typename VID_T>
+class LocalVertexMapBuilder : public vineyard::ObjectBuilder {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
+  using vid_array_t = typename vineyard::ConvertToArrowType<vid_t>::ArrayType;
+  using vineyard_oid_array_t =
+      typename vineyard::InternalType<oid_t>::vineyard_array_type;
+
+ public:
+  explicit LocalVertexMapBuilder(vineyard::Client& client) : client_(client) {}
+
+  void SetInnerOidArray(const vineyard_oid_array_t& oid_array) {
+    this->inner_lid2Oid_ = oid_array;
+  }
+  void SetOuterOidArray(const vineyard_oid_array_t& oid_array) {
+    this->outer_lid2Oid_ = oid_array;
+  }
+
+  void SetPidArray(const vineyard::NumericArray<int32_t>& pid_array) {
+    this->pid_array_ = pid_array;
+  }
+
+  std::shared_ptr<vineyard::Object> _Seal(vineyard::Client& client) {
+    // ensure the builder hasn't been sealed yet.
+    ENSURE_NOT_SEALED(this);
+
+    VINEYARD_CHECK_OK(this->Build(client));
+
+    auto vertex_map = std::make_shared<LocalVertexMap<oid_t, vid_t>>();
+    vertex_map->meta_.SetTypeName(type_name<LocalVertexMap<oid_t, vid_t>>());
+
+    {
+      vertex_map->inner_lid2Oid_ = inner_lid2Oid_;
+      vertex_map->ivnum_ = inner_lid2Oid_.GetArray()->length();
+      vertex_map->meta_.AddKeyValue("ivnum", vertex_map->ivnum_);
+
+      vertex_map->outer_lid2Oid_ = outer_lid2Oid_;
+      vertex_map->ovnum_ = outer_lid2Oid_.GetArray()->length();
+      vertex_map->meta_.AddKeyValue("ovnum", vertex_map->ovnum_);
+    }
+    size_t nbytes = 0;
+
+    vertex_map->meta_.AddMember("inner_lid2Oid", inner_lid2Oid_.meta());
+    nbytes += inner_lid2Oid_.nbytes();
+    vertex_map->meta_.AddMember("outer_lid2Oid", outer_lid2Oid_.meta());
+    nbytes += outer_lid2Oid_.nbytes();
+    vertex_map->meta_.AddMember("pid_array", pid_array_.meta());
+    nbytes += pid_array_.nbytes();
+
+    VLOG(10) << "total bytes: " << nbytes;
+    vertex_map->meta_.SetNBytes(nbytes);
+
+    VINEYARD_CHECK_OK(
+        client.CreateMetaData(vertex_map->meta_, vertex_map->id_));
+    // mark the builder as sealed
+    this->set_sealed(true);
+
+    return std::static_pointer_cast<vineyard::Object>(vertex_map);
+  }
+
+ private:
+  vineyard::Client& client_;
+  vineyard_oid_array_t inner_lid2Oid_, outer_lid2Oid_;
+  vineyard::NumericArray<int32_t> pid_array_;
+};
+
+template <typename OID_T, typename VID_T>
+class BasicLocalVertexMapBuilder : public LocalVertexMapBuilder<OID_T, VID_T> {
+  using oid_t = OID_T;
+  using vid_t = VID_T;
+  using oid_array_t = typename vineyard::ConvertToArrowType<oid_t>::ArrayType;
+  using oid_array_builder_t =
+      typename vineyard::ConvertToArrowType<oid_t>::BuilderType;
+  using pid_array_builder_t =
+      typename vineyard::ConvertToArrowType<int32_t>::BuilderType;
+
+ public:
+  BasicLocalVertexMapBuilder(vineyard::Client& client,
+                             oid_array_builder_t& inner_oids_builder,
+                             oid_array_builder_t& outer_oids_builder,
+                             pid_array_builder_t& pid_array_builder)
+      : LocalVertexMapBuilder<oid_t, vid_t>(client) {
+    CHECK(inner_oids_builder.Finish(&inner_oids_).ok());
+    CHECK(outer_oids_builder.Finish(&outer_oids_).ok());
+    CHECK(pid_array_builder.Finish(&pid_array_).ok());
+  }
+
+  vineyard::Status Build(vineyard::Client& client) override {
+#if defined(WITH_PROFILING)
+    auto start_ts = grape::GetCurrentTime();
+#endif
+
+    typename vineyard::InternalType<oid_t>::vineyard_builder_type
+        inner_array_builder(client, inner_oids_);
+    this->SetInnerOidArray(
+        *std::dynamic_pointer_cast<vineyard::NumericArray<oid_t>>(
+            inner_array_builder.Seal(client)));
+    typename vineyard::InternalType<oid_t>::vineyard_builder_type
+        outer_array_builder(client, outer_oids_);
+    this->SetOuterOidArray(
+        *std::dynamic_pointer_cast<vineyard::NumericArray<oid_t>>(
+            outer_array_builder.Seal(client)));
+
+    typename vineyard::InternalType<int32_t>::vineyard_builder_type
+        pid_array_builder(client, pid_array_);
+    this->SetPidArray(
+        *std::dynamic_pointer_cast<vineyard::NumericArray<int32_t>>(
+            pid_array_builder.Seal(client)));
+    LOG(INFO) << "Finish setting inner and outer oids";
+
+#if defined(WITH_PROFILING)
+    auto finish_seal_ts = grape::GetCurrentTime();
+    LOG(INFO) << "Seal hashmaps uses " << (finish_seal_ts - start_ts)
+              << " seconds";
+#endif
+    return vineyard::Status::OK();
+  }
+  std::shared_ptr<LocalVertexMap<oid_t, vid_t>> MySeal(
+      vineyard::Client& client) {
+    return std::dynamic_pointer_cast<LocalVertexMap<oid_t, vid_t>>(
+        this->Seal(client));
+  }
+
+ private:
+  std::shared_ptr<oid_array_t> inner_oids_, outer_oids_;
+  std::shared_ptr<arrow::Int32Array> pid_array_;
+};
+
+}  // namespace gs
+
+#endif  // ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_LOCAL_VERTEX_MAP_H_

--- a/analytical_engine/core/java/graphx/vertex_data.h
+++ b/analytical_engine/core/java/graphx/vertex_data.h
@@ -1,0 +1,303 @@
+
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_VERTEX_DATA_H_
+#define ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_VERTEX_DATA_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/array.h"
+
+#include "grape/grape.h"
+#include "grape/utils/vertex_array.h"
+#include "vineyard/basic/ds/array.h"
+#include "vineyard/basic/ds/arrow.h"
+#include "vineyard/basic/ds/arrow_utils.h"
+#include "vineyard/client/client.h"
+
+#include "core/config.h"
+#include "core/fragment/arrow_projected_fragment.h"
+
+namespace gs {
+template <typename VID_T, typename VD_T>
+class VertexData : public vineyard::Registered<VertexData<VID_T, VD_T>> {
+  using vid_t = VID_T;
+  using vdata_t = VD_T;
+  using vid_array_t = typename vineyard::ConvertToArrowType<vid_t>::ArrayType;
+  using vdata_array_t = typename vineyard::Array<vdata_t>;
+  using vertex_t = grape::Vertex<VID_T>;
+
+ public:
+  VertexData() {}
+  ~VertexData() {}
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<VertexData<VID_T, VD_T>>{
+            new VertexData<VID_T, VD_T>()});
+  }
+
+  void Construct(const vineyard::ObjectMeta& meta) override {
+    this->meta_ = meta;
+    this->id_ = meta.GetId();
+    this->frag_vnums_ = meta.GetKeyValue<fid_t>("frag_vnums");
+    vdatas_.Construct(meta.GetMemberMeta("vdatas"));
+
+    vdatas_accessor_.Init(vdatas_);
+    VLOG(10) << "Finish construct vertex data, frag vnums: " << frag_vnums_;
+  }
+
+  vid_t VerticesNum() { return frag_vnums_; }
+
+  VD_T GetData(const vid_t& lid) { return vdatas_accessor_[lid]; }
+
+  VD_T GetData(const vertex_t& v) { return GetData(v.GetValue()); }
+
+  gs::arrow_projected_fragment_impl::TypedArray<vdata_t>& GetVdataArray() {
+    return vdatas_accessor_;
+  }
+
+ private:
+  vid_t frag_vnums_;
+  vdata_array_t vdatas_;
+  gs::arrow_projected_fragment_impl::TypedArray<vdata_t> vdatas_accessor_;
+
+  template <typename _VID_T, typename _VD_T>
+  friend class VertexDataBuilder;
+};
+
+template <typename VID_T>
+class VertexData<VID_T, std::string>
+    : public vineyard::Registered<VertexData<VID_T, std::string>> {
+  using vid_t = VID_T;
+  using vdata_t = std::string;
+  using vid_array_t = typename vineyard::ConvertToArrowType<vid_t>::ArrayType;
+
+  using vdata_array_t = arrow::LargeStringArray;
+  using vertex_t = grape::Vertex<VID_T>;
+
+ public:
+  VertexData() {}
+  ~VertexData() {}
+  static std::unique_ptr<vineyard::Object> Create() __attribute__((used)) {
+    return std::static_pointer_cast<vineyard::Object>(
+        std::unique_ptr<VertexData<VID_T, std::string>>{
+            new VertexData<VID_T, std::string>()});
+  }
+
+  void Construct(const vineyard::ObjectMeta& meta) override {
+    this->meta_ = meta;
+    this->id_ = meta.GetId();
+    this->frag_vnums_ = meta.GetKeyValue<fid_t>("frag_vnums");
+    VLOG(10) << "frag_vnums: " << frag_vnums_;
+    {
+      vineyard::LargeStringArray vineyard_array;
+      vineyard_array.Construct(meta.GetMemberMeta("vdatas"));
+      vdatas_ = vineyard_array.GetArray();
+    }
+
+    vdatas_accessor_.Init(vdatas_);
+    VLOG(10) << "Finish construct vertex data, frag vnums: " << frag_vnums_;
+  }
+
+  vid_t VerticesNum() { return frag_vnums_; }
+
+  arrow::util::string_view GetData(const vid_t& lid) {
+    return vdatas_->GetView(lid);
+  }
+
+  arrow::util::string_view GetData(const vertex_t& v) {
+    return vdatas_->GetView(v.GetValue());
+  }
+
+  gs::arrow_projected_fragment_impl::TypedArray<vdata_t>& GetVdataArray() {
+    return vdatas_accessor_;
+  }
+
+ private:
+  vid_t frag_vnums_;
+  std::shared_ptr<vdata_array_t> vdatas_;
+  gs::arrow_projected_fragment_impl::TypedArray<std::string> vdatas_accessor_;
+
+  template <typename _VID_T, typename _VD_T>
+  friend class VertexDataBuilder;
+};
+
+template <typename VID_T, typename VD_T>
+class VertexDataBuilder : public vineyard::ObjectBuilder {
+  using vid_t = VID_T;
+  using vdata_t = VD_T;
+  using vdata_array_builder_t = vineyard::ArrayBuilder<vdata_t>;
+  using vdata_array_t = vineyard::Array<vdata_t>;
+
+ public:
+  VertexDataBuilder(vineyard::Client& client, vid_t frag_vnums,
+                    vdata_t init_value)
+      : frag_vnums_(frag_vnums), vdata_builder_(client, frag_vnums) {
+    for (int64_t i = 0; i < static_cast<int64_t>(frag_vnums); ++i) {
+      vdata_builder_[i] = init_value;
+    }
+    VLOG(10) << "Create vertex data size: " << frag_vnums
+             << "init value: " << init_value;
+  }
+  VertexDataBuilder(vineyard::Client& client, vid_t frag_vnums)
+      : frag_vnums_(frag_vnums), vdata_builder_(client, frag_vnums) {
+    VLOG(10) << "Create vertex data size: " << frag_vnums
+             << " with no init value";
+  }
+
+  VertexDataBuilder(vineyard::Client& client, std::vector<VD_T>& vec)
+      : frag_vnums_(vec.size()), vdata_builder_(client, vec) {
+    VLOG(10) << "Create vertex data with array " << vec.size();
+  }
+  ~VertexDataBuilder() {}
+
+  vdata_array_builder_t& GetArrayBuilder() { return vdata_builder_; }
+
+  std::shared_ptr<VertexData<vid_t, vdata_t>> MySeal(vineyard::Client& client) {
+    return std::dynamic_pointer_cast<VertexData<vid_t, vdata_t>>(
+        this->Seal(client));
+  }
+
+  std::shared_ptr<vineyard::Object> _Seal(vineyard::Client& client) override {
+    // ensure the builder hasn't been sealed yet.
+    ENSURE_NOT_SEALED(this);
+    VINEYARD_CHECK_OK(this->Build(client));
+    auto vertex_data = std::make_shared<VertexData<vid_t, vdata_t>>();
+    vertex_data->meta_.SetTypeName(type_name<VertexData<vid_t, vdata_t>>());
+
+    size_t nBytes = 0;
+    vertex_data->vdatas_ = *vdata_array_.get();
+    vertex_data->frag_vnums_ = frag_vnums_;
+    vertex_data->vdatas_accessor_.Init(vertex_data->vdatas_);
+    vertex_data->meta_.AddKeyValue("frag_vnums", frag_vnums_);
+    vertex_data->meta_.AddMember("vdatas", vdata_array_->meta());
+    nBytes += vdata_array_->nbytes();
+    VLOG(10) << "total bytes: " << nBytes;
+    vertex_data->meta_.SetNBytes(nBytes);
+    VINEYARD_CHECK_OK(
+        client.CreateMetaData(vertex_data->meta_, vertex_data->id_));
+    // mark the builder as sealed
+    this->set_sealed(true);
+    return std::static_pointer_cast<vineyard::Object>(vertex_data);
+  }
+
+  vineyard::Status Build(vineyard::Client& client) override {
+    vdata_array_ =
+        std::dynamic_pointer_cast<vdata_array_t>(vdata_builder_.Seal(client));
+    VLOG(10) << "Finish building vertex data;";
+    return vineyard::Status::OK();
+  }
+
+ private:
+  vid_t frag_vnums_;
+  std::shared_ptr<vdata_array_t> vdata_array_;
+  vdata_array_builder_t vdata_builder_;
+};
+
+template <typename VID_T>
+class VertexDataBuilder<VID_T, std::string> : public vineyard::ObjectBuilder {
+  using vid_t = VID_T;
+  using vdata_array_builder_t = arrow::LargeStringBuilder;
+  using vdata_array_t = arrow::LargeStringArray;
+  using bitset_words_t =
+      typename vineyard::ConvertToArrowType<int64_t>::ArrayType;
+  using bitset_words_builder_t =
+      typename vineyard::ConvertToArrowType<int64_t>::BuilderType;
+
+ public:
+  VertexDataBuilder() {}
+  ~VertexDataBuilder() {}
+
+  void Init(vid_t frag_vnums, std::vector<char>& vdata_buffer,
+            std::vector<int32_t>& offsets) {
+    this->frag_vnums_ = frag_vnums;
+    vdata_array_builder_t builder;
+    VLOG(10) << "Vdata buffer has " << vdata_buffer.size() << " bytes";
+    builder.Reserve(vdata_buffer.size());
+    const char* ptr = vdata_buffer.data();
+    for (auto offset : offsets) {
+      builder.UnsafeAppend(ptr, offset);
+      ptr += offset;
+    }
+    builder.Finish(&vdata_array_);
+    VLOG(10) << "Init vertex data with " << frag_vnums_;
+  }
+
+  std::shared_ptr<VertexData<vid_t, std::string>> MySeal(
+      vineyard::Client& client) {
+    return std::dynamic_pointer_cast<VertexData<vid_t, std::string>>(
+        this->Seal(client));
+  }
+
+  std::shared_ptr<vineyard::Object> _Seal(vineyard::Client& client) {
+    // ensure the builder hasn't been sealed yet.
+    ENSURE_NOT_SEALED(this);
+    VINEYARD_CHECK_OK(this->Build(client));
+    auto vertex_data = std::make_shared<VertexData<vid_t, std::string>>();
+    vertex_data->meta_.SetTypeName(type_name<VertexData<vid_t, std::string>>());
+
+    size_t nBytes = 0;
+    vertex_data->vdatas_ = vineyard_array.GetArray();
+    vertex_data->frag_vnums_ = frag_vnums_;
+    vertex_data->vdatas_accessor_.Init(vertex_data->vdatas_);
+    vertex_data->meta_.AddKeyValue("frag_vnums", frag_vnums_);
+    vertex_data->meta_.AddMember("vdatas", vineyard_array.meta());
+    nBytes += vineyard_array.nbytes();
+    VLOG(10) << "total bytes: " << nBytes;
+    vertex_data->meta_.SetNBytes(nBytes);
+    VINEYARD_CHECK_OK(
+        client.CreateMetaData(vertex_data->meta_, vertex_data->id_));
+    // mark the builder as sealed
+    this->set_sealed(true);
+    return std::static_pointer_cast<vineyard::Object>(vertex_data);
+  }
+
+  vineyard::Status Build(vineyard::Client& client) override {
+    vineyard::LargeStringArrayBuilder vdata_builder(client, this->vdata_array_);
+    vineyard_array = *std::dynamic_pointer_cast<vineyard::LargeStringArray>(
+        vdata_builder.Seal(client));
+
+    VLOG(10) << "Finish building vertex data;";
+    return vineyard::Status::OK();
+  }
+
+ private:
+  vid_t frag_vnums_;
+  std::shared_ptr<vdata_array_t> vdata_array_;
+  vineyard::LargeStringArray vineyard_array;
+};
+
+template <typename VID_T, typename VD_T>
+class VertexDataGetter {
+  using vid_t = VID_T;
+  using vdata_t = VD_T;
+
+ public:
+  VertexDataGetter() {}
+  ~VertexDataGetter() {}
+  std::shared_ptr<VertexData<vid_t, vdata_t>> Get(vineyard::Client& client,
+                                                  vineyard::ObjectID id) {
+    auto vertexData = std::dynamic_pointer_cast<VertexData<vid_t, vdata_t>>(
+        client.GetObject(id));
+    VLOG(10) << "Got VertexData: " << id
+             << " frag vnum: " << vertexData->VerticesNum();
+    return vertexData;
+  }
+};
+}  // namespace gs
+#endif  // ANALYTICAL_ENGINE_CORE_JAVA_GRAPHX_VERTEX_DATA_H_

--- a/analytical_engine/core/java/graphx_runner.cc
+++ b/analytical_engine/core/java/graphx_runner.cc
@@ -1,0 +1,181 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+#include "core/java/graphx/graphx_runner.h"
+
+#include <dlfcn.h>
+#include <unistd.h>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include <boost/leaf/error.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include "gflags/gflags.h"
+#include "gflags/gflags_declare.h"
+#include "glog/logging.h"
+
+#include "grape/config.h"
+#include "grape/grape.h"
+#include "vineyard/client/client.h"
+
+#include "core/java/graphx/graphx_vertex_map.h"
+#include "core/java/utils.h"
+
+DEFINE_string(task, "", "construct_vertex_map or graphx_pregel");
+
+DEFINE_string(ipc_socket, "/tmp/vineyard.sock", "vineyard socket addr");
+// for vertex map loading
+DEFINE_string(local_vm_ids, "", "local vm ids");
+
+// for graphx pregel
+DEFINE_string(user_lib_path, "/opt/graphscope/lib/libgrape-jni.so",
+              "user jni lib");
+DEFINE_string(app_class, "com.alibaba.graphscope.app.GraphXParallelAdaptor",
+              "graphx driver class");  // graphx_driver_class
+DEFINE_string(context_class,
+              "com.alibaba.graphscope.context.GraphXParallelAdaptorContext",
+              "graphx driver context class");  // graphx_driver_class
+DEFINE_string(vd_class, "", "int64_t,int32_t,double,std::string");
+DEFINE_string(ed_class, "", "int64_t,int32_t,double,std::string");
+DEFINE_string(msg_class, "", "int64_t,int32_t,double,std::string");
+DEFINE_int32(max_iterations, 100, "max iterations");
+DEFINE_string(frag_ids, "", "frag ids");
+DEFINE_string(serial_path, "", "serial path");
+DEFINE_string(num_part, "", "num partition in total, specified in graphx");
+
+std::string build_generic_class(const std::string& base_class,
+                                const std::string& vd_class,
+                                const std::string& ed_class,
+                                const std::string& msg_class) {
+  std::stringstream ss;
+  ss << base_class << "<" << vd_class << "," << ed_class << "," << msg_class
+     << ">";
+  return ss.str();
+}
+// put all flags in a json str
+std::string flags2JsonStr() {
+  boost::property_tree::ptree pt;
+  if (FLAGS_user_lib_path.empty()) {
+    LOG(ERROR) << "user jni lib not set";
+  }
+  pt.put("user_lib_path", FLAGS_user_lib_path);
+  // Different from other type of apps, we need to specify
+  // vd and ed type in app_class for generic class creations
+  pt.put("app_class", build_generic_class(FLAGS_app_class, FLAGS_vd_class,
+                                          FLAGS_ed_class, FLAGS_msg_class));
+  pt.put("graphx_context_class",
+         build_generic_class(FLAGS_context_class, FLAGS_vd_class,
+                             FLAGS_ed_class, FLAGS_msg_class));
+  pt.put("msg_class", FLAGS_msg_class);
+  pt.put("vd_class", FLAGS_vd_class);
+  pt.put("ed_class", FLAGS_ed_class);
+  pt.put("max_iterations", FLAGS_max_iterations);
+  pt.put("serial_path", FLAGS_serial_path);
+  pt.put("num_part", FLAGS_num_part);
+
+  std::stringstream ss;
+  boost::property_tree::json_parser::write_json(ss, pt);
+  return ss.str();
+}
+
+void runGraphXPregel() {
+  std::string params = flags2JsonStr();
+  if (std::strcmp(FLAGS_vd_class.c_str(), "int64_t") == 0 &&
+      std::strcmp(FLAGS_ed_class.c_str(), "int64_t") == 0) {
+    gs::Run<int64_t, uint64_t, int64_t, int64_t>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "int64_t") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "int32_t") == 0) {
+    gs::Run<int64_t, uint64_t, int64_t, int32_t>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "int64_t") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "double") == 0) {
+    gs::Run<int64_t, uint64_t, int64_t, double>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "int32_t") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "int64_t") == 0) {
+    gs::Run<int64_t, uint64_t, int32_t, int64_t>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "int32_t") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "int32_t") == 0) {
+    gs::Run<int64_t, uint64_t, int32_t, int32_t>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "int32_t") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "double") == 0) {
+    gs::Run<int64_t, uint64_t, int32_t, double>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "double") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "int64_t") == 0) {
+    gs::Run<int64_t, uint64_t, double, int64_t>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "double") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "int32_t") == 0) {
+    gs::Run<int64_t, uint64_t, double, int32_t>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "double") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "double") == 0) {
+    gs::Run<int64_t, uint64_t, double, double>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "std::string") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "double") == 0) {
+    gs::Run<int64_t, uint64_t, std::string, double>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "std::string") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "int64_t") == 0) {
+    gs::Run<int64_t, uint64_t, std::string, int64_t>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "std::string") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "int32_t") == 0) {
+    gs::Run<int64_t, uint64_t, std::string, int32_t>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "int32_t") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "std::string") == 0) {
+    gs::Run<int64_t, uint64_t, int32_t, std::string>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "int64_t") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "std::string") == 0) {
+    gs::Run<int64_t, uint64_t, int64_t, std::string>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "double") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "std::string") == 0) {
+    gs::Run<int64_t, uint64_t, double, std::string>(params);
+  } else if (std::strcmp(FLAGS_vd_class.c_str(), "std::string") == 0 &&
+             std::strcmp(FLAGS_ed_class.c_str(), "std::string") == 0) {
+    gs::Run<int64_t, uint64_t, std::string, std::string>(params);
+  } else {
+    LOG(ERROR) << "current not supported: " << FLAGS_vd_class << ", "
+               << FLAGS_ed_class;
+  }
+}
+
+int main(int argc, char* argv[]) {
+  FLAGS_stderrthreshold = 0;
+
+  grape::gflags::SetUsageMessage(
+      "Usage: mpiexec [mpi_opts] ./graphx_runner [options]");
+  if (argc == 1) {
+    gflags::ShowUsageWithFlagsRestrict(argv[0], "graphx-runner");
+    exit(1);
+  }
+  grape::gflags::ParseCommandLineFlags(&argc, &argv, true);
+  grape::gflags::ShutDownCommandLineFlags();
+
+  google::InitGoogleLogging("graphx-runner");
+  google::InstallFailureSignalHandler();
+
+  if (FLAGS_task.empty()) {
+    LOG(ERROR)
+        << "Please specify task to run, construct_vertex_map or graphx_pregel";
+  } else if (std::strcmp(FLAGS_task.c_str(), gs::CONSTRUCT_VERTEX_MAP) == 0) {
+    CHECK(!FLAGS_local_vm_ids.empty());
+    vineyard::Client client;
+    VINEYARD_CHECK_OK(client.Connect(FLAGS_ipc_socket));
+    gs::LoadGraphXVertexMap<int64_t, uint64_t>(FLAGS_local_vm_ids, client);
+  } else if (std::strcmp(FLAGS_task.c_str(), gs::GRAPHX_PREGEL_TASK) == 0) {
+    runGraphXPregel();
+  } else {
+    LOG(ERROR) << "Not recognized task " << FLAGS_task << ", use legal tasks "
+               << gs::GRAPHX_PREGEL_TASK << "," << gs::CONSTRUCT_VERTEX_MAP;
+  }
+
+  google::ShutdownGoogleLogging();
+}

--- a/analytical_engine/core/java/type_alias.h
+++ b/analytical_engine/core/java/type_alias.h
@@ -27,6 +27,7 @@
 
 #include "core/context/column.h"
 #include "core/fragment/arrow_projected_fragment.h"
+#include "core/java/graphx/graphx_csr.h"
 
 // Type alias for ease of use of some template types in Java.
 namespace gs {
@@ -86,6 +87,9 @@ using LongColumn = Column<FRAG_T, uint64_t>;
 
 template <typename FRAG_T>
 using IntColumn = Column<FRAG_T, uint32_t>;
+
+template <typename VID_T, typename ED_T>
+using DefaultImmutableCSR = grape::ImmutableCSR<VID_T, grape::Nbr<VID_T, ED_T>>;
 
 template <typename T>
 using ArrowArrayBuilder = typename vineyard::ConvertToArrowType<T>::BuilderType;

--- a/analytical_engine/core/java/utils.h
+++ b/analytical_engine/core/java/utils.h
@@ -62,6 +62,9 @@ static constexpr const char* OPTION_DIRECTED = "directed";
 static constexpr const char* OPTION_IPC_SOCKET = "ipc_socket";
 static constexpr const char* OPTION_FRAG_IDS = "frag_ids";
 
+static constexpr const char* GRAPHX_PREGEL_TASK = "graphx_pregel";
+static constexpr const char* CONSTRUCT_VERTEX_MAP = "construct_vertex_map";
+
 using ptree = boost::property_tree::ptree;
 void string2ptree(const std::string& params, ptree& pt) {
   std::stringstream ss;

--- a/analytical_engine/java/construct_graphx_vertex_map.sh
+++ b/analytical_engine/java/construct_graphx_vertex_map.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+#
+# Copyright 2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+TASK=$1
+shift
+NUM_WORKERS=$1
+shift
+HOSTS=$1
+shift
+LOCAL_VM_IDS=$1
+shift
+IPC_SOCKET=$1
+shift
+
+echo "task                    "${TASK}
+echo "num workers:            "${NUM_WORKERS}
+echo "hosts :                 "${HOSTS}
+echo "local vm ids            "${LOCAL_VM_IDS}
+echo "ipc socket              "${IPC_SOCKET}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+
+if [ -z "${GRAPHSCOPE_HOME}" ]; then
+    export GRAPHSCOPE_HOME=${SCRIPT_DIR}/../
+    echo "using probed GRAPHSCOPE_HOME: "${GRAPHSCOPE_HOME}
+else
+    echo "using GRAPHSCOPE_HOME: "${GRAPHSCOPE_HOME}
+fi
+
+GRAPHX_RUNNER=${GRAPHSCOPE_HOME}/bin/graphx_runner
+MPIRUN_EXECUTABLE=${GRAPHSCOPE_HOME}/openmpi/bin/mpirun
+source  ${GRAPHSCOPE_HOME}/conf/grape_jvm_opts
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GRAPHSCOPE_HOME}/lib/:${GRAPHSCOPE_HOME}/lib64
+
+if [ -f "${GRAPHX_RUNNER}" ]; then
+    echo "graphx runner exists."
+else
+    echo "graphx runner doesn't exist"
+    exit 1;
+fi
+
+cmd="GLOG_v=10 ${MPIRUN_EXECUTABLE} -n ${NUM_WORKERS} --host ${HOSTS} \
+-x GLOG_v ${GRAPHX_RUNNER} --task ${TASK} --local_vm_ids ${LOCAL_VM_IDS} --ipc_socket ${IPC_SOCKET}"
+echo "running cmd: "$cmd >&2
+
+eval $cmd

--- a/analytical_engine/java/giraph-on-grape/pom.xml
+++ b/analytical_engine/java/giraph-on-grape/pom.xml
@@ -25,7 +25,7 @@
 
   <artifactId>giraph-on-grape</artifactId>
   <packaging>jar</packaging>
-  <name>giraph-on-grape</name>
+  <name>Giraph on Grape</name>
 
   <properties>
     <benchmark.filter>org.apache.hadoop.io.StdVectorTest.write*</benchmark.filter>

--- a/analytical_engine/java/grape-demo/pom.xml
+++ b/analytical_engine/java/grape-demo/pom.xml
@@ -26,7 +26,7 @@
 
   <artifactId>grape-demo</artifactId>
   <packaging>jar</packaging>
-  <name>grape-demo</name>
+  <name>Grape Demo</name>
 
   <dependencies>
     <dependency>
@@ -49,6 +49,11 @@
       <classifier>shaded</classifier>
     </dependency>
     <dependency>
+      <groupId>com.alibaba.graphscope</groupId>
+      <artifactId>graphx-on-graphscope</artifactId>
+      <classifier>shaded</classifier>
+    </dependency>
+    <dependency>
       <groupId>com.alibaba.fastffi</groupId>
       <artifactId>annotation-processor</artifactId>
     </dependency>
@@ -64,13 +69,55 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-graphx_2.12</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.12</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -98,6 +145,7 @@
                 <includes>
                   <include>com.alibaba.graphscope:*</include>
                   <include>com.alibaba.fastffi:*</include>
+                  <include>org.apache.spark:spark-graphx_2.12*</include>
                   <include>it.unimi.dsi:fastutil*</include>
                 </includes>
               </artifactSet>

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/BFSTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/BFSTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.graphx.{Graph, GraphLoader, VertexId}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+object BFSTest extends Logging{
+  def main(args: Array[String]): Unit = {
+    // Creates a SparkSession.
+    val spark = GSSparkSession
+      .builder
+      .appName(s"${this.getClass.getSimpleName}")
+      .getOrCreate()
+    val sc = spark.sparkContext
+    if (args.length < 3) {
+      println("Expect 1 args")
+      return 0;
+    }
+    val efile = args(0)
+    val partNum = args(1).toInt
+    val sourceId = args(2).toLong
+    val graph: Graph[Int, Int] =
+      GraphLoader.edgeListFile(sc, efile,canonicalOrientation = false, partNum)
+    // Initialize the graph such that all vertices except the root have distance infinity.
+    val initialGraph = graph.mapVertices((id, _) =>
+      if (id == sourceId) 0 else Int.MaxValue)
+    val sssp = initialGraph.pregel(Int.MaxValue, 100)(
+      (id, dist, newDist) =>{
+        math.min(dist, newDist); // Vertex Program
+      },
+      triplet => {  // Send Message
+        if (triplet.srcAttr < triplet.dstAttr - 1) {
+          Iterator((triplet.dstId, triplet.srcAttr + 1))
+        } else {
+          Iterator.empty
+        }
+      },
+      (a, b) => math.min(a, b) // Merge Message
+    )
+    log.info(s"sssp graph num of vertices ${sssp.numVertices}, num of edges ${sssp.numEdges}")
+    spark.stop()
+  }
+}

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/CCTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/CCTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+// $example on$
+import org.apache.spark.graphx.Graph
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+/**
+ * Connect components on orc dataset
+ */
+object CCTest extends Logging{
+  def main(args: Array[String]): Unit = {
+    // Creates a SparkSession.
+    val spark = GSSparkSession
+      .builder
+      .appName(s"${this.getClass.getSimpleName}")
+      .getOrCreate()
+    val sc = spark.sparkContext
+    if (args.length < 3) {
+      println("Expect 3 args")
+      return 0;
+    }
+    val efile = args(0)
+    val partNum = args(1).toInt
+    val engine = args(2)
+    val time0 = System.nanoTime()
+    val loaded = spark.read.option("inferSchema",true).orc(efile)
+    val rdd = loaded.rdd
+    val lineRdd = rdd.map(row => (row.get(0).asInstanceOf[Long], row.get(1).asInstanceOf[Long])).coalesce(partNum)
+    val graph: Graph[Int, Int] = {
+      if (engine.equals("gs")) {
+        spark.fromLineRDD(lineRdd, partNum)
+      }
+      else if (engine.equals("graphx")){
+        Graph.fromEdgeTuples(lineRdd,1)
+      }
+      else {
+        throw new IllegalStateException("gs or graphx")
+      }
+    }
+    // Initialize the graph such that all vertices except the root have distance infinity.
+    log.info(s"initial graph count ${graph.numVertices}, ${graph.numEdges}")
+    val time1 = System.nanoTime()
+
+    val cc = graph.connectedComponents().cache()
+    log.info(s"cc graph count ${cc.numVertices}, ${cc.numEdges}")
+    val time2 = System.nanoTime()
+    log.info(s"Pregel took ${(time2 - time1)/1000000}ms, load graph ${(time1 - time0)/1000000}ms")
+    spark.stop()
+  }
+}
+

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/GSSessionTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/GSSessionTest.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+object GSSessionTest extends Logging{
+  def main(args: Array[String]) : Unit = {
+    val session = GSSparkSession.builder().vineyardMemory("10Gi").getOrCreate()
+
+    if (args.length != 2){
+      log.error(s"Expect 2 params, receive ${args.length}")
+      return
+    }
+    val vFile = args(0)
+    val eFile = args(1)
+    val graph = session.loadGraphToGS[Long,Long](vFile,eFile,64)
+    val res = graph.mapVertices((vid,vd) => vd).mapTriplets(triplet => triplet.srcId).cache()
+
+    log.info(s"load graph to gs numVertices ${res.numVertices}, edges ${res.numEdges}")
+    session.close()
+  }
+}

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/GSTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/GSTest.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+object GSTest extends Logging {
+  def main(args: Array[String]) : Unit = {
+    val session = GSSparkSession.builder().vineyardMemory("10Gi").getOrCreate()
+
+    session.close()
+  }
+}

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/GraphConvertTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/GraphConvertTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.graphx.GraphLoader
+import org.apache.spark.graphx.impl.GraphImpl
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+object GraphConvertTest extends Logging{
+  def main(array: Array[String]) : Unit = {
+    require(array.length == 2)
+    val path = array(0)
+    val numPart = array(1).toInt
+    val spark = SparkSession
+      .builder
+      .appName(s"${this.getClass.getSimpleName}")
+      .getOrCreate()
+    val sc = spark.sparkContext
+
+    val graphxGraph = GraphLoader.edgeListFile(sc, path,false, numPart).mapVertices((id,vd)=> id).mapEdges(edge => edge.dstId).cache()
+    log.info(s"Loaded graphx graph ${graphxGraph.numVertices} vertices, ${graphxGraph.numEdges} edges")
+
+    val grapeGraph = GSSparkSession.graphXtoGSGraph(graphxGraph.asInstanceOf[GraphImpl[Long,Long]])
+    log.info(s"Converted to grape graph ${grapeGraph.numVertices} vertices, ${grapeGraph.numEdges} edges")
+    val res = grapeGraph.mapVertices((id,vd) => vd + 10).mapTriplets(triplet => triplet.attr + 1).cache()
+    log.info(s"Converted to grape graph ${res.numVertices} vertices, ${res.numEdges} edges")
+
+    sc.stop()
+  }
+}

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/OperatorTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/OperatorTest.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.graphx.impl.GraphImpl
+import org.apache.spark.graphx.{Graph, GraphLoader}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+object OperatorTest extends Logging{
+    def main(array: Array[String]) : Unit = {
+      require(array.length == 2)
+      val fileName = array(0)
+      val partNum = array(1).toInt
+      val spark = SparkSession
+        .builder
+        .appName(s"${this.getClass.getSimpleName}")
+        .getOrCreate()
+      val sc = spark.sparkContext
+
+      val rawGraph = GraphLoader.edgeListFile(sc, fileName,false, partNum)
+      val graph = rawGraph.mapVertices((vid,vd)=>vd.toLong).mapEdges(edge=>edge.attr.toLong).cache()
+      val grapeGraph = GSSparkSession.graphXtoGSGraph[Long,Long](graph.asInstanceOf[GraphImpl[Long,Long]]).cache()
+
+
+      def mapping(graph : Graph[Long,Long])  : Graph[Long,Long] = {
+        log.info("[Operator test]: start Mapping")
+        graph.mapVertices((vid, vd) => vd + vid)
+          .mapEdges(edge=> edge.srcId + edge.dstId + edge.attr)
+          .mapTriplets(triplet => triplet.srcAttr + triplet.dstAttr + triplet.attr + triplet.srcId + triplet.dstId)
+      }
+
+      def outerJoin(graph : Graph[Long,Long]) : Graph[Long,Long] = {
+        log.info("[Operator test]: start outer join")
+        val inDegrees = graph.inDegrees
+        graph.joinVertices[Int](inDegrees)((id, ovd, newVd) => {
+          newVd.toLong
+        })
+      }
+
+      val graphxRes = outerJoin(mapping(graph))
+      val grapeRes = outerJoin(mapping(grapeGraph))
+
+      log.info(s"after test grape rdd ${grapeRes.vertices.count()}, edges ${grapeRes.edges.count()}")
+      log.info(s"after test graphx rdd ${graphxRes.vertices.count()}, edges ${graphxRes.edges.count()}")
+
+      sc.stop()
+    }
+  }
+

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/OrcSSSP.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/OrcSSSP.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.graphx.Graph
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+object OrcSSSP extends Logging{
+  def main(args: Array[String]): Unit = {
+    // Creates a SparkSession.
+    val spark = GSSparkSession
+      .builder
+      .appName(s"${this.getClass.getSimpleName}")
+      .getOrCreate()
+    val sc = spark.sparkContext
+    if (args.length < 4) {
+      println("Expect 4 args")
+      return 0;
+    }
+    val efile = args(0)
+    val partNum = args(1).toInt
+    val sourceId = args(2).toLong
+    val engine = args(3)
+    val time0 = System.nanoTime()
+    val loaded = spark.read.option("inferSchema",true).orc(efile)
+    val rdd = loaded.rdd
+    val lineRdd = rdd.map(row => (row.get(0).asInstanceOf[Long], row.get(1).asInstanceOf[Long])).coalesce(partNum)
+    val graph: Graph[Int, Int] = {
+      if (engine.equals("gs")) {
+        spark.fromLineRDD(lineRdd,partNum)
+      }
+      else if (engine.equals("graphx")){
+        Graph.fromEdgeTuples(lineRdd,1)
+      }
+      else {
+        throw new IllegalStateException("gs or graphx")
+      }
+    }
+    // Initialize the graph such that all vertices except the root have distance infinity.
+    val initialGraph = graph.mapVertices((id, _) =>
+      if (id == sourceId) 0.0 else Double.PositiveInfinity).cache()
+    log.info(s"initial graph count ${initialGraph.numVertices}, ${initialGraph.numEdges}")
+    val time1 = System.nanoTime()
+
+
+    val sssp = initialGraph.pregel(Double.PositiveInfinity)(
+      (id, dist, newDist) =>{
+        math.min(dist, newDist); // Vertex Program
+      },
+      triplet => {  // Send Message
+        if (triplet.srcAttr + triplet.attr < triplet.dstAttr) {
+          Iterator((triplet.dstId, triplet.srcAttr + triplet.attr))
+        } else {
+          Iterator.empty
+        }
+      },
+      (a, b) => math.min(a, b) // Merge Message
+    ).cache()
+    log.info(s"initial graph count ${sssp.numVertices}, ${sssp.numEdges}")
+    val time2 = System.nanoTime()
+    log.info(s"Pregel took ${(time2 - time1)/1000000}ms, map load graph ${(time1 - time0)/1000000}ms")
+
+    spark.close()
+  }
+}

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/PageRankTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/PageRankTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.graphx.Graph
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+object PageRankTest extends Logging{
+  def main(args: Array[String]): Unit = {
+    // Creates a SparkSession.
+    val spark = GSSparkSession
+      .builder
+      .appName(s"${this.getClass.getSimpleName}")
+      .getOrCreate()
+    val sc = spark.sparkContext
+    if (args.length < 3) {
+      println("Expect 4 args")
+      return 0;
+    }
+    val efile = args(0)
+    val partNum = args(1).toInt
+    val engine = args(2)
+    val time0 = System.nanoTime()
+
+    val orcRDD = spark.read.option("inferSchema",true).orc(efile).rdd.map(row => (row.get(0).asInstanceOf[Long], row.get(1).asInstanceOf[Long]))
+
+    val graph: Graph[Int, Double] = {
+      if (engine.equals("gs")) {
+        spark.fromLineRDD(orcRDD, partNum).mapEdges(e => e.attr.toDouble).cache()
+      }
+      else if (engine.equals("graphx")){
+        //graphx has no variant of edges.
+        val orcRDD2 = orcRDD.coalesce(partNum)
+        Graph.fromEdgeTuples(orcRDD2,1).mapEdges(e => e.attr.toDouble).cache()
+      }
+      else {
+        throw new IllegalStateException("gs or graphx")
+      }
+    }
+    // Initialize the graph such that all vertices except the root have distance infinity.
+    log.info(s"initial graph count ${graph.numVertices}, ${graph.numEdges}")
+    val time1 = System.nanoTime()
+
+    val pagerank = graph.pageRank(0.001).cache()
+
+    log.info(s"pagerank graph count ${graph.numVertices}, ${graph.numEdges}")
+    val time2 = System.nanoTime()
+    log.info(s"Pregel took ${(time2 - time1)/1000000}ms, load graph ${(time1 - time0)/1000000}ms")
+
+    spark.stop()
+
+  }
+}

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/StringVEDTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/StringVEDTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.graphx.{Graph, GraphLoader}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+
+object StringVEDTest extends Logging{
+  def main(args: Array[String]) : Unit = {
+    val spark = SparkSession
+      .builder
+      .appName(s"${this.getClass.getSimpleName}")
+      .getOrCreate()
+    val sc = spark.sparkContext
+    if (args.length < 2) {
+      println("Expect 1 args")
+      return 0;
+    }
+    val eFilePath = args(0);
+    val numPartitions = args(1).toInt;
+
+    val graph : Graph[Long,Long] = GraphLoader.edgeListFile(sc, eFilePath, false, numEdgePartitions = numPartitions).mapVertices((id,vd)=>vd.toLong).mapEdges(edge=>edge.attr.toLong).cache()
+    val graph2 = graph.mapVertices((id,vd) => id).mapVertices((id,vd)=>(vd,vd))
+    val graph3 = graph2.mapEdges(edge => (edge.srcId,edge.dstId))
+    val res = graph3.pregel((5L,5L), maxIterations = 10)(
+      (id, dist, newDist) => {
+        log.info(s"visiting vertex ${id}(${dist}), new dist${newDist}")
+        newDist
+      },
+      triplet => { // Send Message
+        log.info(s"visiting triplet ${triplet.srcId}(${triplet.srcAttr}) -> ${triplet.dstId}(${triplet.dstAttr}), attr ${triplet.attr}")
+        Iterator((triplet.dstId, (2L,2L)))
+      },
+      (a, b) => (Math.min(a._1,b._1),Math.max(a._2,b._2)) // Merge Message
+    )
+    sc.stop()
+  }
+}

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/TraverseTest.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/TraverseTest.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.graphx.{Graph, GraphLoader}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+
+object TraverseTest extends Logging{
+  def main(array: Array[String]) : Unit = {
+    val spark = SparkSession
+      .builder
+      .appName(s"${this.getClass.getSimpleName}")
+      .getOrCreate()
+    val sc = spark.sparkContext
+
+
+    val graph : Graph[Long,Long] = GraphLoader.edgeListFile(sc, "/home/graphscope/data/lei.e", false, numEdgePartitions = 1).mapVertices((id,vd)=>vd.toLong).mapEdges(edge=>edge.attr.toLong).cache()
+    val graph2 = graph.mapVertices((id,vd) => (vd,vd))
+    val graph3 = graph2.mapEdges(edge => edge.attr + 10L)
+    val res = graph3.pregel(1L, maxIterations = 10)(
+      (id, dist, newDist) => (newDist,newDist),
+      triplet => { // Send Message
+        log.info(s"visiting triplet ${triplet.srcId}(${triplet.srcAttr}) -> ${triplet.dstId}(${triplet.dstAttr}), attr ${triplet.attr}")
+        Iterator.empty
+      },
+      (a, b) => math.min(a, b) // Merge Message
+    )
+    sc.stop()
+  }
+}

--- a/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/TriangleCount.scala
+++ b/analytical_engine/java/grape-demo/src/main/scala/com/alibaba/graphscope/example/graphx/TriangleCount.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.example.graphx
+
+import org.apache.spark.graphx.{Graph, GraphLoader}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.SparkSession
+
+object TriangleCount extends Logging{
+  def main(args: Array[String]): Unit = {
+    // Creates a SparkSession.
+    val spark = SparkSession
+      .builder
+      .appName(s"${this.getClass.getSimpleName}")
+      .getOrCreate()
+    val sc = spark.sparkContext
+    if (args.length < 2) {
+      println("Expect 1 args")
+      return 0;
+    }
+    val efile = args(0)
+    val partNum = args(1).toInt
+    val graph: Graph[Int, Int] =
+      GraphLoader.edgeListFile(sc, efile,canonicalOrientation = false, partNum)
+    // Initialize the graph such that all vertices except the root have distance infinity.
+    val triCounts = graph.triangleCount().vertices
+    triCounts.saveAsTextFile(s"/tmp/triCounts-${java.time.LocalDateTime.now()}")
+    spark.stop()
+  }
+}

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -25,7 +25,7 @@
 
   <artifactId>grape-jdk</artifactId>
   <packaging>jar</packaging>
-  <name>grape-jdk</name>
+  <name>Grape JDK</name>
 
   <properties>
     <jacoco.version>0.8.7</jacoco.version>
@@ -65,6 +65,10 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
     </dependency>
   </dependencies>
 

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/context/ffi/FFIVertexDataContext.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/context/ffi/FFIVertexDataContext.java
@@ -18,6 +18,7 @@ package com.alibaba.graphscope.context.ffi;
 
 import static com.alibaba.graphscope.utils.CppClassName.VERTEX_DATA_CONTEXT;
 import static com.alibaba.graphscope.utils.CppHeaderName.ARROW_PROJECTED_FRAGMENT_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H;
 
 import com.alibaba.fastffi.CXXHead;
 import com.alibaba.fastffi.CXXReference;
@@ -32,6 +33,7 @@ import com.alibaba.graphscope.utils.JNILibraryName;
 @FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
 @CXXHead(CppHeaderName.VERTEX_DATA_CONTEXT_H)
 @CXXHead(ARROW_PROJECTED_FRAGMENT_H)
+@CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
 @FFITypeAlias(VERTEX_DATA_CONTEXT)
 public interface FFIVertexDataContext<FRAG_T, DATA_T> extends FFIPointer {
 

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/ds/ImmutableCSR.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/ds/ImmutableCSR.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.ds;
+
+import static com.alibaba.graphscope.utils.CppClassName.GS_DEFAULT_IMMUTABLE_CSR;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_TYPE_ALIAS_H;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CORE_JAVA_TYPE_ALIAS_H)
+@CXXHead(system = "cstdint")
+@FFITypeAlias(GS_DEFAULT_IMMUTABLE_CSR)
+public interface ImmutableCSR<VID_T, ED> extends FFIPointer { // grape::Nbr
+
+    @FFINameAlias("vertex_num")
+    VID_T vertexNum();
+
+    @FFINameAlias("edge_num")
+    long edgeNum();
+
+    @FFINameAlias("degree")
+    int degree(VID_T lid);
+
+    @FFINameAlias("is_empty")
+    boolean isEmpty(VID_T lid);
+
+    @FFINameAlias("get_begin")
+    GrapeNbr<VID_T, ED> getBegin(VID_T lid);
+
+    @FFINameAlias("get_end")
+    GrapeNbr<VID_T, ED> getEnd(VID_T lid);
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/ArrowFragmentGroupGetter.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/ArrowFragmentGroupGetter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.graphx.VineyardClient;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_FRAGMENT_GETTER_H)
+@CXXHead(system = {"stdint.h", "memory"})
+@CXXHead(CppHeaderName.ARROW_FRAGMENT_GROUP_H)
+@CXXHead(CppHeaderName.VINEYARD_CLIENT_H)
+@FFITypeAlias(CppClassName.ARROW_FRAGMENT_GROUP_GETTER)
+public interface ArrowFragmentGroupGetter extends FFIPointer {
+
+    @FFINameAlias("Get")
+    @CXXValue
+    @FFITypeAlias("std::shared_ptr<vineyard::ArrowFragmentGroup>")
+    StdSharedPtr<ArrowFragmentGroup> get(@CXXReference VineyardClient client, long groupId);
+
+    @FFIFactory
+    interface Factory {
+
+        ArrowFragmentGroupGetter create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/ArrowProjectedFragmentGetter.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/ArrowProjectedFragmentGetter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.graphx.VineyardClient;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.ARROW_FRAGMENT_H)
+@CXXHead(CppHeaderName.CORE_JAVA_FRAGMENT_GETTER_H)
+@FFITypeAlias(CppClassName.GS_ARROW_PROJECTED_FRAGMENT_GETTER)
+public interface ArrowProjectedFragmentGetter<OID, VID, VD, ED> extends FFIPointer {
+
+    @FFINameAlias("Get")
+    @CXXValue
+    StdSharedPtr<ArrowProjectedFragment<OID, VID, VD, ED>> get(
+            @CXXReference VineyardClient client, long objectID);
+
+    @FFIFactory
+    interface Factory<OID, VID, VD, ED> {
+        ArrowProjectedFragmentGetter<OID, VID, VD, ED> create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/ArrowProjectedFragmentMapper.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/ArrowProjectedFragmentMapper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment;
+
+import static com.alibaba.graphscope.utils.CppClassName.ARROW_PROJECTED_FRAGMENT_MAPPER;
+import static com.alibaba.graphscope.utils.CppHeaderName.ARROW_PROJECTED_FRAGMENT_MAPPER_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_TYPE_ALIAS_H;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.arrow.array.ArrowArrayBuilder;
+import com.alibaba.graphscope.graphx.VineyardClient;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(ARROW_PROJECTED_FRAGMENT_MAPPER_H)
+@CXXHead(CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(ARROW_PROJECTED_FRAGMENT_MAPPER)
+public interface ArrowProjectedFragmentMapper<OID_T, VID_T, OLD_V_T, NEW_V_T, OLD_E_T, NEW_E_T>
+        extends FFIPointer {
+
+    @FFINameAlias("Map")
+    @CXXValue
+    StdSharedPtr<ArrowProjectedFragment<OID_T, VID_T, NEW_V_T, NEW_E_T>> map(
+            @CXXReference ArrowProjectedFragment<OID_T, VID_T, OLD_V_T, OLD_E_T> oldFrag,
+            @CXXReference ArrowArrayBuilder<NEW_V_T> vdBuilder,
+            @CXXReference ArrowArrayBuilder<NEW_E_T> edBuilder,
+            @CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<OID_T, VID_T, OLD_V_T, NEW_V_T, OLD_E_T, NEW_E_T> {
+
+        ArrowProjectedFragmentMapper<OID_T, VID_T, OLD_V_T, NEW_V_T, OLD_E_T, NEW_E_T> create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/BaseGraphXFragment.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/BaseGraphXFragment.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment;
+
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.graphscope.ds.PropertyNbrUnit;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.graphx.GraphXCSR;
+import com.alibaba.graphscope.graphx.GraphXVertexMap;
+
+public interface BaseGraphXFragment<OID_T, VID_T, VD_T, ED_T>
+        extends EdgecutFragment<OID_T, VID_T, VD_T, ED_T> {
+
+    long id();
+
+    @FFINameAlias("GetIEBegin")
+    PropertyNbrUnit<VID_T> getIEBegin(@CXXReference Vertex<VID_T> vertex);
+
+    @FFINameAlias("GetIEEnd")
+    PropertyNbrUnit<VID_T> getIEEnd(@CXXReference Vertex<VID_T> vertex);
+
+    @FFINameAlias("GetOEBegin")
+    PropertyNbrUnit<VID_T> getOEBegin(@CXXReference Vertex<VID_T> vertex);
+
+    @FFINameAlias("GetOEEnd")
+    PropertyNbrUnit<VID_T> getOEEnd(@CXXReference Vertex<VID_T> vertex);
+
+    @FFINameAlias("GetCSR")
+    @CXXReference
+    GraphXCSR<VID_T> getCSR();
+
+    @FFINameAlias("GetVM")
+    @CXXReference
+    GraphXVertexMap<OID_T, VID_T> getVM();
+
+    @FFINameAlias("GetInEdgeNum")
+    long getInEdgeNum();
+
+    @FFINameAlias("GetOutEdgeNum")
+    long getOutEdgeNum();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/FragmentType.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/FragmentType.java
@@ -19,5 +19,9 @@ package com.alibaba.graphscope.fragment;
 public enum FragmentType {
     ArrowFragment,
     ArrowProjectedFragment,
+    GraphXFragment,
+    GraphXStringVDFragment,
+    GraphXStringEDFragment,
+    GraphXStringVEDFragment,
     ImmutableEdgecutFragment
 }

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/GraphXFragment.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/GraphXFragment.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment;
+
+import static com.alibaba.graphscope.utils.CppClassName.GRAPHX_FRAGMENT;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+/**
+ * We extend Immutable edgecut fragment just to reuse the interface, no annotations should be
+ * inherited.
+ */
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
+@CXXHead(system = "stdint.h")
+@FFITypeAlias(GRAPHX_FRAGMENT)
+public interface GraphXFragment<OID_T, VID_T, VD_T, ED_T>
+        extends BaseGraphXFragment<OID_T, VID_T, VD_T, ED_T> {
+
+    @FFINameAlias("GetEdataArray")
+    @CXXReference
+    TypedArray<ED_T> getEdataArray();
+
+    @FFINameAlias("GetVdataArray")
+    @CXXReference
+    TypedArray<VD_T> getVdataArray();
+
+    @FFINameAlias("GetData")
+    @CXXReference
+    VD_T getData(@CXXReference Vertex<VID_T> vertex);
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/GraphXStringEDFragment.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/GraphXStringEDFragment.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment;
+
+import static com.alibaba.graphscope.utils.CppClassName.GRAPHX_FRAGMENT;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.StringTypedArray;
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
+@CXXHead(system = "stdint.h")
+@FFITypeAlias(GRAPHX_FRAGMENT)
+public interface GraphXStringEDFragment<OID_T, VID_T, VD_T, ED_T>
+        extends BaseGraphXFragment<OID_T, VID_T, VD_T, ED_T> {
+
+    @FFINameAlias("GetEdataArray")
+    @CXXReference
+    StringTypedArray getEdataArray();
+
+    @FFINameAlias("GetVdataArray")
+    @CXXReference
+    TypedArray<VD_T> getVdataArray();
+
+    @FFINameAlias("GetData")
+    @CXXReference
+    VD_T getData(@CXXReference Vertex<VID_T> vertex);
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/GraphXStringVDFragment.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/GraphXStringVDFragment.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment;
+
+import static com.alibaba.graphscope.utils.CppClassName.GRAPHX_FRAGMENT;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.StringTypedArray;
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
+@CXXHead(system = "stdint.h")
+@FFITypeAlias(GRAPHX_FRAGMENT)
+public interface GraphXStringVDFragment<OID_T, VID_T, VD_T, ED_T>
+        extends BaseGraphXFragment<OID_T, VID_T, VD_T, ED_T> {
+
+    @FFINameAlias("GetEdataArray")
+    @CXXReference
+    TypedArray<ED_T> getEdataArray();
+
+    @FFINameAlias("GetVdataArray")
+    @CXXReference
+    StringTypedArray getVdataArray();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/GraphXStringVEDFragment.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/GraphXStringVEDFragment.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment;
+
+import static com.alibaba.graphscope.utils.CppClassName.GRAPHX_FRAGMENT;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.StringTypedArray;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
+@CXXHead(system = "stdint.h")
+@FFITypeAlias(GRAPHX_FRAGMENT)
+public interface GraphXStringVEDFragment<OID_T, VID_T, VD_T, ED_T>
+        extends BaseGraphXFragment<OID_T, VID_T, VD_T, ED_T> {
+
+    @FFINameAlias("GetEdataArray")
+    @CXXReference
+    StringTypedArray getEdataArray();
+
+    @FFINameAlias("GetVdataArray")
+    @CXXReference
+    StringTypedArray getVdataArray();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/AbstractGraphXFragmentAdaptor.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/AbstractGraphXFragmentAdaptor.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment.adaptor;
+
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.ds.VertexRange;
+import com.alibaba.graphscope.ds.adaptor.AdjList;
+import com.alibaba.graphscope.fragment.EdgecutFragment;
+import com.alibaba.graphscope.fragment.IFragment;
+
+public abstract class AbstractGraphXFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T>
+        implements IFragment<OID_T, VID_T, VDATA_T, EDATA_T> {
+
+    private EdgecutFragment<OID_T, VID_T, VDATA_T, EDATA_T> edgecutFragment;
+
+    public AbstractGraphXFragmentAdaptor(EdgecutFragment<OID_T, VID_T, VDATA_T, EDATA_T> fragment) {
+        this.edgecutFragment = fragment;
+    }
+
+    /**
+     * Get the actual fragment FFIPointer we are using.
+     *
+     * @return a ffipointer
+     */
+    @Override
+    public FFIPointer getFFIPointer() {
+        return edgecutFragment;
+    }
+
+    /**
+     * @return The id of current fragment.
+     */
+    @Override
+    public int fid() {
+        return edgecutFragment.fid();
+    }
+
+    /**
+     * Number of fragments.
+     *
+     * @return number of fragments.
+     */
+    @Override
+    public int fnum() {
+        return edgecutFragment.fnum();
+    }
+
+    /**
+     * Returns the number of edges in this fragment.
+     *
+     * @return the number of edges in this fragment.
+     */
+    @Override
+    public long getEdgeNum() {
+        return edgecutFragment.getEdgeNum();
+    }
+
+    /**
+     * Returns the number of vertices in this fragment.
+     *
+     * @return the number of vertices in this fragment.
+     */
+    @Override
+    public VID_T getVerticesNum() {
+        return edgecutFragment.getVerticesNum();
+    }
+
+    /**
+     * Returns the number of vertices in the entire graph.
+     *
+     * @return The number of vertices in the entire graph.
+     */
+    @Override
+    public long getTotalVerticesNum() {
+        return edgecutFragment.getTotalVerticesNum();
+    }
+
+    /**
+     * Get all vertices referenced to this fragment.
+     *
+     * @return A vertex set can be iterate on.
+     */
+    @Override
+    public VertexRange<VID_T> vertices() {
+        return edgecutFragment.vertices();
+    }
+
+    /**
+     * Get the vertex handle from the original id.
+     *
+     * @param oid    input original id.
+     * @param vertex output vertex handle
+     * @return If find the vertex in this fragment, return true. Otherwise, return false.
+     */
+    @Override
+    public boolean getVertex(OID_T oid, Vertex<VID_T> vertex) {
+        return edgecutFragment.getVertex(oid, vertex);
+    }
+
+    /**
+     * Get the original Id of a vertex.
+     *
+     * @param vertex querying vertex.
+     * @return original id.
+     */
+    @Override
+    public OID_T getId(Vertex<VID_T> vertex) {
+        return edgecutFragment.getId(vertex);
+    }
+
+    /**
+     * To which fragment the vertex belongs.
+     *
+     * @param vertex querying vertex.
+     * @return frag id.
+     */
+    @Override
+    public int getFragId(Vertex<VID_T> vertex) {
+        return edgecutFragment.getFragId(vertex);
+    }
+
+    @Override
+    public int getLocalInDegree(Vertex<VID_T> vertex) {
+        return edgecutFragment.getLocalInDegree(vertex);
+    }
+
+    @Override
+    public int getLocalOutDegree(Vertex<VID_T> vertex) {
+        return edgecutFragment.getLocalOutDegree(vertex);
+    }
+
+    @Override
+    public boolean gid2Vertex(VID_T gid, Vertex<VID_T> vertex) {
+        return edgecutFragment.gid2Vertex(gid, vertex);
+    }
+
+    @Override
+    public VID_T vertex2Gid(Vertex<VID_T> vertex) {
+        return edgecutFragment.vertex2Gid(vertex);
+    }
+
+    /**
+     * Get the number of inner vertices.
+     *
+     * @return number of inner vertices.
+     */
+    @Override
+    public long getInnerVerticesNum() {
+        return edgecutFragment.getInnerVerticesNum();
+    }
+
+    /**
+     * Get the number of outer vertices.
+     *
+     * @return umber of outer vertices.
+     */
+    @Override
+    public long getOuterVerticesNum() {
+        return edgecutFragment.getOuterVerticesNum();
+    }
+
+    /**
+     * Obtain vertex range contains all inner vertices.
+     *
+     * @return vertex range.
+     */
+    @Override
+    public VertexRange<VID_T> innerVertices() {
+        return edgecutFragment.innerVertices();
+    }
+
+    /**
+     * Obtain vertex range contains all outer vertices.
+     *
+     * @return vertex range.
+     */
+    @Override
+    public VertexRange<VID_T> outerVertices() {
+        return edgecutFragment.outerVertices();
+    }
+
+    /**
+     * Check whether a vertex is a inner vertex for a fragment.
+     *
+     * @param vertex querying vertex.
+     * @return true if is inner vertex.
+     */
+    @Override
+    public boolean isInnerVertex(Vertex<VID_T> vertex) {
+        return edgecutFragment.isInnerVertex(vertex);
+    }
+
+    /**
+     * Check whether a vertex is a outer vertex for a fragment.
+     *
+     * @param vertex querying vertex.
+     * @return true if is outer vertex.
+     */
+    @Override
+    public boolean isOuterVertex(Vertex<VID_T> vertex) {
+        return edgecutFragment.isOuterVertex(vertex);
+    }
+
+    /**
+     * Check whether a vertex, represented in OID_T, is a inner vertex. If yes, if true and put
+     * inner representation id in the second param. Else return false.
+     *
+     * @param oid    querying vertex in OID_T.
+     * @param vertex placeholder for VID_T, if oid belongs to this fragment.
+     * @return inner vertex or not.
+     */
+    @Override
+    public boolean getInnerVertex(OID_T oid, Vertex<VID_T> vertex) {
+        return edgecutFragment.getInnerVertex(oid, vertex);
+    }
+
+    /**
+     * Check whether a vertex, represented in OID_T, is a outer vertex. If yes, if true and put
+     * outer representation id in the second param. Else return false.
+     *
+     * @param oid    querying vertex in OID_T.
+     * @param vertex placeholder for VID_T, if oid doesn't belong to this fragment.
+     * @return outer vertex or not.
+     */
+    @Override
+    public boolean getOuterVertex(OID_T oid, Vertex<VID_T> vertex) {
+        return edgecutFragment.getOuterVertex(oid, vertex);
+    }
+
+    /**
+     * Obtain vertex id from original id, only for inner vertex.
+     *
+     * @param vertex querying vertex.
+     * @return original id.
+     */
+    @Override
+    public OID_T getInnerVertexId(Vertex<VID_T> vertex) {
+        return edgecutFragment.getInnerVertexId(vertex);
+    }
+
+    /**
+     * Obtain vertex id from original id, only for outer vertex.
+     *
+     * @param vertex querying vertex.
+     * @return original id.
+     */
+    @Override
+    public OID_T getOuterVertexId(Vertex<VID_T> vertex) {
+        return edgecutFragment.getOuterVertexId(vertex);
+    }
+
+    /**
+     * Convert from global id to an inner vertex handle.
+     *
+     * @param gid    Input global id.
+     * @param vertex Output vertex handle.
+     * @return True if exists an inner vertex of this fragment with global id as gid, false
+     * otherwise.
+     */
+    @Override
+    public boolean innerVertexGid2Vertex(VID_T gid, Vertex<VID_T> vertex) {
+        return edgecutFragment.innerVertexGid2Vertex(gid, vertex);
+    }
+
+    /**
+     * Convert from global id to an outer vertex handle.
+     *
+     * @param gid    Input global id.
+     * @param vertex Output vertex handle.
+     * @return True if exists an outer vertex of this fragment with global id as gid, false
+     * otherwise.
+     */
+    @Override
+    public boolean outerVertexGid2Vertex(VID_T gid, Vertex<VID_T> vertex) {
+        return edgecutFragment.outerVertexGid2Vertex(gid, vertex);
+    }
+
+    /**
+     * Convert from inner vertex handle to its global id.
+     *
+     * @param vertex Input vertex handle.
+     * @return Global id of the vertex.
+     */
+    @Override
+    public VID_T getOuterVertexGid(Vertex<VID_T> vertex) {
+        return edgecutFragment.getOuterVertexGid(vertex);
+    }
+
+    /**
+     * Convert from outer vertex handle to its global id.
+     *
+     * @param vertex Input vertex handle.
+     * @return Global id of the vertex.
+     */
+    @Override
+    public VID_T getInnerVertexGid(Vertex<VID_T> vertex) {
+        return edgecutFragment.getInnerVertexGid(vertex);
+    }
+
+    /**
+     * Return the incoming edge destination fragment ID list of a inner vertex.
+     *
+     * <p>For inner vertex v of fragment-0, if outer vertex u and w are parents of v. u belongs to
+     * fragment-1 and w belongs to fragment-2, then 1 and 2 are in incoming edge destination
+     * fragment ID list of v.
+     *
+     * <p>This method is encapsulated in the corresponding sending message API,
+     * SendMsgThroughIEdges, so it is not recommended to use this method directly in application
+     * programs.
+     *
+     * @param vertex Input vertex.
+     * @return The incoming edge destination fragment ID list.
+     */
+
+    /**
+     * Return the outgoing edge destination fragment ID list of a inner vertex.
+     *
+     * <p>For inner vertex v of fragment-0, if outer vertex u and w are children of v. u belongs to
+     * fragment-1 and w belongs to fragment-2, then 1 and 2 are in outgoing edge destination
+     * fragment ID list of v.
+     *
+     * <p>This method is encapsulated in the corresponding sending message API,
+     * SendMsgThroughOEdges, so it is not recommended to use this method directly in application
+     * programs.
+     *
+     * @param vertex Input vertex.
+     * @return The outgoing edge destination fragment ID list.
+     */
+
+    /**
+     * Get both the in edges and out edges.
+     *
+     * @param vertex query vertex.
+     * @return The outgoing and incoming edge destination fragment ID list.
+     */
+    @Override
+    public AdjList<VID_T, EDATA_T> getIncomingAdjList(Vertex<VID_T> vertex) {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public AdjList<VID_T, EDATA_T> getOutgoingAdjList(Vertex<VID_T> vertex) {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    /**
+     * Update vertex data with a new value.
+     *
+     * @param vertex querying vertex.
+     * @param vdata  new vertex data.
+     */
+    @Override
+    public void setData(Vertex<VID_T> vertex, VDATA_T vdata) {
+        throw new IllegalStateException("Not implemented");
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/GraphXFragmentAdaptor.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/GraphXFragmentAdaptor.java
@@ -1,0 +1,412 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment.adaptor;
+
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.ds.VertexRange;
+import com.alibaba.graphscope.ds.adaptor.AdjList;
+import com.alibaba.graphscope.fragment.FragmentType;
+import com.alibaba.graphscope.fragment.GraphXFragment;
+import com.alibaba.graphscope.fragment.IFragment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GraphXFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T>
+        implements IFragment<OID_T, VID_T, VDATA_T, EDATA_T> {
+
+    private static Logger logger = LoggerFactory.getLogger(GraphXFragmentAdaptor.class.getName());
+
+    private GraphXFragment<OID_T, VID_T, VDATA_T, EDATA_T> fragment;
+
+    public GraphXFragmentAdaptor(GraphXFragment<OID_T, VID_T, VDATA_T, EDATA_T> fragment) {
+        this.fragment = fragment;
+    }
+
+    public GraphXFragment<OID_T, VID_T, VDATA_T, EDATA_T> getFragment() {
+        return fragment;
+    }
+
+    /**
+     * Return the underlying fragment type,i.e. ArrowProjected or Simple.
+     *
+     * @return underlying fragment type.
+     */
+    @Override
+    public FragmentType fragmentType() {
+        return FragmentType.GraphXFragment;
+    }
+
+    /**
+     * Get the actual fragment FFIPointer we are using.
+     *
+     * @return a ffipointer
+     */
+    @Override
+    public FFIPointer getFFIPointer() {
+        return fragment;
+    }
+
+    /**
+     * @return The id of current fragment.
+     */
+    @Override
+    public int fid() {
+        return fragment.fid();
+    }
+
+    /**
+     * Number of fragments.
+     *
+     * @return number of fragments.
+     */
+    @Override
+    public int fnum() {
+        return fragment.fnum();
+    }
+
+    /**
+     * Returns the number of edges in this fragment.
+     *
+     * @return the number of edges in this fragment.
+     */
+    @Override
+    public long getEdgeNum() {
+        return fragment.getEdgeNum();
+    }
+
+    @Override
+    public long getInEdgeNum() {
+        return fragment.getInEdgeNum();
+    }
+
+    @Override
+    public long getOutEdgeNum() {
+        return fragment.getOutEdgeNum();
+    }
+
+    /**
+     * Returns the number of vertices in this fragment.
+     *
+     * @return the number of vertices in this fragment.
+     */
+    @Override
+    public VID_T getVerticesNum() {
+        return fragment.getVerticesNum();
+    }
+
+    /**
+     * Returns the number of vertices in the entire graph.
+     *
+     * @return The number of vertices in the entire graph.
+     */
+    @Override
+    public long getTotalVerticesNum() {
+        return fragment.getTotalVerticesNum();
+    }
+
+    /**
+     * Get all vertices referenced to this fragment.
+     *
+     * @return A vertex set can be iterate on.
+     */
+    @Override
+    public VertexRange<VID_T> vertices() {
+        return fragment.vertices();
+    }
+
+    /**
+     * Get the vertex handle from the original id.
+     *
+     * @param oid    input original id.
+     * @param vertex output vertex handle
+     * @return If find the vertex in this fragment, return true. Otherwise, return false.
+     */
+    @Override
+    public boolean getVertex(OID_T oid, Vertex<VID_T> vertex) {
+        return fragment.getVertex(oid, vertex);
+    }
+
+    /**
+     * Get the original Id of a vertex.
+     *
+     * @param vertex querying vertex.
+     * @return original id.
+     */
+    @Override
+    public OID_T getId(Vertex<VID_T> vertex) {
+        return fragment.getId(vertex);
+    }
+
+    /**
+     * To which fragment the vertex belongs.
+     *
+     * @param vertex querying vertex.
+     * @return frag id.
+     */
+    @Override
+    public int getFragId(Vertex<VID_T> vertex) {
+        return fragment.getFragId(vertex);
+    }
+
+    @Override
+    public int getLocalInDegree(Vertex<VID_T> vertex) {
+        return fragment.getLocalInDegree(vertex);
+    }
+
+    @Override
+    public int getLocalOutDegree(Vertex<VID_T> vertex) {
+        return fragment.getLocalOutDegree(vertex);
+    }
+
+    @Override
+    public boolean gid2Vertex(VID_T gid, Vertex<VID_T> vertex) {
+        return fragment.gid2Vertex(gid, vertex);
+    }
+
+    @Override
+    public VID_T vertex2Gid(Vertex<VID_T> vertex) {
+        return fragment.vertex2Gid(vertex);
+    }
+
+    /**
+     * Get the number of inner vertices.
+     *
+     * @return number of inner vertices.
+     */
+    @Override
+    public long getInnerVerticesNum() {
+        return fragment.getInnerVerticesNum();
+    }
+
+    /**
+     * Get the number of outer vertices.
+     *
+     * @return umber of outer vertices.
+     */
+    @Override
+    public long getOuterVerticesNum() {
+        return fragment.getOuterVerticesNum();
+    }
+
+    /**
+     * Obtain vertex range contains all inner vertices.
+     *
+     * @return vertex range.
+     */
+    @Override
+    public VertexRange<VID_T> innerVertices() {
+        return fragment.innerVertices();
+    }
+
+    /**
+     * Obtain vertex range contains all outer vertices.
+     *
+     * @return vertex range.
+     */
+    @Override
+    public VertexRange<VID_T> outerVertices() {
+        return fragment.outerVertices();
+    }
+
+    /**
+     * Check whether a vertex is a inner vertex for a fragment.
+     *
+     * @param vertex querying vertex.
+     * @return true if is inner vertex.
+     */
+    @Override
+    public boolean isInnerVertex(Vertex<VID_T> vertex) {
+        return fragment.isInnerVertex(vertex);
+    }
+
+    /**
+     * Check whether a vertex is a outer vertex for a fragment.
+     *
+     * @param vertex querying vertex.
+     * @return true if is outer vertex.
+     */
+    @Override
+    public boolean isOuterVertex(Vertex<VID_T> vertex) {
+        return fragment.isOuterVertex(vertex);
+    }
+
+    /**
+     * Check whether a vertex, represented in OID_T, is a inner vertex. If yes, if true and put
+     * inner representation id in the second param. Else return false.
+     *
+     * @param oid    querying vertex in OID_T.
+     * @param vertex placeholder for VID_T, if oid belongs to this fragment.
+     * @return inner vertex or not.
+     */
+    @Override
+    public boolean getInnerVertex(OID_T oid, Vertex<VID_T> vertex) {
+        return fragment.getInnerVertex(oid, vertex);
+    }
+
+    /**
+     * Check whether a vertex, represented in OID_T, is a outer vertex. If yes, if true and put
+     * outer representation id in the second param. Else return false.
+     *
+     * @param oid    querying vertex in OID_T.
+     * @param vertex placeholder for VID_T, if oid doesn't belong to this fragment.
+     * @return outer vertex or not.
+     */
+    @Override
+    public boolean getOuterVertex(OID_T oid, Vertex<VID_T> vertex) {
+        return fragment.getOuterVertex(oid, vertex);
+    }
+
+    /**
+     * Obtain vertex id from original id, only for inner vertex.
+     *
+     * @param vertex querying vertex.
+     * @return original id.
+     */
+    @Override
+    public OID_T getInnerVertexId(Vertex<VID_T> vertex) {
+        return fragment.getInnerVertexId(vertex);
+    }
+
+    /**
+     * Obtain vertex id from original id, only for outer vertex.
+     *
+     * @param vertex querying vertex.
+     * @return original id.
+     */
+    @Override
+    public OID_T getOuterVertexId(Vertex<VID_T> vertex) {
+        return fragment.getOuterVertexId(vertex);
+    }
+
+    /**
+     * Convert from global id to an inner vertex handle.
+     *
+     * @param gid    Input global id.
+     * @param vertex Output vertex handle.
+     * @return True if exists an inner vertex of this fragment with global id as gid, false
+     * otherwise.
+     */
+    @Override
+    public boolean innerVertexGid2Vertex(VID_T gid, Vertex<VID_T> vertex) {
+        return fragment.innerVertexGid2Vertex(gid, vertex);
+    }
+
+    /**
+     * Convert from global id to an outer vertex handle.
+     *
+     * @param gid    Input global id.
+     * @param vertex Output vertex handle.
+     * @return True if exists an outer vertex of this fragment with global id as gid, false
+     * otherwise.
+     */
+    @Override
+    public boolean outerVertexGid2Vertex(VID_T gid, Vertex<VID_T> vertex) {
+        return fragment.outerVertexGid2Vertex(gid, vertex);
+    }
+
+    /**
+     * Convert from inner vertex handle to its global id.
+     *
+     * @param vertex Input vertex handle.
+     * @return Global id of the vertex.
+     */
+    @Override
+    public VID_T getOuterVertexGid(Vertex<VID_T> vertex) {
+        return fragment.getOuterVertexGid(vertex);
+    }
+
+    /**
+     * Convert from outer vertex handle to its global id.
+     *
+     * @param vertex Input vertex handle.
+     * @return Global id of the vertex.
+     */
+    @Override
+    public VID_T getInnerVertexGid(Vertex<VID_T> vertex) {
+        return fragment.getInnerVertexGid(vertex);
+    }
+
+    /**
+     * Return the incoming edge destination fragment ID list of a inner vertex.
+     *
+     * <p>For inner vertex v of fragment-0, if outer vertex u and w are parents of v. u belongs to
+     * fragment-1 and w belongs to fragment-2, then 1 and 2 are in incoming edge destination
+     * fragment ID list of v.
+     *
+     * <p>This method is encapsulated in the corresponding sending message API,
+     * SendMsgThroughIEdges, so it is not recommended to use this method directly in application
+     * programs.
+     *
+     * @param vertex Input vertex.
+     * @return The incoming edge destination fragment ID list.
+     */
+
+    /**
+     * Return the outgoing edge destination fragment ID list of a inner vertex.
+     *
+     * <p>For inner vertex v of fragment-0, if outer vertex u and w are children of v. u belongs to
+     * fragment-1 and w belongs to fragment-2, then 1 and 2 are in outgoing edge destination
+     * fragment ID list of v.
+     *
+     * <p>This method is encapsulated in the corresponding sending message API,
+     * SendMsgThroughOEdges, so it is not recommended to use this method directly in application
+     * programs.
+     *
+     * @param vertex Input vertex.
+     * @return The outgoing edge destination fragment ID list.
+     */
+
+    /**
+     * Get both the in edges and out edges.
+     *
+     * @param vertex query vertex.
+     * @return The outgoing and incoming edge destination fragment ID list.
+     */
+    @Override
+    public AdjList<VID_T, EDATA_T> getIncomingAdjList(Vertex<VID_T> vertex) {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public AdjList<VID_T, EDATA_T> getOutgoingAdjList(Vertex<VID_T> vertex) {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    /**
+     * Get the data on vertex.
+     *
+     * @param vertex querying vertex.
+     * @return vertex data
+     */
+    @Override
+    public VDATA_T getData(Vertex<VID_T> vertex) {
+        return fragment.getData(vertex);
+    }
+
+    /**
+     * Update vertex data with a new value.
+     *
+     * @param vertex querying vertex.
+     * @param vdata  new vertex data.
+     */
+    @Override
+    public void setData(Vertex<VID_T> vertex, VDATA_T vdata) {
+        throw new IllegalStateException("Not implemented");
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/GraphXStringEDFragmentAdaptor.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/GraphXStringEDFragmentAdaptor.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment.adaptor;
+
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.FragmentType;
+import com.alibaba.graphscope.fragment.GraphXStringEDFragment;
+
+public class GraphXStringEDFragmentAdaptor<OID_T, VID_T, VD_T, ED_T>
+        extends AbstractGraphXFragmentAdaptor<OID_T, VID_T, VD_T, ED_T> {
+
+    private GraphXStringEDFragment<OID_T, VID_T, VD_T, ED_T> graphXStringEDFragment;
+
+    public GraphXStringEDFragmentAdaptor(
+            GraphXStringEDFragment<OID_T, VID_T, VD_T, ED_T> graphXStringEDFragment) {
+        super(graphXStringEDFragment);
+        this.graphXStringEDFragment = graphXStringEDFragment;
+    }
+
+    public GraphXStringEDFragment<OID_T, VID_T, VD_T, ED_T> getFragment() {
+        return graphXStringEDFragment;
+    }
+    /**
+     * Return the underlying fragment type,i.e. ArrowProjected or Simple.
+     *
+     * @return underlying fragment type.
+     */
+    @Override
+    public FragmentType fragmentType() {
+        return FragmentType.GraphXStringEDFragment;
+    }
+
+    @Override
+    public long getInEdgeNum() {
+        return graphXStringEDFragment.getInEdgeNum();
+    }
+
+    @Override
+    public long getOutEdgeNum() {
+        return graphXStringEDFragment.getOutEdgeNum();
+    }
+
+    /**
+     * Get the data on vertex.
+     *
+     * @param vertex querying vertex.
+     * @return vertex data
+     */
+    @Override
+    public VD_T getData(Vertex<VID_T> vertex) {
+        return graphXStringEDFragment.getData(vertex);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/GraphXStringVDFragmentAdaptor.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/GraphXStringVDFragmentAdaptor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment.adaptor;
+
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.FragmentType;
+import com.alibaba.graphscope.fragment.GraphXStringVDFragment;
+
+public class GraphXStringVDFragmentAdaptor<OID_T, VID_T, VD_T, ED_T>
+        extends AbstractGraphXFragmentAdaptor<OID_T, VID_T, VD_T, ED_T> {
+
+    private GraphXStringVDFragment<OID_T, VID_T, VD_T, ED_T> graphXStringVDFragment;
+
+    public GraphXStringVDFragmentAdaptor(
+            GraphXStringVDFragment<OID_T, VID_T, VD_T, ED_T> graphXStringVDFragment) {
+        super(graphXStringVDFragment);
+        this.graphXStringVDFragment = graphXStringVDFragment;
+    }
+
+    public GraphXStringVDFragment<OID_T, VID_T, VD_T, ED_T> getFragment() {
+        return graphXStringVDFragment;
+    }
+
+    /**
+     * Return the underlying fragment type,i.e. ArrowProjected or Simple.
+     *
+     * @return underlying fragment type.
+     */
+    @Override
+    public FragmentType fragmentType() {
+        return FragmentType.GraphXStringVDFragment;
+    }
+
+    @Override
+    public long getInEdgeNum() {
+        return graphXStringVDFragment.getInEdgeNum();
+    }
+
+    @Override
+    public long getOutEdgeNum() {
+        return graphXStringVDFragment.getOutEdgeNum();
+    }
+
+    /**
+     * Get the data on vertex.
+     *
+     * @param vertex querying vertex.
+     * @return vertex data
+     */
+    @Override
+    public VD_T getData(Vertex<VID_T> vertex) {
+        throw new IllegalStateException("Not implemented");
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/GraphXStringVEDFragmentAdaptor.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/adaptor/GraphXStringVEDFragmentAdaptor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.fragment.adaptor;
+
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.FragmentType;
+import com.alibaba.graphscope.fragment.GraphXStringVEDFragment;
+
+public class GraphXStringVEDFragmentAdaptor<OID_T, VID_T, VD_T, ED_T>
+        extends AbstractGraphXFragmentAdaptor<OID_T, VID_T, VD_T, ED_T> {
+
+    private GraphXStringVEDFragment<OID_T, VID_T, VD_T, ED_T> graphXStringVEDFragment;
+
+    public GraphXStringVEDFragmentAdaptor(
+            GraphXStringVEDFragment<OID_T, VID_T, VD_T, ED_T> graphXStringVEDFragment) {
+        super(graphXStringVEDFragment);
+        this.graphXStringVEDFragment = graphXStringVEDFragment;
+    }
+
+    public GraphXStringVEDFragment<OID_T, VID_T, VD_T, ED_T> getFragment() {
+        return graphXStringVEDFragment;
+    }
+
+    /**
+     * Return the underlying fragment type,i.e. ArrowProjected or Simple.
+     *
+     * @return underlying fragment type.
+     */
+    @Override
+    public FragmentType fragmentType() {
+        return FragmentType.GraphXStringVEDFragment;
+    }
+
+    @Override
+    public long getInEdgeNum() {
+        return graphXStringVEDFragment.getInEdgeNum();
+    }
+
+    @Override
+    public long getOutEdgeNum() {
+        return graphXStringVEDFragment.getOutEdgeNum();
+    }
+
+    /**
+     * Get the data on vertex.
+     *
+     * @param vertex querying vertex.
+     * @return vertex data
+     */
+    @Override
+    public VD_T getData(Vertex<VID_T> vertex) {
+        throw new IllegalStateException("Not implemented");
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/BasicGraphXCSRBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/BasicGraphXCSRBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.stdcxx.StdVector;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_CSR_H)
+@CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(CppClassName.GS_BASIC_GRAPHX_CSR_BUILDER)
+public interface BasicGraphXCSRBuilder<OID_T, VID_T> extends FFIPointer {
+
+    @FFINameAlias("LoadEdges")
+    void loadEdges(
+            @CXXReference StdVector<OID_T> srcs,
+            @CXXReference StdVector<OID_T> dsts,
+            @CXXReference GraphXVertexMap<OID_T, VID_T> graphXVertexMap,
+            int localNum);
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<GraphXCSR<VID_T>> seal(@CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<OID_T, VID_T> {
+        BasicGraphXCSRBuilder<OID_T, VID_T> create(@CXXReference VineyardClient vineyardClient);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/BasicLocalVertexMapBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/BasicLocalVertexMapBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.arrow.array.ArrowArrayBuilder;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_LOCAL_VERTEX_MAP_H)
+@CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(CppClassName.GS_GRAPHX_LOCAL_VERTEX_MAP_BUILDER)
+public interface BasicLocalVertexMapBuilder<OID_T, VID_T> extends FFIPointer {
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<LocalVertexMap<OID_T, VID_T>> seal(@CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<OID_T, VID_T> {
+        BasicLocalVertexMapBuilder<OID_T, VID_T> create(
+                @CXXReference VineyardClient client,
+                @CXXReference ArrowArrayBuilder<OID_T> innerOids,
+                @CXXReference ArrowArrayBuilder<OID_T> outerOids,
+                @CXXReference @FFITypeAlias("gs::ArrowArrayBuilder<int32_t>")
+                        ArrowArrayBuilder<Integer> pids);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/EdgeData.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/EdgeData.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_EDGE_DATA_H)
+@FFITypeAlias(CppClassName.GS_EDGE_DATA)
+public interface EdgeData<VID, ED> extends FFIPointer {
+
+    long id();
+
+    /**
+     * Could contain outer vertices data
+     *
+     * @return nums
+     */
+    @FFINameAlias("GetEdgeNum")
+    long getEdgeNum();
+
+    @FFINameAlias("GetEdgeDataByEid")
+    ED getEdgeDataByEid(long eid);
+
+    @FFINameAlias("GetEdataArray")
+    @CXXReference
+    TypedArray<ED> getEdataArray();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/EdgeDataBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/EdgeDataBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.stdcxx.StdVector;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_EDGE_DATA_H)
+@CXXHead(CppHeaderName.VINEYARD_ARRAY_BUILDER_H)
+@FFITypeAlias(CppClassName.GS_EDGE_DATA_BUILDER)
+public interface EdgeDataBuilder<VID, ED> extends FFIPointer {
+
+    @FFINameAlias("GetArrayBuilder")
+    @CXXReference
+    VineyardArrayBuilder<ED> getArrayBuilder();
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<EdgeData<VID, ED>> seal(@CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<VID, ED> {
+
+        EdgeDataBuilder<VID, ED> create(
+                @CXXReference VineyardClient client, @CXXReference StdVector<ED> arrayBuilder);
+
+        EdgeDataBuilder<VID, ED> create(@CXXReference VineyardClient client, long size);
+
+        default EdgeData<VID, ED> createAndBuild(VineyardClient client, StdVector<ED> newValues) {
+            EdgeDataBuilder<VID, ED> builder = create(client, newValues);
+            StdSharedPtr<EdgeData<VID, ED>> res = builder.seal(client);
+            return res.get();
+        }
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/GraphXCSR.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/GraphXCSR.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.PropertyNbrUnit;
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+import java.io.Serializable;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_CSR_H)
+@CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(CppClassName.GS_GRAPHX_CSR)
+public interface GraphXCSR<VID_T> extends FFIPointer, Serializable {
+
+    long id();
+
+    @FFINameAlias("GetInDegree")
+    long getInDegree(VID_T vid);
+
+    @FFINameAlias("GetOutDegree")
+    long getOutDegree(VID_T vid);
+
+    @FFINameAlias("IsIEEmpty")
+    boolean isInEdgesEmpty(VID_T vid);
+
+    @FFINameAlias("IsOEEmpty")
+    boolean isOutEdgesEmpty(VID_T vid);
+
+    @FFINameAlias("GetIEBegin")
+    PropertyNbrUnit<VID_T> getIEBegin(VID_T lid);
+
+    @FFINameAlias("GetIEEnd")
+    PropertyNbrUnit<VID_T> getIEEnd(VID_T lid);
+
+    @FFINameAlias("GetOEBegin")
+    PropertyNbrUnit<VID_T> getOEBegin(VID_T lid);
+
+    @FFINameAlias("GetOEEnd")
+    PropertyNbrUnit<VID_T> getOEEnd(VID_T lid);
+
+    @FFINameAlias("GetOEOffset")
+    long getOEOffset(long ind);
+
+    @FFINameAlias("GetIEOffset")
+    long getIEOffset(long ind);
+
+    @FFINameAlias("GetOEOffsetArray")
+    @CXXReference
+    @FFITypeAlias("gs::arrow_projected_fragment_impl::TypedArray<int64_t>")
+    TypedArray<Long> getOEOffsetsArray();
+
+    @FFINameAlias("GetIEOffsetArray")
+    @CXXReference
+    @FFITypeAlias("gs::arrow_projected_fragment_impl::TypedArray<int64_t>")
+    TypedArray<Long> getIEOffsetsArray();
+
+    /**
+     * Inner vnum
+     *
+     * @return
+     */
+    @FFINameAlias("VertexNum")
+    VID_T vertexNum();
+
+    @FFINameAlias("GetInEdgesNum")
+    long getInEdgesNum();
+
+    @FFINameAlias("GetOutEdgesNum")
+    long getOutEdgesNum();
+
+    @FFINameAlias("GetTotalEdgesNum")
+    long getTotalEdgesNum();
+
+    /**
+     * @param begin inclusive
+     * @param end   exclusive
+     * @return
+     */
+    @FFINameAlias("GetPartialInEdgesNum")
+    long getPartialInEdgesNum(VID_T begin, VID_T end);
+
+    @FFINameAlias("GetPartialOutEdgesNum")
+    long getPartialOutEdgesNum(VID_T begin, VID_T end);
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/GraphXFragmentBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/GraphXFragmentBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.fragment.GraphXFragment;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
+@FFITypeAlias(CppClassName.GRAPHX_FRAGMENT_BUILDER)
+public interface GraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> extends FFIPointer {
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<GraphXFragment<OID_T, VID_T, VD_T, ED_T>> seal(
+            @CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<OID_T, VID_T, VD_T, ED_T> {
+
+        GraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> create(
+                @CXXReference VineyardClient vineyardClient,
+                long vmId,
+                long csrId,
+                long vdataId,
+                long edataId);
+
+        GraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> create(
+                @CXXReference VineyardClient vineyardClient,
+                @CXXReference GraphXVertexMap<OID_T, VID_T> vm,
+                @CXXReference GraphXCSR<VID_T> csr,
+                @CXXReference VertexData<VID_T, VD_T> vdata,
+                @CXXReference EdgeData<VID_T, ED_T> edata);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/GraphXVertexMap.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/GraphXVertexMap.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+import java.io.Serializable;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_VERTEX_MAP_H)
+@CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(CppClassName.GS_GRAPHX_GRAPHX_VERTEX_MAP)
+public interface GraphXVertexMap<OID_T, VID_T> extends FFIPointer, Serializable {
+
+    long id();
+
+    int fid();
+
+    int fnum();
+
+    @FFINameAlias("GetId")
+    @CXXValue
+    OID_T getId(VID_T vertex);
+
+    @FFINameAlias("GetFragId")
+    @CXXValue
+    int getFragId(VID_T lid);
+
+    @FFINameAlias("GetVertex")
+    boolean getVertex(OID_T oid, @CXXReference Vertex<VID_T> vertex);
+
+    @FFINameAlias("GetInnerVertex")
+    boolean getInnerVertex(OID_T oid, @CXXReference Vertex<VID_T> vertex);
+
+    @FFINameAlias("GetOuterVertex")
+    boolean getOuterVertex(OID_T oid, @CXXReference Vertex<VID_T> vertex);
+
+    @FFINameAlias("GetTotalVertexSize")
+    long getTotalVertexSize();
+
+    @FFINameAlias("GetVertexSize")
+    VID_T getVertexSize();
+
+    @FFINameAlias("GetInnerVertexSize")
+    long getInnerVertexSize(int fid);
+
+    @FFINameAlias("InnerVertexLid2Oid")
+    OID_T innerVertexLid2Oid(VID_T lid);
+
+    @FFINameAlias("OuterVertexLid2Oid")
+    OID_T outerVertexLid2Oid(VID_T lid);
+
+    @FFINameAlias("GetOuterVertexSize")
+    long getOuterVertexSize();
+
+    @FFINameAlias("InnerOid2Gid")
+    VID_T innerOid2Gid(OID_T oid);
+
+    @FFINameAlias("GetOuterVertexGid")
+    VID_T getOuterVertexGid(VID_T lid);
+
+    @FFINameAlias("Fid2GraphxPid")
+    int fid2GraphxPid(int fid);
+
+    @FFINameAlias("OuterVertexGid2Vertex")
+    boolean outerVertexGid2Vertex(VID_T gid, @CXXReference Vertex<VID_T> vertex);
+
+    default long innerVertexSize() {
+        return getInnerVertexSize(fid());
+    }
+
+    @FFINameAlias("GetLid2OidsAccessor")
+    @CXXReference
+    TypedArray<OID_T> getLid2OidAccessor(int fid);
+
+    @FFINameAlias("GetOuterLid2GidsAccessor")
+    @CXXReference
+    TypedArray<VID_T> getOuterLid2GidAccessor();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/GraphXVertexMapGetter.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/GraphXVertexMapGetter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_VERTEX_MAP_H)
+@CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(CppClassName.GS_GRAPHX_GRAPHX_VERTEX_MAP_GETTER)
+public interface GraphXVertexMapGetter<OID_T, VID_T> extends FFIPointer {
+    @FFINameAlias("Get")
+    @CXXValue
+    StdSharedPtr<GraphXVertexMap<OID_T, VID_T>> get(
+            @CXXReference VineyardClient client, long globalVMID);
+
+    @FFIFactory
+    interface Factory<OID_T, VID_T> {
+        GraphXVertexMapGetter<OID_T, VID_T> create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/Json.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/Json.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import static com.alibaba.graphscope.utils.CppClassName.VINEYARD_JSON;
+import static com.alibaba.graphscope.utils.CppHeaderName.VINEYARD_JSON_H;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIByteString;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(value = VINEYARD_JSON_H)
+@FFITypeAlias(VINEYARD_JSON)
+public interface Json extends FFIPointer {
+
+    @FFINameAlias("dump")
+    @CXXValue
+    FFIByteString dump();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/LocalVertexMap.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/LocalVertexMap.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+import java.io.Serializable;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_LOCAL_VERTEX_MAP_H)
+@CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(CppClassName.GS_GRAPHX_LOCAL_VERTEX_MAP)
+public interface LocalVertexMap<OID_T, VID_T> extends FFIPointer, Serializable {
+    long id();
+
+    @FFINameAlias("GetInnerVerticesNum")
+    long getInnerVerticesNum();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringEDGraphXFragmentBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringEDGraphXFragmentBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.fragment.GraphXStringEDFragment;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
+@FFITypeAlias(CppClassName.GRAPHX_FRAGMENT_BUILDER)
+public interface StringEDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> extends FFIPointer {
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<GraphXStringEDFragment<OID_T, VID_T, VD_T, ED_T>> seal(
+            @CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<OID_T, VID_T, VD_T, ED_T> {
+
+        StringEDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> create(
+                @CXXReference VineyardClient vineyardClient,
+                long vmId,
+                long csrId,
+                long vdataId,
+                long edId);
+
+        StringEDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> create(
+                @CXXReference VineyardClient vineyardClient,
+                @CXXReference GraphXVertexMap<OID_T, VID_T> vm,
+                @CXXReference GraphXCSR<VID_T> csr,
+                @CXXReference VertexData<VID_T, VD_T> vdata,
+                @CXXReference StringEdgeData<VID_T, ED_T> edata);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringEdgeData.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringEdgeData.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.StringTypedArray;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_EDGE_DATA_H)
+@CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(CppClassName.GS_STRING_EDGE_DATA)
+public interface StringEdgeData<VID, T> extends FFIPointer {
+
+    long id();
+
+    /**
+     * Could contain outer vertices data
+     *
+     * @return nums
+     */
+    @FFINameAlias("GetEdgeNum")
+    long getEdgeNum();
+
+    @FFINameAlias("GetEdataArray")
+    @CXXReference
+    @FFITypeAlias("gs::arrow_projected_fragment_impl::TypedArray<std::string>")
+    StringTypedArray getEdataArray();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringEdgeDataBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringEdgeDataBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.stdcxx.StdVector;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_EDGE_DATA_H)
+@FFITypeAlias(CppClassName.GS_STRING_EDGE_DATA_BUILDER)
+public interface StringEdgeDataBuilder<VID, T> extends FFIPointer {
+
+    @FFINameAlias("Init")
+    void init(
+            long edgeNum,
+            @CXXReference @FFITypeAlias("std::vector<char>") StdVector<Byte> vector,
+            @CXXReference @FFITypeAlias("std::vector<int32_t>") StdVector<Integer> length);
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<StringEdgeData<VID, T>> seal(@CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<VID, T> {
+
+        StringEdgeDataBuilder<VID, T> create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVDGraphXFragmentBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVDGraphXFragmentBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.fragment.GraphXStringVDFragment;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
+@FFITypeAlias(CppClassName.GRAPHX_FRAGMENT_BUILDER)
+public interface StringVDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> extends FFIPointer {
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<GraphXStringVDFragment<OID_T, VID_T, VD_T, ED_T>> seal(
+            @CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<OID_T, VID_T, VD_T, ED_T> {
+
+        StringVDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> create(
+                @CXXReference VineyardClient vineyardClient,
+                long vmId,
+                long csrId,
+                long vdataId,
+                long edId);
+
+        StringVDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> create(
+                @CXXReference VineyardClient vineyardClient,
+                @CXXReference GraphXVertexMap<OID_T, VID_T> vm,
+                @CXXReference GraphXCSR<VID_T> csr,
+                @CXXReference StringVertexData<VID_T, VD_T> vdata,
+                @CXXReference EdgeData<VID_T, ED_T> edata);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVEDGraphXFragmentBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVEDGraphXFragmentBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.fragment.GraphXStringVEDFragment;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)
+@FFITypeAlias(CppClassName.GRAPHX_FRAGMENT_BUILDER)
+public interface StringVEDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> extends FFIPointer {
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<GraphXStringVEDFragment<OID_T, VID_T, VD_T, ED_T>> seal(
+            @CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<OID_T, VID_T, VD_T, ED_T> {
+
+        StringVEDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> create(
+                @CXXReference VineyardClient vineyardClient,
+                long vmId,
+                long csrId,
+                long vdataId,
+                long edId);
+
+        StringVEDGraphXFragmentBuilder<OID_T, VID_T, VD_T, ED_T> create(
+                @CXXReference VineyardClient vineyardClient,
+                @CXXReference GraphXVertexMap<OID_T, VID_T> vm,
+                @CXXReference GraphXCSR<VID_T> csr,
+                @CXXReference StringVertexData<VID_T, VD_T> vdata,
+                @CXXReference StringEdgeData<VID_T, ED_T> edata);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVertexData.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVertexData.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.StringTypedArray;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_VERTEX_DATA_H)
+@CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
+@FFITypeAlias(CppClassName.GS_STRING_VERTEX_DATA)
+public interface StringVertexData<VID, T> extends FFIPointer {
+
+    long id();
+
+    /**
+     * Could contain outer vertices data
+     *
+     * @return nums
+     */
+    @FFINameAlias("VerticesNum")
+    VID verticesNum();
+
+    @FFINameAlias("GetVdataArray")
+    @CXXReference
+    @FFITypeAlias("gs::arrow_projected_fragment_impl::TypedArray<std::string>")
+    StringTypedArray getVdataArray();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVertexDataBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVertexDataBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.stdcxx.StdVector;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_VERTEX_DATA_H)
+@FFITypeAlias(CppClassName.GS_STRING_VERTEX_DATA_BUILDER)
+public interface StringVertexDataBuilder<VID, T> extends FFIPointer {
+
+    @FFINameAlias("Init")
+    void init(
+            long frag_vnums,
+            @CXXReference @FFITypeAlias("std::vector<char>") StdVector<Byte> vector,
+            @CXXReference @FFITypeAlias("std::vector<int32_t>") StdVector<Integer> length);
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<StringVertexData<VID, T>> seal(@CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<VID, T> {
+
+        StringVertexDataBuilder<VID, T> create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVertexDataGetter.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/StringVertexDataGetter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_VERTEX_DATA_H)
+@FFITypeAlias(CppClassName.GS_VERTEX_DATA_GETTER)
+public interface StringVertexDataGetter<VID, VD> extends FFIPointer {
+
+    @FFINameAlias("Get")
+    @CXXValue
+    StdSharedPtr<StringVertexData<VID, VD>> get(@CXXReference VineyardClient client, long id);
+
+    @FFIFactory
+    interface Factory<VID, VD> {
+
+        StringVertexDataGetter<VID, VD> create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/V6dStatus.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/V6dStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.VINEYARD_STATUS_H)
+@FFITypeAlias(CppClassName.VINEYARD_STATUS)
+public interface V6dStatus extends FFIPointer {
+
+    boolean ok();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VertexData.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VertexData.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_VERTEX_DATA_H)
+@FFITypeAlias(CppClassName.GS_VERTEX_DATA)
+public interface VertexData<VID, VD> extends FFIPointer {
+
+    long id();
+
+    /**
+     * Could contain outer vertices data
+     *
+     * @return nums
+     */
+    @FFINameAlias("VerticesNum")
+    VID verticesNum();
+
+    @FFINameAlias("GetData")
+    VD getData(VID lid);
+
+    @FFINameAlias("GetVdataArray")
+    @CXXReference
+    TypedArray<VD> getVdataArray();
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VertexDataBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VertexDataBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_VERTEX_DATA_H)
+@FFITypeAlias(CppClassName.GS_VERTEX_DATA_BUILDER)
+public interface VertexDataBuilder<VID, VD> extends FFIPointer {
+
+    //    @FFINameAlias("Init")
+    //    void init(@CXXReference ArrowArrayBuilder<VD> newValues);
+
+    @FFINameAlias("GetArrayBuilder")
+    @CXXReference
+    VineyardArrayBuilder<VD> getArrayBuilder();
+
+    //    @FFINameAlias("SetBitsetWords")
+    //    void setBitsetWords(@CXXReference @FFITypeAlias("arrow::Int64Builder")
+    // ArrowArrayBuilder<Long> words);
+
+    @FFINameAlias("MySeal")
+    @CXXValue
+    StdSharedPtr<VertexData<VID, VD>> seal(@CXXReference VineyardClient client);
+
+    @FFIFactory
+    interface Factory<VID, VD> {
+        VertexDataBuilder<VID, VD> create(
+                @CXXReference VineyardClient client, int fragVnums, VD initValue);
+
+        VertexDataBuilder<VID, VD> create(@CXXReference VineyardClient client, int fragVnums);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VertexDataGetter.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VertexDataGetter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdSharedPtr;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.CORE_JAVA_GRAPHX_VERTEX_DATA_H)
+@FFITypeAlias(CppClassName.GS_VERTEX_DATA_GETTER)
+public interface VertexDataGetter<VID, VD> extends FFIPointer {
+
+    @FFINameAlias("Get")
+    @CXXValue
+    StdSharedPtr<VertexData<VID, VD>> get(@CXXReference VineyardClient client, long id);
+
+    @FFIFactory
+    interface Factory<VID, VD> {
+
+        VertexDataGetter<VID, VD> create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VineyardArrayBuilder.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VineyardArrayBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXOperator;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdVector;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.VINEYARD_ARRAY_BUILDER_H)
+@FFITypeAlias(CppClassName.VINEYARD_ARRAY_BUILDER)
+public interface VineyardArrayBuilder<EDATA_T> extends FFIPointer {
+    @CXXOperator("[]")
+    @CXXReference
+    EDATA_T get(long index);
+
+    @CXXOperator("[]")
+    void set(long index, EDATA_T value);
+
+    long size();
+
+    @FFIFactory
+    interface Factory<EDATA_T> {
+
+        VineyardArrayBuilder<EDATA_T> create(
+                @CXXReference VineyardClient client, @CXXReference StdVector<EDATA_T> newValues);
+
+        VineyardArrayBuilder<EDATA_T> create(@CXXReference VineyardClient client, long size);
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VineyardClient.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/graphx/VineyardClient.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXValue;
+import com.alibaba.fastffi.FFIByteString;
+import com.alibaba.fastffi.FFIConst;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFINameAlias;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.stdcxx.StdMap;
+import com.alibaba.graphscope.utils.CppClassName;
+import com.alibaba.graphscope.utils.CppHeaderName;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(CppHeaderName.VINEYARD_CLIENT_H)
+@CXXHead(CppHeaderName.VINEYARD_JSON_H)
+@CXXHead(system = "map")
+@FFITypeAlias(CppClassName.VINEYARD_CLIENT)
+public interface VineyardClient extends FFIPointer {
+
+    @FFINameAlias("Connect")
+    @CXXValue
+    V6dStatus connect(@FFIConst @CXXReference FFIByteString endPoint);
+
+    @FFINameAlias("ClusterInfo")
+    @CXXValue
+    V6dStatus clusterInfo(
+            @CXXReference @FFITypeAlias("std::map<uint64_t,vineyard::json>")
+                    StdMap<Long, Json> meta); // instance_id to json string.
+
+    @FFIFactory
+    interface Factory {
+        VineyardClient create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/parallel/DefaultMessageManager.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/parallel/DefaultMessageManager.java
@@ -19,6 +19,7 @@ package com.alibaba.graphscope.parallel;
 import static com.alibaba.graphscope.utils.CppClassName.GRAPE_DEFAULT_MESSAGE_MANAGER;
 import static com.alibaba.graphscope.utils.CppClassName.GRAPE_LONG_VERTEX;
 import static com.alibaba.graphscope.utils.CppHeaderName.ARROW_PROJECTED_FRAGMENT_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H;
 import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_JAVA_MESSAGES_H;
 import static com.alibaba.graphscope.utils.CppHeaderName.GRAPE_ADJ_LIST_H;
 import static com.alibaba.graphscope.utils.CppHeaderName.GRAPE_FRAGMENT_IMMUTABLE_EDGECUT_FRAGMENT_H;
@@ -33,6 +34,7 @@ import com.alibaba.fastffi.FFITypeAlias;
 import com.alibaba.graphscope.app.DefaultAppBase;
 import com.alibaba.graphscope.ds.Vertex;
 import com.alibaba.graphscope.fragment.ArrowProjectedFragment;
+import com.alibaba.graphscope.fragment.BaseGraphXFragment;
 import com.alibaba.graphscope.fragment.FragmentType;
 import com.alibaba.graphscope.fragment.IFragment;
 import com.alibaba.graphscope.fragment.ImmutableEdgecutFragment;
@@ -50,6 +52,7 @@ import com.alibaba.graphscope.utils.JNILibraryName;
     GRAPE_FRAGMENT_IMMUTABLE_EDGECUT_FRAGMENT_H,
     ARROW_PROJECTED_FRAGMENT_H,
     CORE_JAVA_JAVA_MESSAGES_H,
+    CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H
 })
 public interface DefaultMessageManager extends MessageManagerBase {
 
@@ -206,6 +209,13 @@ public interface DefaultMessageManager extends MessageManagerBase {
             @CXXReference FRAG_T frag,
             @CXXReference @FFITypeAlias(GRAPE_LONG_VERTEX) Vertex<Long> vertex,
             @CXXReference MSG_T msg);
+
+    @FFINameAlias("SyncStateOnOuterVertex")
+    <FRAG_T extends BaseGraphXFragment, MSG_T, @FFISkip SKIP_T> void syncStateOnOuterVertexGraphX(
+            @CXXReference FRAG_T frag,
+            @CXXReference @FFITypeAlias(GRAPE_LONG_VERTEX) Vertex<Long> vertex,
+            @CXXReference MSG_T msg,
+            @FFISkip SKIP_T skip);
 
     /**
      * Send the a vertex's data to other fragment througn outgoing edges.

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/stdcxx/StdMap.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/stdcxx/StdMap.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.stdcxx;
+
+import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXOperator;
+import com.alibaba.fastffi.CXXReference;
+import com.alibaba.fastffi.CXXTemplate;
+import com.alibaba.fastffi.FFIFactory;
+import com.alibaba.fastffi.FFIGen;
+import com.alibaba.fastffi.FFIPointer;
+import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.utils.JNILibraryName;
+
+@FFIGen(library = JNILibraryName.JNI_LIBRARY_NAME)
+@CXXHead(
+        value = {"stdint.h"},
+        system = {"map"})
+@FFITypeAlias("std::map")
+@CXXTemplate(
+        cxx = {"uint64_t", "vineyard::json"},
+        java = {"java.lang.Long", "com.alibaba.graphscope.graphx.Json"})
+public interface StdMap<K, V> extends FFIPointer {
+
+    @CXXReference
+    @CXXOperator("[]")
+    V get(@CXXReference K key);
+
+    @FFIFactory
+    interface Factory<K, V> {
+        StdMap<K, V> create();
+    }
+}

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/stdcxx/StdSharedPtr.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/stdcxx/StdSharedPtr.java
@@ -17,9 +17,11 @@
 package com.alibaba.graphscope.stdcxx;
 
 import com.alibaba.fastffi.CXXHead;
+import com.alibaba.fastffi.CXXTemplate;
 import com.alibaba.fastffi.FFIGen;
 import com.alibaba.fastffi.FFIPointer;
 import com.alibaba.fastffi.FFITypeAlias;
+import com.alibaba.graphscope.utils.CppClassName;
 import com.alibaba.graphscope.utils.CppHeaderName;
 import com.alibaba.graphscope.utils.JNILibraryName;
 
@@ -28,6 +30,13 @@ import com.alibaba.graphscope.utils.JNILibraryName;
 @CXXHead(CppHeaderName.ARROW_FRAGMENT_H)
 @CXXHead(CppHeaderName.CORE_JAVA_TYPE_ALIAS_H)
 @FFITypeAlias("std::shared_ptr")
+// @CXXTemplate(cxx = "gs::VertexData<uint64_t,std::string>", java =
+// "com.alibaba.graphscope.graphx.StringVertexData")
+// @CXXTemplate(cxx = "gs::EdgeData<uint64_t,std::string>", java =
+// "com.alibaba.graphscope.graphx.StringEdgeData")
+@CXXTemplate(
+        cxx = CppClassName.ARROW_FRAGMENT_GROUP,
+        java = "com.alibaba.graphscope.fragment.ArrowFragmentGroup")
 public interface StdSharedPtr<T extends FFIPointer> extends FFIPointer {
     // & will return the pointer of T.
     // shall be cxxvalue?

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/utils/AppContextGetter.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/utils/AppContextGetter.java
@@ -114,6 +114,9 @@ public class AppContextGetter {
      * @return the base class name.
      */
     public static String getParallelContextName(Class<? extends ParallelAppBase> appClass) {
+        if (appClass.getName().equals("com.alibaba.graphscope.app.GraphXParallelAdaptor")) {
+            return "com.alibaba.graphscope.context.GraphXParallAdaptorContext";
+        }
         Class<? extends ParallelContextBase> clz =
                 (Class<? extends ParallelContextBase>) getInterfaceTemplateType(appClass, 4);
         return clz.getName();

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/utils/CppClassName.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/utils/CppClassName.java
@@ -64,6 +64,9 @@ public class CppClassName {
             "gs::ParallelPropertyMessageManager";
     public static final String GRAPE_COMMUNICATOR = "grape::Communicator";
     public static final String ARROW_PROJECTED_FRAGMENT = "gs::ArrowProjectedFragment";
+    public static final String ARROW_PROJECTED_FRAGMENT_MAPPER = "gs::ArrowProjectedFragmentMapper";
+    public static final String GRAPHX_FRAGMENT = "gs::GraphXFragment";
+    public static final String GRAPHX_FRAGMENT_BUILDER = "gs::GraphXFragmentBuilder";
     public static final String PROJECTED_ADJ_LIST =
             "gs::arrow_projected_fragment_impl::AdjListDefault";
     public static final String PROJECTED_NBR = "gs::arrow_projected_fragment_impl::NbrDefault";
@@ -78,8 +81,27 @@ public class CppClassName {
     public static final String GS_ARROW_PROJECTED_FRAGMENT_IMPL_STRING_TYPED_ARRAY =
             "gs::arrow_projected_fragment_impl::TypedArray<std::string>";
 
+    public static final String GS_EDGE_PARTITION = "gs::EdgePartition";
+    public static final String GS_GRAPHX_CSR = "gs::GraphXCSR";
+    public static final String GS_GRAPHX_CSR_MAPPER = "gs::GraphXCSRMapper";
+    public static final String GS_GRAPHX_LOCAL_VERTEX_MAP = "gs::LocalVertexMap";
+    public static final String GS_GRAPHX_GRAPHX_VERTEX_MAP = "gs::GraphXVertexMap";
+    public static final String GS_GRAPHX_GRAPHX_VERTEX_MAP_GETTER = "gs::GraphXVertexMapGetter";
+    public static final String GS_BASIC_GRAPHX_CSR_BUILDER = "gs::BasicGraphXCSRBuilder";
+    public static final String GS_VERTEX_DATA = "gs::VertexData";
+    public static final String GS_VERTEX_DATA_GETTER = "gs::VertexDataGetter";
+    public static final String GS_EDGE_DATA = "gs::EdgeData";
+    public static final String GS_STRING_VERTEX_DATA = "gs::VertexData";
+    public static final String GS_STRING_EDGE_DATA = "gs::EdgeData";
+    public static final String GS_STRING_EDGE_DATA_BUILDER = "gs::EdgeDataBuilder";
+    public static final String GS_VERTEX_DATA_BUILDER = "gs::VertexDataBuilder";
+    public static final String GS_EDGE_DATA_BUILDER = "gs::EdgeDataBuilder";
+    public static final String GS_STRING_VERTEX_DATA_BUILDER = "gs::VertexDataBuilder";
+    public static final String GS_DEFAULT_IMMUTABLE_CSR = "gs::DefaultImmutableCSR";
     public static final String GS_ARROW_ARRAY_BUILDER = "gs::ArrowArrayBuilder";
     public static final String GS_ARROW_ARRAY = "gs::ArrowArray";
+    public static final String GS_GRAPHX_LOCAL_VERTEX_MAP_BUILDER =
+            "gs::BasicLocalVertexMapBuilder";
     public static final String GS_ARROW_PROJECTED_FRAGMENT_GETTER =
             "gs::ArrowProjectedFragmentGetter";
 

--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/utils/CppHeaderName.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/utils/CppHeaderName.java
@@ -74,6 +74,18 @@ public class CppHeaderName {
     public static final String JAVA_LOADER_INVOKER_H = "core/java/java_loader_invoker.h";
 
     public static final String GS_MEMORY_MAPPED_BUFFER_H = "core/java/memory_mapped_buffer.h";
+    public static final String CORE_JAVA_GRAPHX_EDGE_PARTITION_H =
+            "core/java/graphx/edge_partition.h";
+    public static final String CORE_JAVA_GRAPHX_GRAPHX_CSR_H = "core/java/graphx/graphx_csr.h";
+    public static final String CORE_JAVA_GRAPHX_LOCAL_VERTEX_MAP_H =
+            "core/java/graphx/local_vertex_map.h";
+    public static final String CORE_JAVA_GRAPHX_GRAPHX_VERTEX_MAP_H =
+            "core/java/graphx/graphx_vertex_map.h";
+    public static final String CORE_JAVA_GRAPHX_VERTEX_DATA_H = "core/java/graphx/vertex_data.h";
+    public static final String CORE_JAVA_GRAPHX_EDGE_DATA_H = "core/java/graphx/edge_data.h";
+    public static final String CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H =
+            "core/java/graphx/graphx_fragment.h";
+    public static final String CORE_JAVA_FRAGMENT_GETTER_H = "core/java/graphx/fragment_getter.h";
 
     public static final String VINEYARD_CLIENT_H = "vineyard/client/client.h";
     public static final String VINEYARD_STATUS_H = "vineyard/common/util/status.h";

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -26,7 +26,7 @@
 
   <artifactId>grape-runtime</artifactId>
   <packaging>jar</packaging>
-  <name>grape-runtime</name>
+  <name>Grape Runtime</name>
 
   <properties>
     <maven.compiler.source>8</maven.compiler.source>

--- a/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/annotation/AnnotationInvoker.java
+++ b/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/annotation/AnnotationInvoker.java
@@ -19,10 +19,20 @@ package com.alibaba.graphscope.annotation;
 import static com.alibaba.graphscope.utils.CppClassName.ARROW_FRAGMENT;
 import static com.alibaba.graphscope.utils.CppClassName.ARROW_PROJECTED_FRAGMENT;
 import static com.alibaba.graphscope.utils.CppClassName.DOUBLE_MSG;
+import static com.alibaba.graphscope.utils.CppClassName.GRAPHX_FRAGMENT;
 import static com.alibaba.graphscope.utils.CppClassName.GS_PRIMITIVE_MESSAGE;
 import static com.alibaba.graphscope.utils.CppClassName.GS_VERTEX_ARRAY;
 import static com.alibaba.graphscope.utils.CppClassName.LONG_MSG;
 import static com.alibaba.graphscope.utils.CppHeaderName.ARROW_FRAGMENT_GROUP_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.ARROW_PROJECTED_FRAGMENT_MAPPER_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_EDGE_DATA_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_CSR_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_GRAPHX_VERTEX_MAP_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_LOCAL_VERTEX_MAP_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_GRAPHX_VERTEX_DATA_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.CORE_JAVA_TYPE_ALIAS_H;
+import static com.alibaba.graphscope.utils.CppHeaderName.VINEYARD_JSON_H;
 
 import com.alibaba.fastffi.CXXHead;
 import com.alibaba.fastffi.CXXTemplate;
@@ -84,6 +94,626 @@ import com.alibaba.graphscope.utils.CppClassName;
                         @CXXTemplate(
                                 cxx = {"uint64_t", "int64_t"},
                                 java = {"Long", "Long"}),
+                    }),
+            @FFIGen(type = "com.alibaba.graphscope.graphx.VineyardClient"),
+            @FFIGen(type = "com.alibaba.graphscope.graphx.V6dStatus"),
+            @FFIGen(type = "com.alibaba.graphscope.graphx.Json"),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.stdcxx.StdMap",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "vineyard::json"},
+                                java = {"java.lang.Long", "com.alibaba.graphscope.graphx.Json"},
+                                include = @CXXHead(VINEYARD_JSON_H))
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.stdcxx.StdUnorderedMap",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"unsigned", "uint64_t"},
+                                java = {"java.lang.Integer", "java.lang.Long"})
+                    }),
+            @FFIGen(type = "com.alibaba.graphscope.fragment.ArrowFragmentGroup"),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.ds.Vertex",
+                    templates = {
+                        @CXXTemplate(cxx = "uint64_t", java = "Long"),
+                        @CXXTemplate(cxx = "uint32_t", java = "Integer")
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.ds.PropertyNbrUnit",
+                    templates = {
+                        @CXXTemplate(cxx = "uint64_t", java = "Long"),
+                        @CXXTemplate(cxx = "uint32_t", java = "Integer"),
+                    }),
+            @FFIGen(type = "com.alibaba.graphscope.ds.StringTypedArray"),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.LocalVertexMap",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t"},
+                                java = {"Long", "Long"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.GraphXVertexMap",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t"},
+                                java = {"Long", "Long"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.VertexData",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int64_t"},
+                                java = {"Long", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int32_t"},
+                                java = {"Long", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "double"},
+                                java = {"Long", "Double"}),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.VertexDataGetter",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int64_t"},
+                                java = {"Long", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int32_t"},
+                                java = {"Long", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "double"},
+                                java = {"Long", "Double"}),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.StringVertexDataGetter",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "std::string"},
+                                java = {"Long", "com.alibaba.fastffi.impl.CXXStdString"})
+                    }),
+            @FFIGen(type = "com.alibaba.graphscope.fragment.ArrowFragmentGroupGetter"),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.EdgeData",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int64_t"},
+                                java = {"Long", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int32_t"},
+                                java = {"Long", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "double"},
+                                java = {"Long", "Double"}),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.StringVertexData",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "std::string"},
+                                java = {"Long", "com.alibaba.fastffi.impl.CXXStdString"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.StringEdgeData",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "std::string"},
+                                java = {"Long", "com.alibaba.fastffi.impl.CXXStdString"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.GraphXCSR",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t"},
+                                java = {"Long"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.fragment.GraphXStringVDFragment",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "std::string", "int64_t"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "std::string", "double"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString",
+                                    "Double"
+                                }),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "std::string", "int32_t"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString",
+                                    "Integer"
+                                }),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.fragment.GraphXStringEDFragment",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "std::string"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString"
+                                }),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "std::string"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "Double",
+                                    "com.alibaba.fastffi.impl.CXXStdString"
+                                }),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int32_t", "std::string"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "Integer",
+                                    "com.alibaba.fastffi.impl.CXXStdString"
+                                }),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.fragment.GraphXStringVEDFragment",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "std::string", "std::string"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString",
+                                    "com.alibaba.fastffi.impl.CXXStdString"
+                                }),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.fragment.GraphXFragment",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "int64_t"},
+                                java = {"Long", "Long", "Long", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int32_t", "int64_t"},
+                                java = {"Long", "Long", "Integer", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "int64_t"},
+                                java = {"Long", "Long", "Double", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "int32_t"},
+                                java = {"Long", "Long", "Long", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int32_t", "int32_t"},
+                                java = {"Long", "Long", "Integer", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "int32_t"},
+                                java = {"Long", "Long", "Double", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "double"},
+                                java = {"Long", "Long", "Long", "Double"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int32_t", "double"},
+                                java = {"Long", "Long", "Integer", "Double"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "double"},
+                                java = {"Long", "Long", "Double", "Double"}),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.GraphXFragmentBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "int64_t"},
+                                java = {"Long", "Long", "Long", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int32_t", "int64_t"},
+                                java = {"Long", "Long", "Integer", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "int64_t"},
+                                java = {"Long", "Long", "Double", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "int32_t"},
+                                java = {"Long", "Long", "Long", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int32_t", "int32_t"},
+                                java = {"Long", "Long", "Integer", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "int32_t"},
+                                java = {"Long", "Long", "Double", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "double"},
+                                java = {"Long", "Long", "Long", "Double"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int32_t", "double"},
+                                java = {"Long", "Long", "Integer", "Double"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "double"},
+                                java = {"Long", "Long", "Double", "Double"}),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.StringEDGraphXFragmentBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "std::string"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString"
+                                }),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "std::string"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "Double",
+                                    "com.alibaba.fastffi.impl.CXXStdString"
+                                }),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int32_t", "std::string"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "Integer",
+                                    "com.alibaba.fastffi.impl.CXXStdString"
+                                }),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.StringVDGraphXFragmentBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "std::string", "int64_t"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "std::string", "double"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString",
+                                    "Double"
+                                }),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "std::string", "int32_t"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString",
+                                    "Integer"
+                                }),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.StringVEDGraphXFragmentBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "std::string", "std::string"},
+                                java = {
+                                    "Long",
+                                    "Long",
+                                    "com.alibaba.fastffi.impl.CXXStdString",
+                                    "com.alibaba.fastffi.impl.CXXStdString"
+                                }),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.stdcxx.StdSharedPtr",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = "gs::DoubleColumn<gs::ArrowFragmentDefault<int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.DoubleColumn<com.alibaba.graphscope.fragment.ArrowFragment<java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx = "gs::IntColumn<gs::ArrowFragmentDefault<int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.IntColumn<com.alibaba.graphscope.fragment.ArrowFragment<java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx = "gs::LongColumn<gs::ArrowFragmentDefault<int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.LongColumn<com.alibaba.graphscope.fragment.ArrowFragment<java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::DoubleColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,int64_t,int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.DoubleColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::IntColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,int64_t,int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.IntColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::LongColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,int64_t,int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.LongColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::DoubleColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,double,int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.DoubleColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::IntColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,double,int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.IntColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::LongColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,double,int64_t>>",
+                                java =
+                                        "com.alibaba.graphscope.column.LongColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>>"),
+                        @CXXTemplate(
+                                cxx = "gs::LocalVertexMap<int64_t,uint64_t>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.LocalVertexMap<java.lang.Long,java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_LOCAL_VERTEX_MAP_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXVertexMap<int64_t,uint64_t>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.GraphXVertexMap<java.lang.Long,java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_VERTEX_MAP_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXCSR<uint64_t>",
+                                java = "com.alibaba.graphscope.graphx.GraphXCSR<java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_CSR_H)),
+                        @CXXTemplate(
+                                cxx = "gs::VertexData<uint64_t,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.VertexData<java.lang.Long,java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_VERTEX_DATA_H)),
+                        @CXXTemplate(
+                                cxx = "gs::VertexData<uint64_t,int32_t>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.VertexData<java.lang.Long,java.lang.Integer>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_VERTEX_DATA_H)),
+                        @CXXTemplate(
+                                cxx = "gs::VertexData<uint64_t,double>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.VertexData<java.lang.Long,java.lang.Double>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_VERTEX_DATA_H)),
+                        @CXXTemplate(
+                                cxx = "gs::VertexData<uint64_t,std::string>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.StringVertexData<java.lang.Long,com.alibaba.fastffi.impl.CXXStdString>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_VERTEX_DATA_H)),
+                        @CXXTemplate(
+                                cxx = "gs::EdgeData<uint64_t,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.EdgeData<java.lang.Long,java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_EDGE_DATA_H)),
+                        @CXXTemplate(
+                                cxx = "gs::EdgeData<uint64_t,int32_t>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.EdgeData<java.lang.Long,java.lang.Integer>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_EDGE_DATA_H)),
+                        @CXXTemplate(
+                                cxx = "gs::EdgeData<uint64_t,double>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.EdgeData<java.lang.Long,java.lang.Double>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_EDGE_DATA_H)),
+                        @CXXTemplate(
+                                cxx = "gs::EdgeData<uint64_t,std::string>",
+                                java =
+                                        "com.alibaba.graphscope.graphx.StringEdgeData<java.lang.Long,com.alibaba.fastffi.impl.CXXStdString>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_EDGE_DATA_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,int64_t,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,int64_t,int32_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Integer>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,int64_t,double>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Double>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,int32_t,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Integer,java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,int32_t,int32_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Integer,java.lang.Integer>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,int32_t,double>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Integer,java.lang.Double>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,double,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,double,int32_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Integer>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,double,double>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Double>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,std::string,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXStringVDFragment<java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString,java.lang.Long>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,std::string,double>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXStringVDFragment<java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString,java.lang.Double>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,std::string,int32_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXStringVDFragment<java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString,java.lang.Integer>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,int64_t,std::string>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXStringEDFragment<java.lang.Long,java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,double,std::string>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXStringEDFragment<java.lang.Long,java.lang.Long,java.lang.Double,com.alibaba.fastffi.impl.CXXStdString>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::GraphXFragment<int64_t,uint64_t,int32_t,std::string>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXStringEDFragment<java.lang.Long,java.lang.Long,java.lang.Integer,com.alibaba.fastffi.impl.CXXStdString>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::GraphXFragment<int64_t,uint64_t,std::string,std::string>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.GraphXStringVEDFragment<java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString,com.alibaba.fastffi.impl.CXXStdString>",
+                                include = @CXXHead(CORE_JAVA_GRAPHX_GRAPHX_FRAGMENT_H)),
+                        @CXXTemplate(
+                                cxx = "gs::ArrowProjectedFragment<int64_t,uint64_t,double,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>",
+                                include = @CXXHead(ARROW_PROJECTED_FRAGMENT_MAPPER_H)),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::ArrowProjectedFragment<int64_t,uint64_t,int64_t,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>",
+                                include = @CXXHead(ARROW_PROJECTED_FRAGMENT_MAPPER_H)),
+                        @CXXTemplate(
+                                cxx =
+                                        "gs::ArrowProjectedFragmentMapper<int64_t,uint64_t,int64_t,int64_t,int64_t,int64_t>",
+                                java =
+                                        "com.alibaba.graphscope.fragment.ArrowProjectedFragmentMapper<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>",
+                                include = {
+                                    @CXXHead(ARROW_PROJECTED_FRAGMENT_MAPPER_H),
+                                    @CXXHead(CORE_JAVA_TYPE_ALIAS_H)
+                                }),
+                        @CXXTemplate(
+                                cxx = "vineyard::ArrowFragmentGroup",
+                                java = "com.alibaba.graphscope.fragment.ArrowFragmentGroup",
+                                include = {@CXXHead(ARROW_FRAGMENT_GROUP_H)})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.BasicLocalVertexMapBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t"},
+                                java = {"Long", "Long"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.BasicGraphXCSRBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t"},
+                                java = {"Long", "Long"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.VertexDataBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int32_t"},
+                                java = {"Long", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int64_t"},
+                                java = {"Long", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "double"},
+                                java = {"Long", "Double"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.VineyardArrayBuilder",
+                    templates = {
+                        @CXXTemplate(cxx = "int64_t", java = "Long"),
+                        @CXXTemplate(cxx = "int32_t", java = "Integer"),
+                        @CXXTemplate(cxx = "double", java = "Double")
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.EdgeDataBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int32_t"},
+                                java = {"Long", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int64_t"},
+                                java = {"Long", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "double"},
+                                java = {"Long", "Double"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.StringVertexDataBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "std::string"},
+                                java = {"Long", "com.alibaba.fastffi.impl.CXXStdString"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.StringEdgeDataBuilder",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "std::string"},
+                                java = {"Long", "com.alibaba.fastffi.impl.CXXStdString"})
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.graphx.GraphXVertexMapGetter",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t"},
+                                java = {"Long", "Long"})
+                    }),
+            @FFIGen(
+                    library = "grape-jni",
+                    type = "com.alibaba.graphscope.arrow.array.ArrowArrayBuilder",
+                    templates = {
+                        @CXXTemplate(cxx = "int64_t", java = "Long"),
+                        @CXXTemplate(cxx = "uint64_t", java = "Long"),
+                        @CXXTemplate(cxx = "int32_t", java = "Integer"),
+                        @CXXTemplate(cxx = "double", java = "Double")
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.ds.GrapeNbr",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "double"},
+                                java = {"Long", "Double"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int32_t"},
+                                java = {"Long", "Integer"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int64_t"},
+                                java = {"Long", "Long"}),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.ds.ImmutableCSR",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int64_t"},
+                                java = {"Long", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "double"},
+                                java = {"Long", "Double"}),
+                        @CXXTemplate(
+                                cxx = {"uint64_t", "int32_t"},
+                                java = {"Long", "Integer"})
                     }),
             @FFIGen(
                     type = "com.alibaba.graphscope.ds.TypedArray",
@@ -193,6 +823,30 @@ import com.alibaba.graphscope.utils.CppClassName;
                         @CXXTemplate(
                                 cxx = {"int64_t", "uint64_t", "int64_t", "int64_t"},
                                 java = {"Long", "Long", "Long", "Long"}),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.fragment.ArrowProjectedFragmentMapper",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {
+                                    "int64_t",
+                                    "uint64_t",
+                                    "int64_t",
+                                    "int64_t",
+                                    "int64_t",
+                                    "int64_t"
+                                },
+                                java = {"Long", "Long", "Long", "Long", "Long", "Long"}),
+                    }),
+            @FFIGen(
+                    type = "com.alibaba.graphscope.fragment.ArrowProjectedFragmentGetter",
+                    templates = {
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "double", "int64_t"},
+                                java = {"Long", "Long", "Double", "Long"}),
+                        @CXXTemplate(
+                                cxx = {"int64_t", "uint64_t", "int64_t", "int64_t"},
+                                java = {"Long", "Long", "Long", "Long"})
                     }),
             @FFIGen(
                     type = "com.alibaba.graphscope.ds.ProjectedNbr",
@@ -309,65 +963,6 @@ import com.alibaba.graphscope.utils.CppClassName;
                                 })
                     }),
             @FFIGen(
-                    type = "com.alibaba.graphscope.stdcxx.StdSharedPtr",
-                    templates = {
-                        @CXXTemplate(
-                                cxx = "gs::DoubleColumn<gs::ArrowFragmentDefault<int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.DoubleColumn<com.alibaba.graphscope.fragment.ArrowFragment<java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx = "gs::IntColumn<gs::ArrowFragmentDefault<int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.IntColumn<com.alibaba.graphscope.fragment.ArrowFragment<java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx = "gs::LongColumn<gs::ArrowFragmentDefault<int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.LongColumn<com.alibaba.graphscope.fragment.ArrowFragment<java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx =
-                                        "gs::DoubleColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,int64_t,int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.DoubleColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx =
-                                        "gs::IntColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,int64_t,int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.IntColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx =
-                                        "gs::LongColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,int64_t,int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.LongColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx =
-                                        "gs::DoubleColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,double,int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.DoubleColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx =
-                                        "gs::IntColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,double,int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.IntColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx =
-                                        "gs::LongColumn<gs::ArrowProjectedFragment<int64_t,uint64_t,double,int64_t>>",
-                                java =
-                                        "com.alibaba.graphscope.column.LongColumn<com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>>"),
-                        @CXXTemplate(
-                                cxx = "gs::ArrowProjectedFragment<int64_t,uint64_t,double,int64_t>",
-                                java =
-                                        "com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>"),
-                        @CXXTemplate(
-                                cxx =
-                                        "gs::ArrowProjectedFragment<int64_t,uint64_t,int64_t,int64_t>",
-                                java =
-                                        "com.alibaba.graphscope.fragment.ArrowProjectedFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>"),
-                        @CXXTemplate(
-                                cxx = "vineyard::ArrowFragmentGroup",
-                                java = "com.alibaba.graphscope.fragment.ArrowFragmentGroup",
-                                include = {@CXXHead(ARROW_FRAGMENT_GROUP_H)})
-                    }),
-            @FFIGen(
                     type = "com.alibaba.graphscope.context.ffi.FFILabeledVertexDataContext",
                     templates = {
                         @CXXTemplate(
@@ -386,6 +981,150 @@ import com.alibaba.graphscope.utils.CppClassName;
             @FFIGen(
                     type = "com.alibaba.graphscope.context.ffi.FFIVertexDataContext",
                     templates = {
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,double,int32_t>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Integer>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,double,int64_t>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Long>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,double,double>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Double,java.lang.Double>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,int32_t,int32_t>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Integer,java.lang.Integer>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,int32_t,int64_t>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Integer,java.lang.Long>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,int32_t,double>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Integer,java.lang.Double>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,int64_t,int64_t>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Long>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,int64_t,int32_t>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Integer>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,int64_t,double>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXFragment<java.lang.Long,java.lang.Long,java.lang.Long,java.lang.Double>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,int64_t,std::string>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXStringEDFragment<java.lang.Long,java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,double,std::string>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXStringEDFragment<java.lang.Long,java.lang.Long,java.lang.Double,com.alibaba.fastffi.impl.CXXStdString>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,int32_t,std::string>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXStringEDFragment<java.lang.Long,java.lang.Long,java.lang.Integer,com.alibaba.fastffi.impl.CXXStdString>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,std::string,int32_t>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXStringVDFragment<java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString,java.lang.Integer>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,std::string,int64_t>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXStringVDFragment<java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString,java.lang.Long>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,std::string,double>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXStringVDFragment<java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString,java.lang.Double>",
+                                    "Long"
+                                }),
+                        @CXXTemplate(
+                                cxx = {
+                                    GRAPHX_FRAGMENT + "<int64_t,uint64_t,std::string,std::string>",
+                                    "int64_t"
+                                },
+                                java = {
+                                    "com.alibaba.graphscope.fragment.GraphXStringVEDFragment<java.lang.Long,java.lang.Long,com.alibaba.fastffi.impl.CXXStdString,com.alibaba.fastffi.impl.CXXStdString>",
+                                    "Long"
+                                }),
                         @CXXTemplate(
                                 cxx = {
                                     ARROW_PROJECTED_FRAGMENT + "<int64_t,uint64_t,double,int64_t>",

--- a/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/GraphScopeClassLoader.java
+++ b/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/GraphScopeClassLoader.java
@@ -110,6 +110,12 @@ public class GraphScopeClassLoader {
             URLClassLoader classLoader, String className, String serialPath)
             throws ClassNotFoundException, InstantiationException, IllegalAccessException,
                     InvocationTargetException, NoSuchMethodException {
+        if (className.startsWith("com.alibaba.graphscope.app.GraphXParallelAdaptor")) {
+            return loadGraphXAdaptor(serialPath, classLoader);
+        }
+        if (className.startsWith("com.alibaba.graphscope.context.GraphXParallelAdaptorContext")) {
+            return loadGraphxAdaptorCtx(serialPath, classLoader);
+        }
         logger.info("Load and create: " + formatting(className));
         Class<?> clz = classLoader.loadClass(formatting(className));
         return clz.newInstance();
@@ -343,5 +349,37 @@ public class GraphScopeClassLoader {
             }
         }
         return Integer.parseInt(version);
+    }
+
+    private static Object loadGraphXAdaptor(String serialPath, URLClassLoader classLoader)
+            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
+                    IllegalAccessException {
+        Class<?> graphxClz =
+                classLoader.loadClass("com.alibaba.graphscope.app.GraphXParallelAdaptor");
+        logger.info("Load clz : {}", graphxClz.getName());
+        Method method = graphxClz.getDeclaredMethod("create", URLClassLoader.class, String.class);
+
+        Object obj = method.invoke(null, classLoader, serialPath);
+        logger.debug("Successfully invoked method, got" + obj);
+        return obj;
+    }
+
+    private static Object loadGraphxAdaptorCtx(String serialPath, URLClassLoader classLoader)
+            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException,
+                    IllegalAccessException {
+        logger.debug(
+                "Trying create graphx adaptor context from: "
+                        + serialPath
+                        + " with class loader: "
+                        + classLoader);
+        Class<?> graphxClz =
+                classLoader.loadClass(
+                        "com.alibaba.graphscope.context.GraphXParallelAdaptorContext");
+
+        logger.info("Load clz : {}", graphxClz.getName());
+        Method method = graphxClz.getDeclaredMethod("create", URLClassLoader.class, String.class);
+        Object obj = method.invoke(null, classLoader, serialPath);
+        logger.debug("Successfully invoked method, got" + obj);
+        return obj;
     }
 }

--- a/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/IFragmentHelper.java
+++ b/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/IFragmentHelper.java
@@ -19,9 +19,17 @@ package com.alibaba.graphscope.runtime;
 import static com.alibaba.graphscope.runtime.GraphScopeClassLoader.getTypeArgumentFromInterface;
 
 import com.alibaba.graphscope.fragment.ArrowProjectedFragment;
+import com.alibaba.graphscope.fragment.GraphXFragment;
+import com.alibaba.graphscope.fragment.GraphXStringEDFragment;
+import com.alibaba.graphscope.fragment.GraphXStringVDFragment;
+import com.alibaba.graphscope.fragment.GraphXStringVEDFragment;
 import com.alibaba.graphscope.fragment.IFragment;
 import com.alibaba.graphscope.fragment.ImmutableEdgecutFragment;
 import com.alibaba.graphscope.fragment.adaptor.ArrowProjectedAdaptor;
+import com.alibaba.graphscope.fragment.adaptor.GraphXFragmentAdaptor;
+import com.alibaba.graphscope.fragment.adaptor.GraphXStringEDFragmentAdaptor;
+import com.alibaba.graphscope.fragment.adaptor.GraphXStringVDFragmentAdaptor;
+import com.alibaba.graphscope.fragment.adaptor.GraphXStringVEDFragmentAdaptor;
 import com.alibaba.graphscope.fragment.adaptor.ImmutableEdgecutFragmentAdaptor;
 
 import org.slf4j.Logger;
@@ -58,9 +66,54 @@ public class IFragmentHelper {
             }
             return createImmutableFragmentAdaptor(
                     classes[0], classes[1], classes[2], classes[3], immutableEdgecutFragment);
+        } else if (fragmentImpl instanceof GraphXFragment) {
+            GraphXFragment graphXFragment = (GraphXFragment) fragmentImpl;
+            Class<?>[] classes =
+                    getTypeArgumentFromInterface(GraphXFragment.class, graphXFragment.getClass());
+            if (classes.length != 4) {
+                logger.error("Expected 4 actural type arguments, received: " + classes.length);
+                return null;
+            }
+            return createGraphXFragmentAdaptor(
+                    classes[0], classes[1], classes[2], classes[3], graphXFragment);
+        } else if (fragmentImpl instanceof GraphXStringVDFragment) {
+            GraphXStringVDFragment graphXStringVDFragment = (GraphXStringVDFragment) fragmentImpl;
+            Class<?>[] classes =
+                    getTypeArgumentFromInterface(
+                            GraphXStringVDFragment.class, graphXStringVDFragment.getClass());
+            if (classes.length != 4) {
+                logger.error("Expected 4 actural type arguments, received: " + classes.length);
+                return null;
+            }
+            return createGraphXStringVDFragmentAdaptor(
+                    classes[0], classes[1], classes[2], classes[3], graphXStringVDFragment);
+        } else if (fragmentImpl instanceof GraphXStringEDFragment) {
+            GraphXStringEDFragment graphXStringEDFragment = (GraphXStringEDFragment) fragmentImpl;
+            Class<?>[] classes =
+                    getTypeArgumentFromInterface(
+                            GraphXStringEDFragment.class, graphXStringEDFragment.getClass());
+            if (classes.length != 4) {
+                logger.error("Expected 4 actural type arguments, received: " + classes.length);
+                return null;
+            }
+            return createGraphXStringEDFragmentAdaptor(
+                    classes[0], classes[1], classes[2], classes[3], graphXStringEDFragment);
+        } else if (fragmentImpl instanceof GraphXStringVEDFragment) {
+            GraphXStringVEDFragment graphXStringVEDFragment =
+                    (GraphXStringVEDFragment) fragmentImpl;
+            Class<?>[] classes =
+                    getTypeArgumentFromInterface(
+                            GraphXStringVEDFragment.class, graphXStringVEDFragment.getClass());
+            if (classes.length != 4) {
+                logger.error("Expected 4 actural type arguments, received: " + classes.length);
+                return null;
+            }
+            return createGraphXStringVEDFragmentAdaptor(
+                    classes[0], classes[1], classes[2], classes[3], graphXStringVEDFragment);
         } else {
             logger.info(
-                    "Provided fragment is neither a projected fragment nor a immutable fragment");
+                    "Provided fragment is neither a projected fragment,a immutable fragment or"
+                            + " graphx fragment.");
             return null;
         }
     }
@@ -112,5 +165,48 @@ public class IFragmentHelper {
                             Class<? extends EDATA_T> edataClass,
                             ImmutableEdgecutFragment<OID_T, VID_T, VDATA_T, EDATA_T> fragment) {
         return new ImmutableEdgecutFragmentAdaptor<>(fragment);
+    }
+
+    private static <OID_T, VID_T, VDATA_T, EDATA_T>
+            GraphXFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T> createGraphXFragmentAdaptor(
+                    Class<? extends OID_T> oidClass,
+                    Class<? extends VID_T> vidClass,
+                    Class<? extends VDATA_T> vdClass,
+                    Class<? extends EDATA_T> edClass,
+                    GraphXFragment<OID_T, VID_T, VDATA_T, EDATA_T> fragment) {
+        return new GraphXFragmentAdaptor<>(fragment);
+    }
+
+    private static <OID_T, VID_T, VDATA_T, EDATA_T>
+            GraphXStringVDFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T>
+                    createGraphXStringVDFragmentAdaptor(
+                            Class<? extends OID_T> oidClass,
+                            Class<? extends VID_T> vidClass,
+                            Class<? extends VDATA_T> vdClass,
+                            Class<? extends EDATA_T> edClass,
+                            GraphXStringVDFragment<OID_T, VID_T, VDATA_T, EDATA_T> fragment) {
+        return new GraphXStringVDFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T>(fragment);
+    }
+
+    private static <OID_T, VID_T, VDATA_T, EDATA_T>
+            GraphXStringEDFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T>
+                    createGraphXStringEDFragmentAdaptor(
+                            Class<? extends OID_T> oidClass,
+                            Class<? extends VID_T> vidClass,
+                            Class<? extends VDATA_T> vdClass,
+                            Class<? extends EDATA_T> edClass,
+                            GraphXStringEDFragment<OID_T, VID_T, VDATA_T, EDATA_T> fragment) {
+        return new GraphXStringEDFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T>(fragment);
+    }
+
+    private static <OID_T, VID_T, VDATA_T, EDATA_T>
+            GraphXStringVEDFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T>
+                    createGraphXStringVEDFragmentAdaptor(
+                            Class<? extends OID_T> oidClass,
+                            Class<? extends VID_T> vidClass,
+                            Class<? extends VDATA_T> vdClass,
+                            Class<? extends EDATA_T> edClass,
+                            GraphXStringVEDFragment<OID_T, VID_T, VDATA_T, EDATA_T> fragment) {
+        return new GraphXStringVEDFragmentAdaptor<OID_T, VID_T, VDATA_T, EDATA_T>(fragment);
     }
 }

--- a/analytical_engine/java/grape_jvm_opts
+++ b/analytical_engine/java/grape_jvm_opts
@@ -22,13 +22,27 @@ then
     echo "Infered GRAPHSCOPE_HOME "${gs_runtime}
 fi
 
+if [[ "$SPARK_HOME"x == x ]];
+then
+    echo "[warn] No SPARK_HOME found!"
+fi
+
+GRAPHX_GRAPE_SDK=${GRAPHSCOPE_HOME}/lib/graphx-on-graphscope-0.16.0-shaded.jar
 # This env point to the directory where the output for llvm4jni run.sh on Grape-runtime.jar resides
 if [[ "${RUNTIME_LLVM4JNI_OUTPUT}"x != x ]];
 then
     echo "find env RUNTIME_LLVM4JNI_OUTPUT, append to init java class path"
-    class_path=${RUNTIME_LLVM4JNI_OUTPUT}:${GRAPHSCOPE_HOME}/lib/grape-runtime-0.16.0-shaded.jar
+    class_path=${RUNTIME_LLVM4JNI_OUTPUT}:${GRAPHSCOPE_HOME}/lib/grape-runtime-0.16.0-shaded.jar:${GRAPHX_GRAPE_SDK}
 else 
-    class_path=${GRAPHSCOPE_HOME}/lib/grape-runtime-0.16.0-shaded.jar
+    class_path=${GRAPHSCOPE_HOME}/lib/grape-runtime-0.16.0-shaded.jar:${GRAPHX_GRAPE_SDK}
+fi
+
+#include jars in spark/jars
+if [ ! -z "${SPARK_HOME}" ]; then
+   jars=`ls ${SPARK_HOME}/jars`
+   for jar in ${jars}; do
+       class_path=${class_path}:${SPARK_HOME}/jars/${jar}
+   done
 fi
 
 jvm_version=$(${JAVA_HOME}/bin/javac -version 2>&1 | awk -F ' ' '{print $2}' | awk -F '.' '{print $1}')

--- a/analytical_engine/java/graphx-on-graphscope/pom.xml
+++ b/analytical_engine/java/graphx-on-graphscope/pom.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 Alibaba Group Holding Limited.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~  	http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.alibaba.graphscope</groupId>
+    <artifactId>grape-jdk-parent</artifactId>
+    <version>0.16.0</version>
+  </parent>
+
+  <artifactId>graphx-on-graphscope</artifactId>
+  <packaging>jar</packaging>
+
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <scala.version>2.12.10</scala.version>
+    <skipTests>false</skipTests>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_2.12</artifactId>
+      <version>3.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <!--spark jars are available in class path -->
+    <!-- do not include in the fat jar -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-graphx_2.12</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.12</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.graphscope</groupId>
+      <artifactId>grape-jdk</artifactId>
+      <classifier>shaded</classifier>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.fastffi</groupId>
+      <artifactId>llvm4jni-runtime</artifactId>
+      <!-- <version>0.1</version> -->
+      <!-- <classifier>jar-with-dependencies</classifier> -->
+    </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>none</phase>
+          </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <configuration>
+          <scalaVersion>${scala.version}</scalaVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>test</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>com.alibaba.graphscope:*</include>
+                  <include>com.alibaba.fastffi:*</include>
+                  <include>org.scala-lang:*</include>
+                  <include>org.apache.spark:spark-graphx_2.12*</include>
+                  <include>it.unimi.dsi:fastutil*</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <finalName>${uberjar.name}</finalName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/app/GraphXParallelAdaptor.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/app/GraphXParallelAdaptor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.app;
+
+import com.alibaba.graphscope.context.GraphXParallelAdaptorContext;
+import com.alibaba.graphscope.context.ParallelContextBase;
+import com.alibaba.graphscope.fragment.IFragment;
+import com.alibaba.graphscope.graphx.GraphXParallelPIE;
+import com.alibaba.graphscope.graphx.utils.SerializationUtils;
+import com.alibaba.graphscope.parallel.ParallelMessageManager;
+
+import java.net.URLClassLoader;
+
+public class GraphXParallelAdaptor<VDATA_T, EDATA_T, MSG>
+        implements ParallelAppBase<
+                Long, Long, VDATA_T, EDATA_T, GraphXParallelAdaptorContext<VDATA_T, EDATA_T, MSG>> {
+
+    public static <VD, ED, M> GraphXParallelAdaptor<VD, ED, M> createImpl(
+            Class<? extends VD> vdClass, Class<? extends ED> edClass, Class<? extends M> msgClass) {
+        return new GraphXParallelAdaptor<VD, ED, M>();
+    }
+
+    public static <VD, ED, M> GraphXParallelAdaptor<VD, ED, M> create(
+            URLClassLoader classLoader, String serialPath) throws ClassNotFoundException {
+        Object[] objects = SerializationUtils.read(classLoader, serialPath);
+        if (objects.length != 10) {
+            throw new IllegalStateException(
+                    "Expect 10 deserialzed object, but only got " + objects.length);
+        }
+        Class<?> vdClass = (Class<?>) objects[0];
+        Class<?> edClass = (Class<?>) objects[1];
+        Class<?> msgClass = (Class<?>) objects[2];
+        return (GraphXParallelAdaptor<VD, ED, M>) createImpl(vdClass, edClass, msgClass);
+    }
+
+    @Override
+    public void PEval(
+            IFragment<Long, Long, VDATA_T, EDATA_T> graph,
+            ParallelContextBase<Long, Long, VDATA_T, EDATA_T> context,
+            ParallelMessageManager messageManager) {
+        GraphXParallelAdaptorContext<VDATA_T, EDATA_T, MSG> ctx =
+                (GraphXParallelAdaptorContext<VDATA_T, EDATA_T, MSG>) context;
+        GraphXParallelPIE<VDATA_T, EDATA_T, MSG> proxy = ctx.getGraphXProxy();
+        proxy.ParallelPEval();
+        messageManager.ForceContinue();
+    }
+
+    @Override
+    public void IncEval(
+            IFragment<Long, Long, VDATA_T, EDATA_T> graph,
+            ParallelContextBase<Long, Long, VDATA_T, EDATA_T> context,
+            ParallelMessageManager messageManager) {
+        GraphXParallelAdaptorContext<VDATA_T, EDATA_T, MSG> ctx =
+                (GraphXParallelAdaptorContext<VDATA_T, EDATA_T, MSG>) context;
+        GraphXParallelPIE<VDATA_T, EDATA_T, MSG> proxy = ctx.getGraphXProxy();
+        boolean maxIterationReached = proxy.ParallelIncEval();
+        if (!maxIterationReached) {
+            messageManager.ForceContinue();
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/context/GraphXParallelAdaptorContext.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/context/GraphXParallelAdaptorContext.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.context;
+
+import com.alibaba.fastffi.FFIByteString;
+import com.alibaba.fastffi.FFITypeFactory;
+import com.alibaba.fastffi.impl.CXXStdString;
+import com.alibaba.fastjson.JSONObject;
+import com.alibaba.graphscope.fragment.IFragment;
+import com.alibaba.graphscope.graphx.GraphXConf;
+import com.alibaba.graphscope.graphx.GraphXParallelPIE;
+import com.alibaba.graphscope.graphx.StringVertexData;
+import com.alibaba.graphscope.graphx.VertexData;
+import com.alibaba.graphscope.graphx.VineyardClient;
+import com.alibaba.graphscope.graphx.utils.ScalaFFIFactory;
+import com.alibaba.graphscope.graphx.utils.SerializationUtils;
+import com.alibaba.graphscope.parallel.ParallelMessageManager;
+import com.alibaba.graphscope.utils.VertexDataUtils;
+import com.alibaba.graphscope.utils.array.PrimitiveArray;
+
+import org.apache.spark.graphx.EdgeDirection;
+import org.apache.spark.graphx.EdgeTriplet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Function1;
+import scala.Function2;
+import scala.Function3;
+import scala.Tuple2;
+import scala.collection.Iterator;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URLClassLoader;
+
+public class GraphXParallelAdaptorContext<VDATA_T, EDATA_T, MSG>
+        extends VertexDataContext<IFragment<Long, Long, VDATA_T, EDATA_T>, VDATA_T>
+        implements ParallelContextBase<Long, Long, VDATA_T, EDATA_T> {
+    public static final String pathPrefix = "/tmp/gs_graphx_pie_";
+
+    public static <VD, ED, M> GraphXParallelAdaptorContext<VD, ED, M> createImpl(
+            Class<? extends VD> vdClass,
+            Class<? extends ED> edClass,
+            Class<? extends M> msgClass,
+            Function3 vprog,
+            Function1 sendMsg,
+            Function2 mergeMsg,
+            Object initMsg,
+            String appName,
+            String vineyardSocket,
+            EdgeDirection direction) {
+        return new GraphXParallelAdaptorContext<VD, ED, M>(
+                vdClass,
+                edClass,
+                msgClass,
+                (Function3<Long, VD, M, VD>) vprog,
+                (Function1<EdgeTriplet<VD, ED>, Iterator<Tuple2<Long, M>>>) sendMsg,
+                (Function2<M, M, M>) mergeMsg,
+                (M) initMsg,
+                appName,
+                vineyardSocket,
+                direction);
+    }
+
+    public static <VD, ED, M> GraphXParallelAdaptorContext<VD, ED, M> create(
+            URLClassLoader classLoader, String serialPath) throws ClassNotFoundException {
+        Object[] objects = SerializationUtils.read(classLoader, serialPath);
+        if (objects.length != 10) {
+            throw new IllegalStateException(
+                    "Expect 10 deserialzed object, but only got " + objects.length);
+        }
+        Class<?> vdClass = (Class<?>) objects[0];
+        Class<?> edClass = (Class<?>) objects[1];
+        Class<?> msgClass = (Class<?>) objects[2];
+        Function3 vprog = (Function3) objects[3];
+        Function1 sendMsg = (Function1) objects[4];
+        Function2 mergeMsg = (Function2) objects[5];
+        Object initMsg = objects[6];
+        String appName = (String) objects[7];
+        String socket = (String) objects[8];
+        EdgeDirection direction = (EdgeDirection) objects[9];
+        return (GraphXParallelAdaptorContext<VD, ED, M>)
+                createImpl(
+                        vdClass, edClass, msgClass, vprog, sendMsg, mergeMsg, initMsg, appName,
+                        socket, direction);
+    }
+
+    private static Logger logger =
+            LoggerFactory.getLogger(GraphXParallelAdaptorContext.class.getName());
+    private GraphXConf<VDATA_T, EDATA_T, MSG> conf;
+    private GraphXParallelPIE<VDATA_T, EDATA_T, MSG> graphXProxy;
+    private String appName, vineyardSocket;
+
+    public String getAppName() {
+        return appName;
+    }
+
+    public GraphXConf getConf() {
+        return conf;
+    }
+
+    public GraphXParallelPIE<VDATA_T, EDATA_T, MSG> getGraphXProxy() {
+        return graphXProxy;
+    }
+
+    public GraphXParallelAdaptorContext(
+            Class<? extends VDATA_T> vdClass,
+            Class<? extends EDATA_T> edClass,
+            Class<? extends MSG> msgClass,
+            Function3<Long, VDATA_T, MSG, VDATA_T> vprog,
+            Function1<EdgeTriplet<VDATA_T, EDATA_T>, Iterator<Tuple2<Long, MSG>>> sendMsg,
+            Function2<MSG, MSG, MSG> mergeMsg,
+            MSG initialMsg,
+            String appName,
+            String vineyardSocket,
+            EdgeDirection edgeDirection) {
+        this.conf = new GraphXConf<>(vdClass, edClass, msgClass);
+        // parallelGraphXPIE
+        this.graphXProxy =
+                new GraphXParallelPIE<VDATA_T, EDATA_T, MSG>(
+                        conf, vprog, sendMsg, mergeMsg, initialMsg, edgeDirection);
+        this.appName = appName;
+        this.vineyardSocket = vineyardSocket;
+    }
+
+    /**
+     * Called by grape framework, before any PEval. You can initiating data structures need during
+     * super steps here.
+     *
+     * @param frag           The graph fragment providing accesses to graph data.
+     * @param messageManager The message manger which manages messages between fragments.
+     * @param jsonObject     String args from cmdline.
+     * @see IFragment
+     * @see ParallelMessageManager
+     * @see JSONObject
+     */
+    @Override
+    public void Init(
+            IFragment<Long, Long, VDATA_T, EDATA_T> frag,
+            ParallelMessageManager messageManager,
+            JSONObject jsonObject) {
+
+        int maxIterations = jsonObject.getInteger("max_iterations");
+        logger.info("Max iterations: " + maxIterations);
+        int numPart = jsonObject.getInteger("num_part");
+        int fnum = frag.fnum();
+        int splitSize = (numPart + fnum - 1) / fnum;
+        int myParallelism = calcMyParallelism(numPart, splitSize, frag.fid());
+        logger.info("frag {} parallelism {}", frag.fid(), myParallelism);
+        String workerIdToFidStr = jsonObject.getString("worker_id_to_fid");
+        if (workerIdToFidStr == null || workerIdToFidStr.isEmpty()) {
+            throw new IllegalStateException("expect worker id to fid mapping");
+        }
+
+        try {
+            graphXProxy.init(frag, messageManager, maxIterations, myParallelism, workerIdToFidStr);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new IllegalStateException("initialization error");
+        }
+        logger.info("create graphx proxy: {}", graphXProxy);
+        // NOTE: Currently we don't use this context provided vdata array, just use long class as
+        // default vdata class, and we don't use it.
+        createFFIContext(frag, (Class<? extends VDATA_T>) Long.class, false);
+    }
+
+    /**
+     * Output will be executed when the computations finalizes. Data maintained in this context
+     * shall be outputted here.
+     *
+     * @param frag The graph fragment contains the graph info.
+     * @see IFragment
+     */
+    @Override
+    public void Output(IFragment<Long, Long, VDATA_T, EDATA_T> frag) {
+        PrimitiveArray<VDATA_T> vdArray = graphXProxy.getNewVdataArray();
+        long time0 = System.nanoTime();
+        VineyardClient client = ScalaFFIFactory.newVineyardClient();
+        FFIByteString ffiByteString = FFITypeFactory.newByteString();
+        ffiByteString.copyFrom(this.vineyardSocket);
+        client.connect(ffiByteString);
+        String filePath = pathPrefix + frag.fid();
+        long objId = 0;
+        if (conf.isVDPrimitive()) {
+            VertexData<Long, VDATA_T> vd =
+                    VertexDataUtils.persistPrimitiveArrayToVineyard(
+                            vdArray, client, conf.getVdClass());
+            logger.info(
+                    "successfully persist primitive vd of type {} to {}",
+                    conf.getVdClass().getName(),
+                    vd.id());
+            // write to file
+            objId = vd.id();
+        } else {
+            StringVertexData<Long, CXXStdString> vd =
+                    VertexDataUtils.persistComplexArrayToVineyard(
+                            vdArray, client, conf.getVdClass());
+            logger.info(
+                    "successfully persist complex vd of type {} to {}",
+                    conf.getVdClass().getName(),
+                    vd.id());
+            objId = vd.id();
+        }
+        long time1 = System.nanoTime();
+        logger.info("Finish writing back, cost {} ms", (time1 - time0) / 1000000);
+        FileWriter fileWritter = null;
+        try {
+            fileWritter = new FileWriter(filePath);
+            BufferedWriter bufferedWriter = new BufferedWriter(fileWritter);
+            bufferedWriter.write("" + objId);
+            bufferedWriter.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    int calcMyParallelism(int limit, int splitSize, int fid) {
+        int begin = Math.min(limit, splitSize * fid);
+        int end = Math.min(limit, begin + splitSize);
+        return end - begin;
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/format/LongLong.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/format/LongLong.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.format;
+
+import org.apache.hadoop.io.Writable;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class LongLong implements Writable {
+    public long first;
+    public long second;
+
+    @Override
+    public String toString() {
+        return "LongLong{" + "first=" + first + ", second=" + second + '}';
+    }
+
+    @Override
+    public void write(DataOutput dataOutput) throws IOException {
+        dataOutput.writeLong(first);
+        dataOutput.writeLong(second);
+    }
+
+    @Override
+    public void readFields(DataInput dataInput) throws IOException {
+        first = dataInput.readLong();
+        second = dataInput.readLong();
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/format/LongLongInputFormat.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/format/LongLongInputFormat.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.format;
+
+import com.google.common.base.Charsets;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.CompressionCodecFactory;
+import org.apache.hadoop.io.compress.SplittableCompressionCodec;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobConfigurable;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class LongLongInputFormat extends FileInputFormat<LongWritable, LongLong>
+        implements JobConfigurable {
+
+    private Logger logger = LoggerFactory.getLogger(LongLongInputFormat.class.getName());
+    private CompressionCodecFactory compressionCodecs = null;
+
+    protected boolean isSplitable(FileSystem fs, Path file) {
+        CompressionCodec codec = this.compressionCodecs.getCodec(file);
+        return null == codec ? true : codec instanceof SplittableCompressionCodec;
+    }
+
+    public RecordReader<LongWritable, LongLong> getRecordReader(
+            InputSplit genericSplit, JobConf job, Reporter reporter) throws IOException {
+        reporter.setStatus(genericSplit.toString());
+        String delimiter = job.get("textinputformat.record.delimiter");
+        byte[] recordDelimiterBytes = null;
+        if (null != delimiter) {
+            recordDelimiterBytes = delimiter.getBytes(Charsets.UTF_8);
+        }
+        return new LongLongRecordReader(job, (FileSplit) genericSplit, recordDelimiterBytes);
+    }
+
+    @Override
+    public void configure(JobConf jobConf) {
+        this.compressionCodecs = new CompressionCodecFactory(jobConf);
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/format/LongLongRecordReader.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/format/LongLongRecordReader.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.format;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.LineRecordReader;
+import org.apache.hadoop.mapred.RecordReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+public class LongLongRecordReader implements RecordReader<LongWritable, LongLong> {
+
+    private Logger logger = LoggerFactory.getLogger(LongLongRecordReader.class.getName());
+    private LineRecordReader lineRecordReader;
+    private Text text = new Text();
+
+    public LongLongRecordReader(Configuration job, FileSplit split, byte[] recordDelimiter)
+            throws IOException {
+        lineRecordReader = new LineRecordReader(job, split, recordDelimiter);
+    }
+
+    @Override
+    public boolean next(LongWritable longWritable, LongLong longLong) throws IOException {
+        boolean res = lineRecordReader.next(longWritable, text);
+        if (!res) {
+            return false;
+        }
+        Iterator<String> iter =
+                Splitter.on(CharMatcher.whitespace()).split(text.toString()).iterator();
+        longLong.first = Long.parseLong(iter.next());
+        longLong.second = Long.parseLong(iter.next());
+        return true;
+    }
+
+    @Override
+    public LongWritable createKey() {
+        return new LongWritable();
+    }
+
+    @Override
+    public LongLong createValue() {
+        return new LongLong();
+    }
+
+    @Override
+    public long getPos() throws IOException {
+        return lineRecordReader.getPos();
+    }
+
+    @Override
+    public void close() throws IOException {
+        lineRecordReader.close();
+    }
+
+    @Override
+    public float getProgress() throws IOException {
+        return lineRecordReader.getProgress();
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/graphx/GraphXConf.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/graphx/GraphXConf.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class GraphXConf<VD, ED, MSG> {
+    private Set<Class<?>> primitiveClasses =
+            new HashSet<Class<?>>(
+                    Arrays.asList(
+                            Long.class,
+                            long.class,
+                            Integer.class,
+                            int.class,
+                            Double.class,
+                            double.class));
+    private Class<? extends VD> vdClass;
+    private Class<? extends ED> edClass;
+    private Class<? extends MSG> msgClass;
+
+    public GraphXConf(
+            Class<? extends VD> vdClass,
+            Class<? extends ED> edClass,
+            Class<? extends MSG> msgClass) {
+        this.vdClass = vdClass;
+        this.edClass = edClass;
+        this.msgClass = msgClass;
+    }
+
+    public void setVdClass(Class<? extends VD> vdClass) {
+        this.vdClass = vdClass;
+    }
+
+    public void setMsgClass(Class<? extends MSG> msgClass) {
+        this.msgClass = msgClass;
+    }
+
+    public void setEdClass(Class<? extends ED> edClass) {
+        this.edClass = edClass;
+    }
+
+    public Class<? extends ED> getEdClass() {
+        return edClass;
+    }
+
+    public Class<? extends MSG> getMsgClass() {
+        return msgClass;
+    }
+
+    public Class<? extends VD> getVdClass() {
+        return vdClass;
+    }
+
+    public boolean isVDPrimitive() {
+        return primitiveClasses.contains(vdClass);
+    }
+
+    public boolean isEDPrimitive() {
+        return primitiveClasses.contains(edClass);
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/graphx/GraphXParallelPIE.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/graphx/GraphXParallelPIE.java
@@ -1,0 +1,605 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx;
+
+import com.alibaba.fastffi.llvm4jni.runtime.JavaRuntime;
+import com.alibaba.graphscope.ds.PropertyNbrUnit;
+import com.alibaba.graphscope.ds.StringTypedArray;
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.BaseGraphXFragment;
+import com.alibaba.graphscope.fragment.FragmentType;
+import com.alibaba.graphscope.fragment.GraphXFragment;
+import com.alibaba.graphscope.fragment.GraphXStringEDFragment;
+import com.alibaba.graphscope.fragment.GraphXStringVDFragment;
+import com.alibaba.graphscope.fragment.GraphXStringVEDFragment;
+import com.alibaba.graphscope.fragment.IFragment;
+import com.alibaba.graphscope.fragment.adaptor.GraphXFragmentAdaptor;
+import com.alibaba.graphscope.fragment.adaptor.GraphXStringEDFragmentAdaptor;
+import com.alibaba.graphscope.fragment.adaptor.GraphXStringVDFragmentAdaptor;
+import com.alibaba.graphscope.fragment.adaptor.GraphXStringVEDFragmentAdaptor;
+import com.alibaba.graphscope.graphx.graph.GSEdgeTripletImpl;
+import com.alibaba.graphscope.graphx.utils.DoubleDouble;
+import com.alibaba.graphscope.graphx.utils.IdParser;
+import com.alibaba.graphscope.parallel.MessageInBuffer;
+import com.alibaba.graphscope.parallel.ParallelMessageManager;
+import com.alibaba.graphscope.serialization.FakeFFIByteVectorInputStream;
+import com.alibaba.graphscope.stdcxx.FFIByteVector;
+import com.alibaba.graphscope.stdcxx.FFIByteVectorFactory;
+import com.alibaba.graphscope.stdcxx.FakeFFIByteVector;
+import com.alibaba.graphscope.utils.FFITypeFactoryhelper;
+import com.alibaba.graphscope.utils.InterruptibleTriConsumer;
+import com.alibaba.graphscope.utils.MessageStore;
+import com.alibaba.graphscope.utils.ThreadSafeBitSet;
+import com.alibaba.graphscope.utils.array.PrimitiveArray;
+
+import org.apache.spark.graphx.EdgeDirection;
+import org.apache.spark.graphx.EdgeTriplet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Function1;
+import scala.Function2;
+import scala.Function3;
+import scala.Tuple2;
+import scala.collection.Iterator;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class GraphXParallelPIE<VD, ED, MSG_T> {
+
+    private static Logger logger = LoggerFactory.getLogger(GraphXParallelPIE.class.getName());
+    private static int BATCH_SIZE = 8192;
+    /**
+     * User vertex program: vprog: (VertexId, VD, A) => VD
+     */
+    private Function3<Long, VD, MSG_T, VD> vprog;
+    /**
+     * EdgeTriplet[VD, ED] => Iterator[(VertexId, A)]
+     */
+    private Function1<EdgeTriplet<VD, ED>, Iterator<Tuple2<Long, MSG_T>>> sendMsg;
+    /**
+     * (A, A) => A)
+     */
+    protected Function2<MSG_T, MSG_T, MSG_T> mergeMsg;
+
+    protected IFragment<Long, Long, VD, ED> iFragment; // different from c++ frag
+    protected BaseGraphXFragment<Long, Long, VD, ED> graphXFragment;
+    private MSG_T initialMessage;
+    private ExecutorService executorService;
+    private int numCores, maxIterations, round;
+    private long vprogTime, msgSendTime, receiveTime, flushTime, bitsetTime;
+    private GraphXConf<VD, ED, MSG_T> conf;
+    //    private GSEdgeTripletImpl<VD, ED> edgeTriplet;
+    ParallelMessageManager messageManager;
+    private PrimitiveArray<VD> newVdataArray;
+    private PrimitiveArray<ED> newEdataArray;
+    private int fid;
+    private IdParser idParser;
+    /**
+     * The messageStore stores the result messages after query. 1) Before PEval or IncEval,
+     * messageStore should be clear. 2) After iterateOnEdges, we need to flush messages a. For
+     * message to inner vertex, set them locally b. For message to outer vertex, send via mpi 3)
+     * after flush, clear message store.
+     */
+    private MessageStore<MSG_T> messageStore;
+
+    private int innerVerticesNum, verticesNum;
+    private ThreadSafeBitSet curSet, nextSet;
+    private EdgeDirection direction;
+    private TypedArray<Long>[] lid2Oid;
+    private TypedArray<Long> outerLid2Gid;
+    private PropertyNbrUnit<Long>[] nbrs;
+    private long oeBeginAddress, ieBeginAddress;
+    private TypedArray<Long> oeOffsetArray, ieOffsetArray;
+    private int[] fid2WorkerId;
+    private MessageInBuffer.Factory bufferFactory = FFITypeFactoryhelper.newMessageInBuffer();
+
+    public PrimitiveArray<VD> getNewVdataArray() {
+        return newVdataArray;
+    }
+
+    public GraphXParallelPIE(
+            GraphXConf<VD, ED, MSG_T> conf,
+            Function3<Long, VD, MSG_T, VD> vprog,
+            Function1<EdgeTriplet<VD, ED>, Iterator<Tuple2<Long, MSG_T>>> sendMsg,
+            Function2<MSG_T, MSG_T, MSG_T> mergeMsg,
+            MSG_T initialMessage,
+            EdgeDirection direction) {
+        this.conf = conf;
+        this.vprog = vprog;
+        this.sendMsg = sendMsg;
+        this.mergeMsg = mergeMsg;
+        this.initialMessage = initialMessage;
+        this.direction = direction;
+    }
+
+    public void init(
+            IFragment<Long, Long, VD, ED> fragment,
+            ParallelMessageManager messageManager,
+            int maxIterations,
+            int parallelism,
+            String workerIdToFid)
+            throws IOException, ClassNotFoundException {
+        long time0 = System.nanoTime();
+        this.iFragment = fragment;
+        fid = fragment.fid();
+        idParser = new IdParser(fragment.fnum());
+        this.numCores = parallelism;
+        if (!(iFragment.fragmentType().equals(FragmentType.GraphXFragment)
+                || iFragment.fragmentType().equals(FragmentType.GraphXStringVDFragment)
+                || iFragment.fragmentType().equals(FragmentType.GraphXStringEDFragment)
+                || iFragment.fragmentType().equals(FragmentType.GraphXStringVEDFragment))) {
+            throw new IllegalStateException("Only support graphx fragment");
+        }
+        this.graphXFragment = getBaseGraphXFragment(iFragment);
+        innerVerticesNum = (int) graphXFragment.getInnerVerticesNum();
+        verticesNum = graphXFragment.getVerticesNum().intValue();
+        long time00 = System.nanoTime();
+        Tuple2<PrimitiveArray<VD>, PrimitiveArray<ED>> tuple =
+                initOldAndNewArrays(graphXFragment, conf);
+        long time01 = System.nanoTime();
+        newVdataArray = tuple._1();
+        newEdataArray = tuple._2();
+        curSet =
+                new ThreadSafeBitSet(
+                        ThreadSafeBitSet.DEFAULT_LOG2_SEGMENT_SIZE_IN_BITS, verticesNum);
+        curSet.setUntil(verticesNum);
+        logger.info(" after init curSet, size {}", curSet.cardinality());
+        // initially activate all vertices
+
+        this.messageManager = messageManager;
+        this.messageManager.initChannels(numCores);
+        this.maxIterations = maxIterations;
+
+        nextSet =
+                new ThreadSafeBitSet(
+                        ThreadSafeBitSet.DEFAULT_LOG2_SEGMENT_SIZE_IN_BITS, verticesNum);
+        logger.info("before create store");
+        this.messageStore =
+                MessageStore.create(
+                        (int) verticesNum,
+                        fragment.fnum(),
+                        numCores,
+                        conf.getMsgClass(),
+                        mergeMsg,
+                        nextSet);
+        logger.info("after create store");
+        logger.debug("ivnum {}, tvnum {}", innerVerticesNum, verticesNum);
+
+        round = 0;
+        lid2Oid = new TypedArray[graphXFragment.fnum()];
+        GraphXVertexMap<Long, Long> vm = graphXFragment.getVM();
+        for (int i = 0; i < vm.fnum(); ++i) {
+            lid2Oid[i] = vm.getLid2OidAccessor(i);
+        }
+        outerLid2Gid = vm.getOuterLid2GidAccessor();
+
+        Vertex<Long> vertex = FFITypeFactoryhelper.newVertexLong();
+        vertex.SetValue(0L);
+        oeOffsetArray = graphXFragment.getCSR().getOEOffsetsArray();
+        ieOffsetArray = graphXFragment.getCSR().getIEOffsetsArray();
+        nbrs = new PropertyNbrUnit[parallelism];
+        for (int i = 0; i < parallelism; ++i) {
+            nbrs[i] = graphXFragment.getOEBegin(vertex);
+        }
+
+        oeBeginAddress = graphXFragment.getOEBegin(vertex).getAddress();
+        ieBeginAddress = graphXFragment.getIEBegin(vertex).getAddress();
+
+        executorService = Executors.newFixedThreadPool(numCores);
+        logger.info("Parallelism for frag {} is {}", graphXFragment.fid(), numCores);
+        fid2WorkerId = new int[graphXFragment.fnum()];
+        fillFid2WorkerId(workerIdToFid);
+        msgSendTime = vprogTime = receiveTime = flushTime = bitsetTime = 0;
+        long time1 = System.nanoTime();
+        logger.info(
+                "[Perf:] init cost {}ms, copy array cost {}ms",
+                (time1 - time0) / 1000000,
+                (time01 - time00) / 1000000);
+    }
+
+    long getId(int lid) {
+        if (lid < innerVerticesNum) {
+            return lid2Oid[fid].get(lid);
+        } else {
+            long gid = outerLid2Gid.get(lid - innerVerticesNum);
+            long outerLid = idParser.getLocalId(gid);
+            int fid = idParser.getFragId(gid);
+            return lid2Oid[fid].get(outerLid);
+        }
+    }
+
+    private void runVProg(int startLid, int endLid, boolean firstRound) {
+        for (int lid = curSet.nextSetBit(startLid);
+                lid >= 0 && lid < endLid;
+                lid = curSet.nextSetBit(lid + 1)) {
+            long oid = lid2Oid[fid].get(lid);
+            VD originalVD = newVdataArray.get(lid);
+            // if (originalVD == null){
+            // null indicate the vertex is inactive.
+            //  continue ;
+            // }
+            if (firstRound) {
+                newVdataArray.set(lid, vprog.apply(oid, originalVD, initialMessage));
+            } else {
+                newVdataArray.set(lid, vprog.apply(oid, originalVD, messageStore.get(lid)));
+            }
+        }
+    }
+
+    private void iterateEdge(int startLid, int endLid, int threadId) throws InterruptedException {
+        GSEdgeTripletImpl<VD, ED> edgeTriplet = new GSEdgeTripletImpl<>();
+        long beginOffset, endOffset;
+        for (int lid = curSet.nextSetBit(startLid);
+                lid >= 0 && lid < endLid;
+                lid = curSet.nextSetBit(lid + 1)) {
+            if (newVdataArray.get(lid) == null) {
+                throw new IllegalStateException("received null vertex data");
+            }
+            edgeTriplet.setSrcOid(lid2Oid[fid].get(lid), newVdataArray.get(lid));
+
+            beginOffset = oeOffsetArray.get(lid);
+            endOffset = oeOffsetArray.get(lid + 1);
+            long address = oeBeginAddress + (beginOffset << 4);
+            while (beginOffset < endOffset) {
+                int nbrVid = (int) JavaRuntime.getLong(address);
+                int eid = (int) JavaRuntime.getLong(address + 8);
+                VD dstAttr = newVdataArray.get(nbrVid);
+                if (dstAttr != null) {
+                    edgeTriplet.setDstOid(getId(nbrVid), dstAttr);
+                    edgeTriplet.setAttr(newEdataArray.get(eid));
+                    Iterator<Tuple2<Long, MSG_T>> msgs = sendMsg.apply(edgeTriplet);
+                    if (!msgs.equals(Iterator.empty())) {
+                        messageStore.addMessages(
+                                msgs, graphXFragment, threadId, edgeTriplet, lid, nbrVid);
+                    }
+                }
+                address += 16;
+                beginOffset += 1;
+            }
+        }
+    }
+
+    public void parallelExecute(
+            InterruptibleTriConsumer<Integer, Integer, Integer> function, int limit) {
+        AtomicInteger getter = new AtomicInteger(0);
+        CountDownLatch countDownLatch = new CountDownLatch(numCores);
+        for (int tid = 0; tid < numCores; ++tid) {
+            final int finalTid = tid;
+            executorService.execute(
+                    () -> {
+                        int begin, end;
+                        while (true) {
+                            begin = Math.min(getter.getAndAdd(BATCH_SIZE), limit);
+                            end = Math.min(begin + BATCH_SIZE, limit);
+                            if (begin >= end) {
+                                break;
+                            }
+                            try {
+                                function.accept(begin, end, finalTid);
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                        countDownLatch.countDown();
+                    });
+        }
+        try {
+            countDownLatch.await();
+        } catch (Exception e) {
+            e.printStackTrace();
+            executorService.shutdown();
+        }
+    }
+
+    public void ParallelPEval() {
+        if (fid == 0) {
+            logger.info("[Start PEval]");
+        }
+        vprogTime -= System.nanoTime();
+        // We need to update outer vertex message to vd array, otherwise, we will send out message
+        // infinitely.
+        parallelExecute((begin, end, threadId) -> runVProg(begin, end, true), verticesNum);
+        vprogTime += System.nanoTime();
+
+        msgSendTime -= System.nanoTime();
+        parallelExecute(this::iterateEdge, innerVerticesNum);
+        msgSendTime += System.nanoTime();
+        logger.debug("[PEval] Finish iterate edges for frag {}", graphXFragment.fid());
+        flushTime -= System.nanoTime();
+        try {
+            messageStore.flushMessages(
+                    nextSet, messageManager, graphXFragment, fid2WorkerId, executorService);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        flushTime += System.nanoTime();
+        round = 1;
+    }
+
+    public boolean ParallelIncEval() {
+        if (round >= maxIterations) {
+            return true;
+        }
+
+        bitsetTime -= System.nanoTime();
+        curSet.clearAll();
+        logger.info(
+                "before union curset {} nextset {}", curSet.cardinality(), nextSet.cardinality());
+        curSet = ThreadSafeBitSet.orAll(curSet, nextSet);
+        logger.info(
+                "after union curset {} nextset {}", curSet.cardinality(), nextSet.cardinality());
+        nextSet.clearAll();
+        bitsetTime += System.nanoTime();
+
+        receiveTime -= System.nanoTime();
+        ///////////////////////////////////// Receive message////////////////////
+        receiveMessage();
+        receiveTime += System.nanoTime();
+
+        if (curSet.cardinality() > 0) {
+            logger.info(
+                    "Before running round {}, frag [{}] has {} active vertices",
+                    round,
+                    graphXFragment.fid(),
+                    curSet.cardinality());
+            vprogTime -= System.nanoTime();
+            parallelExecute((begin, end, threadId) -> runVProg(begin, end, false), verticesNum);
+            vprogTime += System.nanoTime();
+
+            msgSendTime -= System.nanoTime();
+            parallelExecute(this::iterateEdge, innerVerticesNum);
+            msgSendTime += System.nanoTime();
+            logger.debug(
+                    "[IncEval {}] Finish iterate edges for frag {}", round, graphXFragment.fid());
+            flushTime -= System.nanoTime();
+            try {
+                messageStore.flushMessages(
+                        nextSet, messageManager, graphXFragment, fid2WorkerId, executorService);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            flushTime += System.nanoTime();
+        } else {
+            logger.info("Frag {} No message received", graphXFragment.fid());
+            round += 1;
+            return true;
+        }
+        round += 1;
+        logger.info(
+                "Round [{}] vprog {}, msgSend {} flushMsg {}, receive time {}, bitset time {}",
+                round,
+                vprogTime / 1000000,
+                msgSendTime / 1000000,
+                flushTime / 1000000,
+                receiveTime / 1000000,
+                bitsetTime / 1000000);
+        return false;
+    }
+
+    /**
+     * To receive message from grape, we need some wrappers. double -> DoubleMessage. long ->
+     * LongMessage. Vprog happens here
+     *
+     * @return true if message received.
+     */
+    private void receiveMessage() {
+        CountDownLatch countDownLatch = new CountDownLatch(numCores);
+        for (int tid = 0; tid < numCores; ++tid) {
+            final int finalTid = tid;
+            executorService.execute(
+                    () -> {
+                        MessageInBuffer messageInBuffer = bufferFactory.create();
+                        FFIByteVector tmpVector =
+                                (FFIByteVector) FFIByteVectorFactory.INSTANCE.create();
+                        long bytesOfReceivedMsg = 0;
+                        while (messageManager.getMessageInBuffer(messageInBuffer)) {
+                            logger.info("thread {} got message inbuffer", finalTid);
+                            messageInBuffer.getPureMessage(tmpVector);
+                            tmpVector.touch();
+                            logger.info(
+                                    "Frag [{}] digest message of size {}",
+                                    graphXFragment.fid(),
+                                    tmpVector.size());
+
+                            messageStore.digest(tmpVector, graphXFragment, curSet);
+                            bytesOfReceivedMsg += tmpVector.size();
+                        }
+                        logger.debug(
+                                "Frag [{}] Totally received {} bytes",
+                                graphXFragment.fid(),
+                                bytesOfReceivedMsg);
+                        countDownLatch.countDown();
+                    });
+        }
+        try {
+            countDownLatch.await();
+        } catch (Exception e) {
+            e.printStackTrace();
+            executorService.shutdown();
+        }
+    }
+
+    private static <VD_T, ED_T, MSG_T_>
+            Tuple2<PrimitiveArray<VD_T>, PrimitiveArray<ED_T>> initOldAndNewArrays(
+                    BaseGraphXFragment<Long, Long, VD_T, ED_T> baseGraphXFragment,
+                    GraphXConf<VD_T, ED_T, MSG_T_> conf)
+                    throws IOException, ClassNotFoundException {
+        // For vd array
+        if (conf.isVDPrimitive() && conf.isEDPrimitive()) {
+            TypedArray<VD_T> oldVdataArray;
+            TypedArray<ED_T> oldEdataArray;
+            GraphXFragment<Long, Long, VD_T, ED_T> graphXFragment =
+                    (GraphXFragment<Long, Long, VD_T, ED_T>) baseGraphXFragment;
+            oldEdataArray = graphXFragment.getEdataArray();
+            oldVdataArray = graphXFragment.getVdataArray();
+            logger.info(
+                    "vdata array size {}, frag vnum{}",
+                    oldVdataArray.getLength(),
+                    graphXFragment.getVerticesNum());
+            if (oldVdataArray.getLength() != graphXFragment.getVerticesNum()) {
+                throw new IllegalStateException(
+                        "not equal"
+                                + oldVdataArray.getLength()
+                                + ","
+                                + graphXFragment.getVerticesNum());
+            }
+            PrimitiveArray<ED_T> newEdataArray =
+                    wrapReadOnlyArray(oldEdataArray, conf.getEdClass());
+            // Should contain outer vertices
+            PrimitiveArray<VD_T> newVdataArray =
+                    processPrimitiveArray(oldVdataArray, conf.getVdClass());
+            return new Tuple2<>(newVdataArray, newEdataArray);
+        } else if (!conf.isVDPrimitive() && conf.isEDPrimitive()) {
+            StringTypedArray oldVdataArray;
+            TypedArray<ED_T> oldEdataArray;
+            GraphXStringVDFragment<Long, Long, VD_T, ED_T> graphXFragment =
+                    (GraphXStringVDFragment<Long, Long, VD_T, ED_T>) baseGraphXFragment;
+            oldEdataArray = graphXFragment.getEdataArray();
+            oldVdataArray = graphXFragment.getVdataArray();
+            logger.info(
+                    "total bytes in vd array {}, vertices num {}",
+                    oldVdataArray.getLength(),
+                    graphXFragment.getVerticesNum());
+
+            PrimitiveArray<ED_T> newEdataArray =
+                    wrapReadOnlyArray(oldEdataArray, conf.getEdClass());
+            PrimitiveArray<VD_T> newVdataArray =
+                    processComplexArray(oldVdataArray, conf.getVdClass());
+            return new Tuple2<>(newVdataArray, newEdataArray);
+        } else if (conf.isVDPrimitive() && !conf.isEDPrimitive()) {
+            StringTypedArray oldEDdataArray;
+            TypedArray<VD_T> oldVdataArray;
+            GraphXStringEDFragment<Long, Long, VD_T, ED_T> graphXFragment =
+                    (GraphXStringEDFragment<Long, Long, VD_T, ED_T>) baseGraphXFragment;
+            oldEDdataArray = graphXFragment.getEdataArray();
+            oldVdataArray = graphXFragment.getVdataArray();
+            logger.info(
+                    "total bytes in vd array {}, vertices num {}",
+                    oldVdataArray.getLength(),
+                    graphXFragment.getVerticesNum());
+
+            PrimitiveArray<VD_T> newVdataArray =
+                    processPrimitiveArray(oldVdataArray, conf.getVdClass());
+            PrimitiveArray<ED_T> newEdataArray =
+                    processComplexArray(oldEDdataArray, conf.getEdClass());
+            return new Tuple2<>(newVdataArray, newEdataArray);
+        } else if (!conf.isVDPrimitive() && !conf.isEDPrimitive()) {
+            StringTypedArray oldEDdataArray;
+            StringTypedArray oldVdataArray;
+            GraphXStringVEDFragment<Long, Long, VD_T, ED_T> graphXFragment =
+                    (GraphXStringVEDFragment<Long, Long, VD_T, ED_T>) baseGraphXFragment;
+            oldEDdataArray = graphXFragment.getEdataArray();
+            oldVdataArray = graphXFragment.getVdataArray();
+            logger.info(
+                    "total bytes in vd array {}, total bytes in ed array {}, vertices num {}",
+                    oldVdataArray.getLength(),
+                    oldEDdataArray.getLength(),
+                    graphXFragment.getVerticesNum());
+
+            PrimitiveArray<VD_T> newVdataArray =
+                    processComplexArray(oldVdataArray, conf.getVdClass());
+            PrimitiveArray<ED_T> newEdataArray =
+                    processComplexArray(oldEDdataArray, conf.getEdClass());
+            return new Tuple2<>(newVdataArray, newEdataArray);
+        } else {
+            logger.error(
+                    "Not implemented for vd {} ed {}", conf.isVDPrimitive(), conf.isEDPrimitive());
+            throw new IllegalStateException("not implemented");
+        }
+    }
+
+    public static <T> PrimitiveArray<T> processComplexArray(
+            StringTypedArray oldArray, Class<? extends T> clz)
+            throws IOException, ClassNotFoundException {
+        FakeFFIByteVector vector =
+                new FakeFFIByteVector(oldArray.getRawData(), oldArray.getRawDataLength());
+        FakeFFIByteVectorInputStream ffiInput = new FakeFFIByteVectorInputStream(vector);
+        long len = oldArray.getLength();
+        logger.info("reading {} objects from array of bytes {}", len, oldArray.getLength());
+        PrimitiveArray<T> newArray = PrimitiveArray.create(clz, (int) len);
+        if (clz.equals(DoubleDouble.class)) {
+            for (int i = 0; i < len; ++i) {
+                double a = ffiInput.readDouble();
+                double b = ffiInput.readDouble();
+                newArray.set(i, (T) new DoubleDouble(a, b));
+            }
+        } else {
+            ObjectInputStream objectInputStream = new ObjectInputStream(ffiInput);
+            for (int i = 0; i < len; ++i) {
+                T obj = (T) objectInputStream.readObject();
+                newArray.set(i, obj);
+            }
+        }
+        return newArray;
+    }
+
+    private static <T> PrimitiveArray<T> wrapReadOnlyArray(
+            TypedArray<T> oldArray, Class<? extends T> clz) {
+        return PrimitiveArray.createImmutable(oldArray, clz);
+    }
+
+    private static <T> PrimitiveArray<T> processPrimitiveArray(
+            TypedArray<T> oldArray, Class<? extends T> clz) {
+        PrimitiveArray<T> newArray = PrimitiveArray.create(clz, (int) oldArray.getLength());
+        long time0 = System.nanoTime();
+        long len = oldArray.getLength();
+        for (int i = 0; i < len; ++i) {
+            newArray.set(i, oldArray.get(i));
+        }
+        long time1 = System.nanoTime();
+        return newArray;
+    }
+
+    private BaseGraphXFragment<Long, Long, VD, ED> getBaseGraphXFragment(
+            IFragment<Long, Long, VD, ED> iFragment) {
+        if (iFragment.fragmentType().equals(FragmentType.GraphXStringVDFragment)) {
+            return ((GraphXStringVDFragmentAdaptor<Long, Long, VD, ED>) iFragment).getFragment();
+        } else if (iFragment.fragmentType().equals(FragmentType.GraphXFragment)) {
+            return ((GraphXFragmentAdaptor<Long, Long, VD, ED>) iFragment).getFragment();
+        } else if (iFragment.fragmentType().equals(FragmentType.GraphXStringEDFragment)) {
+            return ((GraphXStringEDFragmentAdaptor<Long, Long, VD, ED>) iFragment).getFragment();
+        } else if (iFragment.fragmentType().equals(FragmentType.GraphXStringVEDFragment)) {
+            return ((GraphXStringVEDFragmentAdaptor<Long, Long, VD, ED>) iFragment).getFragment();
+        } else {
+            throw new IllegalStateException("Not implemented" + iFragment);
+        }
+    }
+
+    private void fillFid2WorkerId(String str) {
+        String[] splited = str.split(";");
+        if (splited.length != fid2WorkerId.length) {
+            throw new IllegalStateException(
+                    "length neq " + splited.length + "," + fid2WorkerId.length);
+        }
+        for (String tuple : splited) {
+            String[] tmp = tuple.split(":");
+            if (tmp.length != 2) {
+                throw new IllegalStateException("length neq 2" + tmp.length);
+            }
+            int workerId = Integer.parseInt(tmp[0]);
+            int fid = Integer.parseInt(tmp[1]);
+            fid2WorkerId[fid] = workerId;
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/AbstractMessageStore.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/AbstractMessageStore.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.BaseGraphXFragment;
+import com.alibaba.graphscope.graphx.graph.GSEdgeTripletImpl;
+import com.alibaba.graphscope.graphx.utils.IdParser;
+import com.alibaba.graphscope.parallel.ParallelMessageManager;
+import com.alibaba.graphscope.serialization.FFIByteVectorOutputStream;
+
+import scala.Tuple2;
+import scala.collection.Iterator;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+
+public abstract class AbstractMessageStore<T> implements MessageStore<T> {
+
+    protected Vertex<Long> tmpVertex[];
+    protected ThreadSafeBitSet nextSet;
+    protected IdParser idParser;
+    protected FFIByteVectorOutputStream[] outputStream;
+
+    abstract void threadSafeSet(int ind, T value);
+
+    abstract void mergeAndSet(int ind, T value);
+
+    abstract void writeMessageToStream(BaseGraphXFragment<Long, Long, ?, ?> fragment)
+            throws IOException;
+
+    public AbstractMessageStore(int fnum, int numCores, ThreadSafeBitSet nextSet) {
+        tmpVertex = new Vertex[numCores];
+        for (int i = 0; i < numCores; ++i) {
+            tmpVertex[i] = FFITypeFactoryhelper.newVertexLong();
+        }
+        outputStream = new FFIByteVectorOutputStream[fnum];
+        for (int i = 0; i < fnum; ++i) {
+            outputStream[i] = new FFIByteVectorOutputStream();
+        }
+        idParser = new IdParser(fnum);
+        this.nextSet = nextSet;
+    }
+
+    @Override
+    public void addMessages(
+            Iterator<Tuple2<Long, T>> msgs,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            int threadId,
+            GSEdgeTripletImpl edgeTriplet,
+            int srcLid,
+            int dstLid)
+            throws InterruptedException {
+        while (msgs.hasNext()) {
+            Tuple2<Long, T> msg = msgs.next();
+            // the oid must from src or dst, we first find with lid.
+            long oid = msg._1();
+            int lid;
+            if (oid == edgeTriplet.dstId()) {
+                lid = dstLid;
+            } else {
+                lid = srcLid;
+            }
+            if (nextSet.get(lid)) {
+                mergeAndSet(lid, msg._2());
+            } else {
+                threadSafeSet(lid, msg._2());
+                nextSet.set(lid);
+            }
+        }
+    }
+
+    @Override
+    public void flushMessages(
+            ThreadSafeBitSet nextSet,
+            ParallelMessageManager messageManager,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            int[] fid2WorkerId,
+            ExecutorService executorService)
+            throws IOException {
+        CountDownLatch countDownLatch = new CountDownLatch(fragment.fnum());
+        writeMessageToStream(fragment);
+        for (int i = 0; i < fragment.fnum(); ++i) {
+            final int tid = i;
+            executorService.execute(
+                    () -> {
+                        if (tid != fragment.fid()) {
+                            outputStream[tid].finishSetting();
+                            if (outputStream[tid].getVector().size() > 0) {
+                                int workerId = fid2WorkerId[tid];
+                                messageManager.sendToFragment(
+                                        workerId, outputStream[tid].getVector(), tid);
+                                logger.info(
+                                        "fragment [{}] send {} bytes to [{}]",
+                                        fragment.fid(),
+                                        outputStream[tid].getVector().size(),
+                                        tid);
+                            }
+                            outputStream[tid].reset();
+                        }
+                        countDownLatch.countDown();
+                    });
+        }
+        try {
+            countDownLatch.await();
+        } catch (Exception e) {
+            e.printStackTrace();
+            executorService.shutdown();
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/CallUtils.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/CallUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class CallUtils {
+    private static Logger logger = LoggerFactory.getLogger(CallUtils.class.getName());
+
+    /**
+     * Get the caller class name of the class which called us.
+     * @return class name
+     */
+    public static String getCallerCallerClassName() {
+        StackTraceElement[] stElements = Thread.currentThread().getStackTrace();
+        int index = 0;
+        while (index < stElements.length) {
+            if (stElements[index].getClassName().equals(CallUtils.class.getName())) {
+                break;
+            }
+            index += 1;
+        }
+        logger.info("Find CallUtils at {},total len {}", index, stElements.length);
+        while (index + 1 < stElements.length
+                && stElements[index].getClassName().equals(stElements[index + 1].getClassName())) {
+            index += 1;
+        }
+        index += 1;
+        if (index >= stElements.length) {
+            // we are already at last pos, so we must failed.
+            throw new IllegalStateException(
+                    "already reach last "
+                            + index
+                            + " "
+                            + stElements.length
+                            + ", "
+                            + Arrays.stream(stElements)
+                                    .map(StackTraceElement::getClassName)
+                                    .collect(Collectors.joining("\n")));
+        }
+        // now we are at the first position of class calling CallUtils.
+        logger.info("The class called CallUtils is " + stElements[index].getClassName());
+        int callers = 0;
+        while (index < stElements.length) {
+            if (!stElements[index].getClassName().equals(stElements[index - 1].getClassName())) {
+                logger.info("new caller find: " + stElements[index + 1]);
+                callers += 1;
+            }
+            if (callers == 3) {
+                return stElements[index].getClassName();
+            }
+            index += 1;
+        }
+        throw new IllegalStateException(
+                "failed"
+                        + Arrays.stream(stElements)
+                                .map(StackTraceElement::getClassName)
+                                .collect(Collectors.joining("\n")));
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/DoubleMessageStore.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/DoubleMessageStore.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.BaseGraphXFragment;
+import com.alibaba.graphscope.serialization.FFIByteVectorInputStream;
+import com.alibaba.graphscope.stdcxx.FFIByteVector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Function2;
+
+import java.io.IOException;
+
+public class DoubleMessageStore extends AbstractMessageStore<Double> {
+
+    private Logger logger = LoggerFactory.getLogger(DoubleMessageStore.class.getName());
+
+    private AtomicDoubleArrayWrapper values;
+    private Function2<Double, Double, Double> mergeMessage;
+
+    public DoubleMessageStore(
+            int len,
+            int fnum,
+            int numCores,
+            Function2<Double, Double, Double> function2,
+            ThreadSafeBitSet nextSet) {
+        super(fnum, numCores, nextSet);
+        values = new AtomicDoubleArrayWrapper(len);
+        mergeMessage = function2;
+    }
+
+    @Override
+    public Double get(int index) {
+        return values.get(index);
+    }
+
+    @Override
+    public void set(int index, Double value) {
+        values.set(index, value);
+    }
+
+    @Override
+    public int size() {
+        return values.getSize();
+    }
+
+    @Override
+    void threadSafeSet(int ind, Double value) {
+        values.compareAndSet(ind, value);
+    }
+
+    @Override
+    void mergeAndSet(int ind, Double value) {
+        double original = get(ind);
+        double newValue = mergeMessage.apply(original, value);
+        values.compareAndSet(ind, newValue);
+    }
+
+    @Override
+    void writeMessageToStream(BaseGraphXFragment<Long, Long, ?, ?> fragment) throws IOException {
+        int ivnum = (int) fragment.getInnerVerticesNum();
+        int cnt = 0;
+        Vertex<Long> vertex = tmpVertex[0];
+        TypedArray<Long> outerLid2Gids = fragment.getVM().getOuterLid2GidAccessor();
+
+        for (int i = nextSet.nextSetBit(ivnum); i >= 0; i = nextSet.nextSetBit(i + 1)) {
+            vertex.SetValue((long) i);
+            long outerGid = outerLid2Gids.get(i - ivnum);
+            int dstFid = idParser.getFragId(outerGid);
+            long dstLid = idParser.getLocalId(outerGid);
+            outputStream[dstFid].writeLong(dstLid);
+            outputStream[dstFid].writeDouble(values.get(i));
+            cnt += 1;
+        }
+        logger.debug("Frag [{}] try to send {} msg to outer vertices", fragment.fid(), cnt);
+    }
+
+    @Override
+    public void digest(
+            FFIByteVector vector,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            ThreadSafeBitSet curSet) {
+        FFIByteVectorInputStream inputStream = new FFIByteVectorInputStream(vector);
+        int size = (int) vector.size();
+        if (size <= 0) {
+            throw new IllegalStateException("The received vector can not be empty");
+        }
+
+        try {
+            while (inputStream.available() > 0) {
+                int lid = (int) inputStream.readLong();
+                double msg = inputStream.readDouble();
+                if (curSet.get(lid)) {
+                    values.set(lid, mergeMessage.apply(values.get(lid), msg));
+                } else {
+                    values.set(lid, msg);
+                    curSet.set(lid);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/IntMessageStore.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/IntMessageStore.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.BaseGraphXFragment;
+import com.alibaba.graphscope.serialization.FFIByteVectorInputStream;
+import com.alibaba.graphscope.stdcxx.FFIByteVector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Function2;
+
+import java.io.IOException;
+
+public class IntMessageStore extends AbstractMessageStore<Integer> {
+
+    private Logger logger = LoggerFactory.getLogger(IntMessageStore.class.getName());
+
+    private AtomicIntegerArrayWrapper values;
+    private Function2<Integer, Integer, Integer> mergeMessage;
+
+    public IntMessageStore(
+            int len,
+            int fnum,
+            int numCores,
+            Function2<Integer, Integer, Integer> function2,
+            ThreadSafeBitSet nextSet) {
+        super(fnum, numCores, nextSet);
+        values = new AtomicIntegerArrayWrapper(len);
+        mergeMessage = function2;
+    }
+
+    @Override
+    public Integer get(int index) {
+        return values.get(index);
+    }
+
+    @Override
+    public void set(int index, Integer value) {
+        values.set(index, value);
+    }
+
+    @Override
+    public int size() {
+        return values.getSize();
+    }
+
+    @Override
+    void threadSafeSet(int ind, Integer value) {
+        values.compareAndSet(ind, value);
+    }
+
+    @Override
+    void mergeAndSet(int ind, Integer value) {
+        int original = get(ind);
+        int newValue = mergeMessage.apply(original, value);
+        values.compareAndSet(ind, newValue);
+    }
+
+    void writeMessageToStream(BaseGraphXFragment<Long, Long, ?, ?> fragment) throws IOException {
+        int ivnum = (int) fragment.getInnerVerticesNum();
+        int cnt = 0;
+        Vertex<Long> vertex = tmpVertex[0];
+        TypedArray<Long> outerLid2Gids = fragment.getVM().getOuterLid2GidAccessor();
+
+        for (int i = nextSet.nextSetBit(ivnum); i >= 0; i = nextSet.nextSetBit(i + 1)) {
+            vertex.SetValue((long) i);
+            long outerGid = outerLid2Gids.get(i - ivnum);
+            int dstFid = idParser.getFragId(outerGid);
+            long dstLid = idParser.getLocalId(outerGid);
+            outputStream[dstFid].writeLong(dstLid);
+            outputStream[dstFid].writeInt(values.get(i));
+            cnt += 1;
+        }
+        logger.debug("Frag [{}] try to send {} msg to outer vertices", fragment.fid(), cnt);
+    }
+
+    @Override
+    public void digest(
+            FFIByteVector vector,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            ThreadSafeBitSet curSet) {
+        FFIByteVectorInputStream inputStream = new FFIByteVectorInputStream(vector);
+        int size = (int) vector.size();
+        if (size <= 0) {
+            throw new IllegalStateException("The received vector can not be empty");
+        }
+
+        try {
+            while (inputStream.available() > 0) {
+                int lid = (int) inputStream.readLong();
+                int msg = inputStream.readInt();
+                if (curSet.get(lid)) {
+                    values.set(lid, mergeMessage.apply(values.get(lid), msg));
+                } else {
+                    values.set(lid, msg);
+                    curSet.set(lid);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/LongMessageStore.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/LongMessageStore.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.BaseGraphXFragment;
+import com.alibaba.graphscope.serialization.FFIByteVectorInputStream;
+import com.alibaba.graphscope.stdcxx.FFIByteVector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Function2;
+
+import java.io.IOException;
+
+public class LongMessageStore extends AbstractMessageStore<Long> {
+
+    private Logger logger = LoggerFactory.getLogger(LongMessageStore.class.getName());
+
+    private AtomicLongArrayWrapper values;
+    private Function2<Long, Long, Long> mergeMessage;
+
+    public LongMessageStore(
+            int len,
+            int fnum,
+            int numCores,
+            Function2<Long, Long, Long> mergeMessage,
+            ThreadSafeBitSet nextSet) {
+        super(fnum, numCores, nextSet);
+        values = new AtomicLongArrayWrapper(len);
+        this.mergeMessage = mergeMessage;
+    }
+
+    @Override
+    public Long get(int index) {
+        return values.get(index);
+    }
+
+    @Override
+    public void set(int index, Long value) {
+        values.compareAndSet(index, value);
+    }
+
+    @Override
+    public int size() {
+        return values.getSize();
+    }
+
+    @Override
+    void threadSafeSet(int ind, Long value) {
+        values.compareAndSet(ind, value);
+    }
+
+    @Override
+    void mergeAndSet(int ind, Long value) {
+        long original = get(ind);
+        long newValue = mergeMessage.apply(original, value);
+        values.compareAndSet(ind, newValue);
+    }
+
+    @Override
+    void writeMessageToStream(BaseGraphXFragment<Long, Long, ?, ?> fragment) throws IOException {
+        int ivnum = (int) fragment.getInnerVerticesNum();
+        int cnt = 0;
+        Vertex<Long> vertex = tmpVertex[0];
+        TypedArray<Long> outerLid2Gids = fragment.getVM().getOuterLid2GidAccessor();
+
+        for (int i = nextSet.nextSetBit(ivnum); i >= 0; i = nextSet.nextSetBit(i + 1)) {
+            vertex.SetValue((long) i);
+            long outerGid = outerLid2Gids.get(i - ivnum);
+            int dstFid = idParser.getFragId(outerGid);
+            long dstLid = idParser.getLocalId(outerGid);
+            outputStream[dstFid].writeLong(dstLid);
+            outputStream[dstFid].writeLong(values.get(i));
+            cnt += 1;
+        }
+        logger.debug("Frag [{}] try to send {} msg to outer vertices", fragment.fid(), cnt);
+    }
+
+    @Override
+    public void digest(
+            FFIByteVector vector,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            ThreadSafeBitSet curSet) {
+        FFIByteVectorInputStream inputStream = new FFIByteVectorInputStream(vector);
+        int size = (int) vector.size();
+        if (size <= 0) {
+            throw new IllegalStateException("The received vector can not be empty");
+        }
+
+        try {
+            while (inputStream.available() > 0) {
+                int lid = (int) inputStream.readLong();
+                long msg = inputStream.readLong();
+                if (curSet.get(lid)) {
+                    values.set(lid, mergeMessage.apply(values.get(lid), msg));
+                } else {
+                    values.set(lid, msg);
+                    curSet.set(lid);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/MPIUtils.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/MPIUtils.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import com.alibaba.graphscope.graphx.utils.GrapeUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+public class MPIUtils {
+
+    private static Logger logger = LoggerFactory.getLogger(MPIUtils.class.getName());
+    private static final String GRAPHSCOPE_HOME, SPARK_HOME;
+    private static final String CONSTRUCT_GRAPHX_VERTEX_MAP_SHELL_SCRIPT,
+            LAUNCH_GRAPHX_SHELL_SCRIPT;
+    private static final String VM_PATTERN = "GlobalVertexMapID:";
+    private static final String FINALIZE_PATTERN = "Workers finalized.";
+    private static final String CONSTRUCT_GLOBAL_VM_TASK = "construct_vertex_map";
+    private static final String GRAPHX_PREGEL_TASK = "graphx_pregel";
+
+    static {
+        SPARK_HOME = System.getenv("SPARK_HOME");
+        if (SPARK_HOME == null || SPARK_HOME.isEmpty()) {
+            throw new IllegalStateException("SPARK_HOME empty");
+        }
+
+        GRAPHSCOPE_HOME = System.getenv("GRAPHSCOPE_HOME");
+        if (GRAPHSCOPE_HOME == null || GRAPHSCOPE_HOME.isEmpty()) {
+            throw new IllegalStateException("GRAPHSCOPE_HOME empty");
+        }
+
+        LAUNCH_GRAPHX_SHELL_SCRIPT = GRAPHSCOPE_HOME + "/bin/run_graphx.sh";
+        if (!fileExists(LAUNCH_GRAPHX_SHELL_SCRIPT)) {
+            throw new IllegalStateException(
+                    "script " + LAUNCH_GRAPHX_SHELL_SCRIPT + "doesn't exist");
+        }
+        CONSTRUCT_GRAPHX_VERTEX_MAP_SHELL_SCRIPT =
+                GRAPHSCOPE_HOME + "/bin/construct_graphx_vertex_map.sh";
+        if (!fileExists(CONSTRUCT_GRAPHX_VERTEX_MAP_SHELL_SCRIPT)) {
+            throw new IllegalStateException(
+                    "script " + CONSTRUCT_GRAPHX_VERTEX_MAP_SHELL_SCRIPT + "doesn't exist");
+        }
+    }
+
+    public static <MSG, VD, ED> List<String> launchGraphX(
+            String[] fragIds,
+            Class<? extends VD> vdClass,
+            Class<? extends ED> edClass,
+            Class<? extends MSG> msgClass,
+            String serialPath,
+            int maxIteration,
+            int numPart,
+            String ipcSocket,
+            String userJarPath) {
+        int numWorkers = fragIds.length;
+        String hostNameSlots = generateHostNameAndSlotsFromIDs(fragIds);
+        logger.info("running mpi with {} workers", numWorkers);
+        List<String> vertexDataIds = new ArrayList<>(numWorkers);
+        String[] commands = {
+            "/bin/bash",
+            LAUNCH_GRAPHX_SHELL_SCRIPT,
+            GRAPHX_PREGEL_TASK,
+            String.valueOf(numWorkers),
+            hostNameSlots,
+            GrapeUtils.classToStr(vdClass, true),
+            GrapeUtils.classToStr(edClass, true),
+            GrapeUtils.classToStr(msgClass, true),
+            serialPath,
+            String.join(",", fragIds),
+            String.valueOf(maxIteration),
+            String.valueOf(numPart),
+            ipcSocket,
+            userJarPath
+        };
+
+        logger.info("Running with commands: " + String.join(" ", commands));
+        long startTime = System.nanoTime();
+        ProcessBuilder processBuilder = new ProcessBuilder();
+        processBuilder.command(commands);
+        //        processBuilder.inheritIO();
+        Process process = null;
+        try {
+            process = processBuilder.start();
+            BufferedReader stdInput =
+                    new BufferedReader(new InputStreamReader(process.getErrorStream()));
+            String str;
+            int cnt = 0;
+            while ((str = stdInput.readLine()) != null) {
+                System.out.println(str);
+                if (str.contains(FINALIZE_PATTERN)) {
+                    cnt += 1;
+                }
+                if (cnt >= numWorkers) {
+                    logger.info("Got all workers in finalized, eager finish with kill");
+                    break;
+                }
+            }
+            if (cnt >= numWorkers) {
+                process.destroyForcibly();
+                logger.info("kill mpi processes forcibly");
+            } else {
+                int exitCode = process.waitFor();
+                logger.info("Mpi process exit code {}", exitCode);
+                if (exitCode != 0) {
+                    throw new IllegalStateException("Error in mpi process" + exitCode);
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        long endTime = System.nanoTime();
+        logger.info(
+                "Total time spend on running mpi processes : {}ms",
+                (endTime - startTime) / 1000000);
+        return vertexDataIds;
+    }
+
+    private static void check(String oidType, String vidType) {
+        if (oidType != "int64_t" || vidType != "uint64_t") {
+            throw new IllegalStateException("Not supported: " + oidType + " " + vidType);
+        }
+    }
+
+    /**
+     * Input : d50:0:123457,d51:1:1232431 Output d50:1,d51:1
+     *
+     * @param ids
+     * @return
+     */
+    private static String generateHostNameAndSlotsFromIDs(String[] ids) {
+        HashMap<String, Integer> map = new HashMap<>();
+        for (String str : ids) {
+            String[] splited = str.split(":");
+            if (splited.length != 3) {
+                throw new IllegalStateException("Unexpected input " + Arrays.toString(ids));
+            }
+            if (map.containsKey(splited[0])) {
+                map.put(splited[0], map.get(splited[0]) + 1);
+            } else {
+                map.put(splited[0], 1);
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String key : map.keySet()) {
+            Integer value = map.get(key);
+            sb.append(key);
+            sb.append(":");
+            sb.append(value);
+            sb.append(",");
+        }
+        sb.deleteCharAt(sb.length() - 1);
+        return sb.toString();
+    }
+
+    public static <MSG, VD, ED> List<String> constructGlobalVM(
+            String[] localVMIDs, String ipcSocket, String oidType, String vidType) {
+        check(oidType, vidType);
+        logger.info("Try to construct global vm from: {}", Arrays.toString(localVMIDs));
+        int numWorkers = localVMIDs.length;
+        logger.info("running mpi with {} workers", numWorkers);
+        String hostNameAndSlots = generateHostNameAndSlotsFromIDs(localVMIDs);
+        String[] commands = {
+            "/bin/bash",
+            CONSTRUCT_GRAPHX_VERTEX_MAP_SHELL_SCRIPT,
+            CONSTRUCT_GLOBAL_VM_TASK,
+            String.valueOf(numWorkers),
+            hostNameAndSlots,
+            String.join(",", localVMIDs),
+            ipcSocket
+        };
+        logger.info("Running with commands: " + String.join(" ", commands));
+        List<String> globalVMIDs = new ArrayList<>(numWorkers);
+        long startTime = System.nanoTime();
+        ProcessBuilder processBuilder = new ProcessBuilder();
+        processBuilder.command(commands);
+        //        processBuilder.inheritIO();
+        Process process = null;
+        try {
+            process = processBuilder.start();
+            BufferedReader stdInput =
+                    new BufferedReader(new InputStreamReader(process.getErrorStream()));
+            String str;
+            while ((str = stdInput.readLine()) != null) {
+                System.out.println(str);
+                if (str.contains(VM_PATTERN)) {
+                    globalVMIDs.add(
+                            (str.substring(str.indexOf(VM_PATTERN) + VM_PATTERN.length()).trim()));
+                }
+            }
+            int exitCode = process.waitFor();
+            logger.info("Mpi process exit code {}", exitCode);
+            if (exitCode != 0) {
+                throw new IllegalStateException("Error in mpi process" + exitCode);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        long endTime = System.nanoTime();
+        logger.info(
+                "Total time spend on Loading global vertex Map : {}ms",
+                (endTime - startTime) / 1000000);
+        return globalVMIDs;
+    }
+
+    private static boolean fileExists(String p) {
+        return Files.exists(Paths.get(p));
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/MessageStore.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/MessageStore.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import com.alibaba.graphscope.fragment.BaseGraphXFragment;
+import com.alibaba.graphscope.graphx.graph.GSEdgeTripletImpl;
+import com.alibaba.graphscope.parallel.ParallelMessageManager;
+import com.alibaba.graphscope.stdcxx.FFIByteVector;
+import com.alibaba.graphscope.utils.array.PrimitiveArray;
+
+import scala.Function2;
+import scala.Tuple2;
+import scala.collection.Iterator;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Message store with bitset indicating validity.
+ * @param <T> type
+ */
+public interface MessageStore<T> extends PrimitiveArray<T> {
+
+    void addMessages(
+            Iterator<Tuple2<Long, T>> msgs,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            int threadId,
+            GSEdgeTripletImpl triplet,
+            int srcLid,
+            int dstLid)
+            throws InterruptedException;
+
+    void flushMessages(
+            ThreadSafeBitSet nextSet,
+            ParallelMessageManager messageManager,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            int[] fid2WorkerId,
+            ExecutorService executorService)
+            throws IOException;
+
+    void digest(
+            FFIByteVector vector,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            ThreadSafeBitSet curSet);
+
+    static <T> MessageStore<T> create(
+            int len,
+            int fnum,
+            int numCores,
+            Class<? extends T> clz,
+            Function2<T, T, T> function2,
+            ThreadSafeBitSet nextSet)
+            throws IOException {
+        if (clz.equals(Long.class) || clz.equals(long.class)) {
+            return (MessageStore<T>)
+                    new LongMessageStore(
+                            len, fnum, numCores, (Function2<Long, Long, Long>) function2, nextSet);
+        } else if (clz.equals(Double.class) || clz.equals(double.class)) {
+            return (MessageStore<T>)
+                    new DoubleMessageStore(
+                            len,
+                            fnum,
+                            numCores,
+                            (Function2<Double, Double, Double>) function2,
+                            nextSet);
+        } else if (clz.equals(Integer.class) || clz.equals(int.class)) {
+            return (MessageStore<T>)
+                    new IntMessageStore(
+                            len,
+                            fnum,
+                            numCores,
+                            (Function2<Integer, Integer, Integer>) function2,
+                            nextSet);
+        } else return new ObjectMessageStore<>(len, fnum, numCores, clz, function2, nextSet);
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/ObjectMessageStore.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/ObjectMessageStore.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import com.alibaba.graphscope.ds.TypedArray;
+import com.alibaba.graphscope.ds.Vertex;
+import com.alibaba.graphscope.fragment.BaseGraphXFragment;
+import com.alibaba.graphscope.parallel.ParallelMessageManager;
+import com.alibaba.graphscope.serialization.FFIByteVectorInputStream;
+import com.alibaba.graphscope.stdcxx.FFIByteVector;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Function2;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.concurrent.ExecutorService;
+
+public class ObjectMessageStore<T> extends AbstractMessageStore<T> {
+
+    private Logger logger = LoggerFactory.getLogger(ObjectMessageStore.class.getName());
+
+    private AtomicObjectArrayWrapper<T> values;
+    private Class<? extends T> clz;
+    private Function2<T, T, T> mergeMessage;
+    private ObjectOutputStream[] objectOutputStreams;
+
+    public ObjectMessageStore(
+            int len,
+            int fnum,
+            int numCores,
+            Class<? extends T> clz,
+            Function2<T, T, T> function2,
+            ThreadSafeBitSet nextSet) {
+        super(fnum, numCores, nextSet);
+        this.clz = clz;
+        values = new AtomicObjectArrayWrapper<>(len);
+        mergeMessage = function2;
+        objectOutputStreams = new ObjectOutputStream[fnum];
+        for (int i = 0; i < fnum; ++i) {
+            try {
+                objectOutputStreams[i] = new ObjectOutputStream(outputStream[i]);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public T get(int index) {
+        return values.get(index);
+    }
+
+    @Override
+    public void set(int index, T value) {
+        values.set(index, value);
+    }
+
+    @Override
+    public int size() {
+        return values.getSize();
+    }
+
+    @Override
+    void threadSafeSet(int ind, T value) {
+        values.compareAndSet(ind, value);
+    }
+
+    @Override
+    void mergeAndSet(int ind, T value) {
+        T original = get(ind);
+        T newValue = mergeMessage.apply(original, value);
+        values.compareAndSet(ind, newValue);
+    }
+
+    @Override
+    void writeMessageToStream(BaseGraphXFragment<Long, Long, ?, ?> fragment) throws IOException {
+        int ivnum = (int) fragment.getInnerVerticesNum();
+        int cnt = 0;
+        Vertex<Long> vertex = tmpVertex[0];
+        TypedArray<Long> outerLid2Gids = fragment.getVM().getOuterLid2GidAccessor();
+
+        for (int i = nextSet.nextSetBit(ivnum); i >= 0; i = nextSet.nextSetBit(i + 1)) {
+            vertex.SetValue((long) i);
+            long outerGid = outerLid2Gids.get(i - ivnum);
+            int dstFid = idParser.getFragId(outerGid);
+            long dstLid = idParser.getLocalId(outerGid);
+            objectOutputStreams[dstFid].writeLong(dstLid);
+            objectOutputStreams[dstFid].writeObject(values.get(i));
+            cnt += 1;
+        }
+        logger.debug("Frag [{}] try to send {} msg to outer vertices", fragment.fid(), cnt);
+    }
+
+    @Override
+    public void flushMessages(
+            ThreadSafeBitSet nextSet,
+            ParallelMessageManager messageManager,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            int[] fid2WorkerId,
+            ExecutorService executorService)
+            throws IOException {
+        // finish stream
+        for (int i = 0; i < fragment.fnum(); ++i) {
+            if (i != fragment.fid()) {
+                objectOutputStreams[i].flush();
+            }
+        }
+        super.flushMessages(nextSet, messageManager, fragment, fid2WorkerId, executorService);
+        for (int i = 0; i < fragment.fnum(); ++i) {
+            if (i != fragment.fid()) {
+                objectOutputStreams[i] = new ObjectOutputStream(outputStream[i]);
+            }
+        }
+    }
+
+    @Override
+    public void digest(
+            FFIByteVector vector,
+            BaseGraphXFragment<Long, Long, ?, ?> fragment,
+            ThreadSafeBitSet curSet) {
+        ObjectInputStream inputStream = null;
+        try {
+            inputStream = new ObjectInputStream(new FFIByteVectorInputStream(vector));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        int size = (int) vector.size();
+        if (size <= 0) {
+            throw new IllegalStateException("The received vector can not be empty");
+        }
+
+        try {
+            while (inputStream.available() > 0) {
+                int lid = (int) inputStream.readLong();
+                T msg = (T) inputStream.readObject();
+                if (curSet.get(lid)) {
+                    values.set(lid, mergeMessage.apply(values.get(lid), msg));
+                } else {
+                    values.set(lid, msg);
+                    curSet.set(lid);
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/PythonInterpreter.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/PythonInterpreter.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * A python interpreter wrapped with java subprocess. We use this to executor graphscope python
+ * code.
+ */
+public class PythonInterpreter {
+    private final int MAX_TIME_WAIT_SECOND = 20;
+
+    private Logger logger = LoggerFactory.getLogger(PythonInterpreter.class);
+    private Process process;
+    private BlockingQueue<String> outputQueue, inputQueue, errorQueue;
+    private InterpreterOutputStream os;
+    private InterpreterInputStream is;
+    private InterpreterErrorStream errorStream;
+
+    public PythonInterpreter() {}
+
+    public void init() throws IOException {
+        ProcessBuilder builder = new ProcessBuilder("/usr/bin/env", "python3", "-i");
+        process = builder.start();
+        outputQueue = new LinkedBlockingQueue<>();
+        inputQueue = new LinkedBlockingQueue<>();
+        errorQueue = new LinkedBlockingQueue<>();
+        logger.info("Start process {}", process);
+        os = new InterpreterOutputStream(process.getInputStream(), outputQueue);
+        is = new InterpreterInputStream(process.getOutputStream(), inputQueue);
+        errorStream = new InterpreterErrorStream(process.getErrorStream());
+        os.start();
+        is.start();
+        errorStream.start();
+    }
+
+    public void runCommand(String str) {
+        inputQueue.offer(str);
+        logger.info("offering cmd str: {}", str);
+    }
+
+    public String getResult() throws InterruptedException {
+        if (is.isAlive()) {
+            logger.info("input stream thread alive, use take");
+            return outputQueue.take();
+        } else {
+            logger.info("input stream thread dead, use poll");
+            return outputQueue.poll();
+        }
+    }
+
+    public String getMatched(String pattern) throws InterruptedException {
+        String str;
+        while (true) {
+            str = outputQueue.take();
+            if (str.contains(pattern)) {
+                return str;
+            } else {
+                //                logger.info("got cmd output " + str + " but not matched");
+                logger.info(str);
+            }
+        }
+    }
+
+    public void close() throws InterruptedException {
+        is.end();
+        logger.info("closing input stream thread");
+        is.interrupt();
+        os.join();
+        errorStream.join();
+        logger.info("");
+    }
+
+    public static class InterpreterInputStream extends Thread {
+
+        private Logger logger = LoggerFactory.getLogger(InterpreterInputStream.class.getName());
+        private PrintWriter writer;
+        private BlockingQueue<String> queue;
+
+        public InterpreterInputStream(OutputStream os, BlockingQueue<String> inputQueue) {
+            writer = new PrintWriter(new OutputStreamWriter(os));
+            queue = inputQueue;
+        }
+
+        @Override
+        public void run() {
+            String cmd;
+            while (!interrupted()) {
+                try {
+                    cmd = queue.take();
+                    writer.println(cmd);
+                    logger.info("Submitting command: {}", cmd);
+                    writer.flush();
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+
+        public void end() {
+            boolean res = queue.offer("exit()");
+            if (!res) {
+                throw new IllegalStateException("exit from subprocess failed");
+            }
+        }
+    }
+
+    public static class InterpreterOutputStream extends Thread {
+
+        private Logger logger = LoggerFactory.getLogger(InterpreterOutputStream.class.getName());
+        private BufferedReader reader;
+        private BlockingQueue<String> queue;
+
+        public InterpreterOutputStream(InputStream is, BlockingQueue<String> queue) {
+            reader = new BufferedReader(new InputStreamReader(is));
+            this.queue = queue;
+        }
+
+        @Override
+        public void run() {
+            String line;
+            int cnt = 0;
+            while (true) {
+                try {
+                    if ((line = reader.readLine()) == null) {
+                        break;
+                    } else {
+                        queue.add(line);
+                        cnt += 1;
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            logger.info("totally {} lines were read from interpreter", cnt);
+        }
+    }
+
+    public static class InterpreterErrorStream extends Thread {
+
+        private Logger logger = LoggerFactory.getLogger(InterpreterErrorStream.class.getName());
+        private BufferedReader reader;
+
+        public InterpreterErrorStream(InputStream is) {
+            reader = new BufferedReader(new InputStreamReader(is));
+        }
+
+        @Override
+        public void run() {
+            String line;
+            int cnt = 0;
+            while (true) {
+                try {
+                    if ((line = reader.readLine()) == null) {
+                        break;
+                    } else {
+                        logger.info("Error Stream: {}", line);
+                        cnt += 1;
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            logger.info("totally {} lines were read from error stream", cnt);
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/ThreadSafeBitSet.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/ThreadSafeBitSet.java
@@ -1,0 +1,517 @@
+/*
+ *  Copyright 2016-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+package com.alibaba.graphscope.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * This is a lock-free, thread-safe version of a {@link java.util.BitSet}.<p>
+ *
+ * Instead of a long array to hold the bits, this implementation uses an AtomicLongArray, then
+ * does the appropriate compare-and-swap operations when setting the bits.
+ *
+ * @author dkoszewnik
+ *
+ */
+public class ThreadSafeBitSet {
+    private static Logger logger = LoggerFactory.getLogger(ThreadSafeBitSet.class.getName());
+
+    public static final int DEFAULT_LOG2_SEGMENT_SIZE_IN_BITS = 14;
+
+    private final int numLongsPerSegment;
+    private final int log2SegmentSize;
+    private final int segmentMask;
+    private final AtomicReference<ThreadSafeBitSetSegments> segments;
+
+    public ThreadSafeBitSet() {
+        this(DEFAULT_LOG2_SEGMENT_SIZE_IN_BITS); // / 16384 bits, 2048 bytes, 256 longs per segment
+    }
+
+    public ThreadSafeBitSet(int log2SegmentSizeInBits) {
+        this(log2SegmentSizeInBits, 0);
+    }
+
+    public ThreadSafeBitSet(int log2SegmentSizeInBits, int numBitsToPreallocate) {
+        if (log2SegmentSizeInBits < 6)
+            throw new IllegalArgumentException(
+                    "Cannot specify fewer than 64 bits in each segment!");
+
+        this.log2SegmentSize = log2SegmentSizeInBits;
+        this.numLongsPerSegment = (1 << (log2SegmentSizeInBits - 6));
+        this.segmentMask = numLongsPerSegment - 1;
+
+        long numBitsPerSegment = numLongsPerSegment * 64;
+        int numSegmentsToPreallocate =
+                numBitsToPreallocate == 0
+                        ? 1
+                        : (int) (((numBitsToPreallocate - 1) / numBitsPerSegment) + 1);
+
+        segments = new AtomicReference<ThreadSafeBitSetSegments>();
+        segments.set(new ThreadSafeBitSetSegments(numSegmentsToPreallocate, numLongsPerSegment));
+    }
+
+    public void set(int position) {
+        int segmentPosition =
+                position >>> log2SegmentSize; // / which segment -- div by num bits per segment
+        int longPosition =
+                (position >>> 6)
+                        & segmentMask; /// which long in the segment -- remainder of div by num bits
+        // per segment
+        int bitPosition =
+                position & 0x3F; // / which bit in the long -- remainder of div by num bits in long
+        // (64)
+
+        AtomicLongArray segment = getSegment(segmentPosition);
+
+        long mask = 1L << bitPosition;
+
+        // Thread safety: we need to loop until we win the race to set the long value.
+        while (true) {
+            // determine what the new long value will be after we set the appropriate bit.
+            long currentLongValue = segment.get(longPosition);
+            long newLongValue = currentLongValue | mask;
+
+            // if no other thread has modified the value since we read it, we won the race and we
+            // are done.
+            if (segment.compareAndSet(longPosition, currentLongValue, newLongValue)) break;
+        }
+    }
+
+    public void setUntil(int position) {
+        //        int segmentPosition = position >>> log2SegmentSize; /// which segment -- div by
+        // num bits per segment
+        //        for (int i = 0; i < segmentPosition; ++i){
+        //            AtomicLongArray segment = getSegment(segmentPosition);
+        //            for (int j = 0; j < segment.length(); ++j){
+        //                segment.set(j, -1);
+        //            }
+        //        }
+        //        int start = (segmentPosition << log2SegmentSize);
+        //        for (int i = start; i < position; ++i){
+        //            set(i);
+        //        }
+        long time0 = System.nanoTime();
+        for (int i = 0; i < position; ++i) {
+            set(i);
+        }
+        long time1 = System.nanoTime();
+        logger.info("Set unitl {} cost {} ms", position, (time1 - time0) / 1000000);
+    }
+
+    public void clear(int position) {
+        int segmentPosition =
+                position >>> log2SegmentSize; // / which segment -- div by num bits per segment
+        int longPosition =
+                (position >>> 6)
+                        & segmentMask; /// which long in the segment -- remainder of div by num bits
+        // per segment
+        int bitPosition =
+                position & 0x3F; // / which bit in the long -- remainder of div by num bits in long
+        // (64)
+
+        AtomicLongArray segment = getSegment(segmentPosition);
+
+        long mask = ~(1L << bitPosition);
+
+        // Thread safety: we need to loop until we win the race to set the long value.
+        while (true) {
+            // determine what the new long value will be after we set the appropriate bit.
+            long currentLongValue = segment.get(longPosition);
+            long newLongValue = currentLongValue & mask;
+
+            // if no other thread has modified the value since we read it, we won the race and we
+            // are done.
+            if (segment.compareAndSet(longPosition, currentLongValue, newLongValue)) break;
+        }
+    }
+
+    public boolean get(int position) {
+        int segmentPosition =
+                position >>> log2SegmentSize; // / which segment -- div by num bits per segment
+        int longPosition =
+                (position >>> 6)
+                        & segmentMask; /// which long in the segment -- remainder of div by num bits
+        // per segment
+        int bitPosition =
+                position & 0x3F; // / which bit in the long -- remainder of div by num bits in long
+        // (64)
+
+        AtomicLongArray segment = getSegment(segmentPosition);
+
+        long mask = 1L << bitPosition;
+
+        return ((segment.get(longPosition) & mask) != 0);
+    }
+
+    public long maxSetBit() {
+        ThreadSafeBitSetSegments segments = this.segments.get();
+
+        int segmentIdx = segments.numSegments() - 1;
+
+        for (; segmentIdx >= 0; segmentIdx--) {
+            AtomicLongArray segment = segments.getSegment(segmentIdx);
+            for (int longIdx = segment.length() - 1; longIdx >= 0; longIdx--) {
+                long l = segment.get(longIdx);
+                if (l != 0)
+                    return (segmentIdx << log2SegmentSize)
+                            + (longIdx * 64)
+                            + (63 - Long.numberOfLeadingZeros(l));
+            }
+        }
+
+        return -1;
+    }
+
+    public int nextSetBit(int fromIndex) {
+        if (fromIndex < 0) throw new IndexOutOfBoundsException("fromIndex < 0: " + fromIndex);
+
+        int segmentPosition = fromIndex >>> log2SegmentSize;
+
+        ThreadSafeBitSetSegments segments = this.segments.get();
+
+        if (segmentPosition >= segments.numSegments()) return -1;
+
+        int longPosition = (fromIndex >>> 6) & segmentMask;
+        int bitPosition = fromIndex & 0x3F;
+        AtomicLongArray segment = segments.getSegment(segmentPosition);
+
+        long word = segment.get(longPosition) & (0xffffffffffffffffL << bitPosition);
+
+        while (true) {
+            if (word != 0)
+                return (segmentPosition << (log2SegmentSize))
+                        + (longPosition << 6)
+                        + Long.numberOfTrailingZeros(word);
+            if (++longPosition > segmentMask) {
+                segmentPosition++;
+                if (segmentPosition >= segments.numSegments()) return -1;
+                segment = segments.getSegment(segmentPosition);
+                longPosition = 0;
+            }
+
+            word = segment.get(longPosition);
+        }
+    }
+
+    /**
+     * @return the number of bits which are set in this bit set.
+     */
+    public int cardinality() {
+        ThreadSafeBitSetSegments segments = this.segments.get();
+
+        int numSetBits = 0;
+
+        for (int i = 0; i < segments.numSegments(); i++) {
+            AtomicLongArray segment = segments.getSegment(i);
+            for (int j = 0; j < segment.length(); j++) {
+                numSetBits += Long.bitCount(segment.get(j));
+            }
+        }
+
+        return numSetBits;
+    }
+
+    public long[] getWords() {
+        int len = 0;
+        ThreadSafeBitSetSegments segments = this.segments.get();
+        for (int i = 0; i < segments.numSegments(); ++i) {
+            AtomicLongArray segment = segments.getSegment(i);
+            len += segment.length();
+        }
+        long[] res = new long[len];
+        int ind = 0;
+        for (int i = 0; i < segments.numSegments(); ++i) {
+            AtomicLongArray segment = segments.getSegment(i);
+            for (int j = 0; j < segment.length(); ++j) {
+                res[ind] = segment.get(j);
+                ind += 1;
+            }
+        }
+        return res;
+    }
+
+    /**
+     * @return the number of bits which are current specified by this bit set.  This is the maximum value
+     * to which you might need to iterate, if you were to iterate over all bits in this set.
+     */
+    public int currentCapacity() {
+        return segments.get().numSegments() * (1 << log2SegmentSize);
+    }
+
+    /**
+     * Clear all bits to 0.
+     */
+    public void clearAll() {
+        ThreadSafeBitSetSegments segments = this.segments.get();
+
+        for (int i = 0; i < segments.numSegments(); i++) {
+            AtomicLongArray segment = segments.getSegment(i);
+
+            for (int j = 0; j < segment.length(); j++) {
+                segment.set(j, 0L);
+            }
+        }
+    }
+
+    /**
+     * Return a new bit set which contains all bits which are contained in this bit set, and which are NOT contained in the <code>other</code> bit set.<p>
+     *
+     * In other words, return a new bit set, which is a bitwise and with the bitwise not of the other bit set.
+     *
+     * @param other the other bit set
+     * @return the resulting bit set
+     */
+    public ThreadSafeBitSet andNot(ThreadSafeBitSet other) {
+        if (other.log2SegmentSize != log2SegmentSize)
+            throw new IllegalArgumentException("Segment sizes must be the same");
+
+        ThreadSafeBitSetSegments thisSegments = this.segments.get();
+        ThreadSafeBitSetSegments otherSegments = other.segments.get();
+        ThreadSafeBitSetSegments newSegments =
+                new ThreadSafeBitSetSegments(thisSegments.numSegments(), numLongsPerSegment);
+
+        for (int i = 0; i < thisSegments.numSegments(); i++) {
+            AtomicLongArray thisArray = thisSegments.getSegment(i);
+            AtomicLongArray otherArray =
+                    (i < otherSegments.numSegments()) ? otherSegments.getSegment(i) : null;
+            AtomicLongArray newArray = newSegments.getSegment(i);
+
+            for (int j = 0; j < thisArray.length(); j++) {
+                long thisLong = thisArray.get(j);
+                long otherLong = (otherArray == null) ? 0 : otherArray.get(j);
+
+                newArray.set(j, thisLong & ~otherLong);
+            }
+        }
+
+        ThreadSafeBitSet andNot = new ThreadSafeBitSet(log2SegmentSize);
+        andNot.segments.set(newSegments);
+        return andNot;
+    }
+
+    /**
+     * Return a new bit set which contains all bits which are contained in *any* of the specified bit sets.
+     *
+     * @param bitSets the other bit sets
+     * @return the resulting bit set
+     */
+    public static ThreadSafeBitSet orAll(ThreadSafeBitSet... bitSets) {
+        if (bitSets.length == 0) return new ThreadSafeBitSet();
+
+        int log2SegmentSize = bitSets[0].log2SegmentSize;
+        int numLongsPerSegment = bitSets[0].numLongsPerSegment;
+
+        ThreadSafeBitSetSegments segments[] = new ThreadSafeBitSetSegments[bitSets.length];
+        int maxNumSegments = 0;
+
+        for (int i = 0; i < bitSets.length; i++) {
+            if (bitSets[i].log2SegmentSize != log2SegmentSize)
+                throw new IllegalArgumentException("Segment sizes must be the same");
+
+            segments[i] = bitSets[i].segments.get();
+            if (segments[i].numSegments() > maxNumSegments)
+                maxNumSegments = segments[i].numSegments();
+        }
+
+        ThreadSafeBitSetSegments newSegments =
+                new ThreadSafeBitSetSegments(maxNumSegments, numLongsPerSegment);
+
+        AtomicLongArray segment[] = new AtomicLongArray[segments.length];
+
+        for (int i = 0; i < maxNumSegments; i++) {
+            for (int j = 0; j < segments.length; j++) {
+                segment[j] = i < segments[j].numSegments() ? segments[j].getSegment(i) : null;
+            }
+
+            AtomicLongArray newSegment = newSegments.getSegment(i);
+
+            for (int j = 0; j < numLongsPerSegment; j++) {
+                long value = 0;
+                for (int k = 0; k < segments.length; k++) {
+                    if (segment[k] != null) value |= segment[k].get(j);
+                }
+                newSegment.set(j, value);
+            }
+        }
+
+        ThreadSafeBitSet or = new ThreadSafeBitSet(log2SegmentSize);
+        or.segments.set(newSegments);
+        return or;
+    }
+
+    /**
+     * Get the segment at <code>segmentIndex</code>.  If this segment does not yet exist, create it.
+     *
+     * @param segmentIndex the segment index
+     * @return the segment
+     */
+    private AtomicLongArray getSegment(int segmentIndex) {
+        ThreadSafeBitSetSegments visibleSegments = segments.get();
+
+        while (visibleSegments.numSegments() <= segmentIndex) {
+            /// Thread safety:  newVisibleSegments contains all of the segments from the currently
+            // visible segments, plus extra.
+            /// all of the segments in the currently visible segments are canonical and will not
+            // change.
+            ThreadSafeBitSetSegments newVisibleSegments =
+                    new ThreadSafeBitSetSegments(
+                            visibleSegments, segmentIndex + 1, numLongsPerSegment);
+
+            /// because we are using a compareAndSet, if this thread "wins the race" and
+            // successfully sets this variable, then the segments
+            /// which are newly defined in newVisibleSegments become canonical.
+            if (segments.compareAndSet(visibleSegments, newVisibleSegments)) {
+                visibleSegments = newVisibleSegments;
+            } else {
+                /// If we "lose the race" and are growing the ThreadSafeBitSet segments larger,
+                /// then we will gather the new canonical sets from the update which we missed on
+                // the next iteration of this loop.
+                /// Newly defined segments in newVisibleSegments will be discarded, they do not get
+                // to become canonical.
+                visibleSegments = segments.get();
+            }
+        }
+
+        return visibleSegments.getSegment(segmentIndex);
+    }
+
+    private static class ThreadSafeBitSetSegments {
+
+        private final AtomicLongArray segments[];
+
+        private ThreadSafeBitSetSegments(int numSegments, int segmentLength) {
+            AtomicLongArray segments[] = new AtomicLongArray[numSegments];
+
+            for (int i = 0; i < numSegments; i++) {
+                segments[i] = new AtomicLongArray(segmentLength);
+            }
+
+            /// Thread safety: Because this.segments is final, the preceding operations in this
+            // constructor are guaranteed to be visible to any
+            /// other thread which accesses this.segments.
+            this.segments = segments;
+        }
+
+        private ThreadSafeBitSetSegments(
+                ThreadSafeBitSetSegments copyFrom, int numSegments, int segmentLength) {
+            AtomicLongArray segments[] = new AtomicLongArray[numSegments];
+
+            for (int i = 0; i < numSegments; i++) {
+                segments[i] =
+                        i < copyFrom.numSegments()
+                                ? copyFrom.getSegment(i)
+                                : new AtomicLongArray(segmentLength);
+            }
+
+            /// see above re: thread-safety of this assignment
+            this.segments = segments;
+        }
+
+        public int numSegments() {
+            return segments.length;
+        }
+
+        public AtomicLongArray getSegment(int index) {
+            return segments[index];
+        }
+    }
+
+    public void serializeBitsTo(DataOutputStream os) throws IOException {
+        ThreadSafeBitSetSegments segments = this.segments.get();
+
+        os.writeInt(segments.numSegments() * numLongsPerSegment);
+
+        for (int i = 0; i < segments.numSegments(); i++) {
+            AtomicLongArray arr = segments.getSegment(i);
+
+            for (int j = 0; j < arr.length(); j++) {
+                os.writeLong(arr.get(j));
+            }
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof ThreadSafeBitSet)) return false;
+
+        ThreadSafeBitSet other = (ThreadSafeBitSet) obj;
+
+        if (other.log2SegmentSize != log2SegmentSize)
+            throw new IllegalArgumentException("Segment sizes must be the same");
+
+        ThreadSafeBitSetSegments thisSegments = this.segments.get();
+        ThreadSafeBitSetSegments otherSegments = other.segments.get();
+
+        for (int i = 0; i < thisSegments.numSegments(); i++) {
+            AtomicLongArray thisArray = thisSegments.getSegment(i);
+            AtomicLongArray otherArray =
+                    (i < otherSegments.numSegments()) ? otherSegments.getSegment(i) : null;
+
+            for (int j = 0; j < thisArray.length(); j++) {
+                long thisLong = thisArray.get(j);
+                long otherLong = (otherArray == null) ? 0 : otherArray.get(j);
+
+                if (thisLong != otherLong) return false;
+            }
+        }
+
+        for (int i = thisSegments.numSegments(); i < otherSegments.numSegments(); i++) {
+            AtomicLongArray otherArray = otherSegments.getSegment(i);
+
+            for (int j = 0; j < otherArray.length(); j++) {
+                long l = otherArray.get(j);
+
+                if (l != 0) return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = log2SegmentSize;
+        result = 31 * result + Arrays.hashCode(segments.get().segments);
+        return result;
+    }
+
+    /**
+     * @return a new BitSet with same bits set
+     */
+    public BitSet toBitSet() {
+        BitSet resultSet = new BitSet();
+        int ordinal = this.nextSetBit(0);
+        while (ordinal != -1) {
+            resultSet.set(ordinal);
+            ordinal = this.nextSetBit(ordinal + 1);
+        }
+        return resultSet;
+    }
+
+    @Override
+    public String toString() {
+        return toBitSet().toString();
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/VertexDataUtils.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/java/com/alibaba/graphscope/utils/VertexDataUtils.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import com.alibaba.fastffi.FFITypeFactory;
+import com.alibaba.fastffi.impl.CXXStdString;
+import com.alibaba.graphscope.arrow.array.ArrowArrayBuilder;
+import com.alibaba.graphscope.ds.StringTypedArray;
+import com.alibaba.graphscope.graphx.StringVertexData;
+import com.alibaba.graphscope.graphx.StringVertexDataBuilder;
+import com.alibaba.graphscope.graphx.VertexData;
+import com.alibaba.graphscope.graphx.VertexDataBuilder;
+import com.alibaba.graphscope.graphx.VineyardArrayBuilder;
+import com.alibaba.graphscope.graphx.VineyardClient;
+import com.alibaba.graphscope.graphx.utils.DoubleDouble;
+import com.alibaba.graphscope.graphx.utils.GrapeUtils;
+import com.alibaba.graphscope.serialization.FFIByteVectorOutputStream;
+import com.alibaba.graphscope.serialization.FakeFFIByteVectorInputStream;
+import com.alibaba.graphscope.stdcxx.FFIByteVector;
+import com.alibaba.graphscope.stdcxx.FFIIntVector;
+import com.alibaba.graphscope.stdcxx.FFIIntVectorFactory;
+import com.alibaba.graphscope.stdcxx.FakeFFIByteVector;
+import com.alibaba.graphscope.utils.array.PrimitiveArray;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+public class VertexDataUtils {
+
+    private static Logger logger = LoggerFactory.getLogger(VertexDataUtils.class.getName());
+
+    public static <VD> VertexData<Long, VD> persistPrimitiveArrayToVineyard(
+            PrimitiveArray<VD> primitiveArray, VineyardClient client, Class<? extends VD> vdClz) {
+        long size = primitiveArray.size();
+        VertexDataBuilder<Long, VD> vdBuilder = createPrimitiveVDBuilder(client, (int) size, vdClz);
+        VineyardArrayBuilder<VD> vdVineyardArrayBuilder = vdBuilder.getArrayBuilder();
+        if (vdVineyardArrayBuilder.size() != size) {
+            throw new IllegalStateException(
+                    "size neq " + size + ", " + vdVineyardArrayBuilder.size());
+        }
+        for (int i = 0; i < size; ++i) {
+            vdVineyardArrayBuilder.set(i, primitiveArray.get(i));
+        }
+        logger.info("create vd builder success");
+        return vdBuilder.seal(client).get();
+    }
+
+    public static <VD> StringVertexData<Long, CXXStdString> persistComplexArrayToVineyard(
+            PrimitiveArray<VD> primitiveArray, VineyardClient client, Class<? extends VD> vdClz) {
+        long size = primitiveArray.size();
+        StringVertexDataBuilder<Long, CXXStdString> vdBuilder =
+                createComplexVDBuilder(client, (int) size);
+        logger.info("create vd builder success");
+        try {
+            Tuple2<FFIByteVector, FFIIntVector> tuple2 =
+                    fillStringVertexArray(primitiveArray, vdClz);
+            vdBuilder.init(size, tuple2._1(), tuple2._2());
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return vdBuilder.seal(client).get();
+    }
+
+    private static <VD> VertexDataBuilder<Long, VD> createPrimitiveVDBuilder(
+            VineyardClient client, int fragVnums, Class<? extends VD> clz) {
+        VertexDataBuilder.Factory<Long, VD> factory =
+                FFITypeFactory.getFactory(
+                        VertexDataBuilder.class,
+                        "gs::VertexDataBuilder<uint64_t," + GrapeUtils.classToStr(clz, true) + ">");
+        return factory.create(client, fragVnums);
+    }
+
+    private static StringVertexDataBuilder<Long, CXXStdString> createComplexVDBuilder(
+            VineyardClient client, int fragVnums) {
+        StringVertexDataBuilder.Factory<Long, CXXStdString> factory =
+                FFITypeFactory.getFactory(
+                        StringVertexDataBuilder.class,
+                        "gs::VertexDataBuilder<uint64_t,std::string>");
+        return factory.create();
+    }
+
+    private static <VD> Tuple2<FFIByteVector, FFIIntVector> fillStringVertexArray(
+            PrimitiveArray<VD> array, Class<? extends VD> clz) throws IOException {
+        int size = array.size();
+        FFIByteVectorOutputStream ffiByteVectorOutput = new FFIByteVectorOutputStream();
+        FFIIntVector ffiOffset = (FFIIntVector) FFIIntVectorFactory.INSTANCE.create();
+        ffiOffset.resize(size);
+        ffiOffset.touch();
+        long prevBytesWritten = 0;
+        if (clz.equals(DoubleDouble.class)) {
+            ffiByteVectorOutput.getVector().resize(size * 16L);
+            ffiByteVectorOutput.getVector().touch();
+            for (int i = 0; i < size; ++i) {
+                DoubleDouble dd = (DoubleDouble) array.get(i);
+                ffiByteVectorOutput.writeDouble(dd.a());
+                ffiByteVectorOutput.writeDouble(dd.b());
+                ffiOffset.set(i, (int) (ffiByteVectorOutput.bytesWriten() - prevBytesWritten));
+                prevBytesWritten = ffiByteVectorOutput.bytesWriten();
+            }
+        } else {
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(ffiByteVectorOutput);
+            for (int i = 0; i < size; ++i) {
+                objectOutputStream.writeObject(array.get(i));
+                ffiOffset.set(i, (int) (ffiByteVectorOutput.bytesWriten() - prevBytesWritten));
+                prevBytesWritten = ffiByteVectorOutput.bytesWriten();
+            }
+            objectOutputStream.flush();
+        }
+
+        ffiByteVectorOutput.finishSetting();
+        long writenBytes = ffiByteVectorOutput.bytesWriten();
+        logger.info(
+                "write data array {} of type {}, writen bytes {}",
+                size,
+                clz.getName(),
+                writenBytes);
+        return new Tuple2<>(ffiByteVectorOutput.getVector(), ffiOffset);
+    }
+
+    private static <VD> ArrowArrayBuilder<VD> newArrowArrayBuilder(Class<? extends VD> clz) {
+        if (clz.equals(Long.class) || clz.equals(long.class)) {
+            ArrowArrayBuilder.Factory<VD> factory =
+                    FFITypeFactory.getFactory(
+                            ArrowArrayBuilder.class, "gs::ArrowArrayBuilder<int64_t>");
+            return factory.create();
+        } else if (clz.equals(Double.class) || clz.equals(double.class)) {
+            ArrowArrayBuilder.Factory<VD> factory =
+                    FFITypeFactory.getFactory(
+                            ArrowArrayBuilder.class, "gs::ArrowArrayBuilder<double>");
+            return factory.create();
+        } else if (clz.equals(Integer.class) || clz.equals(int.class)) {
+            ArrowArrayBuilder.Factory<VD> factory =
+                    FFITypeFactory.getFactory(
+                            ArrowArrayBuilder.class, "gs::ArrowArrayBuilder<int32_t>");
+            return factory.create();
+        } else {
+            throw new IllegalStateException("Not recognized " + clz.getName());
+        }
+    }
+
+    public static <T> T[] readComplexArray(StringTypedArray oldArray, Class<? extends T> clz)
+            throws IOException, ClassNotFoundException {
+        FakeFFIByteVector vector =
+                new FakeFFIByteVector(oldArray.getRawData(), oldArray.getRawDataLength());
+        FakeFFIByteVectorInputStream ffiInput = new FakeFFIByteVectorInputStream(vector);
+        long len = oldArray.getLength();
+        logger.info("reading {} objects from array of bytes {}", len, oldArray.getLength());
+
+        if (clz.equals(DoubleDouble.class)) {
+            T[] newArray = (T[]) new DoubleDouble[(int) len];
+            for (int i = 0; i < len; ++i) {
+                double a = ffiInput.readDouble();
+                double b = ffiInput.readDouble();
+                newArray[i] = (T) new DoubleDouble(a, b);
+            }
+            return newArray;
+        } else {
+            T[] newArray = (T[]) new Object[(int) len];
+            ObjectInputStream objectInputStream = new ObjectInputStream(ffiInput);
+            for (int i = 0; i < len; ++i) {
+                T obj = (T) objectInputStream.readObject();
+                newArray[i] = obj;
+            }
+            return newArray;
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/GSClientWrapper.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/GSClientWrapper.scala
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import com.alibaba.fastffi.FFITypeFactory
+import com.alibaba.graphscope.graphx.GSClientWrapper._
+import com.alibaba.graphscope.graphx.utils.GrapeUtils
+import com.alibaba.graphscope.utils.PythonInterpreter
+import org.apache.spark.SparkContext
+import org.apache.spark.graphx.grape.GrapeGraphImpl
+import org.apache.spark.graphx.scheduler.cluster.ExecutorInfoHelper
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+/** A wrapper for GraphScope python session.
+ * socketPath indicate vineyard already started.
+ *  */
+class GSClientWrapper(sc : SparkContext, socketPath : String = "", val sharedMemSize : String) extends Logging{
+
+
+  val graph2GraphName : mutable.HashMap[GrapeGraphImpl[_,_], String] = new mutable.HashMap[GrapeGraphImpl[_,_], String]()
+  val executorInfo = ExecutorInfoHelper.getExecutorsHost2Id(sc)
+  val executorNum = executorInfo.size
+  val gsHostsArr: Array[String] = executorInfo.keys.toArray.distinct.sorted
+  log.info(s"Available executors ${executorInfo.toIterator.toArray.mkString(",")}, hosts str ${gsHostsArr.map(v => "\'" + v + "\'").mkString(",")}")
+  val pythonInterpreter = new PythonInterpreter
+  pythonInterpreter.init()
+  pythonInterpreter.runCommand("import graphscope")
+  pythonInterpreter.runCommand("graphscope.set_option(show_log=True)")
+  var initSessionCmd: String = "sess = graphscope.session(cluster_type=\"hosts\", num_workers="+ executorNum +
+    ", hosts=" + arr2PythonArrStr(gsHostsArr)
+  if (socketPath.nonEmpty){
+    initSessionCmd += ",vineyard_socket= \""+ socketPath + "\""
+  }
+   initSessionCmd += ",vineyard_shared_mem=\"" + sharedMemSize + "\")"
+  log.info(s"init session with: ${initSessionCmd}")
+  pythonInterpreter.runCommand(initSessionCmd)
+
+  pythonInterpreter.getMatched("GraphScope coordinator service connected")
+  log.info("Successfully start gs session")
+
+  //vineyard socket
+  val startedSocket: String = getStartedSocket(pythonInterpreter)
+  log.info(s"sess start vineyard on ${startedSocket}")
+  sc.getConf.set("spark.gs.vineyard.sock", startedSocket)
+
+  val v6dClient: VineyardClient = createVineyardClient(startedSocket)
+  /**
+   *
+   * @param vfilePath vertex file path
+   * @param efilePath edge file path, should be property edge file.
+   * @return
+   */
+  def loadGraph[VD: ClassTag, ED : ClassTag](vfilePath : String, efilePath : String, userNumPartitions : Int) : GrapeGraphImpl[VD,ED] = {
+    val graphName = generateGraphName()
+    val createGraphCmd = graphName + " = sess.g()"
+    pythonInterpreter.runCommand(createGraphCmd)
+    val loadVertexCmd = graphName + " = " + graphName + ".add_vertices(\"" + vfilePath + "\",\"person\")"
+    log.info(s"load vertex cmd: ${loadVertexCmd}")
+    pythonInterpreter.runCommand(loadVertexCmd)
+    val loadEdgeCmd = graphName + " = "+ graphName + ".add_edges(\"" + efilePath + "\",label=\"knows\",src_label=\"person\",dst_label=\"person\")"
+    log.info(s"load edge cmd: ${loadEdgeCmd}")
+    pythonInterpreter.runCommand(loadEdgeCmd)
+
+    //project
+    val projectGraph = graphName + "_proj"
+    val projectCmd = projectGraph  + " = " + graphName + ".project(vertices={\"person\":[\"weight\"]}, edges={\"knows\" : [\"dist\"]})"
+    log.info(s"project cmd: ${projectCmd}")
+    pythonInterpreter.runCommand(projectCmd)
+
+    //get simple
+    val simpleGraph = graphName + "_simple"
+    val simpleCmd = simpleGraph +  " = " + projectGraph + "._project_to_simple()"
+    log.info(s"project to simple cmd: ${projectCmd}")
+    pythonInterpreter.runCommand(simpleCmd)
+
+    //get id cmd
+    val getIdCmd = "\"res_str:\"+" + simpleGraph + ".template_str + \";\"+str(" + simpleGraph + ".vineyard_id)"
+    log.info(s"get simple vineyard id cmd: ${getIdCmd}")
+    pythonInterpreter.runCommand(getIdCmd)
+
+    var rawRes = pythonInterpreter.getMatched(RES_PATTERN)
+    if (rawRes.startsWith("\'") || rawRes.endsWith("\"")){
+      rawRes = rawRes.substring(1)
+    }
+    if (rawRes.endsWith("\'") || rawRes.endsWith("\"")){
+      rawRes = rawRes.substring(0, rawRes.length - 1)
+    }
+    val resStr = rawRes.substring(rawRes.indexOf(RES_PATTERN) + RES_PATTERN.length + 1).trim
+    log.info(s"res str ${resStr}")
+    val splited = resStr.split(";")
+    require(splited.length == 2, "result str can't be splited into two parts")
+    val fragName = splited(0)
+    val fragGroupId = splited(1)
+    log.info(s"frag name : ${fragName}")
+    log.info(s"frag group id ${fragGroupId}")
+    //as this graph can later be used to run in graphscope session, we need to keep the matching between
+    //java object and vineyard objectId,
+
+    val fragGroupObjId = fragGroupId.toLong
+    val hostIdsStr = GrapeUtils.getHostIdStrFromFragmentGroup(v6dClient, fragGroupObjId)
+    log.info(s"parse from group id ${fragGroupObjId}, res ${hostIdsStr}")
+
+    val sparkSession : GSSparkSession = GSSparkSession.getDefaultSession.getOrElse(throw new IllegalStateException("empty session")).asInstanceOf[GSSparkSession]
+    val res = sparkSession.loadFragmentAsGraph[VD,ED](sc, userNumPartitions, hostIdsStr, fragName, socketPath)
+    log.info(s"got grapeGraph ${res} from host frag ids ${hostIdsStr}, graph name ${fragName}")
+    graph2GraphName(res) = graphName
+    res
+  }
+
+
+  def close() : Unit = {
+    pythonInterpreter.close()
+    log.info("GS session closed")
+  }
+}
+
+object GSClientWrapper{
+  val RES_PATTERN = "res_str";
+  //A safe word which we append to the execution of python code, its appearance in
+  // output stream, indicating command has been successfully executoed.
+  val SAFE_WORD = "Spark-GraphScope-OK"
+  val graphNameCounter = new AtomicInteger(0)
+  val VINEYARD_DEFAULT_SHARED_MEM = "10Gi"
+
+  def arr2PythonArrStr(arr : Array[String]) : String = {
+    if (arr.length == 0){
+      throw new IllegalStateException("array of size 0 is impossible")
+    }
+    else "[" + arr.map(v => "\'" + v + "\'").mkString(",") + "]"
+  }
+
+  /**
+   * we need a str name as handler in gs.
+   * @return
+   */
+  def generateGraphName() : String = {
+    val ind = graphNameCounter.getAndAdd(1)
+    "graph" + ind
+  }
+
+  def createVineyardClient(socket : String) : VineyardClient = {
+    val client = FFITypeFactory.getFactory(classOf[VineyardClient]).asInstanceOf[VineyardClient.Factory].create()
+    val ffiByteString = FFITypeFactory.newByteString()
+    ffiByteString.copyFrom(socket)
+    client.connect(ffiByteString)
+    client
+  }
+
+  def getStartedSocket(client : PythonInterpreter): String = {
+    val cmd = "sess.engine_config[\"vineyard_socket\"]"
+    client.runCommand(cmd)
+    val res = client.getResult
+    res.replace("\'", "")
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/GraphScopePregel.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/GraphScopePregel.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import com.alibaba.graphscope.graphx.utils.SerializationUtils
+import com.alibaba.graphscope.utils.MPIUtils
+import org.apache.spark.SparkContext
+import org.apache.spark.graphx.grape.GrapeGraphImpl
+import org.apache.spark.graphx.impl.GraphImpl
+import org.apache.spark.graphx.{EdgeDirection, EdgeTriplet, Graph, VertexId}
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+
+import scala.reflect.{ClassTag, classTag}
+
+class GraphScopePregel[VD: ClassTag, ED: ClassTag, MSG: ClassTag]
+(sc: SparkContext, graph: Graph[VD, ED], initialMsg: MSG, maxIteration: Int, activeDirection: EdgeDirection, vprog: (VertexId, VD, MSG) => VD,
+ sendMsg: EdgeTriplet[VD, ED] => Iterator[(VertexId, MSG)],
+ mergeMsg: (MSG, MSG) => MSG) extends Logging {
+  val SERIAL_PATH = "/tmp/graphx-meta"
+  val msgClass: Class[MSG] = classTag[MSG].runtimeClass.asInstanceOf[java.lang.Class[MSG]]
+  val vdClass: Class[VD] = classTag[VD].runtimeClass.asInstanceOf[java.lang.Class[VD]]
+  val edClass: Class[ED] = classTag[ED].runtimeClass.asInstanceOf[java.lang.Class[ED]]
+
+  def run(): Graph[VD,ED] = {
+    //Can accept both grapeGraph or GraphXGraph
+    val grapeGraph : GrapeGraphImpl[VD,ED] = {
+      graph match {
+        case graphImpl : GraphImpl[VD,ED] =>  GSSparkSession.graphXtoGSGraph[VD,ED](graphImpl)
+        case grapeGraphImpl: GrapeGraphImpl[VD,ED] => grapeGraphImpl
+      }
+    }
+    //0. write back vertex.
+    //1. serialization
+    log.info("[Driver:] start serialization functions.")
+    val sparkSession = GSSparkSession
+      .getDefaultSession.getOrElse(throw new IllegalStateException("empty session"))
+      .asInstanceOf[GSSparkSession]
+    SerializationUtils.write(SERIAL_PATH, vdClass, edClass, msgClass, vprog, sendMsg, mergeMsg, initialMsg, sc.appName, sparkSession.socketPath ,activeDirection)
+
+    val numPart = grapeGraph.grapeVertices.getNumPartitions
+    //launch mpi processes. and run.
+    val t0 = System.nanoTime()
+
+    /** Generate a json string contains necessary info to reconstruct a graphx graph, can be like
+     * workerName:*/
+    val fragIds = grapeGraph.fragmentIds.collect()
+    log.info(s"[GraphScopePregel]: Collected frag ids ${fragIds.mkString(",")}, numPartitions = ${numPart}")
+
+    //running pregel will not change vertex data type.
+    MPIUtils.launchGraphX[MSG,VD,ED](fragIds,vdClass,edClass,msgClass, SERIAL_PATH,maxIteration, numPart, sparkSession.socketPath, sparkSession.userJarPath)
+    val newVertexRDD = grapeGraph.grapeVertices.updateAfterPIE().cache() //read from file
+    //usually we need to construct graph vertices attributes from vineyard array.
+
+    val t1 = System.nanoTime()
+    log.info(s"[GraphScopePregel: ] running MPI process cost :${(t1 - t0) / 1000000} ms")
+    GrapeGraphImpl.fromExistingRDDs(newVertexRDD,grapeGraph.grapeEdges)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/GSEdgeTriplet.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/GSEdgeTriplet.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.graph
+
+import org.apache.spark.graphx.EdgeTriplet
+
+abstract class GSEdgeTriplet[VD,ED] extends EdgeTriplet[VD,ED]{
+  var eid : Long = -1
+  var offset : Long = -1;
+  var srcLid : Long = -1;
+  var dstLid : Long = -1;
+
+//  var eid : Long = -1
+  def getSrcOid : Long = srcId
+  def getSrcAttr : VD = srcAttr
+  def getDstOid : Long = dstId
+  def getDstAttr : VD = dstAttr
+  def getAttr : ED = attr
+
+  def setSrcOid(srcId : Long, srcAttr : VD): Unit
+  def setSrcOid(srcId : Long): Unit
+  def setDstOid(dstId : Long, dstAttr : VD): Unit
+  def setDstOid(dst : Long): Unit
+  def setAttr(edgeAttr: ED) : Unit
+}
+class GSEdgeTripletImpl[@specialized(Long,Int,Double)VD, @specialized(Long,Int,Double)ED] extends GSEdgeTriplet[VD,ED]{
+
+  @inline
+  override def setSrcOid(srcId : Long, srcAttr : VD): Unit ={
+    this.srcId = srcId
+    this.srcAttr = srcAttr
+  }
+
+  @inline
+  override def setDstOid(dstId : Long, dstAttr : VD): Unit ={
+    this.dstId = dstId;
+    this.dstAttr = dstAttr
+  }
+
+  override def setSrcOid(srcId: Long): Unit = this.srcId = srcId
+
+  override def setDstOid(dstId: Long): Unit = this.dstId = dstId
+
+  override def setAttr(edgeAttr: ED): Unit = this.attr = edgeAttr
+
+  override def toString(): String = "GSEdgeTripletImpl(" + "srcId=" +srcId +
+    ",dstId=" +dstId + ",srcAttr=" + srcAttr + ",dstAttr=" + dstAttr + ",attr=" + attr + ")"
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/GraphStructure.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/GraphStructure.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.graph
+
+import com.alibaba.graphscope.ds.Vertex
+import com.alibaba.graphscope.graphx.graph.GraphStructureTypes.GraphStructureType
+import com.alibaba.graphscope.graphx.store.{EdgeDataStore, VertexDataStore}
+import com.alibaba.graphscope.graphx.utils.BitSetWithOffset
+import com.alibaba.graphscope.utils.ThreadSafeBitSet
+import org.apache.spark.graphx.{Edge, EdgeTriplet}
+
+import scala.reflect.ClassTag
+
+/**
+ * Defines the interface of graph structure, include vm, csr. But doesn't contain vertex attribute
+ * and edge attribute(or contained but we don't use)
+ */
+object GraphStructureTypes extends Enumeration{
+  type GraphStructureType = Value
+  val GraphXFragmentStructure,ArrowProjectedStructure = Value
+}
+
+trait GraphStructure extends Serializable {
+
+  val structureType : GraphStructureType
+
+  def inDegreeArray(startLid : Long, endLid : Long) :Array[Int]
+
+  def outDegreeArray(startLid : Long, endLid : Long) : Array[Int]
+
+  def inOutDegreeArray(startLid : Long, endLid : Long) : Array[Int]
+
+  def iterator[ED : ClassTag](startLid : Long, endLid : Long, edatas : EdgeDataStore[ED], activeSet: BitSetWithOffset, reversed : Boolean = false) : Iterator[Edge[ED]]
+
+  def tripletIterator[VD: ClassTag,ED : ClassTag](startLid : Long, endLid : Long, vertexDataStore: VertexDataStore[VD], edatas : EdgeDataStore[ED], activeSet: BitSetWithOffset, edgeReversed : Boolean = false, includeSrc: Boolean = true, includeDst: Boolean = true, reuseTriplet : Boolean = false, includeLid : Boolean = false): Iterator[EdgeTriplet[VD, ED]]
+
+  def iterateEdges[ED : ClassTag,ED2 : ClassTag](startLid : Long, endLid : Long, f: Edge[ED] => ED2, edatas : EdgeDataStore[ED], activeSet : BitSetWithOffset, edgeReversed : Boolean = false, newArray : EdgeDataStore[ED2]) : Unit
+
+  def iterateTriplets[VD : ClassTag, ED : ClassTag,ED2 : ClassTag](startLid : Long, endLid : Long, f : EdgeTriplet[VD,ED] => ED2, activeVertices : BitSetWithOffset, innerVertexDataStore: VertexDataStore[VD], edatas : EdgeDataStore[ED], activeSet : BitSetWithOffset, edgeReversed : Boolean = false, includeSrc : Boolean = true, includeDst : Boolean = true, newArray : EdgeDataStore[ED2]) : Unit
+
+  /** get the oe begin offset */
+  def getOEBeginOffset(vid: Int) : Long
+
+  def getOEEndOffset(vid: Int) : Long
+
+  def getInDegree(vertex: Vertex[Long]): Long
+
+  def getOutDegree(vertex: Vertex[Long]): Long
+
+  /** get the ie begin offset */
+  def getIEBeginOffset(vid: Int) : Long
+
+  def getIEEndOffset(vid: Int) : Long
+
+  def getOutNbrIds(vertex: Vertex[Long]) : Array[Long]
+
+  def getInNbrIds(vertex: Vertex[Long]) : Array[Long]
+
+  def getInOutNbrIds(vertex: Vertex[Long]) : Array[Long]
+
+  def isInEdgesEmpty(vertex: Vertex[Long]): Boolean
+
+  def isOutEdgesEmpty(vertex: Vertex[Long]): Boolean
+
+  def getInEdgesNum: Long
+
+  def getOutEdgesNum: Long
+
+  //all edges in this frag
+  def getTotalEdgesNum : Long
+
+  def fid(): Int
+
+  def fnum(): Int
+
+  def getId(vertex: Vertex[Long]): Long
+
+  def getVertex(oid: Long, vertex: Vertex[Long]): Boolean
+
+  def getOuterVertex(oid : Long, vertex : Vertex[Long]) : Boolean
+
+  def getInnerVertex(oid : Long, vertex: Vertex[Long]) : Boolean
+
+  def getTotalVertexSize: Long
+
+  def getVertexSize: Long
+
+  def getInnerVertexSize: Long
+
+  def innerVertexLid2Oid(vertex: Vertex[Long]): Long
+
+  def outerVertexLid2Oid(vertex: Vertex[Long]): Long
+
+  def getOuterVertexSize: Long
+
+  def getOuterVertexGid(vertex: Vertex[Long]): Long
+
+  def fid2GraphxPid(fid: Int): Int
+
+  def outerVertexGid2Vertex(gid: Long, vertex: Vertex[Long]): Boolean
+
+  def getOEOffsetRange(startLid : Long, endLid : Long) : (Long,Long)
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/ReusableEdge.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/ReusableEdge.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.graph
+
+import org.apache.spark.graphx.{Edge, VertexId}
+
+trait ReusableEdge[ED] extends Edge[ED]{
+  var eid : Long = -1
+  var offset : Long = -1
+//  var eid : Long = -1
+  def setSrcId(vertexId: VertexId)
+  def setDstId(vertexId: VertexId)
+  def setAttr(ed : ED)
+}
+
+class ReusableEdgeImpl[@specialized(Long,Int,Double)ED] extends ReusableEdge[ED] {
+  override def setSrcId(vertexId: VertexId) = {
+    this.srcId = vertexId
+  }
+  override def setDstId(vertexId: VertexId) = {
+    this.dstId = vertexId
+  }
+
+  override def setAttr(ed : ED) = {
+    this.attr = ed
+  }
+
+  override def toString: String = {
+    "GSEdge(src=" + srcId + ",dst=" + dstId + ",attr=" + attr +")"
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/impl/AbstractGraphStructure.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/impl/AbstractGraphStructure.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.graph.impl
+
+import com.alibaba.graphscope.ds.{PropertyNbrUnit, Vertex}
+import com.alibaba.graphscope.graphx.graph.{GSEdgeTripletImpl, GraphStructure, ReusableEdgeImpl}
+import com.alibaba.graphscope.graphx.store.{EdgeDataStore, VertexDataStore}
+import com.alibaba.graphscope.graphx.utils.BitSetWithOffset
+import com.alibaba.graphscope.utils.FFITypeFactoryhelper
+import org.apache.spark.graphx.{Edge, EdgeTriplet}
+import org.apache.spark.internal.Logging
+
+import scala.reflect.ClassTag
+
+abstract class AbstractGraphStructure extends GraphStructure with Logging{
+
+  def getTripletIterator[VD: ClassTag, ED : ClassTag]
+  (myNbr : PropertyNbrUnit[Long],startLid : Long, endLid : Long, vertexDataStore: VertexDataStore[VD], edatas : EdgeDataStore[ED],
+   activeEdgeSet : BitSetWithOffset, edgeReversed : Boolean = false,
+   includeSrc: Boolean = true, includeDst: Boolean = true, reuseTriplet : Boolean = false, includeLid : Boolean = false): Iterator[EdgeTriplet[VD,ED]] = {
+    new Iterator[EdgeTriplet[VD, ED]] {
+      var curLid = startLid.toInt
+      val myAddress = myNbr.getAddress
+      var curOffset = 0L
+      var endOffset = 0L
+      val vertex = {
+        val r = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+        r.SetValue(curLid)
+        r
+      }
+      var srcId = innerVertexLid2Oid(vertex)
+      var srcAttr = vertexDataStore.get(curLid)
+      override def hasNext: Boolean = {
+        if (curOffset < 0){
+          return false
+        }
+        if (curOffset < endOffset){
+          true
+        }
+        else {
+          curLid += 1
+          var flag = true
+          while (flag && curLid < endLid){
+            curOffset = activeEdgeSet.nextSetBit(getOEBeginOffset(curLid).toInt)
+            endOffset = getOEEndOffset(curLid)
+            if (curOffset >= endOffset){
+              curLid += 1
+            }
+            else flag = false
+          }
+          if (curLid >= endLid || curOffset < 0) false
+          else {
+            srcId = innerVertexLid2Oid(vertex)
+            srcAttr = vertexDataStore.get(curLid)
+            true
+          }
+        }
+      }
+
+      override def next(): EdgeTriplet[VD, ED] = {
+        val edgeTriplet = new GSEdgeTripletImpl[VD, ED]
+        val curAddress = curOffset * 16 + myAddress
+        myNbr.setAddress(curAddress)
+        val dstLid = myNbr.vid().toInt
+        val eid = myNbr.eid().toInt
+        vertex.SetValue(dstLid)
+        if (edgeReversed){
+          edgeTriplet.dstId = srcId
+          edgeTriplet.dstAttr = srcAttr
+          edgeTriplet.srcId = getId(vertex)
+          edgeTriplet.srcAttr = vertexDataStore.get(dstLid)
+        }
+        else {
+          edgeTriplet.srcId = srcId
+          edgeTriplet.srcAttr = srcAttr
+          edgeTriplet.dstId = getId(vertex)
+          edgeTriplet.dstAttr = vertexDataStore.get(dstLid)
+        }
+        edgeTriplet.attr = edatas.getWithEID(eid)
+        curOffset = activeEdgeSet.nextSetBit(curOffset.toInt + 1)
+        edgeTriplet
+      }
+    }
+  }
+
+  def getEdgeIterator[ED: ClassTag](myNbr : PropertyNbrUnit[Long], startLid : Long, endLid : Long, edatas: EdgeDataStore[ED], activeEdgeSet : BitSetWithOffset, edgeReversed : Boolean = false) : Iterator[Edge[ED]] = {
+    new Iterator[Edge[ED]] {
+      var curLid = startLid.toInt
+      val myAddress = myNbr.getAddress
+      var curOffset = 0L
+      var endOffset = 0L
+      val vertex = {
+        val t = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+        t.SetValue(curLid)
+        t
+      }
+      var srcId = innerVertexLid2Oid(vertex)
+      val edge = new ReusableEdgeImpl[ED]
+
+      override def hasNext: Boolean = {
+        if (curOffset < 0){
+          return false
+        }
+        else if (curOffset < endOffset){
+          true
+        }
+        else {
+          curLid += 1
+          var flag = true
+          while (flag && curLid < endLid){
+            curOffset = activeEdgeSet.nextSetBit(getOEBeginOffset(curLid).toInt)
+            endOffset = getOEEndOffset(curLid)
+            if (curOffset >= endOffset){
+              curLid += 1
+            }
+            else flag = false
+          }
+          if (curLid >= endLid || curOffset < 0) false
+          else {
+            vertex.SetValue(curLid)
+            srcId = innerVertexLid2Oid(vertex)
+            true
+          }
+        }
+      }
+
+      override def next(): Edge[ED] = {
+        val curAddress = curOffset * 16 + myAddress
+        myNbr.setAddress(curAddress)
+        val dstLid = myNbr.vid().toInt
+        val eid = myNbr.eid().toInt
+        vertex.SetValue(dstLid)
+        if (edgeReversed) {
+          edge.dstId = srcId
+          edge.srcId = getId(vertex)
+        }
+        else {
+          edge.srcId = srcId
+          edge.dstId = getId(vertex)
+        }
+        edge.attr = edatas.getWithEID(eid)
+        curOffset = activeEdgeSet.nextSetBit(curOffset.toInt + 1)
+        edge
+      }
+    }
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/impl/FragmentStructure.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/impl/FragmentStructure.scala
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.graph.impl
+
+import com.alibaba.graphscope.ds.{PropertyNbrUnit, TypedArray, Vertex}
+import com.alibaba.graphscope.fragment.adaptor.ArrowProjectedAdaptor
+import com.alibaba.graphscope.fragment.{ArrowProjectedFragment, FragmentType, IFragment}
+import com.alibaba.graphscope.graphx.graph.GraphStructureTypes.{ArrowProjectedStructure, GraphStructureType}
+import com.alibaba.graphscope.graphx.graph.{GSEdgeTripletImpl, GraphStructure, ReusableEdgeImpl}
+import com.alibaba.graphscope.graphx.store.{EdgeDataStore, VertexDataStore}
+import com.alibaba.graphscope.graphx.utils.BitSetWithOffset
+import com.alibaba.graphscope.utils.{FFITypeFactoryhelper, LongPointerAccessor, ThreadSafeBitSet}
+import org.apache.spark.graphx._
+import org.apache.spark.internal.Logging
+
+import scala.reflect.ClassTag
+
+class FragmentStructure(val fragment : IFragment[Long,Long,_,_]) extends AbstractGraphStructure with Logging with Serializable {
+  val fid2Pid = new Array[Int](fragment.fnum())
+  val ivnum = fragment.getInnerVerticesNum
+
+  var oePtr,iePtr : PropertyNbrUnit[Long] = null
+  var oePtrStartAddr,iePtrStartAddr : Long = 0
+  var oeOffsetBeginArray,ieOffsetBeginArray : LongPointerAccessor = null
+  var oeOffsetEndArray,ieOffsetEndArray : LongPointerAccessor = null
+  var fragEdgeNum = 0
+
+  if (fragment.fragmentType().equals(FragmentType.ArrowProjectedFragment)) {
+    val projectedFragment = fragment.asInstanceOf[ArrowProjectedAdaptor[Long,Long,_,_]].getArrowProjectedFragment.asInstanceOf[ArrowProjectedFragment[Long,Long,_,_]]
+    oePtr = projectedFragment.getOutEdgesPtr
+    iePtr = projectedFragment.getInEdgesPtr
+    oePtrStartAddr = oePtr.getAddress
+    iePtrStartAddr = iePtr.getAddress
+    oeOffsetBeginArray = new LongPointerAccessor(projectedFragment.getOEOffsetsBeginPtr)
+    ieOffsetBeginArray = new LongPointerAccessor(projectedFragment.getIEOffsetsBeginPtr)
+    oeOffsetEndArray = new LongPointerAccessor(projectedFragment.getOEOffsetsEndPtr)
+    ieOffsetEndArray = new LongPointerAccessor(projectedFragment.getIEOffsetsEndPtr)
+  }
+  else {
+    throw new IllegalStateException(s"not supported type ${fragment.fragmentType()}")
+  }
+
+  val lid2Oid : Array[Long] = {
+    val res = new Array[Long](fragment.getVerticesNum.toInt)
+    var i = 0L
+    val limit = res.length
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (i < limit){
+      vertex.SetValue(i)
+      res(i.toInt) = fragment.getId(vertex)
+      i += 1
+    }
+    res
+  }
+
+  val startLid = 0
+  val endLid: Long = fragment.getInnerVerticesNum()
+
+  @inline
+  override def getOEBeginOffset(lid : Int) : Long = {
+    oeOffsetBeginArray.get(lid)
+  }
+
+  @inline
+  override def getIEBeginOffset(lid : Int) : Long = {
+    ieOffsetBeginArray.get(lid)
+  }
+
+  @inline
+  override def getOEEndOffset(lid : Int) : Long = {
+    oeOffsetEndArray.get(lid + 1)
+  }
+
+  @inline
+  override def getIEEndOffset(lid : Int) : Long = {
+    ieOffsetEndArray.get(lid + 1)
+  }
+
+  def outDegreeArray(startLid : Long, endLid : Long) : Array[Int] = {
+    val time0 = System.nanoTime()
+    val len = fragment.getVerticesNum.toInt
+    val res = new Array[Int](len)
+    var i = startLid.toInt
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (i < endLid){
+      vertex.SetValue(i)
+      res(i) = getOutDegree(vertex).toInt
+      i += 1
+    }
+    while (i < len){
+      res(i) = 0
+      i += 1
+    }
+    val time1 = System.nanoTime()
+    log.info(s"Get out degree array cost ${(time1 - time0)/1000000} ms")
+    res
+  }
+
+  def inDegreeArray(startLid : Long, endLid : Long) : Array[Int] = {
+    val time0 = System.nanoTime()
+    val len = fragment.getVerticesNum.toInt
+    val res = new Array[Int](len)
+    var i = startLid.toInt
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (i < endLid){
+      vertex.SetValue(i)
+      res(i) = getInDegree(vertex).toInt
+      i += 1
+    }
+    while (i < len){
+      res(i) = 0
+      i += 1
+    }
+    val time1 = System.nanoTime()
+    log.info(s"Get in degree array cost ${(time1 - time0)/1000000} ms")
+    res
+  }
+
+  def inOutDegreeArray(startLid : Long, endLid : Long) : Array[Int] = {
+    val len = fragment.getVerticesNum.toInt
+    val res = new Array[Int](len)
+    var i = 0
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (i < endLid) {
+      vertex.SetValue(i)
+      res(i) = getInDegree(vertex).toInt + getOutDegree(vertex).toInt
+      i += 1
+    }
+    while (i < len) {
+      res(i) =  0
+      i += 1
+    }
+    res
+  }
+
+  override def getInDegree(vertex: Vertex[Long]): Long = {
+    fragment.getLocalInDegree(vertex)
+  }
+
+  override def getOutDegree(vertex: Vertex[Long]): Long = {
+    fragment.getLocalOutDegree(vertex)
+  }
+
+  override def isInEdgesEmpty(vertex: Vertex[Long]): Boolean = {
+    fragment.getLocalInDegree(vertex) == 0
+  }
+
+  override def isOutEdgesEmpty(vertex: Vertex[Long]): Boolean = {
+    fragment.getLocalOutDegree(vertex) == 0
+  }
+
+  override def getInEdgesNum: Long = fragment.getInEdgeNum
+
+  override def getOutEdgesNum: Long = fragment.getOutEdgeNum
+
+  override def getTotalEdgesNum: VertexId = fragEdgeNum
+
+  override def fid(): Int = fragment.fid()
+
+  override def fnum(): Int = fragment.fnum()
+
+  override def getId(vertex: Vertex[VertexId]): VertexId = {
+    fragment.getId(vertex)
+  }
+
+  override def getVertex(oid: Long, vertex: Vertex[Long]): Boolean = {
+    fragment.getVertex(oid, vertex)
+  }
+
+  override def getTotalVertexSize: Long = fragment.getTotalVerticesNum
+
+  override def getVertexSize: Long = fragment.getVerticesNum
+
+  override def getInnerVertexSize: Long = fragment.getInnerVerticesNum
+
+  override def innerVertexLid2Oid(vertex: Vertex[VertexId]): VertexId = {
+    fragment.getInnerVertexId(vertex)
+  }
+
+  override def outerVertexLid2Oid(vertex: Vertex[VertexId]): Long = {
+    fragment.getOuterVertexId(vertex)
+  }
+
+  override def getOuterVertexSize: Long = fragment.getOuterVerticesNum
+
+  override def getOuterVertexGid(vertex: Vertex[Long]): Long = {
+    fragment.getOuterVertexGid(vertex)
+  }
+
+  def initFid2GraphxPid(array: Array[(PartitionID, Int)]) : Unit = {
+    for (tuple <- array){
+      fid2Pid(tuple._2) = tuple._1
+    }
+    log.info(s"Filled fid2 graphx pid ${fid2Pid.mkString("Array(", ", ", ")")}")
+  }
+
+  override def fid2GraphxPid(fid: Int): Int = {
+    fid2Pid(fid)
+  }
+
+  override def outerVertexGid2Vertex(gid: Long, vertex: Vertex[Long]): Boolean = {
+    fragment.outerVertexGid2Vertex(gid, vertex)
+  }
+
+  /** For us, the input edatas should be null, and we shall not reply on it to get edge data. */
+  override def iterator[ED: ClassTag](startLid : Long, endLid : Long, edatas: EdgeDataStore[ED], activeSet: BitSetWithOffset, edgeReversed: Boolean): Iterator[Edge[ED]] = {
+    if (fragment.fragmentType().equals(FragmentType.ArrowProjectedFragment)){
+      val projectedFragment = fragment.asInstanceOf[ArrowProjectedAdaptor[Long,Long,_,ED]]
+      newProjectedIterator(startLid, endLid, projectedFragment.getArrowProjectedFragment.asInstanceOf[ArrowProjectedFragment[Long,Long,_,ED]],edatas,activeSet,edgeReversed)
+    }
+    else {
+      throw new IllegalStateException("Not implemented")
+    }
+  }
+
+  override def tripletIterator[VD: ClassTag, ED: ClassTag](startLid : Long, endLid : Long, innerVertexDataStore: VertexDataStore[VD], edatas: EdgeDataStore[ED], activeSet: BitSetWithOffset, edgeReversed : Boolean = false, includeSrc: Boolean = true, includeDst: Boolean = true, reuseTriplet : Boolean = false, includeLid : Boolean = false): Iterator[EdgeTriplet[VD, ED]] = {
+    if (fragment.fragmentType().equals(FragmentType.ArrowProjectedFragment)){
+      val projectedFragment = fragment.asInstanceOf[ArrowProjectedAdaptor[Long,Long,VD,ED]].getArrowProjectedFragment.asInstanceOf[ArrowProjectedFragment[Long,Long,VD,ED]]
+      log.info(s"creating triplet iterator v2 with java edata, with inner vd store ${innerVertexDataStore}")
+      newProjectedTripletIterator(startLid,endLid,projectedFragment, innerVertexDataStore,edatas,activeSet,edgeReversed,includeSrc,includeDst,reuseTriplet,includeLid)
+    }
+    else {
+      throw new IllegalStateException("Not implemented")
+    }
+  }
+
+  private def newProjectedIterator[ED : ClassTag](startLid : Long, endLid : Long,frag: ArrowProjectedFragment[Long, Long, _, ED], edatas : EdgeDataStore[ED], activeEdgeSet: BitSetWithOffset, edgeReverse : Boolean) : Iterator[Edge[ED]] = {
+    getEdgeIterator(frag.getOutEdgesPtr, startLid,endLid,edatas,activeEdgeSet,edgeReverse)
+  }
+
+  private def newProjectedTripletIterator[VD: ClassTag,ED : ClassTag](startLid : Long, endLid : Long, frag: ArrowProjectedFragment[Long, Long, VD, ED], vertexDataStore: VertexDataStore[VD], edatas : EdgeDataStore[ED], activeEdgeSet: BitSetWithOffset, edgeReversed: Boolean, includeSrc : Boolean, includeDst : Boolean, reuseTriplet : Boolean, includeLid : Boolean = false) : Iterator[EdgeTriplet[VD,ED]] = {
+    getTripletIterator(frag.getOutEdgesPtr,startLid,endLid,vertexDataStore,edatas, activeEdgeSet,
+      edgeReversed, includeSrc, includeDst, reuseTriplet, includeLid)
+  }
+
+  override def getInnerVertex(oid: Long, vertex: Vertex[Long]): Boolean = {
+    require(fragment.getInnerVertex(oid,vertex))
+    true
+  }
+
+  override def getOuterVertex(oid: Long, vertex: Vertex[Long]): Boolean = {
+    require(fragment.getOuterVertex(oid,vertex))
+    true
+  }
+
+  override val structureType: GraphStructureType = ArrowProjectedStructure
+
+
+  override def getOutNbrIds(vertex: Vertex[Long]): Array[VertexId] = {
+    val size = getOutDegree(vertex)
+    val res = new Array[VertexId](size.toInt)
+    fillOutNbrIdsImpl(vertex.GetValue(), res)
+    res
+  }
+
+  def fillOutNbrIdsImpl(vid : VertexId, array : Array[VertexId], startInd : Int = 0) : Unit = {
+    var curOff = oeOffsetBeginArray.get(vid)
+    val endOff = oeOffsetEndArray.get(vid)
+    oePtr.setAddress(oePtrStartAddr + curOff * 16)
+    var i = startInd
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (curOff < endOff){
+      vertex.SetValue(oePtr.vid())
+      val dstOid = getId(vertex)
+      array(i) = dstOid
+      curOff += 1
+      i += 1
+      oePtr.addV(16)
+    }
+  }
+
+  override def getInNbrIds(vertex: Vertex[Long]): Array[VertexId] = {
+    val size = getInDegree(vertex)
+    val res = new Array[VertexId](size.toInt)
+    fillInNbrIdsImpl(vertex.GetValue().toInt, res)
+    res
+  }
+
+  def fillInNbrIdsImpl(vid : Int, array : Array[VertexId], startInd : Int = 0) : Unit = {
+    var curOff = ieOffsetBeginArray.get(vid)
+    val endOff = ieOffsetEndArray.get(vid)
+    iePtr.setAddress(iePtrStartAddr + curOff * 16)
+    var i = startInd
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (curOff < endOff){
+      vertex.SetValue(iePtr.vid())
+      val dstOid = getId(vertex)
+      array(i) = dstOid
+      curOff += 1
+      i += 1
+      iePtr.addV(16)
+    }
+  }
+
+  override def getInOutNbrIds(vertex: Vertex[Long]): Array[VertexId] = {
+    val size = getInDegree(vertex) + getOutDegree(vertex)
+    val res = new Array[VertexId](size.toInt)
+    val vid = vertex.GetValue()
+    fillOutNbrIdsImpl(vid, res, 0)
+    fillInNbrIdsImpl(vid.toInt, res, getOutDegree(vertex).toInt)
+    res
+  }
+
+  override def iterateTriplets[VD: ClassTag, ED: ClassTag,ED2: ClassTag](startLid : Long, endLid : Long, f: EdgeTriplet[VD,ED] => ED2,
+                                                                         activeVertices : BitSetWithOffset, innerVertexDataStore: VertexDataStore[VD],
+                                                                         edatas: EdgeDataStore[ED], activeSet: BitSetWithOffset,
+                                                                         edgeReversed: Boolean, includeSrc: Boolean, includeDst: Boolean, newArray : EdgeDataStore[ED2]): Unit = {
+    if (fragment.fragmentType().equals(FragmentType.ArrowProjectedFragment)){
+      val projectedFragment = fragment.asInstanceOf[ArrowProjectedAdaptor[Long,Long,VD,ED]].getArrowProjectedFragment.asInstanceOf[ArrowProjectedFragment[Long,Long,VD,ED]]
+      iterateProjectedTriplets(projectedFragment,startLid,endLid,f, activeVertices,innerVertexDataStore,edatas,activeSet,edgeReversed,includeSrc,includeDst, newArray)
+    }
+    else {
+      throw new IllegalStateException("Not implemented")
+    }
+  }
+
+  override def iterateEdges[ED: ClassTag, ED2: ClassTag](startLid : Long, endLid : Long, f: Edge[ED] => ED2, edatas: EdgeDataStore[ED], activeSet: BitSetWithOffset,
+                                                         edgeReversed: Boolean, newArray: EdgeDataStore[ED2]): Unit = {
+    if (fragment.fragmentType().equals(FragmentType.ArrowProjectedFragment)){
+      val projectedFragment = fragment.asInstanceOf[ArrowProjectedAdaptor[Long,Long,_,ED]].getArrowProjectedFragment.asInstanceOf[ArrowProjectedFragment[Long,Long,_,ED]]
+      iterateProjectedEdges(projectedFragment,startLid,endLid,f, edatas,activeSet,edgeReversed, newArray)
+    }
+    else {
+      throw new IllegalStateException("Not implemented")
+    }
+  }
+
+  def iterateProjectedTriplets[VD : ClassTag,ED : ClassTag,ED2 : ClassTag](frag: ArrowProjectedFragment[Long, Long, VD, ED],startLid : Long, endLid : Long, f: EdgeTriplet[VD,ED] => ED2,
+                                                                           activeVertices : BitSetWithOffset,
+                                                                           vertexDataStore: VertexDataStore[VD], prevStore: EdgeDataStore[ED], activeSet: BitSetWithOffset, edgeReversed: Boolean,
+                                                                           includeSrc: Boolean, includeDst: Boolean, nextStore : EdgeDataStore[ED2]): Unit = {
+    var curLid = activeVertices.nextSetBit(startLid.toInt)
+    val edgeTriplet = new GSEdgeTripletImpl[VD, ED]
+    log.info(s"start iterating triplets, from ${startLid} to ${endLid}, ivnum ${frag.getInnerVerticesNum}, tvnum ${frag.getVerticesNum}")
+
+    val myNbr = frag.getOutEdgesPtr
+    val myAddress = myNbr.getAddress
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (curLid < endLid && curLid >= 0) {
+      val curAddress = getOEBeginOffset(curLid) * 16 + myAddress
+      val endAddress = getOEEndOffset(curLid) * 16 + myAddress
+      myNbr.setAddress(curAddress)
+      vertex.SetValue(curLid)
+      if (edgeReversed) {
+        edgeTriplet.dstId = innerVertexLid2Oid(vertex)
+        edgeTriplet.dstAttr = vertexDataStore.get(curLid)
+      }
+      else {
+        edgeTriplet.srcId = innerVertexLid2Oid(vertex)
+        edgeTriplet.srcAttr = vertexDataStore.get(curLid)
+      }
+      while (myNbr.getAddress < endAddress) {
+        val dstLid = myNbr.vid().toInt
+        val eid = myNbr.eid().toInt
+        vertex.SetValue(dstLid)
+        if (edgeReversed) {
+          edgeTriplet.srcId = getId(vertex)
+          edgeTriplet.srcAttr = vertexDataStore.get(dstLid)
+        }
+        else {
+          edgeTriplet.dstId = getId(vertex)
+          edgeTriplet.dstAttr = vertexDataStore.get(dstLid)
+        }
+        edgeTriplet.attr = prevStore.getWithEID(eid)
+        nextStore.setWithEID(eid, f(edgeTriplet))
+        myNbr.addV(16)
+      }
+      curLid = activeVertices.nextSetBit(curLid + 1)
+    }
+  }
+
+  def iterateProjectedEdges[ED: ClassTag, ED2: ClassTag](frag: ArrowProjectedFragment[Long, Long, _, ED],startLid : Long, endLid : Long, f: Edge[ED] => ED2, prevStore: EdgeDataStore[ED], activeSet: BitSetWithOffset, edgeReversed: Boolean, nextStore: EdgeDataStore[ED2]): Unit = {
+
+    var curLid = startLid.toInt
+    val edge = new ReusableEdgeImpl[ED]
+    val myNbr = frag.getOutEdgesPtr
+    val myAddress = myNbr.getAddress
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (curLid < endLid && curLid >= 0) {
+      val curAddress = getOEBeginOffset(curLid) * 16 + myAddress
+      val endAddress = getOEEndOffset(curLid) * 16 + myAddress
+      myNbr.setAddress(curAddress)
+      vertex.SetValue(curLid)
+      if (edgeReversed) {
+        edge.dstId = innerVertexLid2Oid(vertex)
+      }
+      else {
+        edge.srcId = innerVertexLid2Oid(vertex)
+      }
+      while (myNbr.getAddress < endAddress) {
+        val dstLid = myNbr.vid().toInt
+        val eid = myNbr.eid().toInt
+        vertex.SetValue(dstLid)
+        if (edgeReversed) {
+          edge.srcId = getId(vertex)
+        }
+        else {
+          edge.dstId = getId(vertex)
+        }
+        edge.attr = prevStore.getWithEID(eid)
+        nextStore.setWithEID(eid, f(edge))
+        myNbr.addV(16)
+      }
+      curLid += 1
+    }
+  }
+
+  override def getOEOffsetRange(startLid: VertexId, endLid: VertexId): (VertexId, VertexId) = {
+    (oeOffsetBeginArray.get(startLid), oeOffsetEndArray.get(endLid - 1))
+  }
+}
+
+object FragmentStructure{
+  val NBR_SIZE = 16
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/impl/GraphXGraphStructure.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/graph/impl/GraphXGraphStructure.scala
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.graph.impl
+
+import com.alibaba.graphscope.ds.{PropertyNbrUnit, TypedArray, Vertex}
+import com.alibaba.graphscope.graphx._
+import com.alibaba.graphscope.graphx.graph.GraphStructureTypes.{GraphStructureType, GraphXFragmentStructure}
+import com.alibaba.graphscope.graphx.graph.{GSEdgeTripletImpl, GraphStructure, ReusableEdgeImpl}
+import com.alibaba.graphscope.graphx.store.{EdgeDataStore, VertexDataStore}
+import com.alibaba.graphscope.graphx.utils.{BitSetWithOffset, IdParser}
+import org.apache.spark.graphx._
+import org.apache.spark.internal.Logging
+
+import scala.reflect.ClassTag
+
+/** the edge array only contains out edges, we use in edge as a comparison  */
+class GraphXGraphStructure(val vm : GraphXVertexMap[Long,Long], val csr : GraphXCSR[Long]) extends AbstractGraphStructure with Logging{
+  val oeBeginNbr: PropertyNbrUnit[VertexId] = csr.getOEBegin(0)
+  val ieBeginNbr: PropertyNbrUnit[VertexId] = csr.getIEBegin(0)
+  val oeBeginAddr: Long = oeBeginNbr.getAddress
+  val oeEndAddr: Long = csr.getOEEnd(vm.innerVertexSize() - 1).getAddress
+  val ieBeginAddr: VertexId = ieBeginNbr.getAddress
+  val ivnum: Long = vm.innerVertexSize()
+  val tvnum: Long = vm.getVertexSize.toInt
+  val lid2Oid: Array[TypedArray[VertexId]] = {
+    val res = new Array[TypedArray[Long]](vm.fnum())
+    for (i <- 0 until fnum()){
+      res(i) = vm.getLid2OidAccessor(i)
+    }
+    res
+  }
+  val idParser = new IdParser(fnum())
+  val outerLid2Gid: TypedArray[VertexId] = vm.getOuterLid2GidAccessor
+  require(outerLid2Gid.getLength == (tvnum - ivnum), s"ovnum neq ${outerLid2Gid.getLength} vs ${tvnum - ivnum}")
+
+  val myFid: Int = vm.fid()
+
+
+  val oeOffsetsArray: TypedArray[Long] = csr.getOEOffsetsArray.asInstanceOf[TypedArray[Long]]
+  val oeOffsetsLen : Long = oeOffsetsArray.getLength
+
+  val ieOffsetsArray : TypedArray[Long] = csr.getIEOffsetsArray.asInstanceOf[TypedArray[Long]]
+
+
+  @inline
+  override def getOEBeginOffset(lid : Int) : Long = {
+    require(lid < oeOffsetsLen, s"index out of range ${lid}, ${oeOffsetsLen}")
+    oeOffsetsArray.get(lid)
+  }
+
+  @inline
+  override def getIEBeginOffset(lid : Int) : Long = {
+    ieOffsetsArray.get(lid)
+  }
+
+  @inline
+  override def getOEEndOffset(lid : Int) : Long = {
+    require(lid + 1 < oeOffsetsLen, s"index out of range ${lid}, ${oeOffsetsLen}")
+    oeOffsetsArray.get(lid + 1)
+  }
+
+  @inline
+  override def getIEEndOffset(lid : Int) : Long = {
+    ieOffsetsArray.get(lid + 1)
+  }
+
+  @inline
+  def getOutDegree(l: Int) : Long = {
+    oeOffsetsArray.get(l + 1) - oeOffsetsArray.get(l)
+  }
+
+  @inline
+  def getInDegree(l: Int) : Long = {
+    ieOffsetsArray.get(l + 1) - ieOffsetsArray.get(l)
+  }
+
+  def outDegreeArray(startLid : Long, endLid : Long) : Array[Int] = {
+    val time0 = System.nanoTime()
+    val len = endLid - startLid
+    val res = new Array[Int](len.toInt)
+    var i = startLid.toInt
+    while (i < endLid){
+      res(i - startLid.toInt) = getOutDegree(i).toInt
+      i += 1
+    }
+    val time1 = System.nanoTime()
+    log.info(s"Get out degree array cost ${(time1 - time0)/1000000} ms")
+    res
+  }
+
+  /** array length equal (end-start), indexed with 0 */
+  def inDegreeArray(startLid : Long, endLid : Long) : Array[Int] = {
+    val time0 = System.nanoTime()
+    val len = endLid - startLid
+    val res = new Array[Int](len.toInt)
+    var i = startLid.toInt
+    while (i < endLid){
+      res(i - startLid.toInt) = getInDegree(i).toInt
+      i += 1
+    }
+    val time1 = System.nanoTime()
+    log.info(s"Get in degree array cost ${(time1 - time0)/1000000} ms")
+    res
+  }
+
+  def inOutDegreeArray(startLid : Long, endLid : Long) : Array[Int] = {
+    val len = endLid - startLid
+    val res = new Array[Int](len.toInt)
+    var i = startLid.toInt
+    while (i < endLid) {
+      res(i -startLid.toInt) = getInDegree(i).toInt + getOutDegree(i).toInt
+      i += 1
+    }
+    res
+  }
+
+  @inline
+  def getOuterVertexFid(lid: Long) : Int = {
+    val gid = outerLid2Gid.get(lid - ivnum)
+    idParser.getFragId(gid)
+  }
+
+  override def isInEdgesEmpty(vertex: Vertex[Long]): Boolean = csr.isInEdgesEmpty(vertex.GetValue())
+
+  override def isOutEdgesEmpty(vertex: Vertex[Long]): Boolean = csr.isOutEdgesEmpty(vertex.GetValue())
+
+  override def getInEdgesNum: Long = csr.getInEdgesNum
+
+  override def getOutEdgesNum: Long = csr.getOutEdgesNum
+
+  override def getTotalEdgesNum: VertexId = csr.getTotalEdgesNum
+
+  override def fid(): Int = myFid
+
+  override def fnum(): Int = vm.fnum()
+
+  @inline
+  override def getId(vertex: Vertex[Long]): Long = {
+    val lid = vertex.GetValue()
+    getId(lid)
+  }
+
+  @inline
+  def getId(lid: VertexId): VertexId = {
+    if (lid < ivnum){
+      innerVertexLid2Oid(lid)
+    }
+    else if (lid < tvnum){
+      outerVertexLid2Oid(lid)
+    }
+    else {
+      throw new IllegalStateException(s"not possible ${lid}")
+    }
+  }
+
+  override def getVertex(oid: Long, vertex: Vertex[Long]): Boolean = vm.getVertex(oid,vertex)
+
+  override def getTotalVertexSize: Long = vm.getTotalVertexSize
+
+  override def getVertexSize: Long = vm.getVertexSize
+
+  override def getInnerVertexSize: Long = vm.innerVertexSize()
+
+  override def innerVertexLid2Oid(vertex: Vertex[VertexId]): VertexId = {
+    lid2Oid(myFid).get(vertex.GetValue())
+  }
+
+  def innerVertexLid2Oid(vertex : Long): VertexId = {
+    lid2Oid(myFid).get(vertex)
+  }
+
+  @inline
+  override def outerVertexLid2Oid(vertex: Vertex[Long]): Long = {
+    val gid = outerLid2Gid.get(vertex.GetValue() - ivnum)
+    val lid = idParser.getLocalId(gid)
+    val dstFid = idParser.getFragId(gid)
+    lid2Oid(dstFid).get(lid)
+  }
+
+  @inline
+  def outerVertexLid2Oid(vertex: Long): Long = {
+    val gid = outerLid2Gid.get(vertex - ivnum)
+    val lid = idParser.getLocalId(gid)
+    val dstFid = idParser.getFragId(gid)
+    lid2Oid(dstFid).get(lid)
+  }
+
+  override def getOuterVertexSize: Long = vm.getOuterVertexSize
+
+  override def getOuterVertexGid(vertex: Vertex[Long]): Long = {
+    outerLid2Gid.get(vertex.GetValue() - ivnum)
+  }
+
+  override def fid2GraphxPid(fid: Int): Int = vm.fid2GraphxPid(fid)
+
+  override def outerVertexGid2Vertex(gid: Long, vertex: Vertex[Long]): Boolean = vm.outerVertexGid2Vertex(gid,vertex)
+
+  override def iterator[ED: ClassTag](startLid : Long, endLid : Long, edatas: EdgeDataStore[ED], activeEdgeSet : BitSetWithOffset, edgeReversed : Boolean = false): Iterator[Edge[ED]] = {
+    getEdgeIterator(csr.getOEBegin(0), startLid,endLid,edatas,activeEdgeSet,edgeReversed)
+  }
+
+  override def tripletIterator[VD: ClassTag,ED : ClassTag](startLid : Long, endLid : Long, vertexDataStore: VertexDataStore[VD], edatas : EdgeDataStore[ED],
+                                                           activeEdgeSet : BitSetWithOffset, edgeReversed : Boolean = false,
+                                                           includeSrc: Boolean = true, includeDst: Boolean = true, reuseTriplet : Boolean = false, includeLid : Boolean = false)
+  : Iterator[EdgeTriplet[VD, ED]] = {
+    getTripletIterator(csr.getOEBegin(0),startLid,endLid,vertexDataStore,edatas,activeEdgeSet,edgeReversed,includeSrc,includeDst,reuseTriplet,includeLid)
+  }
+
+  override def getInnerVertex(oid: Long, vertex: Vertex[Long]): Boolean = {
+    require(vm.getInnerVertex(oid, vertex))
+    require(vertex.GetValue() < ivnum)
+    true
+  }
+
+  override def getOuterVertex(oid: Long, vertex: Vertex[Long]): Boolean = {
+    require(vm.getOuterVertex(oid, vertex))
+    require(vertex.GetValue() >= ivnum)
+    true
+  }
+
+  override val structureType: GraphStructureType = GraphXFragmentStructure
+
+  override def getOutNbrIds(vertex: Vertex[Long]): Array[VertexId] = {
+    val res = new Array[VertexId](getOutDegree(vertex).toInt)
+    fillOutNbrIds(vertex.GetValue().toInt, res)
+    res
+  }
+
+  def fillOutNbrIds(vid : Int, array: Array[VertexId],startInd : Int = 0) : Unit = {
+    var cur = getOEBeginOffset(vid)
+    val end = getOEEndOffset(vid)
+    oeBeginNbr.setAddress(cur * 16 + oeBeginAddr)
+    var i = startInd
+    while (cur < end){
+      val lid = oeBeginNbr.vid()
+      array(i) = getId(lid)
+      cur += 1
+      i += 1
+      oeBeginNbr.addV(16)
+    }
+  }
+
+  override def getInNbrIds(vertex: Vertex[Long]): Array[VertexId] = {
+    val res = new Array[VertexId](getInDegree(vertex).toInt)
+    fillInNbrIds(vertex.GetValue().toInt, res)
+    res
+  }
+
+  def fillInNbrIds(vid :Int, array : Array[VertexId], startInd : Int = 0) : Unit = {
+    val beginNbr = csr.getIEBegin(vid)
+    val endNbr = csr.getIEEnd(vid)
+    var i = startInd
+    while (beginNbr.getAddress < endNbr.getAddress){
+      array(i) = getId(beginNbr.vid().toInt)
+      i += 1
+      beginNbr.addV(16)
+    }
+  }
+
+  override def getInOutNbrIds(vertex: Vertex[Long]): Array[VertexId] = {
+    val size = getInDegree(vertex) + getOutDegree(vertex)
+    val res = new Array[VertexId](size.toInt)
+    fillOutNbrIds(vertex.GetValue().toInt, res, 0)
+    fillInNbrIds(vertex.GetValue().toInt, res, getInDegree(vertex).toInt)
+    res
+  }
+  override def iterateTriplets[VD: ClassTag, ED: ClassTag,ED2 : ClassTag](startLid : Long, endLid : Long, f: EdgeTriplet[VD,ED] => ED2, activeVertices : BitSetWithOffset,
+                                                                          vertexDataStore: VertexDataStore[VD], prevStore: EdgeDataStore[ED], activeEdgeSet: BitSetWithOffset,
+                                                                          edgeReversed: Boolean, includeSrc: Boolean, includeDst: Boolean, nextStore : EdgeDataStore[ED2]): Unit = {
+    var curLid = activeVertices.nextSetBit(startLid.toInt)
+    val edgeTriplet = new GSEdgeTripletImpl[VD, ED]
+    log.info(s"start iterating triplets, from ${startLid} to ${endLid}, ivnum ${vm.innerVertexSize()}, tvnum ${vm.getVertexSize}, oe offset len ${oeOffsetsArray.getLength}, oe offset end ${oeOffsetsArray.get(oeOffsetsLen-1)}")
+
+    val myNbr = csr.getOEBegin(0)
+    val myAddress = myNbr.getAddress
+    while (curLid < endLid && curLid >= 0) {
+      var curOffset = getOEBeginOffset(curLid)
+      val endOffset = getOEEndOffset(curLid)
+      val curAddress = curOffset * 16 + myAddress
+      val endAddress = endOffset * 16 + myAddress
+      myNbr.setAddress(curAddress)
+      if (edgeReversed) {
+        edgeTriplet.dstId = innerVertexLid2Oid(curLid)
+        edgeTriplet.dstAttr = vertexDataStore.get(curLid)
+      }
+      else {
+        edgeTriplet.srcId = innerVertexLid2Oid(curLid)
+        edgeTriplet.srcAttr = vertexDataStore.get(curLid)
+      }
+      while (curOffset < endOffset) {
+        if (activeEdgeSet.get(curOffset.toInt)) {
+          val dstLid = myNbr.vid().toInt
+          val eid = myNbr.eid().toInt
+          if (edgeReversed) {
+            edgeTriplet.srcId = getId(dstLid)
+            edgeTriplet.srcAttr = vertexDataStore.get(dstLid)
+          }
+          else {
+            edgeTriplet.dstId = getId(dstLid)
+            edgeTriplet.dstAttr = vertexDataStore.get(dstLid)
+          }
+          edgeTriplet.attr = prevStore.getWithEID(eid)
+          nextStore.setWithEID(eid, f(edgeTriplet))
+        }
+        myNbr.addV(16)
+        curOffset += 1
+      }
+      curLid = activeVertices.nextSetBit(curLid + 1)
+    }
+  }
+
+  override def iterateEdges[ED: ClassTag, ED2: ClassTag](startLid : Long, endLid : Long, f: Edge[ED] => ED2, prevStore : EdgeDataStore[ED], activeEdgeSet: BitSetWithOffset,
+                                                         edgeReversed: Boolean, nextStore: EdgeDataStore[ED2]): Unit = {
+    var curLid = startLid.toInt
+    val edge = new ReusableEdgeImpl[ED]
+
+    val myNbr = csr.getOEBegin(0)
+    var curOffset = activeEdgeSet.nextSetBit(activeEdgeSet.startBit)
+    var curEndOffset = getOEEndOffset(curLid)
+    if (edgeReversed) {
+      edge.dstId = innerVertexLid2Oid(curLid)
+    }
+    else {
+      edge.srcId = innerVertexLid2Oid(curLid)
+    }
+    var stepSize = 0
+    while (curOffset >= 0){
+      //curLid can not be larger or equal to endLid
+      val prevEndOffset = curEndOffset
+      while (curOffset > curEndOffset){
+        curLid += 1
+        curEndOffset = getOEEndOffset(curLid)
+      }
+      if (prevEndOffset != curEndOffset){//which means curLid has been changed.
+        if (edgeReversed) {
+          edge.dstId = innerVertexLid2Oid(curLid)
+        }
+        else {
+          edge.srcId = innerVertexLid2Oid(curLid)
+        }
+      }
+      myNbr.addV(stepSize * 16)
+      val dstLid = myNbr.vid().toInt
+      val eid = myNbr.eid().toInt
+      if (edgeReversed) {
+        edge.srcId = getId(dstLid)
+      }
+      else {
+        edge.dstId = getId(dstLid)
+      }
+      edge.attr = prevStore.getWithEID(eid)
+      nextStore.setWithEID(eid, f(edge))
+
+      val nextOffset = activeEdgeSet.nextSetBit(curOffset + 1)
+      stepSize = nextOffset - curOffset
+      curOffset = nextOffset
+    }
+  }
+
+  override def getOEOffsetRange(startLid: VertexId, endLid: VertexId): (VertexId, VertexId) = {
+    (csr.getOEOffset(startLid),csr.getOEOffset(endLid))
+  }
+
+  override def getInDegree(vertex: Vertex[VertexId]): VertexId = {
+    getInDegree(vertex.GetValue().toInt)
+  }
+
+  override def getOutDegree(vertex: Vertex[VertexId]): VertexId = {
+    getOutDegree(vertex.GetValue().toInt)
+  }
+}
+

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/FragmentRDD.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/FragmentRDD.scala
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.rdd
+
+import com.alibaba.fastffi.{FFIByteString, FFITypeFactory}
+import com.alibaba.graphscope.ds.Vertex
+import com.alibaba.graphscope.fragment.adaptor.ArrowProjectedAdaptor
+import com.alibaba.graphscope.fragment.{ArrowProjectedFragment, IFragment}
+import com.alibaba.graphscope.graphx.VineyardClient
+import com.alibaba.graphscope.graphx.graph.impl.FragmentStructure
+import com.alibaba.graphscope.graphx.rdd.FragmentPartition.getHost
+import com.alibaba.graphscope.graphx.rdd.impl.GrapeEdgePartition
+import com.alibaba.graphscope.graphx.store.impl.{ImmutableOffHeapEdgeStore, InHeapVertexDataStore}
+import com.alibaba.graphscope.graphx.store.{EdgeDataStore, VertexDataStore}
+import com.alibaba.graphscope.graphx.utils.{EIDAccessor, ScalaFFIFactory}
+import com.alibaba.graphscope.utils.FFITypeFactoryhelper
+import org.apache.spark.graphx.PartitionID
+import org.apache.spark.graphx.grape.{GrapeEdgeRDD, GrapeVertexRDD}
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import java.net.InetAddress
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+class FragmentPartition[VD : ClassTag,ED : ClassTag](rddId : Int, override val index : Int, val hostName : String,val executorId : String,objectID : Long, socket : String, fragName : String) extends Partition with Logging {
+
+  /** mark this val as lazy to let it run on executor rather than driver */
+  lazy val tuple = {
+    if (hostName.equals(getHost)){
+      val client: VineyardClient = ScalaFFIFactory.newVineyardClient()
+      val ffiByteString: FFIByteString = FFITypeFactory.newByteString()
+      ffiByteString.copyFrom(socket)
+      client.connect(ffiByteString)
+      log.info(s"Create vineyard client ${client} and connect to ${socket}")
+      val fragment: IFragment[Long, Long, VD, ED] = ScalaFFIFactory.getFragment[VD,ED](client, objectID, fragName)
+      log.info(s"Got iFragment ${fragment}")
+      (client, fragment)
+    }
+    else {
+      log.info(s"This partition should be evaluated on this host since it is not on the desired host,desired host ${hostName}, cur host ${getHost}")
+      null
+    }
+  }
+
+  override def hashCode(): Int = 31 * (31 + rddId) + index
+
+  override def equals(other: Any): Boolean = super.equals(other)
+
+}
+object FragmentPartition{
+  def getHost : String = {
+    InetAddress.getLocalHost.getHostName
+  }
+}
+
+class FragmentRDD[VD : ClassTag,ED : ClassTag](@transient sc : SparkContext, executorId2Host : mutable.HashMap[String,String],
+                                               fragName: String, objectIDs : String, socket : String = "/tmp/vineyard.sock")  extends RDD[(PartitionID,(VineyardClient,IFragment[Long,Long,VD,ED]))](sc, Nil) with Logging{
+  //objectIds be like d50:id1,d51:id2
+  val objectsSplited: Array[String] = objectIDs.split(",")
+  val map: mutable.Map[String,Long] = mutable.Map[String, Long]()
+  require(objectsSplited.length == executorId2Host.size, s"executor's host names length not equal to object ids ${executorId2Host.toArray.mkString("Array(", ", ", ")")}, ${objectIDs}")
+  for (str <- objectsSplited){
+    val hostAndId = str.split(":")
+    require(hostAndId.length == 2)
+    val host = hostAndId(0)
+    val id = hostAndId(1)
+    require(!map.contains(host), s"entry for host ${host} already set ${map.get(host)}")
+    map(host) = id.toLong
+    log.info(s"host ${host}: objId : ${id}")
+  }
+
+
+  override def compute(split: Partition, context: TaskContext): Iterator[(PartitionID,(VineyardClient,IFragment[Long,Long,VD,ED]))] = {
+    val partitionCasted = split.asInstanceOf[FragmentPartition[VD,ED]]
+    Iterator((partitionCasted.index, partitionCasted.tuple))
+  }
+
+  /** according to spark code comments, this function will be only executed once. */
+  override protected def getPartitions: Array[Partition] = {
+    val array = new Array[Partition](objectsSplited.length)
+    val iter = executorId2Host.iterator
+    for (i <- array.indices) {
+      val (executorId, executorHost) = iter.next()
+      log.info(s"executorId ${executorId}, host ${executorHost}, corresponding obj id ${map(executorHost)}")
+      array(i) = new FragmentPartition[VD,ED](id, i, executorHost, executorId, map(executorHost), socket,fragName)
+    }
+    array
+  }
+
+  /**
+   * Use this to control the location of partition.
+   * @param split
+   * @return
+   */
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    val casted = split.asInstanceOf[FragmentPartition[VD,ED]]
+    //TaskLocation.executorTag = executor_
+    val location = "executor_" + casted.hostName + "_" + casted.executorId
+    log.info(s"get pref location for ${casted.hostName} ${location}")
+    Array(location)
+  }
+
+  def generateEdgeRDD(userNumPartitions: Int) : GrapeEdgeRDD[ED] = {
+    val structAndVEStorePartitions = this.mapPartitions(iter => {
+      if (iter.hasNext){
+        val (pid, (client,frag)) = iter.next()
+        val time0 = System.nanoTime()
+        val structure = new FragmentStructure(frag)
+        //update split num later
+        val vertexDataStore = new InHeapVertexDataStore[VD](frag.getVerticesNum.toInt, 1,client)
+        val parallelism = Runtime.getRuntime.availableProcessors();
+        //fill vertex data store, copy.
+        FragmentRDD.fillVertexStore(vertexDataStore, frag, parallelism)
+        //edge is large,no copy
+        val edgeStore = FragmentRDD.createFragmentEdataStore(frag,parallelism,client)
+        //fill edge data store
+        val time1 = System.nanoTime()
+        log.info(s"[Creating graph structure and vd,ed store cost ]: ${(time1 - time0) / 1000000} ms")
+        Iterator((pid, (client, frag, structure, vertexDataStore, edgeStore)))
+      }
+      else Iterator.empty
+    }).cache()
+    structAndVEStorePartitions.foreachPartition(iter => {
+      if (iter.hasNext) {
+        val (pid,(client,frag, structure, vertexStore, edgeStore)) = iter.next()
+        GrapeEdgePartition.push((pid,structure, client,edgeStore,vertexStore, true))
+      }
+    })
+
+    val partitions = getPartitions
+    val (expandedHosts, expandedLocations, expendedPartitionIds) = expand(userNumPartitions, partitions.map(_.asInstanceOf[FragmentPartition[VD,ED]]))
+    GrapeEdgeRDD.createUserPartitionsAndFormRDD[VD,ED](sc,expandedHosts,expandedLocations,expendedPartitionIds,userNumPartitions)
+  }
+
+  def expand(userNumPartitions : Int, partitions : Array[FragmentPartition[VD,ED]]) : (Array[String],Array[String],Array[Int]) = {
+    val curSize = partitions.length
+    log.info(s"expand ${curSize} frags to ${userNumPartitions} partitions")
+    val hostsArray = new Array[String](userNumPartitions)
+    val locationsArray = new Array[String](userNumPartitions)
+    val partitionsIds = new Array[Int](userNumPartitions)
+
+    for (i <- partitions.indices){
+      hostsArray(i) = partitions(i).hostName
+      locationsArray(i) = "executor_" + partitions(i).hostName + "_" + partitions(i).executorId
+      partitionsIds(i) = i
+    }
+    for (i <- curSize until userNumPartitions){
+      hostsArray(i) = hostsArray(i % curSize)
+      locationsArray(i) = locationsArray(i % curSize)
+      partitionsIds(i) = i
+    }
+    log.info(s"expanded partitions,host names ${hostsArray.mkString("Array(", ", ", ")")}")
+    log.info(s"expanded partitions,locations ${locationsArray.mkString("Array(", ", ", ")")}")
+    log.info(s"expanded partitions,partitionIds ${partitionsIds.mkString("Array(", ", ", ")")}")
+    (hostsArray, locationsArray,partitionsIds)
+  }
+
+  def generateRDD(userNumPartitions : Int, vertexStorageLevel : StorageLevel = StorageLevel.MEMORY_ONLY) : (GrapeVertexRDD[VD],GrapeEdgeRDD[ED]) = {
+    require(userNumPartitions >= getNumPartitions, s"can not construct ${userNumPartitions} partitions from ${getNumPartitions} frag")
+    this.cache()
+    val time0 = System.nanoTime()
+    val edgeRDD = generateEdgeRDD(userNumPartitions)
+
+    val routingTableRDD = GrapeEdgeRDD.edgeRDDToRoutingTable(edgeRDD)
+
+    val vertexRDD = GrapeVertexRDD.fromGrapeEdgeRDD[VD](edgeRDD, routingTableRDD, edgeRDD.grapePartitionsRDD.getNumPartitions, null.asInstanceOf[VD],vertexStorageLevel).cache()
+    log.info(s"num vertices ${vertexRDD.count()}, num edges ${edgeRDD.count()}")
+    val time1 = System.nanoTime()
+    log.info(s"[FragmentRDD:] generate rdd of partition ${userNumPartitions} cost ${(time1 - time0)/1000000}ms")
+    (vertexRDD,edgeRDD)
+  }
+}
+object FragmentRDD{
+
+  def fillVertexStore[VD: ClassTag](vertexDataStore: VertexDataStore[VD],frag: IFragment[Long,Long,VD,_], numCores : Int) : Unit = {
+    val chunkSize = 8192
+    val atomicInt = new AtomicInteger(0)
+    val threads = new Array[Thread](numCores)
+    var tid = 0
+    val ivnum = frag.getInnerVerticesNum
+    while (tid < numCores) {
+      val threadId= tid
+      val newThread = new Thread() {
+        override def run(): Unit = {
+          var flag = true
+          val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+          while (flag) {
+            val got = atomicInt.getAndAdd(1);
+            val begin = Math.min(ivnum, got * chunkSize)
+            val end = Math.min(ivnum, begin + chunkSize)
+            if (begin >= end) {
+              flag = false
+            }
+            else {
+              var i = begin
+              while (i < end){
+                vertex.SetValue(i)
+                vertexDataStore.set(i.toInt, frag.getData(vertex))
+                i += 1
+              }
+            }
+          }
+        }
+      }
+      newThread.start()
+      threads(tid) = newThread
+      tid += 1
+    }
+    for (i <- 0 until numCores) {
+      threads(i).join()
+    }
+  }
+
+  def createFragmentEdataStore[ED: ClassTag](frag : IFragment[Long,Long,_,ED], numCores : Int, client : VineyardClient) : EdgeDataStore[ED] = {
+    frag match {
+      case adaptor : ArrowProjectedAdaptor[Long,Long,_,ED] => {
+        val projectedFragment = adaptor.getArrowProjectedFragment.asInstanceOf[ArrowProjectedFragment[Long,Long,_,ED]]
+        val edataArray = projectedFragment.getEdataArrayAccessor
+        val edataStore = new ImmutableOffHeapEdgeStore[ED](edataArray.getLength.toInt, 1, client, new EIDAccessor(projectedFragment.getOutEdgesPtr.getAddress), edataArray)
+        edataStore
+        //no need to copy
+      }
+      case _ => {
+        throw new IllegalStateException(s"Not supported adaptor ${frag}")
+      }
+    }
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/LocationAwareRDD.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/LocationAwareRDD.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.rdd
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+class EmptyPartition(val ind : Int,val hostName : String, val loc : String) extends Partition with Logging{
+  override def index: Int = ind
+}
+
+class LocationAwareRDD(sc : SparkContext, val locations : Array[String], val hostNames : Array[String],val partitionsIds : Array[Int]) extends RDD[EmptyPartition](sc, Nil){
+  val parts = new Array[EmptyPartition](locations.length)
+  for  (i <- parts.indices){
+    val ind = partitionsIds(i)
+    parts(ind) = new EmptyPartition(ind,hostNames(i),locations(i))
+  }
+  override def compute(split: Partition, context: TaskContext): Iterator[EmptyPartition] = {
+    val casted = split.asInstanceOf[EmptyPartition]
+    Iterator(casted)
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    parts.asInstanceOf[Array[Partition]]
+  }
+
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    val casted = split.asInstanceOf[EmptyPartition]
+    Array(casted.loc)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/RoutingTable.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/RoutingTable.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.rdd
+
+import com.alibaba.graphscope.graphx.utils.BitSetWithOffset
+import org.apache.spark.internal.Logging
+
+class RoutingTable(val pid2Lids : Array[BitSetWithOffset]) extends Serializable {
+  val numPartitions: Int = pid2Lids.length
+
+  def get(ind : Int) : BitSetWithOffset = {
+    pid2Lids(ind)
+  }
+}
+
+object RoutingTable extends Logging{
+
+  def fromMessage(myPid : Int, partitionNum : Int, startLid : Int,endLid : Int, iter : Iterator[(Int,(Int,Array[Long]))]) : RoutingTable = {
+    val res = Array.fill(partitionNum)(new BitSetWithOffset(startLid,endLid))
+    while (iter.hasNext){
+      val piece = iter.next()
+      val dstPid = piece._1
+      require(myPid == dstPid, s"receive wrong msg, mypid ${myPid}, dst pid ${dstPid}")
+      val fromPid = piece._2._1
+      val arr = piece._2._2
+      var i = 0
+      while (i <  arr.length){
+        val lid = arr(i).toInt
+        require(lid >= startLid && lid < endLid, s"received lid ${lid} not in range of pid ${myPid}, from ${fromPid}, my range ${startLid}, ${endLid}")
+        res(fromPid).set(lid)
+        i += 1
+      }
+    }
+    new RoutingTable(res)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/VineyardRDD.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/VineyardRDD.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.rdd
+
+import com.alibaba.fastffi.{FFIByteString, FFITypeFactory}
+import com.alibaba.graphscope.graphx.VineyardClient
+import com.alibaba.graphscope.graphx.rdd.FragmentPartition.getHost
+import com.alibaba.graphscope.graphx.utils.ScalaFFIFactory
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import java.net.InetAddress
+
+class VineyardPartition(val ind : Int,val hostName : String, val socketPath : String) extends Partition with Logging{
+  lazy val client: VineyardClient = {
+    if (hostName.equals(InetAddress.getLocalHost.getHostName)) {
+      val res = ScalaFFIFactory.newVineyardClient()
+      val ffiByteString: FFIByteString = FFITypeFactory.newByteString()
+      ffiByteString.copyFrom(socketPath)
+      res.connect(ffiByteString)
+      log.info(s"successfully connect to ${socketPath}")
+      res
+    }
+    else {
+      log.info(s"This partition should be evaluated on this host since it is not on the desired host,desired host ${hostName}, cur host ${getHost}")
+      null
+    }
+  }
+  override def index: Int = ind
+}
+
+class VineyardRDD(sc : SparkContext, val locations : Array[String], val hostNames : Array[String]) extends RDD[VineyardClient](sc, Nil){
+  val vineyardParts = new Array[VineyardPartition](locations.length)
+  val sparkSession = GSSparkSession.getDefaultSession.getOrElse(throw new IllegalStateException("empty session")).asInstanceOf[GSSparkSession]
+  for  (i <- vineyardParts.indices){
+    vineyardParts(i) = new VineyardPartition(i,hostNames(i),sparkSession.socketPath)
+  }
+  override def compute(split: Partition, context: TaskContext): Iterator[VineyardClient] = {
+    val casted = split.asInstanceOf[VineyardPartition]
+    Iterator(casted.client)
+  }
+
+  override protected def getPartitions: Array[Partition] = {
+    vineyardParts.asInstanceOf[Array[Partition]]
+  }
+
+  override protected def getPreferredLocations(split: Partition): Seq[String] = {
+    val casted = split.asInstanceOf[VineyardPartition]
+    log.info(s"get pref location for ${casted.hostName} ${casted.ind}")
+    Array(locations(casted.ind))
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/impl/GrapeEdgePartition.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/impl/GrapeEdgePartition.scala
@@ -1,0 +1,958 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.rdd.impl
+
+import com.alibaba.graphscope.arrow.array.ArrowArrayBuilder
+import com.alibaba.graphscope.ds.{PropertyNbrUnit, Vertex}
+import com.alibaba.graphscope.graphx._
+import com.alibaba.graphscope.graphx.graph.{GSEdgeTriplet, GraphStructure, ReusableEdge}
+import com.alibaba.graphscope.graphx.shuffle.{EdgeShuffleReceived, EdgeShuffle}
+import com.alibaba.graphscope.graphx.store.impl.{InHeapEdgeDataStore, OffHeapEdgeDataStore}
+import com.alibaba.graphscope.graphx.store.{EdgeDataStore, VertexDataStore}
+import com.alibaba.graphscope.graphx.utils._
+import com.alibaba.graphscope.stdcxx.StdVector
+import com.alibaba.graphscope.utils.{FFITypeFactoryhelper, ThreadSafeBitSet}
+import org.apache.spark.Partition
+import org.apache.spark.graphx._
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.collection.{BitSet, OpenHashSet}
+
+import java.util
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ArrayBlockingQueue, ConcurrentHashMap, CountDownLatch, Executors, TimeUnit}
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+
+/**
+ * [startLid, endLid), endLid is exclusive
+ */
+class GrapeEdgePartition[VD: ClassTag, ED: ClassTag](val pid : Int,
+                                                     val localId : Int, // the order of partition in this fragment.
+                                                     val localNum : Int, // how many part in this frag.
+                                                     val siblingPid : Array[Int],
+                                                     val startLid : Long,
+                                                     val endLid : Long,
+                                                     var activeEdgeNum : Int = 0, //use a instant variable to accelerate count.
+                                                     val graphStructure: GraphStructure,
+                                                     val client : VineyardClient,
+                                                     var edatas : EdgeDataStore[ED],
+                                                     val edgeReversed : Boolean = false,
+                                                     var activeEdgeSet : BitSetWithOffset = null,
+                                                     var treeMaps : Array[java.util.TreeMap[Long,Int]] = null) extends Logging  with Partition{
+
+  val getVertexSize = endLid - startLid
+
+  /** regard to our design, the card(activeEdgeSet) == partOutEdgeNum, len(edatas) == allEdgesNum, indexed by eid */
+  val partOutEdgeNum : Long = graphStructure.getOutEdgesNum
+  val partInEdgeNum : Long = graphStructure.getInEdgesNum
+  val totalFragEdgeNum : Long = graphStructure.getTotalEdgesNum
+
+
+  if (activeEdgeSet == null){
+    val (startOffset,endOffset) = graphStructure.getOEOffsetRange(startLid,endLid)
+    activeEdgeSet = new BitSetWithOffset(startBit = startOffset.toInt,endBit = endOffset.toInt)
+    activeEdgeSet.setRange(startOffset.toInt, endOffset.toInt)
+    activeEdgeNum = endOffset.toInt - startOffset.toInt
+    log.info(s"part ${pid} local id ${localId}/${localNum} edges range ${startOffset} to ${endOffset}, cardinality ${activeEdgeSet.cardinality()}, ${activeEdgeSet}")
+  }
+  val NBR_SIZE = 16L
+  //to avoid the difficult to get srcLid in iterating over edges.
+
+  // (graphx pid, fid, start lid, end lid)
+  def buildPartitionInfo(infoArray : Array[(Int,Int,Long,Long)]) : Unit = {
+    require(treeMaps == null, "try to build partition info from non empty")
+    treeMaps = new Array[java.util.TreeMap[Long,Int]](graphStructure.fnum())
+    for (i <- 0 until graphStructure.fnum()){
+      treeMaps(i) = new util.TreeMap[Long,Int]()
+    }
+    for (value <- infoArray){
+      val graphxPid = value._1
+      val graphxFid = value._2
+      val startLid = value._3
+      treeMaps(graphxFid).put(startLid, graphxPid)
+    }
+  }
+
+  //array of length fnum, each contains the local id of vertex we need as outer vertex.
+  def generateRoutingMessage() : Array[Array[Long]] = {
+    val ovnum = graphStructure.getOuterVertexSize
+    val ivnum = graphStructure.getInnerVertexSize
+    val chunkSize = (ovnum + localNum - 1) / localNum
+    val begin = ivnum + (chunkSize * localId)
+    val end = Math.min(begin + chunkSize, ovnum + ivnum)
+    val partitionNum = {
+      treeMaps.map(_.size()).sum
+    }
+    if (localId==0) log.info(s"partition num ${partitionNum}")
+    val res = Array.fill(partitionNum)(new PrimitiveVector[Long]())
+
+    val idParser = new IdParser(graphStructure.fnum())
+    var i = begin
+    log.info(s"in generating routing message, from ${pid}, range ${begin}, ${end}")
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (i < end){
+      vertex.SetValue(i)
+      val gid = graphStructure.getOuterVertexGid(vertex)
+      val lid = idParser.getLocalId(gid)
+      val fid = idParser.getFragId(gid)
+      val dstPid = treeMaps(fid).floorEntry(lid).getValue
+      res(dstPid).+=(lid)
+      i += 1
+    }
+    res.map(_.trim().array)
+  }
+
+
+  def getDegreeArray(edgeDirection: EdgeDirection): Array[Int] = {
+    if (edgeDirection.equals(EdgeDirection.In)){
+      graphStructure.inDegreeArray(startLid,endLid)
+    }
+    else if (edgeDirection.equals(EdgeDirection.Out)){
+      graphStructure.outDegreeArray(startLid,endLid)
+    }
+    else{
+      graphStructure.inOutDegreeArray(startLid,endLid)
+    }
+  }
+
+  /** Iterate over out edges only, in edges will be iterated in other partition */
+  def iterator : Iterator[Edge[ED]] = {
+    graphStructure.iterator(startLid, endLid,edatas,activeEdgeSet,edgeReversed)
+  }
+
+  def tripletIterator(innerVertexDataStore: VertexDataStore[VD],
+                      includeSrc: Boolean = true, includeDst: Boolean = true, reuseTriplet : Boolean = false, includeLid : Boolean = false)
+  : Iterator[EdgeTriplet[VD, ED]] = graphStructure.tripletIterator(startLid,endLid,innerVertexDataStore,edatas,activeEdgeSet,edgeReversed,includeSrc,includeDst, reuseTriplet, includeLid)
+
+  def filter(
+              epred: EdgeTriplet[VD, ED] => Boolean,
+              vpred: (VertexId, VD) => Boolean,
+              innerVertexDataStore: VertexDataStore[VD]): GrapeEdgePartition[VD, ED] = {
+    val tripletIter = tripletIterator(innerVertexDataStore, true, true, true).asInstanceOf[Iterator[GSEdgeTriplet[VD,ED]]]
+    val newActiveEdges = new BitSetWithOffset(activeEdgeSet.startBit,activeEdgeSet.endBit)
+    newActiveEdges.union(activeEdgeSet)
+    while (tripletIter.hasNext){
+      val triplet = tripletIter.next()
+      if (!vpred(triplet.srcId,triplet.srcAttr) || !vpred(triplet.dstId, triplet.dstAttr) || !epred(triplet)){
+        newActiveEdges.unset(triplet.offset.toInt)
+      }
+    }
+    this.withNewMask(newActiveEdges)
+  }
+
+  def createNewValues[ED2 : ClassTag] :EdgeDataStore[ED2] = {
+    if (localId == 0){
+      val newValues = edatas.mapToNew[ED2]
+      log.info(s"pid ${pid} create new EdgeStore for part ${siblingPid.mkString(",")}, new class ${GrapeUtils.getRuntimeClass[ED2].getSimpleName}")
+      for (dstPid <- siblingPid){
+        EdgeDataStore.enqueue(dstPid, newValues)
+      }
+    }
+    EdgeDataStore.dequeue(pid).asInstanceOf[EdgeDataStore[ED2]]
+  }
+
+  def groupEdges(merge: (ED, ED) => ED): GrapeEdgePartition[VD, ED] = {
+    val iter = iterator.asInstanceOf[Iterator[ReusableEdge[ED]]]
+    var curSrcId = -1L
+    var curDstId = -1L
+    var prevEdgeInd = -1L // when we find a new one, we unset prevEdgeInd
+    var attrSum = null.asInstanceOf[ED]
+    val newMask = new BitSetWithOffset(activeEdgeSet.startBit,activeEdgeSet.endBit)
+    newMask.union(activeEdgeSet)
+    val newEdata = createNewValues[ED]
+    while (iter.hasNext){
+      val edge = iter.next()
+      val curIndex = edge.offset
+      var flag = false
+      if (flag && edge.srcId == curSrcId && edge.dstId == curDstId){
+        attrSum = merge(attrSum, edge.attr)
+        newMask.unset(prevEdgeInd.toInt)
+        prevEdgeInd = curIndex
+        log.info(s"Merge edge (${curSrcId}, ${curDstId}), val ${attrSum}")
+      }
+      else {
+        if (flag){
+          //a new round start, we add new Edata to this edge
+          newEdata.setWithOffset(prevEdgeInd.toInt, attrSum)
+          log.info(s"end of acculating edge ${curSrcId}, ${curDstId}, ${attrSum}")
+        }
+        curSrcId = edge.srcId
+        curDstId = edge.dstId
+        prevEdgeInd = curIndex
+        attrSum = edge.attr
+      }
+      flag = true
+    }
+    new GrapeEdgePartition[VD,ED](pid,localId,localNum,siblingPid, startLid, endLid, newMask.cardinality(), graphStructure, client,newEdata, edgeReversed, newMask)
+  }
+
+  def map[ED2: ClassTag](f: Edge[ED] => ED2): GrapeEdgePartition[VD, ED2] = {
+    val newData = createNewValues[ED2]
+    graphStructure.iterateEdges(startLid, endLid,f, edatas, activeEdgeSet, edgeReversed, newData)
+    this.withNewEdata(newData)
+  }
+
+  def map[ED2: ClassTag](f: (PartitionID, Iterator[Edge[ED]]) => Iterator[ED2]): GrapeEdgePartition[VD, ED2] = {
+    val newData = createNewValues[ED2]
+    val iter = iterator.asInstanceOf[Iterator[ReusableEdge[ED]]]
+    val resultEdata = f(pid, iter)
+    var ind = activeEdgeSet.nextSetBit(activeEdgeSet.startBit)
+    while (ind >= 0 && resultEdata.hasNext){
+      newData.setWithOffset(ind,resultEdata.next())
+      ind = activeEdgeSet.nextSetBit(ind + 1)
+    }
+    if (resultEdata.hasNext || ind >= 0){
+      throw new IllegalStateException(s"impossible, two iterator should end at the same time ${ind}, ${resultEdata.hasNext}")
+    }
+    this.withNewEdata(newData)
+  }
+
+  def mapTriplets[ED2: ClassTag](f: EdgeTriplet[VD,ED] => ED2,activeVertices: BitSetWithOffset, innerVertexDataStore: VertexDataStore[VD], tripletFields: TripletFields): GrapeEdgePartition[VD, ED2] = {
+    val time0 = System.nanoTime()
+    val newData = createNewValues[ED2]
+    log.info(s"${this.toString} got new edata ${newData}")
+    val time01 = System.nanoTime()
+    graphStructure.iterateTriplets(startLid, endLid, f, activeVertices,innerVertexDataStore, edatas, activeEdgeSet, edgeReversed,tripletFields.useSrc, tripletFields.useDst, newData)
+    val time1 = System.nanoTime()
+    log.info(s"[Perf:] part ${pid}, lid ${localId}, mapping over triplets size ${activeEdgeNum} cost ${(time1 - time0)/1000000} ms, create array cost ${(time01 - time0)/1000000}ms")
+    this.withNewEdata(newData)
+  }
+
+  def mapTriplets[ED2: ClassTag](f: (PartitionID, Iterator[EdgeTriplet[VD, ED]]) => Iterator[ED2], innerVertexDataStore: VertexDataStore[VD], includeSrc  : Boolean = true, includeDst : Boolean = true): GrapeEdgePartition[VD, ED2] = {
+    val newData = createNewValues[ED2]
+    val iter = tripletIterator(innerVertexDataStore,includeSrc,includeDst,reuseTriplet = true).asInstanceOf[Iterator[GSEdgeTriplet[VD,ED]]]
+    val resultEdata = f(pid, iter)
+    var ind = activeEdgeSet.nextSetBit(activeEdgeSet.startBit)
+    while (ind >= 0 && resultEdata.hasNext){
+      newData.setWithOffset(ind,resultEdata.next())
+      ind = activeEdgeSet.nextSetBit(ind + 1)
+    }
+    if (ind >=0 || resultEdata.hasNext){
+      throw new IllegalStateException(s"impossible, two iterator should end at the same time ${ind}, ${resultEdata.hasNext}")
+    }
+    this.withNewEdata(newData)
+  }
+
+  def scanEdgeTriplet[A: ClassTag](innerVertexDataStore: VertexDataStore[VD], sendMsg: EdgeContext[VD, ED, A] => Unit, mergeMsg: (A, A) => A, tripletFields: TripletFields, directionOpt : Option[(EdgeDirection)]) : Iterator[(VertexId, A)] ={
+    val aggregates = new Array[A](innerVertexDataStore.size)
+    val bitset = new BitSet(aggregates.length)
+
+    val ctx = new EdgeContextImpl[VD, ED, A](mergeMsg, aggregates, bitset)
+    val tripletIter = tripletIterator(innerVertexDataStore, tripletFields.useSrc, tripletFields.useDst, reuseTriplet = true,includeLid = true).asInstanceOf[Iterator[GSEdgeTriplet[VD,ED]]]
+    while (tripletIter.hasNext){
+      val triplet = tripletIter.next()
+      ctx.set(triplet.srcId, triplet.dstId, triplet.srcLid.toInt, triplet.dstLid.toInt, triplet.srcAttr,triplet.dstAttr, triplet.attr)
+      sendMsg(ctx)
+    }
+
+    val curFid = graphStructure.fid()
+    val idParser = new IdParser(graphStructure.fnum())
+    bitset.iterator.map( localId => (idParser.generateGlobalId(curFid, localId), aggregates(localId)))
+  }
+
+  def reverse: GrapeEdgePartition[VD, ED] = {
+    new GrapeEdgePartition[VD,ED](pid, localId,localNum, siblingPid,startLid,endLid,activeEdgeNum, graphStructure, client,edatas,!edgeReversed, activeEdgeSet)
+  }
+
+  def withNewEdata[ED2: ClassTag](newEdata : EdgeDataStore[ED2]): GrapeEdgePartition[VD, ED2] = {
+    new GrapeEdgePartition[VD,ED2](pid,localId,localNum, siblingPid,startLid,endLid,activeEdgeNum,  graphStructure, client,newEdata, edgeReversed, activeEdgeSet)
+  }
+
+  def withNewMask(newActiveSet: BitSetWithOffset) : GrapeEdgePartition[VD,ED] = {
+    new GrapeEdgePartition[VD,ED](pid,localId,localNum,siblingPid,startLid,endLid, newActiveSet.cardinality(), graphStructure, client,edatas, edgeReversed, newActiveSet)
+  }
+
+  /**  currently we only support inner join with same vertex map*/
+  def innerJoin[ED2: ClassTag, ED3: ClassTag]
+  (other: GrapeEdgePartition[_, ED2])
+  (f: (VertexId, VertexId, ED, ED2) => ED3): GrapeEdgePartition[VD, ED3] = {
+    if (this.graphStructure != other.graphStructure){
+      throw new IllegalStateException("Currently we only support inner join with same index")
+    }
+    val newMask = this.activeEdgeSet & other.activeEdgeSet
+    val newActiveEdgesNum = newMask.cardinality()
+    log.info(s"Inner join edgePartition 0 has ${this.activeEdgeSet.cardinality()} actives edges, the other has ${other.activeEdgeSet} active edges")
+    log.info(s"after join ${newMask.cardinality()} active edges")
+    val newEData = createNewValues[ED3]
+    val oldIter = iterator.asInstanceOf[Iterator[ReusableEdge[ED]]]
+    while (oldIter.hasNext){
+      val oldEdge = oldIter.next()
+      val oldIndex = oldEdge.offset.toInt
+      if (newMask.get(oldIndex)){
+        newEData.setWithOffset(oldEdge.offset.toInt, f(oldEdge.srcId, oldEdge.dstId, oldEdge.attr, other.edatas.getWithOffset(oldEdge.offset.toInt)))
+      }
+    }
+
+    new GrapeEdgePartition[VD,ED3](pid,localId,localNum, siblingPid,startLid,endLid, newActiveEdgesNum, graphStructure, client,newEData,edgeReversed, newMask)
+  }
+
+  override def toString: String =  super.toString + "(pid=" + pid + ",local id" + localId +
+    ", start lid" + startLid + ", end lid " + endLid + ",graph structure" + graphStructure +
+    ",out edges num" + partOutEdgeNum + ", in edges num" + partInEdgeNum  + ", data store: " + edatas +")"
+
+  override def index: PartitionID = pid
+}
+
+class GrapeEdgePartitionBuilder[VD: ClassTag, ED: ClassTag](val numPartitions : Int,val client : VineyardClient) extends Logging{
+  var receivedShuffles : Array[EdgeShuffleReceived[ED]] = null.asInstanceOf[Array[EdgeShuffleReceived[ED]]]
+  def addEdges(in : Array[EdgeShuffleReceived[ED]]) : Unit = {
+    receivedShuffles = in
+  }
+
+  /**
+   * outer set must be java.util.Set to be thread safe.
+   */
+  def collectOids(inner: OpenHashSet[Long], outer: java.util.Set[Long], shuffles: ArrayBuffer[EdgeShuffle[_, _]], cores: Int, shuffleSize : Int) : Unit = {
+    val time0 = System.nanoTime()
+    val atomicInt = new AtomicInteger(0)
+    val threads = new Array[Thread](cores)
+    val numShuffles = shuffles.length
+    log.info(s"process ${numShuffles} shuffles with ${cores} thread")
+    var tid = 0
+    while (tid < cores) {
+      val newThread = new Thread() {
+        override def run(): Unit = {
+          var flag = true
+          while (flag) {
+            val got = atomicInt.getAndAdd(1);
+            if (got >= numShuffles) {
+              flag = false
+            }
+            else {
+              val edgeShuffle = shuffles(got)
+              if (edgeShuffle.srcs != null) {
+                  var i = 0
+                  val receivedDst = edgeShuffle.dsts
+                  while (i < receivedDst.length) {
+                    val oid = receivedDst(i)
+                    if (!inner.contains(oid)) {
+                      outer.add(oid)
+                    }
+                    i += 1
+                  }
+              }
+            }
+          }
+        }
+      }
+      newThread.start()
+      threads(tid) = newThread
+      tid += 1
+    }
+    for (i <- 0 until cores) {
+      threads(i).join()
+    }
+    log.info(s"after remove iv in outer, size ${outer.size}")
+
+    val time1 = System.nanoTime()
+    log.info(s"[Collect oids cost ${(time1 - time0)/1000000}ms]")
+  }
+
+  def mergeInnerOpenHashSet(oidSets : ArrayBuffer[OpenHashSet[Long]]) : OpenHashSet[Long] = {
+    val t0 = System.nanoTime()
+    val queue = new ArrayBlockingQueue[OpenHashSet[Long]](8 * oidSets.length)
+    for (i <- oidSets.indices){
+      require(queue.offer(oidSets(i)))
+    }
+    val coreNum = Math.min(queue.size(), 64)
+    log.info(s"using ${coreNum} threads for local inner vertex join, queue size ${queue.size()}")
+    val threads = new Array[Thread](coreNum)
+    for (i <- 0 until  coreNum) {
+      threads(i) = new Thread(){
+        override def run() : Unit = {
+          while (queue.size() > 1){
+            val tuple = this.synchronized {
+              if (queue.size() > 1) {
+                val first = queue.take()
+                val second = queue.take()
+                if (first.size < second.size) {
+                  (second, first)
+                }
+                else (first, second)
+              }
+              else null
+            }
+            if (tuple != null) {
+              require(queue.offer(tuple._1.union(tuple._2)))
+            }
+          }
+        }
+      }
+      threads(i).start()
+    }
+    for (i <- 0 until coreNum){
+      threads(i).join()
+    }
+    require(queue.size() == 1)
+    val t1 = System.nanoTime()
+    log.info(s"merge openHashSet cost ${(t1 - t0)/1000000} ms")
+    queue.take()
+  }
+
+  def mergeInnerOids(oidsSet : ArrayBuffer[Array[Long]]) : OpenHashSet[Long] = {
+    val t0 = System.nanoTime()
+    val rawSize = oidsSet.map(_.size).sum
+    val consumerNum = 64
+    val consumers = new Array[Thread](consumerNum)
+    val index = new AtomicInteger(0)
+    val numArrays = oidsSet.length
+
+    val coalesce = 4
+    val initSize = rawSize / (30 * coalesce)
+    log.info(s"parallel processing inner oids arr length ${numArrays}, raw size ${rawSize}, set init size ${initSize}")
+
+    val tmpSet = new Array[OpenHashSet[Long]](coalesce)
+    for (i <- tmpSet.indices){
+      tmpSet(i) =  new OpenHashSet[Long](initSize)
+    }
+    for (i <- 0 until  consumerNum) {
+      consumers(i) = new Thread(){
+        var flag = true
+        while (flag){
+          val cur = index.getAndAdd(1)
+          if (cur >= numArrays){
+            flag = false
+          }
+          else {
+            val curArray = oidsSet(cur)
+            val iter= curArray.iterator
+            val set = tmpSet(cur % coalesce)
+            while (iter.hasNext){
+              val value = iter.next()
+              if (!set.contains(value)){
+                set.add(value)
+              }
+            }
+          }
+        }
+      }
+      consumers(i).start()
+    }
+    for (i <- 0 until consumerNum){
+      consumers(i).join()
+    }
+
+    val t01 = System.nanoTime()
+    var result = tmpSet(0)
+    for (i <- 1 until coalesce){
+      result = result.union(tmpSet(i))
+    }
+
+    val t1 = System.nanoTime()
+    log.info(s"merge inner oid cost ${(t01 - t0)/1000000} ms, merge result set ${(t1 - t01)/1000000} ms")
+    result
+  }
+
+  /**
+   * @return the built local vertex map id.
+   */
+  def buildLocalVertexMap(pid : Int, parallelism : Int, shufflePidArr : Array[Int], shuffleSize : Int) : LocalVertexMap[Long,Long] = {
+    //We need to get oid->lid mappings in this executor.
+    val time0 = System.nanoTime()
+    val edgeShuffles = new ArrayBuffer[EdgeShuffle[_, _]]()
+
+    for (receive <- receivedShuffles) {
+      for (edgeShuffle <- receive.fromPid2Shuffle) {
+        if (edgeShuffle != null) {
+          edgeShuffles.+=(edgeShuffle)
+        }
+      }
+    }
+    val innerOidsArray = edgeShuffles.filter(_.oidArray != null).map(_.oidArray)
+    val innerOids : OpenHashSet[Long] = {
+      if (innerOidsArray.length == 0) {
+        log.info("Building inner oid vertex set from [set]")
+        val openHashSets = edgeShuffles.filter(_.oidSet != null).map(_.oidSet)
+        require(openHashSets.length > 0, "set array should empty")
+        mergeInnerOpenHashSet(openHashSets)
+      }
+      else {
+        log.info("Building inner oid vertex set from [array]")
+        mergeInnerOids(innerOidsArray)
+      }
+    }
+
+    log.info(s"Inner oids ${innerOids.size}")
+
+    val outerOids = ConcurrentHashMap.newKeySet[Long](innerOids.size)
+    collectOids(innerOids, outerOids, edgeShuffles, parallelism, shuffleSize)
+
+    log.info(s"Found totally inner ${innerOids.size}, outer ${outerOids.size()} in ${ExecutorUtils.getHostName}:${pid}")
+    if (innerOids.size == 0 && outerOids.size == 0){
+      log.info(s"partition ${pid} empty")
+      return null
+    }
+    val innerOidBuilder : ArrowArrayBuilder[Long] = ScalaFFIFactory.newSignedLongArrayBuilder()
+    val outerOidBuilder : ArrowArrayBuilder[Long] = ScalaFFIFactory.newSignedLongArrayBuilder()
+    val pidBuilder : ArrowArrayBuilder[Int] = ScalaFFIFactory.newSignedIntArrayBuilder()
+    val time01 = System.nanoTime()
+
+    innerOidBuilder.reserve(innerOids.size)
+    //count size
+    var innerSize = 0
+    val innerIter1 = innerOids.iterator
+    while (innerIter1.hasNext){
+      val _ = innerIter1.next()
+      innerSize += 1
+    }
+    require(innerSize == innerOids.size, s"neq ${innerSize}, ${innerOids.size}")
+    val tmp = innerOids.iterator
+    while (tmp.hasNext){
+      innerOidBuilder.unsafeAppend(tmp.next())
+    }
+
+    outerOidBuilder.reserve(outerOids.size)
+    //count size
+    var outerSize = 0
+    val outerIter1 = outerOids.iterator
+    while (outerIter1.hasNext){
+      val _ = outerIter1.next()
+      outerSize += 1
+    }
+    require(outerSize == outerOids.size, s"neq ${outerSize}, ${outerOids.size}")
+    val outerIter = outerOids.iterator
+    while (outerIter.hasNext){
+      outerOidBuilder.unsafeAppend(outerIter.next())
+    }
+    pidBuilder.reserve(shufflePidArr.length)
+    for (v <- shufflePidArr){
+      pidBuilder.unsafeAppend(v)
+    }
+    val time1 = System.nanoTime()
+    val localVertexMapBuilder = ScalaFFIFactory.newLocalVertexMapBuilder(client, innerOidBuilder, outerOidBuilder, pidBuilder)
+    val localVM = localVertexMapBuilder.seal(client).get()
+    val time2 = System.nanoTime()
+    log.info(s"${ExecutorUtils.getHostName}: Finish building local vm: ${localVM.id()}, ${localVM.getInnerVerticesNum}, " +
+      s"select out vertices cost ${(time01 - time0) / 1000000} ms adding buf take ${(time1 - time01)/ 1000000} ms," +
+      s"total building time ${(time2 - time0)/ 1000000} ms")
+    localVM
+  }
+
+  /** The received edata arrays contains both in edges and out edges, but we only need these out edges's edata array */
+  def buildEdataStore(defaultED : ED, totalEdgeNum : Int, client : VineyardClient, eidAccessor : EIDAccessor, localNum : Int = 1) : EdgeDataStore[ED] = {
+    val eDataStore = if (GrapeUtils.isPrimitive[ED]){
+      val edataBuilder = ScalaFFIFactory.newEdgeDataBuilder[ED](client,totalEdgeNum)
+      new OffHeapEdgeDataStore[ED](totalEdgeNum, localNum,client,eidAccessor, edataBuilder)
+    }
+    else {
+      val edataArray = buildArrayStore(defaultED,totalEdgeNum)
+      new InHeapEdgeDataStore[ED](totalEdgeNum, localNum, client, edataArray,eidAccessor)
+    }
+    fillEdataStore(defaultED,totalEdgeNum,eDataStore)
+    eDataStore
+  }
+
+  def buildArrayStore(defaultED : ED, totalEdgeNum : Long) : Array[ED] = {
+    val firstValue = receivedShuffles(0)
+    if (defaultED != null && firstValue.getArrays._3(0) == null){
+      Array.fill[ED](totalEdgeNum.toInt)(defaultED)
+    }
+    else if (defaultED == null && firstValue.getArrays._3(0) != null){
+      val allArrays = receivedShuffles.flatMap(_.getArrays._3)
+      val rawEdgesNum = allArrays.map(_.length).sum
+      require(rawEdgesNum == totalEdgeNum, s"edge num neq ${rawEdgesNum}, ${totalEdgeNum}")
+      val edataArray = new Array[ED](rawEdgesNum)
+      //flat array
+      var ind = 0
+      for (arr <- allArrays){
+        var i = 0
+        val t = arr.length
+        while (i < t){
+          edataArray(ind) = arr(i)
+          i += 1
+          ind += 1
+        }
+      }
+      edataArray
+    }
+    else {
+      throw new IllegalStateException("not possible, default ed and array is both null or bot not empty")
+    }
+  }
+  def fillEdataStore(defaultED : ED, totalEdgeNum : Int, edataStore : EdgeDataStore[ED]) : Unit = {
+    val valueIterator = receivedShuffles.toIterator
+    val firstValue = valueIterator.next()
+    if (defaultED != null && firstValue.getArrays._3(0) == null){
+      var i = 0
+      while (i < totalEdgeNum){
+        edataStore.setWithEID(i, defaultED)
+        i += 1
+      }
+    }
+    else if (defaultED == null && firstValue.getArrays._3(0) != null){
+      log.info("Filling edge data array with shuffle edatas")
+      val allArrays = receivedShuffles.flatMap(_.getArrays._3)
+      val rawEdgesNum = allArrays.map(_.length).sum
+      require(rawEdgesNum == totalEdgeNum, s"edge num neq ${rawEdgesNum}, ${totalEdgeNum}")
+      var ind = 0
+      for (arr <- allArrays){
+        var i = 0
+        val t = arr.length
+        while (i < t){
+          edataStore.setWithEID(ind, arr(i))
+          i += 1
+          ind += 1
+        }
+      }
+    }
+    else {
+      throw new IllegalStateException("not possible, default ed and array is both null or bot not empty")
+    }
+  }
+
+  def createEids(edgeNum : Int, oeBeginNbr : PropertyNbrUnit[Long]) : Array[Long] = {
+    val res = new Array[Long](edgeNum)
+    var i = 0
+    while (i < edgeNum){
+      res(i) = oeBeginNbr.eid()
+      oeBeginNbr.addV(16)
+      i += 1
+    }
+    res
+  }
+
+  // no edata building is needed, we only persist edata to c++ when we run pregel
+  def buildCSR(globalVMID : Long, localNum : Int = 1): (GraphXVertexMap[Long,Long], GraphXCSR[Long]) = {
+    val time0 = System.nanoTime()
+    log.info(s"Constructing csr with global vm ${globalVMID}")
+    val graphxVertexMapGetter = ScalaFFIFactory.newVertexMapGetter()
+    val graphxVertexMap = graphxVertexMapGetter.get(client, globalVMID).get()
+    log.info(s"Got graphx vertex map: ${graphxVertexMap}, total vnum ${graphxVertexMap.getTotalVertexSize}, fid ${graphxVertexMap.fid()}/${graphxVertexMap.fnum()}")
+    val cores = Runtime.getRuntime.availableProcessors();
+    log.info(s"per partition parallel: ${ cores / localNum}")
+
+    val (srcOids, dstOids) = preprocessEdges(cores / localNum)
+    val distinctNum = srcOids.size()
+
+    log.info("Finish adding edges to builders")
+    val graphxCSRBuilder = ScalaFFIFactory.newGraphXCSRBuilder(client)
+    require(srcOids.size() == distinctNum && dstOids.size() == distinctNum, s"src size ${srcOids.size()} dst size ${dstOids.size()}, edgenum ${distinctNum}")
+    graphxCSRBuilder.loadEdges(srcOids,dstOids,graphxVertexMap, localNum)
+    val graphxCSR = graphxCSRBuilder.seal(client).get()
+    val time1 = System.nanoTime()
+    log.info(s"Finish building graphx csr ${graphxVertexMap.fid()}, cost ${(time1 - time0)/1000000} ms")
+    (graphxVertexMap,graphxCSR)
+  }
+
+  def preprocessEdges(cores : Int) : (StdVector[Long],StdVector[Long]) = {
+    val rawEdgesNum = receivedShuffles.map(_.totalSize()).sum
+    log.info(s"Got totally shuffle ${receivedShuffles.size}, edges ${rawEdgesNum} in ${ExecutorUtils.getHostName}")
+    val srcOids = ScalaFFIFactory.newLongVector
+    val dstOids = ScalaFFIFactory.newLongVector
+    srcOids.resize(rawEdgesNum)
+    dstOids.resize(rawEdgesNum)
+    val time0 = System.nanoTime()
+
+    val (srcArrays, dstArrays) = (receivedShuffles.flatMap(_.getArrays._1).toArray,receivedShuffles.flatMap(_.getArrays._2))
+    var tid = 0
+    val atomicInt = new AtomicInteger(0)
+    val outerSize = srcArrays.length
+    log.info(s"use ${cores} threads for ${outerSize} shuffles")
+    val threads = new Array[Thread](cores)
+    val curInd = new AtomicInteger(0)
+    while (tid < cores) {
+      val newThread = new Thread() {
+        override def run(): Unit = {
+          var flag = true
+          while (flag) {
+            var (got,myBegin) = synchronized{
+              val got = atomicInt.getAndAdd(1);
+              if (got >= outerSize) (-1,-1)
+              else {
+                val myBegin = curInd.getAndAdd(srcArrays(got).length)
+                (got, myBegin)
+              }
+            }
+            if (got < 0) {
+              flag = false
+            }
+            else {
+              val innerLimit = srcArrays(got).length
+              require(dstArrays(got).length == innerLimit)
+              val srcArray = srcArrays(got)
+              val dstArray = dstArrays(got)
+              val end = myBegin + innerLimit
+              var innerInd = 0
+              while (myBegin < end){
+                srcOids.set(myBegin, srcArray(innerInd))
+                dstOids.set(myBegin, dstArray(innerInd))
+                myBegin += 1
+                innerInd += 1
+              }
+            }
+          }
+        }
+      }
+      newThread.start()
+      threads(tid) = newThread
+      tid += 1
+    }
+    for (i <- 0 until cores) {
+      threads(i).join()
+    }
+    require(curInd.get() == rawEdgesNum, s"neq ${curInd.get()} ${rawEdgesNum}")
+
+    val time1 = System.nanoTime()
+    log.info(s"preprocess edge array cost ${(time1 - time0)/1000000}ms")
+    (srcOids,dstOids)
+  }
+
+  def fillVertexData(innerVertexData : VertexDataStore[VD], graphStructure: GraphStructure) : Boolean = {
+    val time0 = System.nanoTime()
+    var flag = false
+    for (shuffleReceived <- receivedShuffles){
+      for (shuffle <- shuffleReceived.fromPid2Shuffle){
+        val edgeShuffle = shuffle.asInstanceOf[EdgeShuffle[VD,_]]
+        val innerOids = edgeShuffle.oidArray
+        val innerVertexAttrs = edgeShuffle.vertexAttrs
+        if (innerVertexAttrs == null || innerVertexAttrs.length == 0){
+        }
+        else {
+          val limit = innerOids.size
+          val grapeVertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+          require(limit == innerVertexAttrs.length, s"oid size and vertex attr size neq ${limit}, ${innerVertexAttrs.length}")
+          val ivnum = graphStructure.getInnerVertexSize.toInt
+          var i = 0
+          while (i < limit){
+            val oid = innerOids(i)
+            val vdata = innerVertexAttrs(i)
+            require(graphStructure.getInnerVertex(oid,grapeVertex))
+            val lid = grapeVertex.GetValue().toInt
+            require(lid < ivnum, s"expect no outer vertex ${lid}, ${ivnum}")
+            innerVertexData.set(lid, vdata)
+            i += 1
+          }
+          flag = true
+        }
+      }
+    }
+    val time1 = System.nanoTime()
+    if (flag) {
+      log.info(s"[Perf] filling vertex data cost ${(time1 - time0) / 1000000} ms")
+    }
+    else {
+      log.info("[Perf] no vertex data in shuffle.")
+    }
+    flag
+  }
+
+  //call this to delete c++ ptr and release memory of arrow builders
+  def clearBuilders() : Unit = {
+    receivedShuffles = null
+  }
+
+}
+object GrapeEdgePartition extends Logging {
+  val tupleQueue = new ArrayBlockingQueue[(Int,GraphStructure,VineyardClient,EdgeDataStore[_],VertexDataStore[_], Boolean)](1024)
+  val pidQueue = new ArrayBlockingQueue[Int](1024)
+  var pid2EdgePartition = null.asInstanceOf[mutable.HashMap[Int,GrapeEdgePartition[_,_]]]
+
+  implicit def convert(a : (Long,Long)) = new OrderedLongLong(a)
+
+  def push(in : (Int,GraphStructure,VineyardClient,EdgeDataStore[_],VertexDataStore[_], Boolean)): Unit = {
+    require(tupleQueue.offer(in))
+  }
+
+  def incCount(pid : Int) : Unit = synchronized{
+    require(pidQueue.offer(pid))
+  }
+
+  def createPartitions[VD: ClassTag, ED: ClassTag](pid : Int, totalPartitionNum : Int) : Unit = synchronized{
+    if (pid2EdgePartition == null){
+      synchronized {
+        if (pid2EdgePartition == null){
+          val size = tupleQueue.size()
+          pid2EdgePartition = new mutable.HashMap[Int,GrapeEdgePartition[VD,ED]].asInstanceOf[mutable.HashMap[Int,GrapeEdgePartition[_,_]]]
+          if (size == pidQueue.size()){
+            log.info(s"Totally $size ele in queue, registered partition num ${pidQueue.size()}")
+            for (_ <- 0 until size){
+              val tuple = tupleQueue.poll()
+              val edataStore = tuple._4.asInstanceOf[EdgeDataStore[ED]]
+              edataStore.setLocalNum(1)
+              val vertexDataStore = tuple._5
+              vertexDataStore.setLocalNum(1)
+              val _ = pidQueue.poll()
+              val siblings = new Array[Int](1)
+              siblings(0) = tuple._1
+              pid2EdgePartition(tuple._1) = new GrapeEdgePartition[VD,ED](tuple._1, 0, 1, siblings,0,  tuple._2.getInnerVertexSize,tuple._2.getOutEdgesNum.toInt, tuple._2, tuple._3, edataStore)
+              GrapeVertexPartition.setVertexStore(tuple._1, vertexDataStore, tuple._6)
+            }
+          }
+          else {
+            //find out the new partition ids which didn't appear in frag queue.
+            val candidates = new mutable.Queue[Int]
+            val tuplePids = new BitSet(totalPartitionNum)
+            tupleQueue.forEach(tuple => tuplePids.set(tuple._1))
+            pidQueue.forEach(p => if (!tuplePids.get(p)) candidates.enqueue(p))
+            log.info(s"candidates num ${candidates.size}")
+            require(candidates.size == (pidQueue.size() - tupleQueue.size()), s"candidates size ${candidates.size}, neq ${pidQueue.size()} - ${tupleQueue.size()}")
+            val registeredNum = pidQueue.size()
+            val maxTimes = (registeredNum + size - 1) / size // the largest split num
+            val numLargestSplit = (registeredNum - (maxTimes - 1) * size)
+
+            log.info(s"Totally ${size} ele in queue, registered partition num ${pidQueue.size()}, first ${numLargestSplit} frags are splited into ${maxTimes}, others are splited into ${maxTimes - 1} times")
+            for (i <- 0 until size){
+              val tuple = tupleQueue.poll()
+              val totalIvnum = tuple._2.getInnerVertexSize
+              val times = {
+                if (i < numLargestSplit) maxTimes
+                else maxTimes - 1
+              }
+
+              val graphStructure = tuple._2
+              val innerStore = tuple._5
+              innerStore.setLocalNum(times)
+              val edataStore = tuple._4.asInstanceOf[EdgeDataStore[ED]]
+              edataStore.setLocalNum(times)
+              //split into partitions where each partition has rarely even number of edges.
+              val ranges = splitFragAccordingToEdges(graphStructure, times)
+              val siblingPids = new Array[Int](times)
+              siblingPids(0) = tuple._1
+              for (j <- 1 until times){
+                siblingPids(j) = candidates.dequeue()
+              }
+              for (j <- 0 until times){
+                val startLid = ranges(j)._1
+                val endLid = ranges(j)._2
+                if (j == times - 1){
+                  require(endLid == totalIvnum)
+                }
+                if (j == 0){
+                  pid2EdgePartition(tuple._1) = new GrapeEdgePartition[VD,ED](tuple._1,  j, times,siblingPids, startLid, endLid,0, graphStructure, tuple._3,edataStore)
+                  GrapeVertexPartition.setVertexStore(tuple._1, innerStore,tuple._6)
+                  log.info(s"creating partition for pid ${tuple._1}, (${startLid},${endLid}), fid ${graphStructure.fid()}")
+                }
+                else {
+                  val dstPid = siblingPids(j)
+                  pid2EdgePartition(dstPid) = new GrapeEdgePartition[VD,ED](dstPid,  j, times, siblingPids, startLid, endLid,0, graphStructure, tuple._3, edataStore)
+                  GrapeVertexPartition.setVertexStore(dstPid, innerStore,tuple._6)
+                  log.info(s"creating partition for pid ${dstPid}, (${startLid},${endLid}), fid ${graphStructure.fid()}")
+                }
+              }
+            }
+          }
+          require(tupleQueue.size() == 0, "queue should be empty now")
+        }
+        else {
+          log.info(s"partition ${pid} skip building since array is already created")
+        }
+      }
+    }
+  }
+
+  def get[VD: ClassTag, ED: ClassTag](pid : Int) : GrapeEdgePartition[VD,ED] = synchronized{
+    require(pid2EdgePartition != null, "call create partitions first")
+    pid2EdgePartition(pid).asInstanceOf[GrapeEdgePartition[VD,ED]]
+  }
+
+  def splitFragAccordingToEdges(graphStructure: GraphStructure, numPart : Int) : Array[(Int,Int)] = {
+    val numEdges = graphStructure.getOutEdgesNum
+    val edgesPerSplit = (numEdges + numPart - 1) / numPart
+    var curLid = 0
+    val res = new Array[(Int,Int)](numPart)
+    for (i <- 0 until numPart){
+      val targetOffset = Math.min(edgesPerSplit * (i + 1), numEdges)
+      val beginLid = curLid
+      while (graphStructure.getOEBeginOffset(curLid) < targetOffset){
+        curLid += 1
+      }
+      if (i == numPart - 1){
+        curLid = Math.max(curLid, graphStructure.getInnerVertexSize.toInt)
+      }
+      res(i) = (beginLid, curLid)
+      log.info(s"For part ${i}, startLid ${beginLid}, endLid${curLid}, num edges in this part ${graphStructure.getOEBeginOffset(curLid) - graphStructure.getOEBeginOffset(beginLid)}, total edges ${numEdges}, edges per split ${edgesPerSplit}")
+    }
+    //it is possible that the last vertices has no out edges.
+    require(curLid == graphStructure.getInnerVertexSize, s"after split, should iterate over all ivertex ${curLid}, ${graphStructure.getInnerVertexSize}")
+    res
+  }
+}
+
+private class EdgeContextImpl[VD, ED, A](
+                                                 mergeMsg: (A, A) => A,
+                                                 aggregates: Array[A],
+                                                 bitset: BitSet)
+  extends EdgeContext[VD, ED, A] {
+
+  private[this] var _srcId: VertexId = _
+  private[this] var _dstId: VertexId = _
+  private[this] var _localSrcId: Int = _
+  private[this] var _localDstId: Int = _
+  private[this] var _srcAttr: VD = _
+  private[this] var _dstAttr: VD = _
+  private[this] var _attr: ED = _
+
+  def set(
+           srcId: VertexId, dstId: VertexId,
+           localSrcId: Int, localDstId: Int,
+           srcAttr: VD, dstAttr: VD,
+           attr: ED): Unit = {
+    _srcId = srcId
+    _dstId = dstId
+    _localSrcId = localSrcId
+    _localDstId = localDstId
+    _srcAttr = srcAttr
+    _dstAttr = dstAttr
+    _attr = attr
+  }
+
+  def setSrcOnly(srcId: VertexId, localSrcId: Int, srcAttr: VD): Unit = {
+    _srcId = srcId
+    _localSrcId = localSrcId
+    _srcAttr = srcAttr
+  }
+
+  def setDest(dstId: VertexId, localDstId: Int, dstAttr: VD, attr: ED): Unit = {
+    _dstId = dstId
+    _localDstId = localDstId
+    _dstAttr = dstAttr
+    _attr = attr
+  }
+
+  override def srcId: VertexId = _srcId
+  override def dstId: VertexId = _dstId
+  override def srcAttr: VD = _srcAttr
+  override def dstAttr: VD = _dstAttr
+  override def attr: ED = _attr
+
+  override def sendToSrc(msg: A): Unit = {
+    send(_localSrcId, msg)
+  }
+  override def sendToDst(msg: A): Unit = {
+    send(_localDstId, msg)
+  }
+
+  @inline private def send(localId: Int, msg: A): Unit = {
+    if (bitset.get(localId)) {
+      aggregates(localId) = mergeMsg(aggregates(localId), msg)
+    } else {
+      aggregates(localId) = msg
+      bitset.set(localId)
+    }
+  }
+}
+
+
+class OrderedLongLong(val tuple : (Long,Long)) extends Ordered[(Long,Long)] {
+  override def compare(that: (Long, Long)): Int = {
+    if (tuple._1 == that._1) return (tuple._2 - that._2).toInt
+    else return (tuple._1 - that._1).toInt
+  }
+}
+

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/impl/GrapeVertexPartition.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/rdd/impl/GrapeVertexPartition.scala
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.rdd.impl
+
+import com.alibaba.graphscope.ds.{StringTypedArray, Vertex}
+import com.alibaba.graphscope.graphx.VineyardClient
+import com.alibaba.graphscope.graphx.graph.GraphStructure
+import com.alibaba.graphscope.graphx.rdd.RoutingTable
+import com.alibaba.graphscope.graphx.store.VertexDataStore
+import com.alibaba.graphscope.graphx.store.impl.{AbstractVertexDataStore, ImmutableOffHeapVertexDataStore, InHeapVertexDataStore}
+import com.alibaba.graphscope.graphx.utils.{BitSetWithOffset, DoubleDouble, GrapeUtils, IdParser, PrimitiveVector, ScalaFFIFactory}
+import com.alibaba.graphscope.serialization.FakeFFIByteVectorInputStream
+import com.alibaba.graphscope.stdcxx.FakeFFIByteVector
+import com.alibaba.graphscope.utils.{FFITypeFactoryhelper, VertexDataUtils}
+import org.apache.spark.Partition
+import org.apache.spark.graphx.{EdgeDirection, PartitionID, VertexId}
+import org.apache.spark.internal.Logging
+
+import java.io.{BufferedReader, FileReader, ObjectInputStream}
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+class VertexDataMessage[VD: ClassTag](val dstPid : Int, val fromFid : Int, val gids : Array[Long], val newData : Array[VD]) extends Serializable
+
+class GrapeVertexPartition[VD : ClassTag](val pid : Int,
+                                          val startLid : Int,
+                                          val endLid : Int,
+                                          val localId : Int,
+                                          val localNum : Int,
+                                          val siblingPid : Array[Int],
+                                          val graphStructure: GraphStructure,
+                                          val vertexData: VertexDataStore[VD],
+                                          val client : VineyardClient,
+                                          val routingTable: RoutingTable,
+                                          var bitSet: BitSetWithOffset = null) extends Logging with Partition {
+
+  val partVnum : Long = endLid - startLid
+  val fragVnum : Int = graphStructure.getVertexSize.toInt
+  val ivnum = graphStructure.getInnerVertexSize.toInt
+  val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+  if (bitSet ==null){
+    bitSet = new BitSetWithOffset(startBit = startLid,endBit = endLid)
+    bitSet.setRange(startLid,endLid)
+  }
+
+  def getData(lid : Int) : VD = {
+    vertexData.get(lid)
+  }
+
+  def iterator : Iterator[(VertexId,VD)] = {
+    new Iterator[(VertexId,VD)]{
+      var lid = bitSet.nextSetBit(startLid)
+      val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+      override def hasNext: Boolean = {
+        lid >= 0 && lid < endLid
+      }
+
+      override def next(): (VertexId, VD) = {
+        vertex.SetValue(lid)
+        val res = (graphStructure.innerVertexLid2Oid(vertex), getData(lid))
+        lid = bitSet.nextSetBit(lid + 1)
+        res
+      }
+    }
+  }
+
+  def getNbrIds(vertex: Vertex[Long], edgeDirection: EdgeDirection) : Array[Long] = {
+    if (edgeDirection.equals(EdgeDirection.In)){
+      graphStructure.getInNbrIds(vertex)
+    }
+    else if (edgeDirection.equals(EdgeDirection.Out)){
+      graphStructure.getOutNbrIds(vertex)
+    }
+    else if (edgeDirection.equals(EdgeDirection.Either)){
+      graphStructure.getInOutNbrIds(vertex)
+    }
+    else {
+      throw new IllegalStateException(s"Not supported direction ${edgeDirection.toString()}")
+    }
+  }
+
+  def createNewValues[VD2: ClassTag] :VertexDataStore[VD2] = {
+    if (localId == 0){
+      val newValues = vertexData.mapToNew[VD2].asInstanceOf[VertexDataStore[VD2]]
+      log.info(s"pid ${pid} create new values for part ${siblingPid.mkString(",")}, new class ${GrapeUtils.getRuntimeClass[VD2].getSimpleName}")
+      for (dstPid <- siblingPid){
+        VertexDataStore.enqueue(dstPid, newValues)
+      }
+    }
+    VertexDataStore.dequeue(pid).asInstanceOf[VertexDataStore[VD2]]
+  }
+
+  def collectNbrIds(edgeDirection: EdgeDirection) : GrapeVertexPartition[Array[VertexId]] = {
+    var lid = bitSet.nextSetBit(startLid)
+    val newValues = createNewValues[Array[VertexId]]
+
+    val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    while (lid >= 0 && lid < endLid){
+      vertex.SetValue(lid)
+      newValues.set(lid,getNbrIds(vertex, edgeDirection))
+      lid = bitSet.nextSetBit(lid + 1);
+    }
+    this.withNewValues(newValues)
+  }
+
+  def generateVertexDataMessage : Iterator[(PartitionID, VertexDataMessage[VD])] = {
+    val res = new ArrayBuffer[(PartitionID,VertexDataMessage[VD])]()
+    val curFid = graphStructure.fid()
+    val idParser = new IdParser(graphStructure.fnum())
+    for (i <- 0 until(routingTable.numPartitions)){
+      val verticesToSend = routingTable.get(i)
+      if (verticesToSend != null){
+        val gids = new PrimitiveVector[Long](verticesToSend.size)
+        val newData = new PrimitiveVector[VD](verticesToSend.size)
+        var j = verticesToSend.nextSetBit(startLid)
+        while (j >= 0 && j < endLid){
+          gids.+=(idParser.generateGlobalId(curFid, j))
+          newData.+=(getData(j))
+          require(getData(j) != null, s"generating vd msg encounter null at pos ${j}")
+          j = verticesToSend.nextSetBit(j + 1)
+        }
+        val msg = new VertexDataMessage[VD](i, curFid, gids.trim().array,newData.trim().array)
+        res.+=((i, msg))
+      }
+    }
+    res.toIterator
+  }
+
+  def updateOuterVertexData(vertexDataMessage: Iterator[(PartitionID,VertexDataMessage[VD])]): GrapeVertexPartition[VD] = {
+    val time0 = System.nanoTime()
+    log.info(s"Start updating outer vertex on part ${pid}")
+    val tmpVertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+    if (vertexDataMessage.hasNext) {
+      var tid = 0
+      while (vertexDataMessage.hasNext){
+        val tuple = vertexDataMessage.next()
+        val outerDatas = tuple._2.newData
+        val outerGids = tuple._2.gids
+        var i = 0
+        while (i < outerGids.length) {
+          require(graphStructure.outerVertexGid2Vertex(outerGids(i), tmpVertex))
+          require(outerDatas(i) != null, s"received null msg in ${tuple}, pos ${i}")
+          vertexData.set(tmpVertex.GetValue.toInt, outerDatas(i))
+          i += 1
+        }
+      }
+      val time1 = System.nanoTime()
+      log.info(s"[Perf: ] part ${pid} updating outer vertex data cost ${(time1 - time0) / 1000000}ms,  ovnum ${graphStructure.getOuterVertexSize}")
+    }
+    else {
+      log.info(s"[Perf]: part ${pid} receives no outer vertex data, startLid ${startLid}")
+    }
+    this
+  }
+
+  def map[VD2: ClassTag](f: (VertexId, VD) => VD2): GrapeVertexPartition[VD2] = {
+    // Construct a view of the map transformation
+    val time0 = System.nanoTime()
+    val newValues = createNewValues[VD2]
+    var i = bitSet.nextSetBit(startLid)
+    while (i >= 0 && i < endLid) {
+      vertex.SetValue(i)
+      newValues.set(i,f(graphStructure.getId(vertex), getData(i)))
+      i = bitSet.nextSetBit(i + 1)
+    }
+
+    val time1 = System.nanoTime()
+    log.info(s"part ${pid} from ${startLid} to ${endLid} map vertex partition from ${GrapeUtils.getRuntimeClass[VD].getSimpleName} to ${GrapeUtils.getRuntimeClass[VD2].getSimpleName}, active ${bitSet.cardinality()} cost ${(time1 - time0) / 1000000} ms")
+    this.withNewValues(newValues)
+  }
+
+  def filter(pred: (VertexId, VD) => Boolean): GrapeVertexPartition[VD] = {
+    val newMask = new BitSetWithOffset(startLid,endLid)
+
+    // Iterate over the active bits in the old mask and evaluate the predicate
+    var curLid = bitSet.nextSetBit(startLid)
+    while (curLid >= 0 && curLid < endLid) {
+      vertex.SetValue(curLid)
+      if (pred(graphStructure.getId(vertex), getData(curLid))){
+        newMask.set(curLid)
+      }
+      curLid = bitSet.nextSetBit(curLid + 1)
+    }
+    this.withMask(newMask)
+  }
+
+  def aggregateUsingIndex[VD2: ClassTag](
+                                          iter: Iterator[Product2[VertexId, VD2]],
+                                          reduceFunc: (VD2, VD2) => VD2): GrapeVertexPartition[VD2] = {
+    val newMask = new BitSetWithOffset(startLid,endLid)
+    val newValues = createNewValues[VD2]
+
+    iter.foreach { product =>
+      val oid = product._1
+      val vdata = product._2
+      require(graphStructure.getVertex(oid,vertex))
+      val lid = vertex.GetValue().toInt
+      if (lid >= 0) {
+        if (newMask.get(lid)) {
+          newValues.set(lid,reduceFunc(newValues.get(lid), vdata))
+        } else { // otherwise just store the new value
+          newMask.set(lid)
+          newValues.set(lid,vdata)
+        }
+      }
+    }
+    this.withNewValues(newValues).withMask(newMask)
+  }
+
+  /** Hides the VertexId's that are the same between `this` and `other`. */
+  def minus(other: GrapeVertexPartition[VD]): GrapeVertexPartition[VD] = {
+    if (this.graphStructure != other.graphStructure) {
+      logWarning("Minus operations on two VertexPartitions with different indexes is slow.")
+      minus(createUsingIndex(other.iterator))
+    } else {
+      this.withMask(this.bitSet.andNot(other.bitSet))
+    }
+  }
+
+  def diff(other: GrapeVertexPartition[VD]): GrapeVertexPartition[VD] = {
+    if (this.graphStructure != this.graphStructure) {
+      logWarning("Diffing two VertexPartitions with different indexes is slow.")
+      diff(createUsingIndex(other.iterator))
+    } else {
+      val newMask = this.bitSet & other.bitSet
+      var i = newMask.nextSetBit(startLid)
+      while (i >= 0 && i < endLid) {
+        if (getData(i) == other.getData(i)) {
+          newMask.unset(i)
+        }
+        i = newMask.nextSetBit(i + 1)
+      }
+      this.withNewValues(other.vertexData).withMask(newMask)
+    }
+  }
+
+  def leftJoin[VD2: ClassTag, VD3: ClassTag]
+  (other: GrapeVertexPartition[VD2])
+  (f: (VertexId, VD, Option[VD2]) => VD3): GrapeVertexPartition[VD3] = {
+    if (this.graphStructure != other.graphStructure){
+      logWarning("Joining two VertexPartitions with different indexes is slow.")
+      leftJoin(createUsingIndex(other.iterator))(f)
+    } else {
+      /** for vertex not represented in other, we use original vertex */
+      val time0 = System.nanoTime()
+      log.info(s"${GrapeUtils.getRuntimeClass[VD3].getSimpleName}")
+      val newValues = createNewValues[VD3]
+      var i = this.bitSet.nextSetBit(startLid)
+      while (i >= 0 && i < endLid) {
+        vertex.SetValue(i)
+        val otherV: Option[VD2] = if (other.bitSet.get(i)) Some(other.getData(i)) else None
+        val t = f(this.graphStructure.getId(vertex), this.getData(i), otherV)
+        if (t == null) {
+          log.info(s"when join ${this} and ${other} at pos ${i} result is null")
+          throw new IllegalStateException("null......")
+        }
+        newValues.set(i, t)
+        i = this.bitSet.nextSetBit(i + 1)
+      }
+      val time1 = System.nanoTime()
+      if (localId == 0) {
+        log.info(s"Left join between ${this} and ${other} cost ${(time1 - time0) / 1000000} ms")
+      }
+      this.withNewValues(newValues)
+    }
+  }
+
+  /**
+   * Similar effect as aggregateUsingIndex((a, b) => a)
+   */
+  def createUsingIndex[VD2: ClassTag](iter: Iterator[Product2[VertexId, VD2]])
+  : GrapeVertexPartition[VD2] = {
+    val newMask = new BitSetWithOffset(startLid,endLid)
+    val newValues = createNewValues[VD2]
+    iter.foreach { pair =>
+      val vertexFound = graphStructure.getVertex(pair._1,vertex)
+      if (vertexFound){
+        val lid = vertex.GetValue().toInt
+        newMask.set(lid)
+        newValues.set(lid,pair._2)
+      }
+    }
+    this.withNewValues(newValues).withMask(newMask)
+  }
+
+  /** Inner join another VertexPartition. */
+  def innerJoin[U: ClassTag, VD2: ClassTag]
+  (other: GrapeVertexPartition[U])
+  (f: (VertexId, VD, U) => VD2): GrapeVertexPartition[VD2] = {
+    if (this.graphStructure != other.graphStructure){
+      logWarning("Joining two VertexPartitions with different indexes is slow.")
+      innerJoin(createUsingIndex(other.iterator))(f)
+    } else {
+      val newMask = this.bitSet & other.bitSet
+      val newView = createNewValues[VD2]
+      var i = newMask.nextSetBit(startLid)
+      while (i >= 0 && i < endLid) {
+        vertex.SetValue(i)
+        newView.set(i, f(this.graphStructure.getId(vertex), this.getData(i), other.getData(i)))
+        i = newMask.nextSetBit(i + 1)
+      }
+      this.withNewValues(newView).withMask(newMask)
+    }
+  }
+
+  /**
+   * create a new vertex partition with vertex updated according to the read vineyard id.
+   * @param pathPrefix prefix of persisted vd path.
+   * @return
+   */
+  def updateAfterPIE(pathPrefix : String) : GrapeVertexPartition[VD] = {
+    if (localId == 0) {
+      val path = pathPrefix + graphStructure.fid();
+      val reader = new BufferedReader(new FileReader(path))
+      val line = reader.readLine()
+      require(line != null && line.nonEmpty, "read empty line")
+      val vertexDataId = line.toLong
+      if (GrapeUtils.isPrimitive[VD]) {
+        log.info(s"frag ${graphStructure.fid()} got primitive new vertex data id ${vertexDataId}")
+        val vertexDataGetter = ScalaFFIFactory.newVertexDataGetter[VD]
+        val ptr = vertexDataGetter.get(client, vertexDataId)
+        val newValues = new ImmutableOffHeapVertexDataStore[VD](vertexData.size(), vertexData.getLocalNum, client, ptr.get())
+        log.info(s"pid ${pid} create immutable offHeap vertex data")
+        for (dstPid <- siblingPid) {
+          VertexDataStore.enqueue(dstPid, newValues)
+        }
+      }
+      else {
+        log.info(s"frag ${graphStructure.fid()} got string new vertex data id ${vertexDataId}")
+        val vertexDataGetter = ScalaFFIFactory.newStringVertexDataGetter
+        val ptr = vertexDataGetter.get(client, vertexDataId)
+        val typedArray = ptr.get().getVdataArray
+        val newValues = copyStringTypedArrayToHeap[VD](typedArray)
+        log.info(s"pid ${pid} read string vd from off Heap size ${newValues.length}, type ${GrapeUtils.getRuntimeClass[VD].getSimpleName}")
+        val newStore = new InHeapVertexDataStore[VD](newValues.length, vertexData.getLocalNum, client,newValues).asInstanceOf[VertexDataStore[VD]]
+        for (dstPid <- siblingPid) {
+          VertexDataStore.enqueue(dstPid, newStore)
+        }
+      }
+    }
+    val newStore = VertexDataStore.dequeue(pid).asInstanceOf[VertexDataStore[VD]]
+    this.withNewValues(newStore)
+  }
+
+  def copyStringTypedArrayToHeap[T : ClassTag](typedArray : StringTypedArray) : Array[T]= {
+    val vector = new FakeFFIByteVector(typedArray.getRawData, typedArray.getRawDataLength)
+    val ffiInput = new FakeFFIByteVectorInputStream(vector)
+    val len = typedArray.getLength
+    log.info("reading {} objects from array of bytes {}", len, typedArray.getLength)
+    val clz = GrapeUtils.getRuntimeClass[T]
+    if (clz.equals(classOf[DoubleDouble])) {
+      val newArray = new Array[DoubleDouble](len.toInt).asInstanceOf[Array[T]]
+      var i = 0
+      while (i < len) {
+        val a = ffiInput.readDouble
+        val b = ffiInput.readDouble
+        newArray(i) = new DoubleDouble(a, b).asInstanceOf[T]
+        i += 1
+      }
+      newArray
+    }
+    else {
+      val newArray = new Array[T](len.toInt)
+      val objectInputStream = new ObjectInputStream(ffiInput)
+      var i = 0
+      while (i < len) {
+        val obj = objectInputStream.readObject.asInstanceOf[T]
+        newArray(i) = obj
+        i += 1
+      }
+      newArray
+    }
+  }
+
+  def withNewValues[VD2 : ClassTag](vds: VertexDataStore[VD2]) : GrapeVertexPartition[VD2] = {
+    new GrapeVertexPartition[VD2](pid, startLid,endLid,localId, localNum,siblingPid, graphStructure, vds, client, routingTable, bitSet)
+  }
+
+  def withMask(newMask: BitSetWithOffset): GrapeVertexPartition[VD] ={
+    new GrapeVertexPartition[VD](pid, startLid,endLid,localId, localNum,siblingPid,graphStructure, vertexData, client,routingTable, newMask)
+  }
+
+  override def toString: String = "GrapeVertexPartition{" + "pid=" + pid + ",startLid=" + startLid + ", endLid=" + endLid + ",active=" + bitSet.cardinality() + '}'
+
+  override def index: PartitionID = pid
+}
+
+object GrapeVertexPartition extends Logging{
+  val pid2VertexStore : mutable.HashMap[Int,(Boolean,VertexDataStore[_])] = new mutable.HashMap[Int,(Boolean,VertexDataStore[_])]
+
+  /**
+   *
+   * @param pid
+   * @param initialized inidicate whether the pushed vertex data store has been filled with data array in shuffle
+   * @param store
+   */
+  def setVertexStore(pid : Int,  store:VertexDataStore[_],initialized : Boolean) : Unit = {
+    require(!pid2VertexStore.contains(pid))
+    pid2VertexStore(pid) = (initialized,store)
+    log.info(s"storing part ${pid}'s inner vd store ${store.toString}'")
+  }
+
+  def fromEdgePartition[VD: ClassTag](value : VD, pid : Int, startLid : Long, endLid : Long, localId: Int, localNum : Int, siblingPids : Array[Int], client : VineyardClient, graphStructure: GraphStructure, routingTable: RoutingTable) : GrapeVertexPartition[VD] = {
+    //copy to heap
+    val (initialized, vertexStore) = (pid2VertexStore(pid)._1, pid2VertexStore(pid)._2.asInstanceOf[AbstractVertexDataStore[VD]])
+    if (!initialized) {
+      if (localId == 0) {
+        log.info(s"As vertex data is not initialized, setting value to default vd ${value}")
+      }
+      var i = startLid.toInt
+      val limit = endLid
+      while (i < limit) {
+        vertexStore.set(i, value)
+        i += 1
+      }
+    }
+    else {
+      if (localId == 0){
+        log.info("No need for initializing vertex attr")
+      }
+    }
+
+    new GrapeVertexPartition[VD](pid, startLid.toInt, endLid.toInt,localId, localNum,siblingPids, graphStructure, vertexStore, client,routingTable)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/shuffle/EdgeShuffle.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/shuffle/EdgeShuffle.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.shuffle
+
+import com.alibaba.graphscope.graphx.utils.PrimitiveVector
+import org.apache.spark.HashPartitioner
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.collection.OpenHashSet
+
+import java.util.concurrent.ArrayBlockingQueue
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+
+class EdgeShuffle[VD : ClassTag,ED : ClassTag](val fromPid : Int, val dstPid :Int, val oidArray : Array[Long], val oidSet : OpenHashSet[Long], val srcs : Array[Long], val dsts : Array[Long],
+                                               val attrs: Array[ED] = null,
+                                               val vertexAttrs : Array[VD] = null) extends Serializable with Logging {
+  def size() : Long = srcs.length
+
+  override def toString: String = "EdgeShuffleV2:{from "+ fromPid +",to "+ dstPid +  ",srcs: " + srcs.length + ",dsts: " + dsts.length
+
+  def shuffleInEdges(originalDstPid : Int, pid2Host : Array[Int], partitioner : HashPartitioner, srcBuffer: Array[PrimitiveVector[Long]], dstBuffer : Array[PrimitiveVector[Long]]) : Unit = {
+    //from my self, generate shuffles to dst node. result a iterator with two elelments.
+    require(originalDstPid == dstPid, s"neq ${originalDstPid}, ${dstPid}")
+    var i = 0
+    val myHostId = pid2Host(originalDstPid)
+
+    var cnt = 0;
+    while (i < srcs.length){
+      val dstShuffleId = partitioner.getPartition(dsts(i))
+      if (dstShuffleId != originalDstPid && pid2Host(dstShuffleId) != myHostId){
+        srcBuffer(dstShuffleId).+=(srcs(i))
+        dstBuffer(dstShuffleId).+=(dsts(i))
+        cnt += 1
+      }
+      i += 1
+    }
+  }
+}
+
+class EdgeShuffleReceived[ED: ClassTag] extends Logging{
+  val fromPid2Shuffle = new ArrayBuffer[EdgeShuffle[_,ED]]
+
+  def add(edgeShuffle: EdgeShuffle[_,ED]): Unit = {
+    fromPid2Shuffle.+=(edgeShuffle)
+  }
+
+  def getArrays: (Array[Array[Long]], Array[Array[Long]], Array[Array[ED]]) = {
+    val size = fromPid2Shuffle.size
+    val srcArrays = new Array[Array[Long]](size)
+    val dstArrays = new Array[Array[Long]](size)
+    val attrArrays = new Array[Array[ED]](size)
+    var i = 0
+    while (i < size){
+      srcArrays(i) = fromPid2Shuffle(i).srcs
+      dstArrays(i) = fromPid2Shuffle(i).dsts
+      attrArrays(i) = fromPid2Shuffle(i).attrs
+      i += 1
+    }
+    (srcArrays,dstArrays,attrArrays)
+  }
+
+  /**
+   * How many edges in received by us
+   */
+  def totalSize() : Long = {
+    var i = 0;
+    var res = 0L;
+    while (i < fromPid2Shuffle.size){
+      res += fromPid2Shuffle(i).size()
+      i += 1
+    }
+    res
+  }
+
+  override def toString: String ={
+    var res = "EdgeShuffleReceived @Partition: "
+    for (shuffle <- fromPid2Shuffle){
+      res += s"(from ${shuffle.fromPid}, receive size ${shuffle.srcs.length});"
+    }
+    res
+  }
+}
+
+object EdgeShuffleReceived extends Logging {
+    val queue = new ArrayBlockingQueue[EdgeShuffleReceived[_]](1024000)
+    var array = null.asInstanceOf[Array[EdgeShuffleReceived[_]]]
+    val distinctPids = null.asInstanceOf[Array[Int]]
+
+  def push(in : EdgeShuffleReceived[_]): Unit = {
+    require(queue.offer(in))
+  }
+
+  def getArray : Array[EdgeShuffleReceived[_]] = {
+    if (array == null) {
+      log.info(s"convert to array size ${queue.size()}")
+      array = new Array[EdgeShuffleReceived[_]](queue.size())
+      queue.toArray[EdgeShuffleReceived[_]](array)
+    }
+    array
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/shuffle/VertexShuffle.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/shuffle/VertexShuffle.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.shuffle
+
+import com.alibaba.graphscope.graphx.shuffle.VertexShuffle.INIT_SIZE
+import com.alibaba.graphscope.graphx.utils.PrimitiveVector
+import com.alibaba.graphscope.stdcxx.StdVector
+import com.alibaba.graphscope.utils.FFITypeFactoryhelper
+import org.apache.spark.internal.Logging
+
+
+class VertexShuffle(val dstPid : Int, val fromPid: Int, val array : Array[Long]) extends Serializable{
+  def size() : Int = array.size
+}
+
+class VertexShuffleBuilder (val dstPid : Int, val fromPid: Int) extends Logging {
+  @transient val oidArray = new PrimitiveVector[Long](INIT_SIZE)
+
+  def addOid(oid : Long) : Unit = oidArray.+=(oid)
+
+  def finish() : VertexShuffle = {
+    new VertexShuffle(dstPid, fromPid, oidArray.trim().array)
+  }
+}
+
+object VertexShuffle extends Logging {
+  val INIT_SIZE = 4;
+  val vectorFactory : StdVector.Factory[Long] = FFITypeFactoryhelper.getStdVectorFactory("std::vector<int64_t>").asInstanceOf[StdVector.Factory[Long]]
+  def toVector(vertexShuffle: VertexShuffle) : StdVector[Long] = {
+    val vector = vectorFactory.create()
+    vector.resize(vertexShuffle.size())
+    var i = 0;
+    log.info(s"Writing vertex shuffle to vector ${vector} size ${vector.size()}")
+    val array = vertexShuffle.array
+    while (i < array.size){
+      vector.set(i, array(i))
+      i += 1
+    }
+    vector
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/EdgeDataStore.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/EdgeDataStore.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.store
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.KnownSizeEstimationPorter
+
+import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue, TimeUnit}
+import scala.reflect.ClassTag
+
+trait EdgeDataStore[T] extends KnownSizeEstimationPorter{
+  def size() : Int
+  def getWithEID(eid : Int) : T
+  def getWithOffset(offset: Int): T
+  def setWithEID(ind : Int, ed : T) : Unit
+  def setWithOffset(ind : Int, ed: T) : Unit
+  def mapToNew[T2 : ClassTag] : EdgeDataStore[T2]
+  def getLocalNum : Int
+  def setLocalNum(localNum : Int) : Unit
+}
+
+object EdgeDataStore extends Logging {
+  val map = new ConcurrentHashMap[Int,LinkedBlockingQueue[EdgeDataStore[_]]]
+
+  def enqueue(pid : Int, edgeStore: EdgeDataStore[_]) : Unit = {
+    createQueue(pid)
+    val q = map.get(pid)
+    q.offer(edgeStore)
+  }
+
+  def dequeue(pid : Int) : EdgeDataStore[_] = {
+    createQueue(pid)
+    require(map.containsKey(pid), s"no queue available for ${pid}")
+    val res = map.get(pid).take()
+    res
+  }
+
+  def createQueue(pid : Int) : Unit = synchronized{
+    if (!map.containsKey(pid)){
+      map.put(pid, new LinkedBlockingQueue)
+    }
+  }
+
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/VertexDataStore.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/VertexDataStore.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.store
+
+import com.alibaba.graphscope.graphx.store.VertexDataStore.log
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.KnownSizeEstimationPorter
+
+import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue}
+import scala.reflect.ClassTag
+
+trait VertexDataStore[T] extends KnownSizeEstimationPorter{
+  def size() : Int
+  def get(ind : Int) : T
+  def set(ind: Int, vd : T): Unit
+  def mapToNew[T2 : ClassTag] : VertexDataStore[T2]
+  def getLocalNum : Int
+  def setLocalNum(localNum : Int) : Unit
+}
+
+object VertexDataStore extends Logging{
+  val map = new ConcurrentHashMap[Int,LinkedBlockingQueue[VertexDataStore[_]]]
+
+  def enqueue(pid : Int, inHeapVertexDataStore: VertexDataStore[_]) : Unit = {
+    createQueue(pid)
+    val q = map.get(pid)
+    q.offer(inHeapVertexDataStore)
+  }
+
+  def dequeue(pid : Int) : VertexDataStore[_] = {
+    createQueue(pid)
+    require(map.containsKey(pid), s"no queue available for ${pid}")
+    val res = map.get(pid).take()
+    res
+  }
+
+  def createQueue(pid : Int) : Unit = synchronized{
+    if (!map.containsKey(pid)){
+      map.put(pid, new LinkedBlockingQueue)
+    }
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/AbstractEdgeDataStore.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/AbstractEdgeDataStore.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.store.impl
+
+import com.alibaba.graphscope.graphx.VineyardClient
+import com.alibaba.graphscope.graphx.store.EdgeDataStore
+import com.alibaba.graphscope.graphx.utils.{EIDAccessor, GrapeUtils, ScalaFFIFactory}
+
+import scala.reflect.ClassTag
+
+abstract class AbstractEdgeDataStore[T](val length : Int, var localNum : Int, val client : VineyardClient,val eidAccessor: EIDAccessor) extends EdgeDataStore[T]{
+  def mapToNew[T2 : ClassTag] : EdgeDataStore[T2] = {
+      if (!GrapeUtils.isPrimitive[T2]) {
+        new InHeapEdgeDataStore[T2](length, localNum, client, new Array[T2](length), eidAccessor)
+      }
+      else {
+        new OffHeapEdgeDataStore[T2](length, localNum, client,eidAccessor,ScalaFFIFactory.newEdgeDataBuilder[T2](client,length))
+      }
+  }
+
+  override def size() : Int = length;
+
+  override def getLocalNum: Int = localNum
+
+  override def setLocalNum(localNum : Int) : Unit = {
+    this.localNum = localNum
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/AbstractVertexDataStore.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/AbstractVertexDataStore.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.store.impl
+
+import com.alibaba.graphscope.graphx.VineyardClient
+import com.alibaba.graphscope.graphx.store.VertexDataStore
+import com.alibaba.graphscope.graphx.utils.{GrapeUtils, ScalaFFIFactory}
+
+import scala.reflect.ClassTag
+
+abstract class AbstractVertexDataStore[T](val length : Int, var localNum : Int, val client : VineyardClient) extends VertexDataStore[T]{
+  override def mapToNew[T2 : ClassTag] : VertexDataStore[T2] = {
+    new InHeapVertexDataStore[T2](length,localNum,client)
+  }
+
+  override def size() : Int = length;
+
+  override def getLocalNum: Int = localNum
+
+  override def setLocalNum(localNum: Int): Unit = {
+    this.localNum = localNum
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/InHeapEdgeDataStore.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/InHeapEdgeDataStore.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.store.impl
+
+import com.alibaba.graphscope.graphx.VineyardClient
+import com.alibaba.graphscope.graphx.utils.{EIDAccessor, GrapeUtils}
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.SizeEstimator
+
+import scala.reflect.ClassTag
+
+class InHeapEdgeDataStore[ED: ClassTag](length : Int, localNum : Int, client : VineyardClient, val edataArray : Array[ED], eidAccessor : EIDAccessor) extends AbstractEdgeDataStore[ED](length, localNum,client,eidAccessor) with Logging{
+  def this(length : Int,localNum : Int, client : VineyardClient, eidAccessor: EIDAccessor) = {
+    this(length, localNum, client,new Array[ED](length), eidAccessor)
+  }
+
+  override def getWithOffset(offset : Int) : ED = {
+    val eid = eidAccessor.getEid(offset).toInt
+    edataArray(eid)
+  }
+
+  override def setWithOffset(offset : Int, value : ED) : Unit = {
+    val eid = eidAccessor.getEid(offset).toInt
+    edataArray(eid) = value
+  }
+
+  override def getWithEID(eid: Int): ED = {
+    edataArray(eid)
+  }
+
+  override def setWithEID(ind: Int, ed: ED): Unit = {
+    edataArray(ind) = ed
+  }
+  override def estimatedSize: Long = {
+    val arraySize = SizeEstimator.estimate(edataArray)
+    val res = SizeEstimator.estimate(client) +  (arraySize/ localNum) + 8
+    res
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/InHeapVertexDataStore.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/InHeapVertexDataStore.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.store.impl
+
+import com.alibaba.graphscope.graphx.VineyardClient
+import com.alibaba.graphscope.graphx.utils.GrapeUtils
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.SizeEstimator
+
+import scala.reflect.ClassTag
+
+class InHeapVertexDataStore[VD: ClassTag](length : Int, localNum : Int, client : VineyardClient, val array :Array[VD]) extends AbstractVertexDataStore[VD](length, localNum,client) with Logging{
+  def this(length: Int, localNum : Int, client : VineyardClient){
+    this(length, localNum, client,new Array[VD](length));
+  }
+
+  override def get(ind: Int): VD = array(ind)
+
+  override def set(ind: Int,vd : VD): Unit = array(ind) = vd
+
+  override def estimatedSize: Long = {
+    val arraySize = SizeEstimator.estimate(array)
+    val res = SizeEstimator.estimate(client) +  arraySize/ localNum +8
+    res
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/OffHeapEdgeDataStore.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/OffHeapEdgeDataStore.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.store.impl
+
+import com.alibaba.graphscope.ds.TypedArray
+import com.alibaba.graphscope.graphx.store.EdgeDataStore
+import com.alibaba.graphscope.graphx.utils.{EIDAccessor, GrapeUtils, ScalaFFIFactory}
+import com.alibaba.graphscope.graphx.{EdgeDataBuilder, VineyardArrayBuilder, VineyardClient}
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.SizeEstimator
+
+import scala.reflect.ClassTag
+
+class OffHeapEdgeDataStore[ED: ClassTag](length : Int, localNum : Int, client : VineyardClient, eidAccessor: EIDAccessor,val edataBuilder: EdgeDataBuilder[Long, ED]) extends AbstractEdgeDataStore[ED](length,localNum, client,eidAccessor) with EdgeDataStore[ED] with Logging{
+  def this(length : Int,  localNum : Int, client: VineyardClient, eidAccessor : EIDAccessor){
+    this(length, localNum,client,eidAccessor,ScalaFFIFactory.newEdgeDataBuilder[ED](client,length))
+  }
+
+  require(GrapeUtils.isPrimitive[ED])
+  val arrayBuilder: VineyardArrayBuilder[ED] = edataBuilder.getArrayBuilder
+
+  override def size: Int = length
+
+  override def getWithOffset(offset: Int): ED = {
+    val eid = eidAccessor.getEid(offset).toInt
+    arrayBuilder.get(eid)
+  }
+
+  override def setWithOffset(offset: Int, ed: ED): Unit = {
+    val eid = eidAccessor.getEid(offset).toInt
+    arrayBuilder.set(eid, ed)
+  }
+
+  override def getWithEID(eid: Int): ED = arrayBuilder.get(eid)
+
+  override def setWithEID(ind: Int, ed : ED): Unit = arrayBuilder.set(ind, ed)
+
+  override def estimatedSize: Long = {
+    val res = SizeEstimator.estimate(client) + SizeEstimator.estimate(edataBuilder) + 8
+//    log.info(s"${this.toString} computing estimated size ${GrapeUtils.bytesToString(res)}")
+    res
+  }
+}
+class ImmutableOffHeapEdgeStore[ED: ClassTag](length : Int, localNum : Int, client : VineyardClient, eidAccessor: EIDAccessor, typedArray : TypedArray[ED]) extends AbstractEdgeDataStore[ED](length,localNum, client,eidAccessor) with EdgeDataStore[ED] with Logging {
+
+  require(GrapeUtils.isPrimitive[ED])
+
+  override def size: Int = length
+
+  override def getWithOffset(offset: Int): ED = {
+    val eid = eidAccessor.getEid(offset).toInt
+    typedArray.get(eid)
+  }
+
+  override def setWithOffset(offset: Int, ed: ED): Unit = {
+    throw new IllegalStateException("Not modifiable")
+  }
+
+  override def getWithEID(eid: Int): ED = typedArray.get(eid)
+
+  override def setWithEID(ind: Int, ed: ED): Unit = {
+    throw new IllegalStateException("Not modifiable")  }
+
+  override def estimatedSize: Long = {
+    val res = SizeEstimator.estimate(client) + SizeEstimator.estimate(typedArray) + 8
+    res
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/OffHeapVertexDataStore.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/store/impl/OffHeapVertexDataStore.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.store.impl
+
+import com.alibaba.graphscope.graphx.{VertexData, VertexDataBuilder, VineyardArrayBuilder, VineyardClient}
+import com.alibaba.graphscope.graphx.utils.{EIDAccessor, GrapeUtils, ScalaFFIFactory}
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.SizeEstimator
+
+import scala.reflect.ClassTag
+
+class OffHeapVertexDataStore[VD: ClassTag](length : Int, localNum : Int, client : VineyardClient, val vdataBuilder : VertexDataBuilder[Long,VD]) extends AbstractVertexDataStore[VD](length, localNum, client) with Logging{
+  def this(length : Int, localNum : Int, client: VineyardClient, defaultVD : VD = null){
+    this(length, localNum, client,ScalaFFIFactory.newVertexDataBuilder[VD](client,length, defaultVD))
+  }
+  require(GrapeUtils.isPrimitive[VD])
+
+  val arrayBuilder: VineyardArrayBuilder[VD] = vdataBuilder.getArrayBuilder
+  override def get(ind: Int): VD = arrayBuilder.get(ind)
+
+  override def set(ind: Int, vd: VD): Unit = arrayBuilder.set(ind, vd)
+
+  override def estimatedSize: Long = {
+    val res = SizeEstimator.estimate(client) + SizeEstimator.estimate(vdataBuilder) + 8
+    res
+  }
+}
+
+class ImmutableOffHeapVertexDataStore[VD: ClassTag](length : Int,localNum : Int, client : VineyardClient, val vertexData : VertexData[Long,VD]) extends AbstractVertexDataStore[VD](length, localNum, client) with Logging {
+  require(GrapeUtils.isPrimitive[VD])
+
+  override def get(ind: Int): VD = vertexData.getData(ind)
+
+  override def set(ind: Int, vd: VD): Unit = {
+    throw new IllegalStateException("not implemented")
+  }
+
+  override def estimatedSize: Long = {
+    val res = SizeEstimator.estimate(client)  + SizeEstimator.estimate(vertexData) + 8
+    res
+
+  }
+}
+

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/ArrayWithOffset.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/ArrayWithOffset.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import scala.reflect.ClassTag
+
+class ArrayWithOffset[@specialized(Long,Int,Double,Float) T :ClassTag](val offset : Int, val array: Array[T]){
+
+  def this(offset : Int, length : Int){
+    this(offset, new Array[T](length))
+  }
+
+  @inline
+  def length : Int = array.length
+
+  @inline
+  def apply(i : Int): T = array(i - offset)
+
+  @inline
+  def update(i : Int, value: T): Unit=  {
+    array.update(i-offset,value)
+  }
+
+  override def clone() : ArrayWithOffset[T] = {
+    new ArrayWithOffset[T](offset, length)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/BitSetWithOffset.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/BitSetWithOffset.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+class BitSetWithOffset(val startBit : Int, val endBit : Int, val bitset : FixedBitSet) {
+  def this(startBit: Int, endBit : Int)  = {
+    this(startBit,endBit,new FixedBitSet(endBit - startBit))
+  }
+  require(endBit > startBit)
+  val size = endBit - startBit
+
+  def set(bit : Int) : Unit = {
+    check(bit)
+    bitset.set(bit - startBit)
+  }
+
+  /** [a,b) */
+  def setRange(a : Int, b :Int) : Unit = {
+    require(a >= startBit && a < endBit, s"${a} out of range ${startBit},${endBit}")
+    require(b > a && b > startBit && b <= endBit, s"${a} out of range ${startBit},${endBit}")
+    var i = a - startBit
+    val limit = b - startBit
+    while (i < limit){
+      bitset.set(i)
+      i += 1
+    }
+  }
+
+  def get(bit : Int) : Boolean = {
+    check(bit)
+    bitset.get(bit - startBit)
+  }
+
+  def unset(bit : Int) : Unit = {
+    check(bit)
+    bitset.unset(bit - startBit)
+  }
+
+  @inline
+  def check(bit : Int) : Unit = {
+    require(bit >= startBit && bit <= endBit, s"index of range ${bit}, range [${startBit},${endBit})")
+  }
+
+  def union(other : BitSetWithOffset): Unit ={
+    require(size == other.size && (startBit == other.startBit) && (endBit == other.endBit), s"can not union between ${this.toString} and ${other.toString}")
+    bitset.union(other.bitset)
+  }
+
+  def &(other : BitSetWithOffset) : BitSetWithOffset = {
+    require(size == other.size && (startBit == other.startBit) && (endBit == other.endBit), s"can not union between ${this.toString} and ${other.toString}")
+    new BitSetWithOffset(startBit, endBit, bitset & other.bitset)
+  }
+
+  def cardinality() : Int = bitset.cardinality()
+
+  def capacity : Int = bitset.capacity
+
+  @inline
+  def nextSetBit(bit : Int) : Int = {
+    val res = bitset.nextSetBit(bit - startBit)
+    if (res < 0) res
+    else res + startBit
+  }
+
+  def andNot(other: BitSetWithOffset) : BitSetWithOffset = {
+    require(size == other.size && (startBit == other.startBit) && (endBit == other.endBit), s"can not union between ${this.toString} and ${other.toString}")
+    new BitSetWithOffset(startBit,endBit, bitset.andNot(other.bitset))
+  }
+
+  override def toString: String = "BitSetWithOffset(start=" + startBit + ",end=" + endBit;
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/DoubleDouble.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/DoubleDouble.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+case class DoubleDouble(var a : Double = 0.0, var b : Double= 0.0) extends Serializable

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/EIDAccessor.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/EIDAccessor.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import com.alibaba.fastffi.llvm4jni.runtime.JavaRuntime
+
+class EIDAccessor(var address : Long) {
+  @inline
+  def getEid(offset : Int) : Long = {
+    JavaRuntime.getLong(address + (offset << 4) + 8)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/ExecutorUtils.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/ExecutorUtils.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import org.apache.spark.internal.Logging
+
+import java.net.InetAddress
+
+/**
+ * Stores info for partitions, executor and hostname. With these info, we can know which
+ *
+ * - Which partitions are in this executor.
+ * - How many partitions are in this executor.
+ * - The host name of this executor.
+ */
+object ExecutorUtils extends Logging{
+  val vineyardEndpoint = "/tmp/vineyard.sock"
+
+  def getHostName : String = InetAddress.getLocalHost.getHostName
+  def getHostIp : String = InetAddress.getLocalHost.getHostAddress
+
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/FixedBitSet.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/FixedBitSet.scala
@@ -1,0 +1,275 @@
+/*
+ * The file GiraphConfiguration.java is referred and derived from
+ * project apache/spark,
+ *
+ *    https://github.com/apache/spark.git
+ *
+ * which has the following license:
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import java.util.Arrays
+
+
+/**
+ * A simple, fixed-size bit set implementation. This implementation is fast because it avoids
+ * safety/bound checking.
+ */
+class FixedBitSet(val words: Array[Long]) extends Serializable {
+
+  def this(numBits : Int) = {
+    this(new Array[Long](((numBits - 1) >> 6) + 1))
+  }
+
+  private val numWords = words.length
+
+  /**
+   * Compute the capacity (number of bits) that can be represented
+   * by this bitset.
+   */
+  def capacity: Int = numWords * 64
+
+  /**
+   * Clear all set bits.
+   */
+  def clear(): Unit = Arrays.fill(words, 0)
+
+  def wordIndex(ind : Int) : Int = {
+    (ind >> 6)
+  }
+
+  def checkRange(l: Int, r: Int) : Unit = {
+    if (l < 0) throw new IndexOutOfBoundsException("fromIndex < 0: " + l)
+    if (r < 0) throw new IndexOutOfBoundsException("toIndex < 0: " + r)
+    if (l > r) throw new IndexOutOfBoundsException("fromIndex: " + l + " > toIndex: " + r)
+  }
+
+  /**
+   * Set all the bits up to a given index
+   */
+  def setUntil(bitIndex: Int): Unit = {
+    val wordIndex = bitIndex >> 6 // divide by 64
+    Arrays.fill(words, 0, wordIndex, -1)
+    if(wordIndex < words.length) {
+      // Set the remaining bits (note that the mask could still be zero)
+      val mask = ~(-1L << (bitIndex & 0x3f))
+      words(wordIndex) |= mask
+    }
+  }
+
+  /**
+   * Clear all the bits up to a given index
+   */
+  def clearUntil(bitIndex: Int): Unit = {
+    val wordIndex = bitIndex >> 6 // divide by 64
+    Arrays.fill(words, 0, wordIndex, 0)
+    if(wordIndex < words.length) {
+      // Clear the remaining bits
+      val mask = -1L << (bitIndex & 0x3f)
+      words(wordIndex) &= mask
+    }
+  }
+
+  /**
+   * Compute the bit-wise AND of the two sets returning the
+   * result.
+   */
+  def &(other: FixedBitSet): FixedBitSet = {
+    val newBS = new FixedBitSet(math.max(capacity, other.capacity))
+    val smaller = math.min(numWords, other.numWords)
+    assert(newBS.numWords >= numWords)
+    assert(newBS.numWords >= other.numWords)
+    var ind = 0
+    while( ind < smaller ) {
+      newBS.words(ind) = words(ind) & other.words(ind)
+      ind += 1
+    }
+    newBS
+  }
+
+  def or(other : FixedBitSet) : FixedBitSet = {
+    this.|(other)
+  }
+
+  /**
+   * Compute the bit-wise OR of the two sets returning the
+   * result.
+   */
+  def |(other: FixedBitSet): FixedBitSet = {
+    val newBS = new FixedBitSet(math.max(capacity, other.capacity))
+    assert(newBS.numWords >= numWords)
+    assert(newBS.numWords >= other.numWords)
+    val smaller = math.min(numWords, other.numWords)
+    var ind = 0
+    while( ind < smaller ) {
+      newBS.words(ind) = words(ind) | other.words(ind)
+      ind += 1
+    }
+    while( ind < numWords ) {
+      newBS.words(ind) = words(ind)
+      ind += 1
+    }
+    while( ind < other.numWords ) {
+      newBS.words(ind) = other.words(ind)
+      ind += 1
+    }
+    newBS
+  }
+
+  /**
+   * Compute the symmetric difference by performing bit-wise XOR of the two sets returning the
+   * result.
+   */
+  def ^(other: FixedBitSet): FixedBitSet = {
+    val newBS = new FixedBitSet(math.max(capacity, other.capacity))
+    val smaller = math.min(numWords, other.numWords)
+    var ind = 0
+    while (ind < smaller) {
+      newBS.words(ind) = words(ind) ^ other.words(ind)
+      ind += 1
+    }
+    if (ind < numWords) {
+      Array.copy( words, ind, newBS.words, ind, numWords - ind )
+    }
+    if (ind < other.numWords) {
+      Array.copy( other.words, ind, newBS.words, ind, other.numWords - ind )
+    }
+    newBS
+  }
+
+  /**
+   * Compute the difference of the two sets by performing bit-wise AND-NOT returning the
+   * result.
+   */
+  def andNot(other: FixedBitSet): FixedBitSet = {
+    val newBS = new FixedBitSet(capacity)
+    val smaller = math.min(numWords, other.numWords)
+    var ind = 0
+    while (ind < smaller) {
+      newBS.words(ind) = words(ind) & ~other.words(ind)
+      ind += 1
+    }
+    if (ind < numWords) {
+      Array.copy( words, ind, newBS.words, ind, numWords - ind )
+    }
+    newBS
+  }
+
+  /**
+   * Sets the bit at the specified index to true.
+   * @param index the bit index
+   */
+  def set(index: Int): Unit = {
+    val bitmask = 1L << (index & 0x3f)  // mod 64 and shift
+    words(index >> 6) |= bitmask        // div by 64 and mask
+  }
+
+  def unset(index: Int): Unit = {
+    val bitmask = 1L << (index & 0x3f)  // mod 64 and shift
+    words(index >> 6) &= ~bitmask        // div by 64 and mask
+  }
+
+  /**
+   * Return the value of the bit with the specified index. The value is true if the bit with
+   * the index is currently set in this BitSet; otherwise, the result is false.
+   *
+   * @param index the bit index
+   * @return the value of the bit with the specified index
+   */
+  def get(index: Int): Boolean = {
+    val bitmask = 1L << (index & 0x3f)   // mod 64 and shift
+    (words(index >> 6) & bitmask) != 0  // div by 64 and mask
+  }
+
+  /**
+   * Get an iterator over the set bits.
+   */
+  def iterator: Iterator[Int] = new Iterator[Int] {
+    var ind = nextSetBit(0)
+    override def hasNext: Boolean = ind >= 0
+    override def next(): Int = {
+      val tmp = ind
+      ind = nextSetBit(ind + 1)
+      tmp
+    }
+  }
+
+
+  /** Return the number of bits set to true in this BitSet. */
+  def cardinality(): Int = {
+    var sum = 0
+    var i = 0
+    while (i < numWords) {
+      sum += java.lang.Long.bitCount(words(i))
+      i += 1
+    }
+    sum
+  }
+
+  /**
+   * Returns the index of the first bit that is set to true that occurs on or after the
+   * specified starting index. If no such bit exists then -1 is returned.
+   *
+   * To iterate over the true bits in a BitSet, use the following loop:
+   *
+   *  for (int i = bs.nextSetBit(0); i >= 0; i = bs.nextSetBit(i+1)) {
+   *    // operate on index i here
+   *  }
+   *
+   * @param fromIndex the index to start checking from (inclusive)
+   * @return the index of the next set bit, or -1 if there is no such bit
+   */
+  def nextSetBit(fromIndex: Int): Int = {
+    var wordIndex = fromIndex >> 6
+    if (wordIndex >= numWords) {
+      return -1
+    }
+
+    // Try to find the next set bit in the current word
+    val subIndex = fromIndex & 0x3f
+    var word = words(wordIndex) >> subIndex
+    if (word != 0) {
+      return (wordIndex << 6) + subIndex + java.lang.Long.numberOfTrailingZeros(word)
+    }
+
+    // Find the next set bit in the rest of the words
+    wordIndex += 1
+    while (wordIndex < numWords) {
+      word = words(wordIndex)
+      if (word != 0) {
+        return (wordIndex << 6) + java.lang.Long.numberOfTrailingZeros(word)
+      }
+      wordIndex += 1
+    }
+
+    -1
+  }
+
+  /**
+   * Compute bit-wise union with another BitSet and overwrite bits in this BitSet with the result.
+   */
+  def union(other: FixedBitSet): Unit = {
+    require(this.numWords <= other.numWords)
+    var ind = 0
+    while( ind < this.numWords ) {
+      this.words(ind) = this.words(ind) | other.words(ind)
+      ind += 1
+    }
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/GSPartitioner.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/GSPartitioner.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import org.apache.spark.Partitioner
+import org.apache.spark.internal.Logging
+import org.apache.spark.util.Utils
+
+import scala.reflect.ClassTag
+
+class GSPartitioner[K : Ordering : ClassTag](val numPartition : Int) extends Partitioner with  Logging{
+
+  override def numPartitions: Int = numPartition
+
+  override def getPartition(key: Any): Int = {
+    key.hashCode()
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/GrapeMeta.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/GrapeMeta.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import com.alibaba.graphscope.graphx.rdd.RoutingTable
+import com.alibaba.graphscope.graphx.rdd.impl.GrapeEdgePartitionBuilder
+import com.alibaba.graphscope.graphx.store.EdgeDataStore
+import com.alibaba.graphscope.graphx.{GraphXCSR, GraphXVertexMap, LocalVertexMap, VineyardClient}
+import org.apache.spark.internal.Logging
+
+import scala.reflect.ClassTag
+
+class GrapeMeta[VD: ClassTag, ED: ClassTag](val partitionID: Int, val partitionNum : Int, val vineyardClient : VineyardClient, val hostName : String) extends Logging {
+
+  var localVertexMap : LocalVertexMap[Long,Long] = null.asInstanceOf[LocalVertexMap[Long,Long]]
+  var edgePartitionBuilder : GrapeEdgePartitionBuilder[VD,ED] = null.asInstanceOf[GrapeEdgePartitionBuilder[VD,ED]]
+  var globalVMId : Long = -1
+  var globalVM : GraphXVertexMap[Long,Long] = null.asInstanceOf[GraphXVertexMap[Long,Long]]
+  var graphxCSR :GraphXCSR[Long] = null.asInstanceOf[GraphXCSR[Long]]
+  var routingTable : RoutingTable = null.asInstanceOf[RoutingTable]
+  var edataStore : EdgeDataStore[ED] = null.asInstanceOf[EdgeDataStore[ED]]
+
+  def setLocalVertexMap(in : LocalVertexMap[Long,Long]): Unit ={
+    this.localVertexMap = in
+  }
+
+  def setEdgePartitionBuilder(edgePartitionBuilder: GrapeEdgePartitionBuilder[VD,ED]) = {
+    this.edgePartitionBuilder = edgePartitionBuilder
+  }
+
+  def setEdataStore(ed : EdgeDataStore[ED]) : Unit = {
+    this.edataStore = ed
+  }
+
+  def setGlobalVM(globalVMId : Long) : Unit = {
+    log.info(s"setting global vm id ${globalVMId}")
+    this.globalVMId = globalVMId
+  }
+
+  def setGlobalVM(globalVM : GraphXVertexMap[Long,Long]) : Unit = {
+    this.globalVM = globalVM
+  }
+
+  def setCSR(csr : GraphXCSR[Long]) : Unit = {
+    this.graphxCSR = csr
+  }
+
+  def setRoutingTable(routingTable: RoutingTable) : Unit = {
+    this.routingTable = routingTable
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/GrapeUtils.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/GrapeUtils.scala
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import com.alibaba.fastffi.impl.CXXStdString
+import com.alibaba.graphscope.arrow.array.ArrowArrayBuilder
+import com.alibaba.graphscope.graphx._
+import com.alibaba.graphscope.graphx.store.impl.OffHeapEdgeDataStore
+import com.alibaba.graphscope.serialization.FFIByteVectorOutputStream
+import com.alibaba.graphscope.stdcxx.{FFIByteVector, FFIIntVector, FFIIntVectorFactory, StdMap, StdVector}
+import com.alibaba.graphscope.utils.ThreadSafeBitSet
+import com.alibaba.graphscope.utils.array.PrimitiveArray
+import org.apache.spark.graphx.PartitionID
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+
+import java.io.ObjectOutputStream
+import java.lang.reflect.Method
+import java.math.{MathContext, RoundingMode}
+import java.net.{InetAddress, UnknownHostException}
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+object GrapeUtils extends Logging{
+  val BATCH_SIZE = 4096
+
+  def class2Int(value: Class[_]): Int = {
+    if (value.equals(classOf[java.lang.Long]) || value.equals(classOf[Long])) {
+      4
+    }
+    else if (value.equals(classOf[java.lang.Integer]) || value.equals(classOf[Int])) {
+      2
+    }
+    else if (value.equals(classOf[java.lang.Double]) || value.eq(classOf[Double])) {
+      7
+    }
+    else throw new IllegalArgumentException(s"unexpected class ${value}")
+  }
+  def bytesForType[VD: ClassTag](value: Class[VD]): Int ={
+    if (value.equals(classOf[Long]) || value.equals(classOf[Double])) 8
+    else if (value.eq(classOf[Int]) || value.equals(classOf[Float])) 4
+    else throw new IllegalStateException("Unrecognized : " + value.getName)
+  }
+
+  def classToStr(value : Class[_], signed : Boolean = true) : String = {
+    if (value.equals(classOf[java.lang.Long]) || value.equals(classOf[Long])) {
+      if (signed) "int64_t"
+      else "uint64_t"
+    }
+    else if (value.equals(classOf[java.lang.Integer]) || value.equals(classOf[Int])) {
+      if (signed) "int32_t"
+      else "uint32_t"
+    }
+    else if (value.equals(classOf[java.lang.Double]) || value.eq(classOf[Double])) {
+      "double"
+    }
+    else if (value.equals(classOf[Json])){
+      "vineyard::json"
+    }
+    else {
+      "std::string"
+    }
+  }
+
+  def getMethodFromClass[T](clz : Class[T], name : String ,paramClasses : Class[_]) : Method = {
+    val method = clz.getDeclaredMethod(name, paramClasses)
+    method.setAccessible(true)
+    require(method != null, "can not find method: " + name)
+    method
+  }
+
+  def generateForeignFragName[VD: ClassTag, ED : ClassTag](vdClass : Class[VD], edClass : Class[ED]): String ={
+    new StringBuilder().+("gs::ArrowProjectedFragment<int64_t,uint64_t").+(classToStr(vdClass)).+(",").+(classToStr(edClass)).+(">")
+  }
+
+  def scalaClass2JavaClass[T: ClassTag](vdClass : Class[T]) : Class[_] = {
+    if (vdClass.equals(classOf[Int])) {
+      classOf[Integer];
+    }
+    else if (vdClass.equals(classOf[Long])) {
+      classOf[java.lang.Long]
+    }
+    else if (vdClass.equals(classOf[Double])) {
+      classOf[java.lang.Double]
+    }
+    else {
+      throw new IllegalStateException("transform failed for " + vdClass.getName);
+    }
+  }
+
+  def getRuntimeClass[T: ClassTag] = implicitly[ClassTag[T]].runtimeClass.asInstanceOf[Class[T]]
+
+  def isPrimitive[T : ClassTag] : Boolean = {
+    val clz = getRuntimeClass[T]
+    clz.equals(classOf[Double]) || clz.equals(classOf[Long]) || clz.equals(classOf[Int]) || clz.equals(classOf[Float])
+  }
+
+  @throws[UnknownHostException]
+  def getSelfHostName = InetAddress.getLocalHost.getHostName
+
+  def dedup(files: Array[String]): Array[String] = {
+    val set = files.toSet
+    set.toArray
+  }
+
+  /**
+   * used to transform offset base edata store to eids based store.
+   * @tparam T data type
+   */
+  def rearrangeArrayWithIndex[T : ClassTag](array : PrimitiveArray[T], index : PrimitiveArray[Long]) : PrimitiveArray[T] = {
+    val len = array.size()
+    require(index.size() == len, s"array size ${len} neq eids array ${index.size()}")
+    val newArray = PrimitiveArray.create(getRuntimeClass[T], len).asInstanceOf[PrimitiveArray[T]]
+    var i = 0
+    while (i < len){
+      newArray.set(i, array.get(index.get(i)))
+      i += 1
+    }
+    newArray
+  }
+
+  def fillPrimitiveArrowArrayBuilder[T : ClassTag](array: Array[T]) : ArrowArrayBuilder[T] = {
+    val size = array.length
+    var i = 0
+    val arrowArrayBuilder = ScalaFFIFactory.newArrowArrayBuilder[T](GrapeUtils.getRuntimeClass[T].asInstanceOf[Class[T]])
+    arrowArrayBuilder.reserve(size)
+    while (i < size) {
+      arrowArrayBuilder.unsafeAppend(array(i))
+      i += 1
+    }
+    arrowArrayBuilder
+  }
+  def fillPrimitiveVector[T : ClassTag](array: Array[T], numThread : Int) : StdVector[T] = {
+    val time0 = System.nanoTime()
+    val size = array.length
+    val vector = ScalaFFIFactory.newVector[T]
+    vector.resize(size)
+    val threadArray = new Array[Thread](numThread)
+    val atomic = new AtomicInteger(0)
+    for (i <- 0 until numThread){
+      threadArray(i) = new Thread(){
+        override def run(): Unit ={
+          var flag = true
+          while (flag){
+            val begin = Math.min(atomic.getAndAdd(BATCH_SIZE), size)
+            val end = Math.min(begin + BATCH_SIZE, size)
+            if (begin >= end){
+              flag = false
+            }
+            else {
+              var i = begin
+              while (i < end){
+                vector.set(i, array(i))
+                i += 1
+              }
+            }
+          }
+        }
+      }
+      threadArray(i).start()
+    }
+    for (i <- 0 until numThread){
+      threadArray(i).join()
+    }
+    val time1 = System.nanoTime()
+    log.info(s"Building primitive array size ${size} with num thread ${numThread} cost ${(time1 - time0)/1000000}ms")
+    vector
+  }
+  def fillPrimitiveVineyardArray[T : ClassTag](array: Array[T], vineyardBuilder : VineyardArrayBuilder[T], numThread : Int) : Unit = {
+    val time0 = System.nanoTime()
+    val size = array.length
+    val threadArray = new Array[Thread](numThread)
+    val atomic = new AtomicInteger(0)
+    for (i <- 0 until numThread){
+      threadArray(i) = new Thread(){
+        override def run(): Unit ={
+          var flag = true
+          while (flag){
+            val begin = Math.min(atomic.getAndAdd(BATCH_SIZE), size)
+            val end = Math.min(begin + BATCH_SIZE, size)
+            if (begin >= end){
+              flag = false
+            }
+            else {
+              var i = begin
+              while (i < end){
+                vineyardBuilder.set(i, array(i))
+                i += 1
+              }
+            }
+          }
+        }
+      }
+      threadArray(i).start()
+    }
+    for (i <- 0 until numThread){
+      threadArray(i).join()
+    }
+    val time1 = System.nanoTime()
+    log.info(s"Building primitive array size ${size} with num thread ${numThread} cost ${(time1 - time0)/1000000}ms")
+  }
+
+  def fillVertexStringArrowArray[T : ClassTag](array: Array[T]) : (FFIByteVector, FFIIntVector) = {//,activeVertices : ThreadSafeBitSet
+    val size = array.length
+    val ffiByteVectorOutput = new FFIByteVectorOutputStream()
+    val ffiOffset = FFIIntVectorFactory.INSTANCE.create().asInstanceOf[FFIIntVector]
+    ffiOffset.resize(size)
+    ffiOffset.touch()
+    var i = 0
+    val limit = size
+    var prevBytesWritten = 0
+    var nullCount = 0
+    if (getRuntimeClass[T] == classOf[DoubleDouble]){
+      ffiByteVectorOutput.getVector.resize(size * 16)
+      ffiByteVectorOutput.getVector.touch()
+      val castedArray = array.asInstanceOf[Array[DoubleDouble]]
+      while (i < limit){
+        val dd = castedArray(i)
+        require(dd != null, s"pos ${i}/${limit} is null")
+        ffiByteVectorOutput.writeDouble(dd.a)
+        ffiByteVectorOutput.writeDouble(dd.b)
+        ffiOffset.set(i, ffiByteVectorOutput.bytesWriten().toInt - prevBytesWritten)
+        prevBytesWritten = ffiByteVectorOutput.bytesWriten().toInt
+        i += 1
+      }
+    }
+    else {
+      val objectOutputStream = new ObjectOutputStream(ffiByteVectorOutput)
+      while (i < limit && i >= 0) {
+        if (array(i) == null) {
+          nullCount += 1
+        }
+        objectOutputStream.writeObject(array(i))
+        ffiOffset.set(i, ffiByteVectorOutput.bytesWriten().toInt - prevBytesWritten)
+        prevBytesWritten = ffiByteVectorOutput.bytesWriten().toInt
+        i += 1
+      }
+      objectOutputStream.flush()
+    }
+
+    ffiByteVectorOutput.finishSetting()
+    val writenBytes = ffiByteVectorOutput.bytesWriten()
+    log.info(s"write data array ${limit} of type ${GrapeUtils.getRuntimeClass[T].getName}, writen bytes ${writenBytes}")
+    (ffiByteVectorOutput.getVector,ffiOffset)
+  }
+  def fillVertexTupleArrowArray[T : ClassTag](array: Array[T],activeVertices : ThreadSafeBitSet) : (FFIByteVector, FFIIntVector) = {
+    val size = array.length
+    val ffiByteVectorOutput = new FFIByteVectorOutputStream()
+    //    val output = new Output(ffiByteVectorOutput)
+    val ffiOffset = FFIIntVectorFactory.INSTANCE.create().asInstanceOf[FFIIntVector]
+    ffiOffset.resize(size)
+    ffiOffset.touch()
+    val objectOutputStream = new ObjectOutputStream(ffiByteVectorOutput)
+    var i = activeVertices.nextSetBit(0)
+    val limit = size
+    var prevBytesWritten = 0
+    var nullCount = 0
+    while (i < limit && i >= 0){
+      if (array(i) == null){
+        nullCount +=1
+      }
+      objectOutputStream.writeObject(array(i))
+      ffiOffset.set(i, ffiByteVectorOutput.bytesWriten().toInt - prevBytesWritten)
+      prevBytesWritten = ffiByteVectorOutput.bytesWriten().toInt
+      i += 1
+    }
+    log.info(s"total size ${size} null count ${nullCount}, active ${activeVertices.cardinality()}")
+    //require(size == (nullCount + activeVertices.cardinality()))
+    objectOutputStream.flush()
+    ffiByteVectorOutput.finishSetting()
+    val writenBytes = ffiByteVectorOutput.bytesWriten()
+    log.info(s"write data array ${limit} of type ${GrapeUtils.getRuntimeClass[T].getName}, writen bytes ${writenBytes}")
+    (ffiByteVectorOutput.getVector,ffiOffset)
+  }
+
+  def fillEdgeStringArrowArray[T : ClassTag](array: Array[T]) : (FFIByteVector, FFIIntVector) = {
+    val size = array.length
+    val ffiByteVectorOutput = new FFIByteVectorOutputStream()
+    val ffiOffset = FFIIntVectorFactory.INSTANCE.create().asInstanceOf[FFIIntVector]
+    ffiOffset.resize(size)
+    ffiOffset.touch()
+    val objectOutputStream = new ObjectOutputStream(ffiByteVectorOutput)
+    val limit = size
+    var i = 0
+    var prevBytesWritten = 0
+    var nullCount = 0
+    while (i < limit && i >= 0){
+      if (array(i) == null){
+        nullCount +=1
+      }
+      objectOutputStream.writeObject(array(i))
+      ffiOffset.set(i, ffiByteVectorOutput.bytesWriten().toInt - prevBytesWritten)
+      prevBytesWritten = ffiByteVectorOutput.bytesWriten().toInt
+      i += 1
+    }
+    objectOutputStream.flush()
+    ffiByteVectorOutput.finishSetting()
+    val writenBytes = ffiByteVectorOutput.bytesWriten()
+    log.info(s"write data array ${limit} of type ${GrapeUtils.getRuntimeClass[T].getName}, writen bytes ${writenBytes}")
+    (ffiByteVectorOutput.getVector,ffiOffset)
+  }
+
+
+  def array2PrimitiveVertexData[T: ClassTag](array : Array[T], client : VineyardClient) : VertexData[Long,T] = {
+    val newVdataBuilder = ScalaFFIFactory.newVertexDataBuilder[T](client,array.length,null.asInstanceOf[T])
+    val valuesBuilder = newVdataBuilder.getArrayBuilder
+    var i = 0
+    while (i < array.length){
+      valuesBuilder.set(i, array(i))
+      i += 1
+    }
+    newVdataBuilder.seal(client).get()
+  }
+
+  def array2PrimitiveEdgeData[T: ClassTag](array : Array[T], client : VineyardClient, numThread : Int) : EdgeData[Long,T] = {
+    val newEdataBuilder = ScalaFFIFactory.newEdgeDataBuilder[T](client,array.size)
+    fillPrimitiveVineyardArray(array,newEdataBuilder.getArrayBuilder,numThread)
+    newEdataBuilder.seal(client).get()
+  }
+
+  def array2StringVertexData[T : ClassTag](array: Array[T],
+                                           client: VineyardClient) : StringVertexData[Long,CXXStdString] = {
+    val (ffiByteVector,ffiIntVector) = fillVertexStringArrowArray(array)
+    val newVdataBuilder = ScalaFFIFactory.newStringVertexDataBuilder()
+    newVdataBuilder.init(array.length, ffiByteVector, ffiIntVector)
+    newVdataBuilder.seal(client).get()
+  }
+
+  def bitSet2longs(bitSetWithOffset: BitSetWithOffset) : ArrowArrayBuilder[Long] = {
+    val longVector = ScalaFFIFactory.newSignedLongArrayBuilder()
+    val words = bitSetWithOffset.bitset.words
+    longVector.reserve(words.length)
+    var i = 0
+    while (i < words.length){
+      longVector.unsafeAppend(words(i))
+      i += 1
+    }
+    longVector
+  }
+  def bitSet2longs(bitSetWithOffset: ThreadSafeBitSet) : ArrowArrayBuilder[Long] = {
+    val longVector = ScalaFFIFactory.newSignedLongArrayBuilder()
+    val words = bitSetWithOffset.getWords
+    longVector.reserve(words.length)
+    var i = 0
+    while (i < words.length){
+      longVector.unsafeAppend(words(i))
+      i += 1
+    }
+    longVector
+  }
+
+  def array2StringEdgeData[T : ClassTag](array: Array[T],client: VineyardClient) : StringEdgeData[Long,CXXStdString] = {
+    val (ffiByteVector,ffiIntVector) = fillEdgeStringArrowArray(array)
+    val newEdataBuilder = ScalaFFIFactory.newStringEdgeDataBuilder()
+    newEdataBuilder.init(array.length, ffiByteVector, ffiIntVector)
+    newEdataBuilder.seal(client).get()
+  }
+
+  def buildPrimitiveEdgeData[T : ClassTag](edgeStore : OffHeapEdgeDataStore[T], client : VineyardClient, localNum : Int): EdgeData[Long,T]  = {
+    edgeStore.edataBuilder.seal(client).get()
+  }
+
+  /**
+   * Convert a quantity in bytes to a human-readable string such as "4.0 MiB".
+   */
+  def bytesToString(size: Long): String = bytesToString(BigInt(size))
+
+  def bytesToString(size: BigInt): String = {
+    val EiB = 1L << 60
+    val PiB = 1L << 50
+    val TiB = 1L << 40
+    val GiB = 1L << 30
+    val MiB = 1L << 20
+    val KiB = 1L << 10
+
+    if (size >= BigInt(1L << 11) * EiB) {
+      // The number is too large, show it in scientific notation.
+      BigDecimal(size, new MathContext(3, RoundingMode.HALF_UP)).toString() + " B"
+    } else {
+      val (value, unit) = {
+        if (size >= 2 * EiB) {
+          (BigDecimal(size) / EiB, "EiB")
+        } else if (size >= 2 * PiB) {
+          (BigDecimal(size) / PiB, "PiB")
+        } else if (size >= 2 * TiB) {
+          (BigDecimal(size) / TiB, "TiB")
+        } else if (size >= 2 * GiB) {
+          (BigDecimal(size) / GiB, "GiB")
+        } else if (size >= 2 * MiB) {
+          (BigDecimal(size) / MiB, "MiB")
+        } else if (size >= 2 * KiB) {
+          (BigDecimal(size) / KiB, "KiB")
+        } else {
+          (BigDecimal(size), "B")
+        }
+      }
+      "%.1f %s".formatLocal(Locale.US, value, unit)
+    }
+  }
+
+  def extractHostInfo[VD : ClassTag, ED : ClassTag](rdd : RDD[(Int,_)], numPartition : Int) : (Array[String], Array[Int]) = {
+    val array = rdd.mapPartitionsWithIndex((ind,iter) => {
+      if (iter.hasNext){
+        val set = new mutable.BitSet()
+        while (iter.hasNext){
+          val (ind,_) = iter.next()
+          set.add(ind)
+        }
+        set.toIterator.map(a => (a,InetAddress.getLocalHost.getHostName))
+      }
+      else Iterator.empty
+    }).collect()
+    log.info(s"num Partitions ${rdd.getNumPartitions}, collected size ${array.length} ele: ${array.mkString(",")}")
+    require(array.length == numPartition, s"result array neq num partitions ${array.length} , ${numPartition}")
+    val tmpMap = new mutable.HashMap[String,ArrayBuffer[Int]]()
+    for (tuple <- array){
+      val host = tuple._2
+      val pid = tuple._1
+      if (!tmpMap.contains(host)) {
+        tmpMap(host) = new ArrayBuffer[PartitionID]()
+      }
+      tmpMap(host).+=(pid)
+    }
+    val numPart = array.length
+    val res = new Array[Int](numPart)
+    val keys = tmpMap.keys.iterator
+    var i = 0
+    while (keys.hasNext){
+      val key = keys.next()
+      val values = tmpMap(key)
+      for (pid <- values){
+        res(pid) = i
+      }
+      i += 1
+    }
+    (tmpMap.keys.toArray,res)
+  }
+
+  def getHostIdStrFromFragmentGroup(client: VineyardClient,groupId : Long) : String = {
+    val fragmentGroupGetter = ScalaFFIFactory.newFragmentGroupGetter()
+    val fragmentGroup = fragmentGroupGetter.get(client, groupId).get()
+    val fnum = fragmentGroup.totalFragNum()
+    log.info(s"group ${groupId} got totally ${fnum} fragments.")
+    val locations = fragmentGroup.fragmentLocations()
+    val fragments = fragmentGroup.fragments()
+    val instances = new Array[Long](fnum)
+    val fragIds = new Array[Long](fnum)
+    for (i <- 0 until fnum){
+      instances(i) = locations.get(i)
+      fragIds(i) = fragments.get(i)
+    }
+    log.info(s"frag ids ${fragIds.mkString(",")}")
+    log.info(s"instances ${instances.mkString(",")}")
+    //get host info from instances.
+    val clusterInfo = ScalaFFIFactory.newStdMap[Long,Json](signed = false) //uint64_t
+    val status = client.clusterInfo(clusterInfo.asInstanceOf[StdMap[java.lang.Long,Json]])
+    require(status.ok())
+    log.info(s"got cluster info ${clusterInfo}")
+    val jsons = instances.map(instance => clusterInfo.get(instance)).map(_.dump().toString)
+    log.info(s"got jsons ${jsons.mkString(",")}")
+    val hostNames = jsons.map(json => com.alibaba.fastjson.JSON.parseObject(json).getString("hostname"))
+    fragIds.indices.map(i => hostNames(i) + ":" + fragIds(i)).mkString(",")
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/IdParser.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/IdParser.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import org.apache.spark.internal.Logging
+
+class IdParser(val fnum : Int)extends Logging{
+  var fid_offset = 0
+  var id_mask = 0
+  init()
+
+  def init() : Unit = {
+    var maxFid = fnum - 1
+    if (maxFid == 0){
+      fid_offset = 63
+    }
+    else {
+      var i = 0
+      while (maxFid > 0){
+        maxFid = (maxFid >>> 1)
+        i += 1
+      }
+      fid_offset = 64 - i
+    }
+    id_mask = (1 << fid_offset) - 1
+  }
+
+  def getLocalId(gid : Long) : Long = {
+    gid & id_mask
+  }
+
+  @inline
+  def getFragId(gid : Long) : Int = {
+    (gid >>> fid_offset).toInt
+  }
+
+  def generateGlobalId(fid : Int, lid : Long) : Long = {
+    val fidLong = fid.toLong
+    val res = (fidLong << fid_offset)
+    res | lid
+  }
+
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/LongVectorBuilder.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/LongVectorBuilder.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import com.alibaba.graphscope.graphx.utils.LongVectorBuilder.initSize
+import com.alibaba.graphscope.stdcxx.StdVector
+
+class LongVectorBuilder() {
+  val data : StdVector[Long] = ScalaFFIFactory.newLongVector
+  data.resize(initSize)
+  var curSize = 0
+
+  def add(value : Long) : Unit = {
+    check
+    data.set(curSize, value)
+    curSize += 1
+  }
+
+  def finish() : StdVector[Long] = {
+    data.resize(curSize)
+    data
+  }
+
+  def check : Unit = {
+    if (curSize >= data.size()){
+      val oldSize = data.size()
+      data.resize(oldSize * 2)
+    }
+  }
+}
+object LongVectorBuilder{
+  val initSize = 64
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/PrimitiveVector.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/PrimitiveVector.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import scala.reflect.ClassTag
+
+/**
+ * An append-only, non-threadsafe, array-backed vector that is optimized for primitive types.
+ */
+class PrimitiveVector[@specialized(Long, Int, Double) V: ClassTag](initialSize: Int = 64) extends Serializable {
+  private var _numElements = 0
+  private var _array: Array[V] = _
+
+  // NB: This must be separate from the declaration, otherwise the specialized parent class
+  // will get its own array with the same initial size.
+  _array = new Array[V](initialSize)
+
+  def this() = {
+    this(64)
+  }
+
+  def apply(index: Int): V = {
+    require(index < _numElements)
+    _array(index)
+  }
+
+  def +=(value: V): Unit = {
+    if (_numElements == _array.length) {
+      resize(_array.length * 2)
+    }
+    _array(_numElements) = value
+    _numElements += 1
+  }
+
+  def capacity: Int = _array.length
+
+  def length: Int = _numElements
+
+  def size: Int = _numElements
+
+  def iterator: Iterator[V] = new Iterator[V] {
+    var index = 0
+    override def hasNext: Boolean = index < _numElements
+    override def next(): V = {
+      if (!hasNext) {
+        throw new NoSuchElementException
+      }
+      val value = _array(index)
+      index += 1
+      value
+    }
+  }
+
+  /** Gets the underlying array backing this vector. */
+  def array: Array[V] = _array
+
+  /** Trims this vector so that the capacity is equal to the size. */
+  def trim(): PrimitiveVector[V] = resize(size)
+
+  /** Resizes the array, dropping elements if the total length decreases. */
+  def resize(newLength: Int): PrimitiveVector[V] = {
+    _array = copyArrayWithLength(newLength)
+    if (newLength < _numElements) {
+      _numElements = newLength
+    }
+    this
+  }
+
+  /** Return a trimmed version of the underlying array. */
+  def toArray: Array[V] = {
+    copyArrayWithLength(size)
+  }
+
+  private def copyArrayWithLength(length: Int): Array[V] = {
+    val copy = new Array[V](length)
+    _array.copyToArray(copy)
+    copy
+  }
+}
+

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/ScalaFFIFactory.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/ScalaFFIFactory.scala
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import com.alibaba.fastffi.FFITypeFactory
+import com.alibaba.fastffi.impl.CXXStdString
+import com.alibaba.graphscope.arrow.array.ArrowArrayBuilder
+import com.alibaba.graphscope.fragment.adaptor.ArrowProjectedAdaptor
+import com.alibaba.graphscope.fragment.{ArrowFragmentGroupGetter, ArrowProjectedFragmentGetter, ArrowProjectedFragmentMapper, IFragment}
+import com.alibaba.graphscope.graphx._
+import com.alibaba.graphscope.stdcxx.{StdMap, StdVector}
+import org.apache.spark.internal.Logging
+
+import java.util.HashMap
+import scala.reflect.ClassTag
+
+object ScalaFFIFactory extends Logging{
+  private val arrowArrayBuilderMap = new HashMap[String, ArrowArrayBuilder.Factory[_]]
+  val clientFactory : VineyardClient.Factory = FFITypeFactory.getFactory(classOf[VineyardClient],"vineyard::Client").asInstanceOf[VineyardClient.Factory]
+  def newLocalVertexMapBuilder(client : VineyardClient, innerOids : ArrowArrayBuilder[Long],
+                               outerOids : ArrowArrayBuilder[Long],
+                               pids : ArrowArrayBuilder[Int]): BasicLocalVertexMapBuilder[Long,Long] = synchronized{
+     val localVertexMapBuilderFactory = FFITypeFactory.getFactory(classOf[BasicLocalVertexMapBuilder[Long,Long]], "gs::BasicLocalVertexMapBuilder<int64_t,uint64_t>").asInstanceOf[BasicLocalVertexMapBuilder.Factory[Long,Long]]
+    localVertexMapBuilderFactory.create(client, innerOids, outerOids,pids.asInstanceOf[ArrowArrayBuilder[java.lang.Integer]])
+  }
+
+  def getArrowArrayBuilderFactory(foreignTypeName: String): ArrowArrayBuilder.Factory[_] = synchronized{
+    if (!arrowArrayBuilderMap.containsKey(foreignTypeName)) {
+      synchronized{
+        if (!arrowArrayBuilderMap.containsKey(foreignTypeName)){
+          arrowArrayBuilderMap.put(foreignTypeName, FFITypeFactory.getFactory(classOf[ArrowArrayBuilder[_]], foreignTypeName))
+        }
+      }
+    }
+    arrowArrayBuilderMap.get(foreignTypeName)
+  }
+
+  def newArrowArrayBuilder[T : ClassTag](clz: Class[T]): ArrowArrayBuilder[T] = synchronized{
+    if (clz.equals(classOf[java.lang.Long]) || clz.equals(classOf[Long])){
+      getArrowArrayBuilderFactory("gs::ArrowArrayBuilder<int64_t>").create().asInstanceOf[ArrowArrayBuilder[T]]
+    }
+    else if (clz.equals(classOf[java.lang.Double]) || clz.equals(classOf[Double])){
+      getArrowArrayBuilderFactory("gs::ArrowArrayBuilder<double>").create().asInstanceOf[ArrowArrayBuilder[T]]
+    }
+    else if (clz.equals(classOf[Integer]) || clz.equals(classOf[Int])){
+      getArrowArrayBuilderFactory("gs::ArrowArrayBuilder<int32_t>").create().asInstanceOf[ArrowArrayBuilder[T]]
+    }
+    else throw new IllegalStateException("Not recognized " + clz.getName)
+  }
+
+  def newLongVector : StdVector[Long] = synchronized{
+    val factory = FFITypeFactory.getFactory(classOf[StdVector[Long]],
+      "std::vector<int64_t>").asInstanceOf[StdVector.Factory[Long]]
+    factory.create()
+  }
+  def newIntVector : StdVector[Int] = synchronized{
+    val factory = FFITypeFactory.getFactory(classOf[StdVector[Int]],
+      "std::vector<int32_t>").asInstanceOf[StdVector.Factory[Int]]
+    factory.create()
+  }
+
+  def newDoubleVector : StdVector[Double] = synchronized{
+    val factory = FFITypeFactory.getFactory(classOf[StdVector[Double]],
+      "std::vector<double>").asInstanceOf[StdVector.Factory[Double]]
+    factory.create()
+  }
+
+  def newVector[T : ClassTag] : StdVector[T] = synchronized{
+    if (GrapeUtils.getRuntimeClass[T].equals(classOf[Long])) newLongVector.asInstanceOf[StdVector[T]]
+    else if (GrapeUtils.getRuntimeClass[T].equals(classOf[Int])) newIntVector.asInstanceOf[StdVector[T]]
+    else if (GrapeUtils.getRuntimeClass[T].equals(classOf[Double])) newDoubleVector.asInstanceOf[StdVector[T]]
+    else throw new IllegalArgumentException(s"unsupported ${GrapeUtils.getRuntimeClass[T].getName}")
+  }
+
+  def newUnsignedLongArrayBuilder(): ArrowArrayBuilder[Long] = synchronized{
+    getArrowArrayBuilderFactory("gs::ArrowArrayBuilder<uint64_t>").create().asInstanceOf[ArrowArrayBuilder[Long]]
+  }
+  def newSignedLongArrayBuilder(): ArrowArrayBuilder[Long] = synchronized{
+    getArrowArrayBuilderFactory("gs::ArrowArrayBuilder<int64_t>").create().asInstanceOf[ArrowArrayBuilder[Long]]
+  }
+  def newSignedIntArrayBuilder(): ArrowArrayBuilder[Int] = synchronized{
+    getArrowArrayBuilderFactory("gs::ArrowArrayBuilder<int32_t>").create().asInstanceOf[ArrowArrayBuilder[Int]]
+  }
+
+  def newVertexMapGetter() : GraphXVertexMapGetter[Long,Long] = synchronized {
+    val factory = FFITypeFactory.getFactory(classOf[GraphXVertexMapGetter[Long,Long]], "gs::GraphXVertexMapGetter<int64_t,uint64_t>").asInstanceOf[GraphXVertexMapGetter.Factory[Long,Long]]
+    factory.create()
+  }
+
+  def newVertexDataGetter[VD : ClassTag] : VertexDataGetter[Long,VD] = synchronized {
+    val factory = FFITypeFactory.getFactory(classOf[VertexDataGetter[Long,VD]],
+      "gs::VertexDataGetter<uint64_t," + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[VD]) + ">")
+      .asInstanceOf[VertexDataGetter.Factory[Long,VD]]
+    factory.create()
+  }
+  def newStringVertexDataGetter: StringVertexDataGetter[Long,CXXStdString] = synchronized {
+    val factory = FFITypeFactory.getFactory(classOf[StringVertexDataGetter[Long,CXXStdString]],
+      "gs::VertexDataGetter<uint64_t,std::string>")
+      .asInstanceOf[StringVertexDataGetter.Factory[Long,CXXStdString]]
+    factory.create()
+  }
+
+  def newGraphXCSRBuilder(client : VineyardClient) : BasicGraphXCSRBuilder[Long,Long] = synchronized {
+    val factory = FFITypeFactory.getFactory(classOf[BasicGraphXCSRBuilder[Long,Long]],
+      "gs::BasicGraphXCSRBuilder<int64_t,uint64_t>").asInstanceOf[BasicGraphXCSRBuilder.Factory[Long,Long]]
+    factory.create(client)
+  }
+
+  def newVertexDataBuilder[VD: ClassTag](client: VineyardClient, fragVnums : Int, defaultVD : VD = null) : VertexDataBuilder[Long,VD] = synchronized {
+    val factory = FFITypeFactory.getFactory(classOf[VertexDataBuilder[Long,VD]],
+      "gs::VertexDataBuilder<uint64_t," + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[VD]) +">").asInstanceOf[VertexDataBuilder.Factory[Long,VD]]
+    if (defaultVD == null) {factory.create(client,fragVnums)}
+    else factory.create(client,fragVnums,defaultVD)
+  }
+
+  def newEdgeDataBuilder[VD: ClassTag](client : VineyardClient, size : Int) : EdgeDataBuilder[Long,VD] = synchronized{
+    val factory = FFITypeFactory.getFactory(classOf[EdgeDataBuilder[Long,VD]],
+      "gs::EdgeDataBuilder<uint64_t," + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[VD]) +">").asInstanceOf[EdgeDataBuilder.Factory[Long,VD]]
+    factory.create(client,size)
+  }
+
+  def newVineyardArrayBuilder[T : ClassTag](client : VineyardClient, size : Int) : VineyardArrayBuilder[T] = {
+    val factory = FFITypeFactory.getFactory(classOf[VineyardArrayBuilder[T]],
+      "vineyard::ArrayBuilder<" + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[T]) +">").asInstanceOf[VineyardArrayBuilder.Factory[T]]
+    factory.create(client,size)
+  }
+
+  def newStringVertexDataBuilder() : StringVertexDataBuilder[Long,CXXStdString] = synchronized{
+    val factory = FFITypeFactory.getFactory(classOf[StringVertexDataBuilder[Long,CXXStdString]],
+      "gs::VertexDataBuilder<uint64_t,std::string>").asInstanceOf[StringVertexDataBuilder.Factory[Long,CXXStdString]]
+    factory.create()
+  }
+
+  def newStringEdgeDataBuilder() : StringEdgeDataBuilder[Long,CXXStdString] = synchronized {
+    val factory = FFITypeFactory.getFactory(classOf[StringEdgeDataBuilder[Long,CXXStdString]],
+      "gs::EdgeDataBuilder<uint64_t,std::string>").asInstanceOf[StringEdgeDataBuilder.Factory[Long,CXXStdString]]
+    factory.create()
+  }
+
+  def newVineyardClient() : VineyardClient = synchronized{
+    synchronized{
+      clientFactory.create()
+    }
+  }
+
+  def newGraphXFragmentBuilder[VD : ClassTag,ED : ClassTag](client : VineyardClient, vmId : Long, csrId : Long, vdId : Long, edId : Long) : GraphXFragmentBuilder[Long,Long,VD,ED] = synchronized{
+    require(GrapeUtils.isPrimitive[VD] && GrapeUtils.isPrimitive[ED])
+    val factory = FFITypeFactory.getFactory(classOf[GraphXFragmentBuilder[Long,Long,VD,ED]], "gs::GraphXFragmentBuilder<int64_t,uint64_t," +
+        GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[VD]) + "," + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[ED]) + ">").asInstanceOf[GraphXFragmentBuilder.Factory[Long,Long,VD,ED]]
+    factory.create(client, vmId, csrId,vdId,edId)
+  }
+
+  def newGraphXFragmentBuilder[VD : ClassTag,ED : ClassTag](client : VineyardClient, vm : GraphXVertexMap[Long,Long], csr : GraphXCSR[Long], vertexData : VertexData[Long,VD], edata : EdgeData[Long,ED]) : GraphXFragmentBuilder[Long,Long,VD,ED] = synchronized{
+    require(GrapeUtils.isPrimitive[VD] && GrapeUtils.isPrimitive[ED])
+    val factory = FFITypeFactory.getFactory(classOf[GraphXFragmentBuilder[Long,Long,VD,ED]], "gs::GraphXFragmentBuilder<int64_t,uint64_t," +
+      GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[VD]) + "," + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[ED]) + ">").asInstanceOf[GraphXFragmentBuilder.Factory[Long,Long,VD,ED]]
+    factory.create(client, vm, csr,vertexData,edata)
+  }
+
+  def newGraphXStringVDFragmentBuiler[ED : ClassTag](client : VineyardClient, vm : GraphXVertexMap[Long,Long], csr : GraphXCSR[Long], vertexData : StringVertexData[Long,CXXStdString],edata : EdgeData[Long,ED]) : StringVDGraphXFragmentBuilder[Long,Long,CXXStdString,ED] = synchronized{
+    require(GrapeUtils.isPrimitive[ED])
+    val factory = FFITypeFactory.getFactory(classOf[StringVDGraphXFragmentBuilder[Long,Long,CXXStdString,ED]], "gs::GraphXFragmentBuilder<int64_t,uint64_t,std::string," +
+        GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[ED]) + ">").asInstanceOf[StringVDGraphXFragmentBuilder.Factory[Long,Long,CXXStdString,ED]]
+    factory.create(client, vm,csr,vertexData,edata)
+  }
+  def newGraphXStringEDFragmentBuilder[VD : ClassTag](client : VineyardClient, vm : GraphXVertexMap[Long,Long], csr : GraphXCSR[Long], vertexData : VertexData[Long,VD],edata : StringEdgeData[Long,CXXStdString]) : StringEDGraphXFragmentBuilder[Long,Long,VD,CXXStdString] = synchronized{
+    require(GrapeUtils.isPrimitive[VD])
+    val factory = FFITypeFactory.getFactory(classOf[StringEDGraphXFragmentBuilder[Long,Long,VD,CXXStdString]], "gs::GraphXFragmentBuilder<int64_t,uint64_t," +
+        GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[VD]) + ",std::string>").asInstanceOf[StringEDGraphXFragmentBuilder.Factory[Long,Long,VD,CXXStdString]]
+    factory.create(client, vm,csr,vertexData,edata)
+  }
+
+  def newGraphXStringVEDFragmentBuilder(client : VineyardClient, vm : GraphXVertexMap[Long,Long], csr : GraphXCSR[Long], vertexData: StringVertexData[Long,CXXStdString], edgeData: StringEdgeData[Long,CXXStdString]) : StringVEDGraphXFragmentBuilder[Long,Long,CXXStdString,CXXStdString] = synchronized{
+    val factory = FFITypeFactory.getFactory(classOf[StringVEDGraphXFragmentBuilder[Long,Long,CXXStdString,CXXStdString]], "gs::GraphXFragmentBuilder<int64_t,uint64_t,std::string,std::string>").asInstanceOf[StringVEDGraphXFragmentBuilder.Factory[Long,Long,CXXStdString,CXXStdString]]
+    factory.create(client, vm,csr,vertexData,edgeData)
+  }
+
+  def newProjectedFragmentMapper[NEW_VD : ClassTag, NEW_ED : ClassTag, OLD_VD, OLD_ED](oldVdClz : Class[OLD_VD], oldEDClz : Class[OLD_ED]) : ArrowProjectedFragmentMapper[Long,Long,OLD_VD,NEW_VD,OLD_ED,NEW_ED] = synchronized{
+    val factory = FFITypeFactory.getFactory(classOf[ArrowProjectedFragmentMapper[Long,Long,OLD_VD,NEW_VD,OLD_ED,NEW_ED]],
+    "gs::ArrowProjectedFragmentMapper<int64_t,uint64_t," +GrapeUtils.classToStr(oldVdClz) + "," + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[NEW_VD]) + ","+ GrapeUtils.classToStr(oldEDClz) + ","
+      + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[NEW_ED]) + ">").asInstanceOf[ArrowProjectedFragmentMapper.Factory[Long,Long,OLD_VD,NEW_VD,OLD_ED, NEW_ED]]
+    factory.create()
+  }
+
+  def getFragment[VD : ClassTag,ED : ClassTag](client : VineyardClient, objectID : Long, fragStr : String) : IFragment[Long,Long,VD,ED]= synchronized{
+    if (fragStr.startsWith("gs::ArrowFragment")){
+      throw new IllegalStateException("Not implemented now")
+    }
+    else if (fragStr.startsWith("gs::ArrowProjectedFragment")){
+      log.info(s"Getting fragment for ${fragStr}, ${objectID}")
+      val getterStr = fragName2FragGetterName(fragStr)
+      val factory = FFITypeFactory.getFactory(classOf[ArrowProjectedFragmentGetter[Long,Long,VD,ED]], getterStr).asInstanceOf[ArrowProjectedFragmentGetter.Factory[Long,Long,VD,ED]]
+      val fragmentGetter = factory.create()
+      val res = fragmentGetter.get(client, objectID)
+      new ArrowProjectedAdaptor[Long,Long,VD,ED](res.get())
+    }
+    else {
+      throw new IllegalStateException(s"Not recognized frag str ${fragStr}")
+    }
+  }
+  /** transform the frag name to frag getter name. */
+  def fragName2FragGetterName(str : String) : String = synchronized{
+    if (str.contains("ArrowProjectedFragment")){
+      str.replace("ArrowProjectedFragment", "ArrowProjectedFragmentGetter")
+    }
+    else if (str.contains("ArrowFragment")){
+      str.replace("ArrowFragment", "ArrowFragmentGetter")
+    }
+    else {
+      throw new IllegalStateException(s"Not recognized ${str}")
+    }
+  }
+
+  def newFragmentGroupGetter() : ArrowFragmentGroupGetter = {
+    val factory = FFITypeFactory.getFactory(classOf[ArrowFragmentGroupGetter],
+      "gs::ArrowFragmentGroupGetter").asInstanceOf[ArrowFragmentGroupGetter.Factory]
+    factory.create()
+  }
+
+  def newStdMap[K : ClassTag, V : ClassTag](signed : Boolean = true) : StdMap[K,V] = {
+    val factory = FFITypeFactory.getFactory(classOf[StdMap[K,V]],
+      "std::map<" + GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[K], signed) + "," +
+    GrapeUtils.classToStr(GrapeUtils.getRuntimeClass[V], signed) + ">").asInstanceOf[StdMap.Factory[K,V]]
+    factory.create()
+  }
+
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/SerializationUtils.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/com/alibaba/graphscope/graphx/utils/SerializationUtils.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx.utils
+
+import org.apache.spark.internal.Logging
+
+import java.io._
+
+/**
+ * Serialize a function obj to a path;
+ * deserialize a function obj from path
+ */
+object SerializationUtils extends Logging{
+  def write[A](path : String, objs: Any*): Unit = {
+    log.info("Write obj " + objs.mkString("Array(", ", ", ")") + " to :" +  path)
+    val bo = new FileOutputStream(new File(path))
+    val outputStream = new ObjectOutputStream(bo)
+    outputStream.writeInt(objs.length)
+    var i = 0
+    while (i < objs.length){
+      if (objs(i).equals(classOf[Long])){
+        outputStream.writeObject(classOf[java.lang.Long])
+      }
+      else if (objs(i).equals(classOf[Int])){
+        outputStream.writeObject(classOf[java.lang.Integer])
+      }
+      else if (objs(i).equals(classOf[Double])){
+        outputStream.writeObject(classOf[java.lang.Double])
+      }
+      else {
+        outputStream.writeObject(objs(i))
+      }
+      i += 1
+    }
+    outputStream.flush()
+    outputStream.close()
+  }
+
+  @throws[ClassNotFoundException]
+  def read(classLoader: ClassLoader,filepath : String): Array[Any] = {
+    log.info("Reading from file path: " + filepath + ", with class loader: " + classLoader)
+    val objectInputStream = new ObjectInputStream(new FileInputStream(new File(filepath))){
+      @throws[IOException]
+      @throws[ClassNotFoundException]
+      protected override def resolveClass(desc: ObjectStreamClass): Class[_] = {
+        if (desc.getName.equals("long")){
+          classOf[java.lang.Long]
+        }
+        else if (desc.getName.equals("double")){
+          classOf[java.lang.Double]
+        }
+        else if (desc.getName.equals("int")){
+          classOf[java.lang.Integer]
+        }
+        else {
+          Class.forName(desc.getName, false, classLoader)
+        }
+      }
+    }
+    val len = objectInputStream.readInt()
+    val res = new Array[Any](len)
+    for (i <- 0 until len){
+      res(i) = objectInputStream.readObject()
+    }
+    res
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/GraphOps.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/GraphOps.scala
@@ -1,0 +1,497 @@
+/*
+ * The file GiraphConfiguration.java is referred and derived from
+ * project apache/spark,
+ *
+ *    https://github.com/apache/spark.git
+ *
+ * which has the following license:
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.graphx
+
+import org.apache.spark.SparkException
+import org.apache.spark.graphx.grape.GrapeGraphImpl
+import org.apache.spark.graphx.impl.GraphImpl
+import org.apache.spark.graphx.lib._
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+import scala.util.Random
+
+/**
+ * Contains additional functionality for [[Graph]]. All operations are expressed in terms of the
+ * efficient GraphX API. This class is implicitly constructed for each Graph object.
+ *
+ * @tparam VD the vertex attribute type
+ * @tparam ED the edge attribute type
+ */
+class GraphOps[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]) extends Serializable {
+
+  /** The number of edges in the graph. */
+  @transient lazy val numEdges: Long = graph.edges.count()
+
+  /** The number of vertices in the graph. */
+  @transient lazy val numVertices: Long = graph.vertices.count()
+
+  /**
+   * The in-degree of each vertex in the graph.
+   * @note Vertices with no in-edges are not returned in the resulting RDD.
+   */
+  @transient lazy val inDegrees: VertexRDD[Int] =
+  degreesRDD(EdgeDirection.In).setName("GraphOps.inDegrees")
+
+  /**
+   * The out-degree of each vertex in the graph.
+   * @note Vertices with no out-edges are not returned in the resulting RDD.
+   */
+  @transient lazy val outDegrees: VertexRDD[Int] =
+  degreesRDD(EdgeDirection.Out).setName("GraphOps.outDegrees")
+
+  /**
+   * The degree of each vertex in the graph.
+   * @note Vertices with no edges are not returned in the resulting RDD.
+   */
+  @transient lazy val degrees: VertexRDD[Int] =
+  degreesRDD(EdgeDirection.Either).setName("GraphOps.degrees")
+
+  /**
+   * Computes the neighboring vertex degrees.
+   *
+   * @param edgeDirection the direction along which to collect neighboring vertex attributes
+   */
+  private def degreesRDD(edgeDirection: EdgeDirection): VertexRDD[Int] = {
+    if (graph.isInstanceOf[GrapeGraphImpl[VD,ED]]){
+      val grapeGraph = graph.asInstanceOf[GrapeGraphImpl[VD,ED]]
+      grapeGraph.generateDegreeRDD(edgeDirection)
+    }
+    else {
+      if (edgeDirection == EdgeDirection.In) {
+        graph.aggregateMessages(_.sendToDst(1), _ + _, TripletFields.None)
+      } else if (edgeDirection == EdgeDirection.Out) {
+        graph.aggregateMessages(_.sendToSrc(1), _ + _, TripletFields.None)
+      } else { // EdgeDirection.Either
+        graph.aggregateMessages(ctx => { ctx.sendToSrc(1); ctx.sendToDst(1) }, _ + _,
+          TripletFields.None)
+      }
+    }
+  }
+
+  /**
+   * Collect the neighbor vertex ids for each vertex.
+   *
+   * @param edgeDirection the direction along which to collect
+   * neighboring vertices
+   *
+   * @return the set of neighboring ids for each vertex
+   */
+  def collectNeighborIds(edgeDirection: EdgeDirection): VertexRDD[Array[VertexId]] = {
+    graph match {
+      case graphxGraph : GraphImpl[VD,ED] =>
+        val nbrs =
+          if (edgeDirection == EdgeDirection.Either) {
+            graph.aggregateMessages[Array[VertexId]](
+              ctx => { ctx.sendToSrc(Array(ctx.dstId)); ctx.sendToDst(Array(ctx.srcId)) },
+              _ ++ _, TripletFields.None)
+          } else if (edgeDirection == EdgeDirection.Out) {
+            graph.aggregateMessages[Array[VertexId]](
+              ctx => ctx.sendToSrc(Array(ctx.dstId)),
+              _ ++ _, TripletFields.None)
+          } else if (edgeDirection == EdgeDirection.In) {
+            graph.aggregateMessages[Array[VertexId]](
+              ctx => ctx.sendToDst(Array(ctx.srcId)),
+              _ ++ _, TripletFields.None)
+          } else {
+            throw new SparkException("It doesn't make sense to collect neighbor ids without a " +
+              "direction. (EdgeDirection.Both is not supported; use EdgeDirection.Either instead.)")
+          }
+        graph.vertices.leftZipJoin(nbrs) { (vid, vdata, nbrsOpt) =>
+          nbrsOpt.getOrElse(Array.empty[VertexId])
+        }
+      case grapeGraphImpl: GrapeGraphImpl[VD,ED] =>
+        grapeGraphImpl.grapeVertices.collectNbrIds(edgeDirection)
+    }
+  } // end of collectNeighborIds
+
+  /**
+   * Collect the neighbor vertex attributes for each vertex.
+   *
+   * @note This function could be highly inefficient on power-law
+   * graphs where high degree vertices may force a large amount of
+   * information to be collected to a single location.
+   *
+   * @param edgeDirection the direction along which to collect
+   * neighboring vertices
+   *
+   * @return the vertex set of neighboring vertex attributes for each vertex
+   */
+  def collectNeighbors(edgeDirection: EdgeDirection): VertexRDD[Array[(VertexId, VD)]] = {
+    val nbrs = edgeDirection match {
+      case EdgeDirection.Either =>
+        graph.aggregateMessages[Array[(VertexId, VD)]](
+          ctx => {
+            ctx.sendToSrc(Array((ctx.dstId, ctx.dstAttr)))
+            ctx.sendToDst(Array((ctx.srcId, ctx.srcAttr)))
+          },
+          (a, b) => a ++ b, TripletFields.All)
+      case EdgeDirection.In =>
+        graph.aggregateMessages[Array[(VertexId, VD)]](
+          ctx => ctx.sendToDst(Array((ctx.srcId, ctx.srcAttr))),
+          (a, b) => a ++ b, TripletFields.Src)
+      case EdgeDirection.Out =>
+        graph.aggregateMessages[Array[(VertexId, VD)]](
+          ctx => ctx.sendToSrc(Array((ctx.dstId, ctx.dstAttr))),
+          (a, b) => a ++ b, TripletFields.Dst)
+      case EdgeDirection.Both =>
+        throw new SparkException("collectEdges does not support EdgeDirection.Both. Use" +
+          "EdgeDirection.Either instead.")
+    }
+    graph.vertices.leftJoin(nbrs) { (vid, vdata, nbrsOpt) =>
+      nbrsOpt.getOrElse(Array.empty[(VertexId, VD)])
+    }
+  } // end of collectNeighbor
+
+  /**
+   * Returns an RDD that contains for each vertex v its local edges,
+   * i.e., the edges that are incident on v, in the user-specified direction.
+   * Warning: note that singleton vertices, those with no edges in the given
+   * direction will not be part of the return value.
+   *
+   * @note This function could be highly inefficient on power-law
+   * graphs where high degree vertices may force a large amount of
+   * information to be collected to a single location.
+   *
+   * @param edgeDirection the direction along which to collect
+   * the local edges of vertices
+   *
+   * @return the local edges for each vertex
+   */
+  def collectEdges(edgeDirection: EdgeDirection): VertexRDD[Array[Edge[ED]]] = {
+    edgeDirection match {
+      case EdgeDirection.Either =>
+        graph.aggregateMessages[Array[Edge[ED]]](
+          ctx => {
+            ctx.sendToSrc(Array(new Edge(ctx.srcId, ctx.dstId, ctx.attr)))
+            ctx.sendToDst(Array(new Edge(ctx.srcId, ctx.dstId, ctx.attr)))
+          },
+          (a, b) => a ++ b, TripletFields.EdgeOnly)
+      case EdgeDirection.In =>
+        graph.aggregateMessages[Array[Edge[ED]]](
+          ctx => ctx.sendToDst(Array(new Edge(ctx.srcId, ctx.dstId, ctx.attr))),
+          (a, b) => a ++ b, TripletFields.EdgeOnly)
+      case EdgeDirection.Out =>
+        graph.aggregateMessages[Array[Edge[ED]]](
+          ctx => ctx.sendToSrc(Array(new Edge(ctx.srcId, ctx.dstId, ctx.attr))),
+          (a, b) => a ++ b, TripletFields.EdgeOnly)
+      case EdgeDirection.Both =>
+        throw new SparkException("collectEdges does not support EdgeDirection.Both. Use" +
+          "EdgeDirection.Either instead.")
+    }
+  }
+
+  /**
+   * Remove self edges.
+   *
+   * @return a graph with all self edges removed
+   */
+  def removeSelfEdges(): Graph[VD, ED] = {
+    graph.subgraph(epred = e => e.srcId != e.dstId)
+  }
+
+  /**
+   * Join the vertices with an RDD and then apply a function from the
+   * vertex and RDD entry to a new vertex value.  The input table
+   * should contain at most one entry for each vertex.  If no entry is
+   * provided the map function is skipped and the old value is used.
+   *
+   * @tparam U the type of entry in the table of updates
+   * @param table the table to join with the vertices in the graph.
+   * The table should contain at most one entry for each vertex.
+   * @param mapFunc the function used to compute the new vertex
+   * values.  The map function is invoked only for vertices with a
+   * corresponding entry in the table otherwise the old vertex value
+   * is used.
+   *
+   * @example This function is used to update the vertices with new
+   * values based on external data.  For example we could add the out
+   * degree to each vertex record
+   *
+   * {{{
+   * val rawGraph: Graph[Int, Int] = GraphLoader.edgeListFile(sc, "webgraph")
+   *   .mapVertices((_, _) => 0)
+   * val outDeg = rawGraph.outDegrees
+   * val graph = rawGraph.joinVertices[Int](outDeg)
+   *   ((_, _, outDeg) => outDeg)
+   * }}}
+   *
+   */
+  def joinVertices[U: ClassTag](table: RDD[(VertexId, U)])(mapFunc: (VertexId, VD, U) => VD)
+  : Graph[VD, ED] = {
+    val uf = (id: VertexId, data: VD, o: Option[U]) => {
+      o match {
+        case Some(u) => mapFunc(id, data, u)
+        case None => data
+      }
+    }
+    graph.outerJoinVertices(table)(uf)
+  }
+
+  /**
+   * Filter the graph by computing some values to filter on, and applying the predicates.
+   *
+   * @param preprocess a function to compute new vertex and edge data before filtering
+   * @param epred edge pred to filter on after preprocess, see more details under
+   *  [[org.apache.spark.graphx.Graph#subgraph]]
+   * @param vpred vertex pred to filter on after preprocess, see more details under
+   *  [[org.apache.spark.graphx.Graph#subgraph]]
+   * @tparam VD2 vertex type the vpred operates on
+   * @tparam ED2 edge type the epred operates on
+   * @return a subgraph of the original graph, with its data unchanged
+   *
+   * @example This function can be used to filter the graph based on some property, without
+   * changing the vertex and edge values in your program. For example, we could remove the vertices
+   * in a graph with 0 outdegree
+   *
+   * {{{
+   * graph.filter(
+   *   graph => {
+   *     val degrees: VertexRDD[Int] = graph.outDegrees
+   *     graph.outerJoinVertices(degrees) {(vid, data, deg) => deg.getOrElse(0)}
+   *   },
+   *   vpred = (vid: VertexId, deg:Int) => deg > 0
+   * )
+   * }}}
+   *
+   */
+  def filter[VD2: ClassTag, ED2: ClassTag](
+                                            preprocess: Graph[VD, ED] => Graph[VD2, ED2],
+                                            epred: (EdgeTriplet[VD2, ED2]) => Boolean = (x: EdgeTriplet[VD2, ED2]) => true,
+                                            vpred: (VertexId, VD2) => Boolean = (v: VertexId, d: VD2) => true): Graph[VD, ED] = {
+    graph.mask(preprocess(graph).subgraph(epred, vpred))
+  }
+
+  /**
+   * Picks a random vertex from the graph and returns its ID.
+   */
+  def pickRandomVertex(): VertexId = {
+    val probability = 50.0 / graph.numVertices
+    var found = false
+    var retVal: VertexId = null.asInstanceOf[VertexId]
+    while (!found) {
+      val selectedVertices = graph.vertices.flatMap { vidVvals =>
+        if (Random.nextDouble() < probability) { Some(vidVvals._1) }
+        else { None }
+      }
+      if (selectedVertices.count > 0) {
+        found = true
+        val collectedVertices = selectedVertices.collect()
+        retVal = collectedVertices(Random.nextInt(collectedVertices.length))
+      }
+    }
+    retVal
+  }
+
+  /**
+   * Convert bi-directional edges into uni-directional ones.
+   * Some graph algorithms (e.g., TriangleCount) assume that an input graph
+   * has its edges in canonical direction.
+   * This function rewrites the vertex ids of edges so that srcIds are smaller
+   * than dstIds, and merges the duplicated edges.
+   *
+   * @param mergeFunc the user defined reduce function which should
+   * be commutative and associative and is used to combine the output
+   * of the map phase
+   *
+   * @return the resulting graph with canonical edges
+   */
+  def convertToCanonicalEdges(
+                               mergeFunc: (ED, ED) => ED = (e1, e2) => e1): Graph[VD, ED] = {
+    val newEdges =
+      graph.edges
+        .map {
+          case e if e.srcId < e.dstId => ((e.srcId, e.dstId), e.attr)
+          case e => ((e.dstId, e.srcId), e.attr)
+        }
+        .reduceByKey(mergeFunc)
+        .map(e => new Edge(e._1._1, e._1._2, e._2))
+    Graph(graph.vertices, newEdges)
+  }
+
+  /**
+   * Execute a Pregel-like iterative vertex-parallel abstraction.  The
+   * user-defined vertex-program `vprog` is executed in parallel on
+   * each vertex receiving any inbound messages and computing a new
+   * value for the vertex.  The `sendMsg` function is then invoked on
+   * all out-edges and is used to compute an optional message to the
+   * destination vertex. The `mergeMsg` function is a commutative
+   * associative function used to combine messages destined to the
+   * same vertex.
+   *
+   * On the first iteration all vertices receive the `initialMsg` and
+   * on subsequent iterations if a vertex does not receive a message
+   * then the vertex-program is not invoked.
+   *
+   * This function iterates until there are no remaining messages, or
+   * for `maxIterations` iterations.
+   *
+   * @tparam A the Pregel message type
+   *
+   * @param initialMsg the message each vertex will receive at the on
+   * the first iteration
+   *
+   * @param maxIterations the maximum number of iterations to run for
+   *
+   * @param activeDirection the direction of edges incident to a vertex that received a message in
+   * the previous round on which to run `sendMsg`. For example, if this is `EdgeDirection.Out`, only
+   * out-edges of vertices that received a message in the previous round will run.
+   *
+   * @param vprog the user-defined vertex program which runs on each
+   * vertex and receives the inbound message and computes a new vertex
+   * value.  On the first iteration the vertex program is invoked on
+   * all vertices and is passed the default message.  On subsequent
+   * iterations the vertex program is only invoked on those vertices
+   * that receive messages.
+   *
+   * @param sendMsg a user supplied function that is applied to out
+   * edges of vertices that received messages in the current
+   * iteration
+   *
+   * @param mergeMsg a user supplied function that takes two incoming
+   * messages of type A and merges them into a single message of type
+   * A.  ''This function must be commutative and associative and
+   * ideally the size of A should not increase.''
+   *
+   * @return the resulting graph at the end of the computation
+   *
+   */
+  def pregel[A: ClassTag](
+                           initialMsg: A,
+                           maxIterations: Int = Int.MaxValue,
+                           activeDirection: EdgeDirection = EdgeDirection.Either)(
+                           vprog: (VertexId, VD, A) => VD,
+                           sendMsg: EdgeTriplet[VD, ED] => Iterator[(VertexId, A)],
+                           mergeMsg: (A, A) => A)
+  : Graph[VD, ED] = {
+    Pregel(graph, initialMsg, maxIterations, activeDirection)(vprog, sendMsg, mergeMsg)
+  }
+
+  /**
+   * Run a dynamic version of PageRank returning a graph with vertex attributes containing the
+   * PageRank and edge attributes containing the normalized edge weight.
+   *
+   * @see [[org.apache.spark.graphx.lib.PageRank$#runUntilConvergence]]
+   */
+  def pageRank(tol: Double, resetProb: Double = 0.15): Graph[Double, Double] = {
+    PageRank.runUntilConvergence(graph, tol, resetProb)
+  }
+
+
+  /**
+   * Run personalized PageRank for a given vertex, such that all random walks
+   * are started relative to the source node.
+   *
+   * @see [[org.apache.spark.graphx.lib.PageRank$#runUntilConvergenceWithOptions]]
+   */
+  def personalizedPageRank(src: VertexId, tol: Double,
+                           resetProb: Double = 0.15): Graph[Double, Double] = {
+    PageRank.runUntilConvergenceWithOptions(graph, tol, resetProb, Some(src))
+  }
+
+  /**
+   * Run parallel personalized PageRank for a given array of source vertices, such
+   * that all random walks are started relative to the source vertices
+   */
+  def staticParallelPersonalizedPageRank(sources: Array[VertexId], numIter: Int,
+                                         resetProb: Double = 0.15) : Graph[Vector, Double] = {
+    PageRank.runParallelPersonalizedPageRank(graph, numIter, resetProb, sources)
+  }
+
+  /**
+   * Run Personalized PageRank for a fixed number of iterations with
+   * with all iterations originating at the source node
+   * returning a graph with vertex attributes
+   * containing the PageRank and edge attributes the normalized edge weight.
+   *
+   * @see [[org.apache.spark.graphx.lib.PageRank$#runWithOptions]]
+   */
+  def staticPersonalizedPageRank(src: VertexId, numIter: Int,
+                                 resetProb: Double = 0.15): Graph[Double, Double] = {
+    PageRank.runWithOptions(graph, numIter, resetProb, Some(src))
+  }
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph with vertex attributes
+   * containing the PageRank and edge attributes the normalized edge weight.
+   *
+   * @see [[org.apache.spark.graphx.lib.PageRank$#run]]
+   */
+  def staticPageRank(numIter: Int, resetProb: Double = 0.15): Graph[Double, Double] = {
+    PageRank.run(graph, numIter, resetProb)
+  }
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph with vertex attributes
+   * containing the PageRank and edge attributes the normalized edge weight, optionally including
+   * including a previous pageRank computation to be used as a start point for the new iterations
+   *
+   * @see [[org.apache.spark.graphx.lib.PageRank$#runWithOptionsWithPreviousPageRank]]
+   */
+  def staticPageRank(numIter: Int, resetProb: Double,
+                     prePageRank: Graph[Double, Double]): Graph[Double, Double] = {
+    PageRank.runWithOptionsWithPreviousPageRank(graph, numIter, resetProb, None, prePageRank)
+  }
+
+  /**
+   * Compute the connected component membership of each vertex and return a graph with the vertex
+   * value containing the lowest vertex id in the connected component containing that vertex.
+   *
+   * @see `org.apache.spark.graphx.lib.ConnectedComponents.run`
+   */
+  def connectedComponents(): Graph[VertexId, ED] = {
+    ConnectedComponents.run(graph)
+  }
+
+  /**
+   * Compute the connected component membership of each vertex and return a graph with the vertex
+   * value containing the lowest vertex id in the connected component containing that vertex.
+   *
+   * @see `org.apache.spark.graphx.lib.ConnectedComponents.run`
+   */
+  def connectedComponents(maxIterations: Int): Graph[VertexId, ED] = {
+    ConnectedComponents.run(graph, maxIterations)
+  }
+
+  /**
+   * Compute the number of triangles passing through each vertex.
+   *
+   * @see [[org.apache.spark.graphx.lib.TriangleCount$#run]]
+   */
+  def triangleCount(): Graph[Int, ED] = {
+    TriangleCount.run(graph)
+  }
+
+  /**
+   * Compute the strongly connected component (SCC) of each vertex and return a graph with the
+   * vertex value containing the lowest vertex id in the SCC containing that vertex.
+   *
+   * @see [[org.apache.spark.graphx.lib.StronglyConnectedComponents$#run]]
+   */
+  def stronglyConnectedComponents(numIter: Int): Graph[VertexId, ED] = {
+    StronglyConnectedComponents.run(graph, numIter)
+  }
+} // end of GraphOps

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/Pregel.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/Pregel.scala
@@ -1,0 +1,159 @@
+/*
+ * The file GiraphConfiguration.java is referred and derived from
+ * project apache/spark,
+ *
+ *    https://github.com/apache/spark.git
+ *
+ * which has the following license:
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.graphx
+
+import com.alibaba.graphscope.graphx.GraphScopePregel
+import org.apache.spark.SparkContext
+
+import scala.reflect.ClassTag
+import org.apache.spark.graphx.util.PeriodicGraphCheckpointer
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.rdd.util.PeriodicRDDCheckpointer
+
+/**
+ * Implements a Pregel-like bulk-synchronous message-passing API.
+ *
+ * Unlike the original Pregel API, the GraphX Pregel API factors the sendMessage computation over
+ * edges, enables the message sending computation to read both vertex attributes, and constrains
+ * messages to the graph structure.  These changes allow for substantially more efficient
+ * distributed execution while also exposing greater flexibility for graph-based computation.
+ *
+ * @example We can use the Pregel abstraction to implement PageRank:
+ * {{{
+ * val pagerankGraph: Graph[Double, Double] = graph
+ *   // Associate the degree with each vertex
+ *   .outerJoinVertices(graph.outDegrees) {
+ *     (vid, vdata, deg) => deg.getOrElse(0)
+ *   }
+ *   // Set the weight on the edges based on the degree
+ *   .mapTriplets(e => 1.0 / e.srcAttr)
+ *   // Set the vertex attributes to the initial pagerank values
+ *   .mapVertices((id, attr) => 1.0)
+ *
+ * def vertexProgram(id: VertexId, attr: Double, msgSum: Double): Double =
+ *   resetProb + (1.0 - resetProb) * msgSum
+ * def sendMessage(id: VertexId, edge: EdgeTriplet[Double, Double]): Iterator[(VertexId, Double)] =
+ *   Iterator((edge.dstId, edge.srcAttr * edge.attr))
+ * def messageCombiner(a: Double, b: Double): Double = a + b
+ * val initialMessage = 0.0
+ * // Execute Pregel for a fixed number of iterations.
+ * Pregel(pagerankGraph, initialMessage, numIter)(
+ *   vertexProgram, sendMessage, messageCombiner)
+ * }}}
+ *
+ */
+object Pregel extends Logging {
+
+  /**
+   * Execute a Pregel-like iterative vertex-parallel abstraction.  The
+   * user-defined vertex-program `vprog` is executed in parallel on
+   * each vertex receiving any inbound messages and computing a new
+   * value for the vertex.  The `sendMsg` function is then invoked on
+   * all out-edges and is used to compute an optional message to the
+   * destination vertex. The `mergeMsg` function is a commutative
+   * associative function used to combine messages destined to the
+   * same vertex.
+   *
+   * On the first iteration all vertices receive the `initialMsg` and
+   * on subsequent iterations if a vertex does not receive a message
+   * then the vertex-program is not invoked.
+   *
+   * This function iterates until there are no remaining messages, or
+   * for `maxIterations` iterations.
+   *
+   * @tparam VD the vertex data type
+   * @tparam ED the edge data type
+   * @tparam A the Pregel message type
+   *
+   * @param graph the input graph.
+   *
+   * @param initialMsg the message each vertex will receive at the first
+   * iteration
+   *
+   * @param maxIterations the maximum number of iterations to run for
+   *
+   * @param activeDirection the direction of edges incident to a vertex that received a message in
+   * the previous round on which to run `sendMsg`. For example, if this is `EdgeDirection.Out`, only
+   * out-edges of vertices that received a message in the previous round will run. The default is
+   * `EdgeDirection.Either`, which will run `sendMsg` on edges where either side received a message
+   * in the previous round. If this is `EdgeDirection.Both`, `sendMsg` will only run on edges where
+   * *both* vertices received a message.
+   *
+   * @param vprog the user-defined vertex program which runs on each
+   * vertex and receives the inbound message and computes a new vertex
+   * value.  On the first iteration the vertex program is invoked on
+   * all vertices and is passed the default message.  On subsequent
+   * iterations the vertex program is only invoked on those vertices
+   * that receive messages.
+   *
+   * @param sendMsg a user supplied function that is applied to out
+   * edges of vertices that received messages in the current
+   * iteration
+   *
+   * @param mergeMsg a user supplied function that takes two incoming
+   * messages of type A and merges them into a single message of type
+   * A.  ''This function must be commutative and associative and
+   * ideally the size of A should not increase.''
+   *
+   * @return the resulting graph at the end of the computation
+   *
+   */
+  def apply[VD: ClassTag, ED: ClassTag, A: ClassTag]
+  (graph: Graph[VD, ED],
+   initialMsg: A,
+   maxIterations: Int = Int.MaxValue,
+   activeDirection: EdgeDirection = EdgeDirection.Either)
+  (vprog: (VertexId, VD, A) => VD,
+   sendMsg: EdgeTriplet[VD, ED] => Iterator[(VertexId, A)],
+   mergeMsg: (A, A) => A)
+  : Graph[VD, ED] =
+  {
+    require(maxIterations > 0, "Maximum number of iterations must be greater than 0," +
+      s" but got ${maxIterations}")
+    /**
+     * The Pregel contains the following steps.
+     * 0) persist vertex data to the memory mapped address. So, that the update data can be readed
+     *    by later launched mpi processes.
+     * 1) Launch mpi processes to run pie query, which get the fragment ids from graph.fragIds.
+     * 2) at the end of query, we get the result graph.Then how to pass the result graph from mpi
+     *    process to graphx executor?
+     *    - We Assume common graph computing will not repartition the graph,vertices,and edgs.
+     *    - We assume no graphx-related communication is not explicitly invoked.
+     *    - The computation result is set to vertex data.
+     *
+     *    So after computation, we can use shared memory to pass the updated vertex data.
+     */
+    val sc = SparkContext.getOrCreate()
+    val vprogCleaned = sc.clean(vprog,true)
+    val sendMsgCleaned = sc.clean(sendMsg, true)
+    val mergeMsgCleaned = sc.clean(mergeMsg, true)
+    val graphScopePregel = new GraphScopePregel[VD,ED,A](sc, graph, initialMsg, maxIterations, activeDirection, vprogCleaned, sendMsgCleaned, mergeMsgCleaned)
+
+    graphScopePregel.run()
+
+  } // end of apply
+
+} // end of class Pregel

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/GrapeEdgeRDD.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/GrapeEdgeRDD.scala
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.graphx.grape
+
+import com.alibaba.fastffi.{FFIByteString, FFITypeFactory}
+import com.alibaba.graphscope.graphx.VineyardClient
+import com.alibaba.graphscope.graphx.graph.impl.GraphXGraphStructure
+import com.alibaba.graphscope.graphx.rdd.impl.{GrapeEdgePartition, GrapeEdgePartitionBuilder}
+import com.alibaba.graphscope.graphx.rdd.{LocationAwareRDD, RoutingTable}
+import com.alibaba.graphscope.graphx.shuffle.{EdgeShuffleReceived, EdgeShuffle}
+import com.alibaba.graphscope.graphx.store.impl.InHeapVertexDataStore
+import com.alibaba.graphscope.graphx.utils._
+import com.alibaba.graphscope.utils.MPIUtils
+import org.apache.spark.graphx.grape.impl.GrapeEdgeRDDImpl
+import org.apache.spark.graphx.scheduler.cluster.ExecutorInfoHelper
+import org.apache.spark.graphx.{Edge, EdgeRDD, PartitionID, VertexId}
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+import org.apache.spark.{Dependency, SparkContext}
+
+import java.net.InetAddress
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+abstract class GrapeEdgeRDD[ED](sc: SparkContext,
+                                deps: Seq[Dependency[_]]) extends EdgeRDD[ED](sc, deps) {
+
+  def grapePartitionsRDD: RDD[GrapeEdgePartition[VD, ED]] forSome { type VD }
+
+  override def partitionsRDD = null
+
+  def mapValues[ED2 : ClassTag](f: Edge[ED] => ED2): GrapeEdgeRDD[ED2]
+
+  override def innerJoin[ED2: ClassTag, ED3: ClassTag](other: EdgeRDD[ED2])
+  (f: (VertexId, VertexId, ED, ED2) => ED3): GrapeEdgeRDD[ED3]
+
+  override def reverse: GrapeEdgeRDD[ED];
+}
+
+object GrapeEdgeRDD extends Logging{
+  def fromPartitions[VD : ClassTag,ED : ClassTag](edgePartitions : RDD[GrapeEdgePartition[VD,ED]]) : GrapeEdgeRDDImpl[VD,ED] = {
+    new GrapeEdgeRDDImpl[VD,ED](edgePartitions)
+  }
+
+  //(dstPid, (myPid,received gids(inner vertices)))
+  def edgeRDDToRoutingTable[ED : ClassTag](rdd : GrapeEdgeRDD[ED]) : RDD[RoutingTable] = {
+    val numPartitions = rdd.getNumPartitions
+    val partitioner = new GSPartitioner[Int](numPartitions)
+    val routingMessage = rdd.grapePartitionsRDD.mapPartitions(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        val messageArr = part.generateRoutingMessage()
+        messageArr.zipWithIndex.map(a => (a._2,(part.pid, a._1))).toIterator
+      }
+      else Iterator.empty
+    }).partitionBy(partitioner)
+    val routingTableRDD = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), rdd.grapePartitionsRDD, routingMessage)((iter1, iter2) => {
+      if (iter1.hasNext){
+        val epart = iter1.next()
+        //for routing messages send to me, construct routing table
+        val routingTable = RoutingTable.fromMessage(epart.pid, numPartitions, epart.startLid.toInt, epart.endLid.toInt, iter2)
+        Iterator(routingTable)
+      }
+      else Iterator.empty
+    })
+    routingTableRDD.cache()
+  }
+
+  def expand(globalVMIds: java.util.List[String], executorInfo: mutable.HashMap[String,String], targetLength : Int) : (Array[String],Array[String],Array[Int]) = {
+    val size = globalVMIds.size()
+    val hostNames = new Array[String](targetLength)
+    val locations = new Array[String](targetLength)
+    val partitionIds = new Array[Int](targetLength)
+    for (i <- 0 until size){
+      val splited = globalVMIds.get(i).split(":")
+      require(splited.length == 3)
+      hostNames(i) = splited(0)
+      locations(i) = "executor_" + hostNames(i) + "_" + executorInfo(hostNames(i))
+      partitionIds(i) = splited(1).toInt
+    }
+
+    var i = size
+    while (i < targetLength){
+      hostNames(i) = hostNames(i % size)
+      locations(i) = locations(i % size)
+      partitionIds(i) = i
+      i += 1
+    }
+    log.info(s"expanded partitions,host names ${hostNames.mkString("Array(", ", ", ")")}")
+    log.info(s"expanded partitions,locations ${locations.mkString("Array(", ", ", ")")}")
+    log.info(s"expanded partitions,partitionIds ${partitionIds.mkString("Array(", ", ", ")")}")
+    (hostNames, locations, partitionIds)
+  }
+
+  def sortLocalVertexMapIds(localVMIds : Array[String]) : Array[String] = {
+    val pids = localVMIds.map(str => str.split(":")(1))
+    val (pidsSorted, indices) = pids.zipWithIndex.sorted.unzip
+    val res = new Array[String](localVMIds.length)
+    var i = 0
+    while (i < pids.length){
+      res(i) = localVMIds(indices(i))
+      i += 1
+    }
+    res
+  }
+
+  def gatherShufflePidArray[ED : ClassTag](numShuffles : Int, shuffleRDD: RDD[(Int, Array[EdgeShuffleReceived[ED]])]): Array[Int] = {
+    val pidsAndShuffleIds = shuffleRDD.mapPartitionsWithIndex((pid,iter) => {
+      if (iter.hasNext){
+        val (_pid, part) = iter.next()
+        require(_pid == pid, s"neq ${_pid} ${pid}")
+        val bitset = new mutable.BitSet()
+        for (received <- part){
+          for (shuffle <- received.fromPid2Shuffle){
+            bitset.add(shuffle.dstPid)
+          }
+        }
+        val array = bitset.toArray
+        log.info(s"empty rdd part ${pid} got shuffles dst ids ${array.mkString(",")}")
+        Iterator((pid, array))
+      }
+      else {
+        log.info(s"part ${pid} in gather shuffle pid array is empty")
+        Iterator.empty
+      }
+    }).collect()
+    val resArray = Array.fill(numShuffles)(-1)
+    for (arr <- pidsAndShuffleIds){
+      val shuffleIds = arr._2
+      val graphxPid = arr._1
+      for (shuffleId <- shuffleIds){
+        if (resArray(shuffleId) != -1){
+          throw new IllegalStateException(s"Not possible, try to set ${shuffleId} but already set with ${resArray(shuffleId)}")
+        }
+        resArray(shuffleId) = graphxPid
+      }
+    }
+    for (i <- resArray.indices){
+      require(resArray(i) != -1, s"index ${i} still -1 after set")
+    }
+    resArray
+  }
+
+  def fromEmptyRDD[VD : ClassTag,ED : ClassTag](sc : SparkContext, numShuffles : Int, userNumPartitions : Int, emptyRDD : LocationAwareRDD, defaultED : ED = null.asInstanceOf[ED]) : GrapeEdgeRDD[ED] = {
+
+    val numFrag = emptyRDD.getNumPartitions
+    //For every executor, we get all partitions in this executor.
+    val sparkSession = GSSparkSession.getDefaultSession.getOrElse(throw new IllegalStateException("empty session")).asInstanceOf[GSSparkSession]
+    val socketPath = sparkSession.socketPath
+    val shufflesRDD = emptyRDD.mapPartitionsWithIndex((pid,iter) => {
+      if (iter.hasNext){
+        val receivedShuffles = EdgeShuffleReceived.getArray.asInstanceOf[Array[EdgeShuffleReceived[ED]]]
+        Iterator((pid,receivedShuffles))
+      }
+      else {
+        log.info(s"part ${pid} is empty")
+        Iterator.empty
+      }
+    },preservesPartitioning = true).cache()
+
+    val shufflePid2Array = gatherShufflePidArray(numShuffles,shufflesRDD)
+    log.info(s"shuffle index to graphx pid mapping ${shufflePid2Array.mkString(",")}")
+
+    val metaRDD = shufflesRDD.mapPartitions(iter => {
+      if (iter.hasNext) {
+        val (pid,receivedShuffles) = iter.next()
+        val client: VineyardClient = {
+          val res = ScalaFFIFactory.newVineyardClient()
+          val ffiByteString: FFIByteString = FFITypeFactory.newByteString()
+          ffiByteString.copyFrom(socketPath)
+          require(res.connect(ffiByteString).ok())
+          log.info(s"successfully connect to ${socketPath}")
+          res
+        }
+        val grapeMeta = new GrapeMeta[VD, ED](pid, numFrag, client, ExecutorUtils.getHostName)
+        val edgePartitionBuilder = new GrapeEdgePartitionBuilder[VD, ED](numFrag, client)
+        //expect size > 1
+        log.info(s"partition ${pid} receive shuffles size ${receivedShuffles.size}")
+        edgePartitionBuilder.addEdges(receivedShuffles)
+        grapeMeta.setEdgePartitionBuilder(edgePartitionBuilder)
+        val parallelism = Runtime.getRuntime.availableProcessors();
+
+        val localVertexMap = edgePartitionBuilder.buildLocalVertexMap(pid, parallelism,shufflePid2Array, numShuffles)
+        if (localVertexMap == null) {
+          Iterator.empty
+        }
+        else {
+          grapeMeta.setLocalVertexMap(localVertexMap)
+          grapeMeta.setEdgePartitionBuilder(edgePartitionBuilder)
+          Iterator(grapeMeta)
+        }
+      }
+      else Iterator.empty
+    },preservesPartitioning = true).cache()
+
+
+    val localVertexMapIds = metaRDD.mapPartitions(iter => {
+      if (iter.hasNext){
+        val meta = iter.next()
+        Iterator(ExecutorUtils.getHostName + ":" + meta.partitionID + ":" + meta.localVertexMap.id())
+      }
+      else Iterator.empty
+    },preservesPartitioning = true).collect().distinct.sorted
+
+    log.info(s"[GrapeEdgeRDD]: got distinct local vm ids ${localVertexMapIds.mkString("Array(", ", ", ")")}")
+    require(localVertexMapIds.length == numFrag, s"${localVertexMapIds.length} neq to num partitoins ${numFrag}")
+    val sortedLocalVMIds = sortLocalVertexMapIds(localVertexMapIds)
+    //pid should match with fid.
+
+    log.info("[GrapeEdgeRDD]: Start constructing global vm")
+    val time0 = System.nanoTime()
+    val globalVMIDs = MPIUtils.constructGlobalVM(sortedLocalVMIds,socketPath  , "int64_t", "uint64_t")
+    log.info(s"[GrapeEdgeRDD]: Finish constructing global vm ${globalVMIDs}, cost ${(System.nanoTime() - time0)/1000000} ms")
+    require(globalVMIDs.size() == numFrag)
+    log.info(s"meta partition size ${metaRDD.count}")
+
+    val metaPartitionsUpdated = metaRDD.mapPartitions(iter => {
+      if (iter.hasNext) {
+        val meta = iter.next()
+        val hostName = InetAddress.getLocalHost.getHostName
+        log.info(s"Doing meta update on ${}, pid ${meta.partitionID}")
+        var res = null.asInstanceOf[String]
+        var i = 0
+        while (i < globalVMIDs.size()) {
+          val ind = globalVMIDs.get(i).indexOf(hostName)
+          if (ind != -1) {
+            val spltted = globalVMIDs.get(i).split(":")
+            require(spltted.length == 3) // hostname,pid,vmid
+            require(spltted(0).equals(hostName))
+            if (spltted(1).toInt == meta.partitionID) {
+              res = spltted(2)
+            }
+          }
+          i += 1
+        }
+        require(res != null, s"after iterate over received global ids, no suitable found for ${hostName}, ${meta.partitionID} : ${globalVMIDs}")
+        meta.setGlobalVM(res.toLong)
+        val (vm, csr) = meta.edgePartitionBuilder.buildCSR(meta.globalVMId)
+        val time0 = System.nanoTime()
+        //We will build a store which underlying is a simple array with length csr.getTotalEdgesNum,
+        //but we can get out edge data from it with oeoffset, with some what conversion.
+        val edatas = meta.edgePartitionBuilder.buildEdataStore(defaultED, csr.getTotalEdgesNum.toInt,meta.vineyardClient, new EIDAccessor(csr.getOEBegin(0).getAddress))
+        val time1 = System.nanoTime()
+        log.info(s"Create edata cost ${(time1 - time0)/1000000}ms")
+        //raw edatas contains all edge datas, i.e. csr edata array.
+        //edatas are out edges edge cache.
+        meta.setGlobalVM(vm)
+        meta.setCSR(csr)
+        meta.setEdataStore(edatas)
+        Iterator(meta)
+      }
+      else Iterator.empty
+    },preservesPartitioning = true).cache()
+
+    metaPartitionsUpdated.foreachPartition(iter => {
+      log.info("doing edge partition building")
+      if (iter.hasNext) {
+        val meta = iter.next()
+        val time0 = System.nanoTime()
+        val vm = meta.globalVM
+        //set numSplit later
+        val vertexDataStore = new InHeapVertexDataStore[VD](vm.getVertexSize.toInt, 1, meta.vineyardClient)
+        val edgeBuilder = meta.edgePartitionBuilder
+        val graphStructure = new GraphXGraphStructure(meta.globalVM, meta.graphxCSR)
+
+        val initialized = edgeBuilder.fillVertexData(vertexDataStore, graphStructure)
+        val time1 = System.nanoTime()
+        log.info(s"[Creating graph structure cost ]: ${(time1 - time0) / 1000000} ms")
+        GrapeEdgePartition.push((meta.partitionID,graphStructure, meta.vineyardClient,meta.edataStore,vertexDataStore, initialized))
+
+        meta.edgePartitionBuilder.clearBuilders()
+        meta.edgePartitionBuilder = null //make it null to let it be gc able
+      }
+    })
+
+    val executorInfo = ExecutorInfoHelper.getExecutorsHost2Id(sc)
+    //meta updated only has fnum partitions, we need to create userNumPartitions partitions.
+    log.info(s"edge shuffle num partition ${numFrag}, target num parts ${userNumPartitions}")
+    val (expandedHosts, expandedLocations,expandedPartitionIds) = expand(globalVMIDs, executorInfo, userNumPartitions)
+    require(expandedHosts.length == userNumPartitions)
+
+    val res = createUserPartitionsAndFormRDD[VD,ED](sc, expandedHosts,expandedLocations,expandedPartitionIds,userNumPartitions)
+    //clear cached builder memory
+    metaPartitionsUpdated.unpersist()
+    metaRDD.unpersist()
+    metaRDD.unpersist()
+    shufflesRDD.unpersist()
+    res
+  }
+
+  /**
+   *
+   * This procedure is shared by fragment rdd and grape rdd. GrapeEdgePartition.push should be called
+   * before this.
+   */
+  def createUserPartitionsAndFormRDD[VD: ClassTag,ED : ClassTag](sc: SparkContext, expandedHosts : Array[String], expandedLocations : Array[String], expandedPartitionIds : Array[Int], userNumPartitions : Int) : GrapeEdgeRDD[ED] = {
+    require(userNumPartitions == expandedHosts.length, s"size neq ${userNumPartitions}, ${expandedHosts.length}")
+    val grapeInitRDD = new LocationAwareRDD(sc, expandedLocations,expandedHosts,expandedPartitionIds)
+    grapeInitRDD.foreachPartition(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        lazy val hostName = InetAddress.getLocalHost.getHostName
+        require(hostName.equals(part.hostName), s"part ${part.ind} host name neq ${part.hostName}, ${InetAddress.getLocalHost.getHostName}")
+        GrapeEdgePartition.incCount(part.ind)
+      }
+    })
+    grapeInitRDD.foreachPartition(iter => {
+      if (iter.hasNext){
+        GrapeEdgePartition.createPartitions[VD,ED](iter.next().ind,userNumPartitions)
+      }
+    })
+    log.info(s"empty rdd size ${grapeInitRDD.getNumPartitions}")
+
+    val grapeEdgePartitions = grapeInitRDD.mapPartitionsWithIndex((pid, iter) => {
+      if (iter.hasNext){
+        val grapeEdgePartition = GrapeEdgePartition.get[VD,ED](pid)
+        log.info(s"part ${pid} got grapeEdgePart ${grapeEdgePartition.toString}")
+        Iterator(grapeEdgePartition)
+      }
+      else Iterator.empty
+    },preservesPartitioning = true).cache()
+
+    //collect partition mapping info
+    val partitionInfo = grapeEdgePartitions.mapPartitions(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        Iterator((part.pid,part.graphStructure.fid(), part.startLid,part.endLid))
+      }
+      else Iterator.empty
+    }).collect() // (graphx pid, fid, start lid, end lid)
+
+    grapeEdgePartitions.foreachPartition(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        part.buildPartitionInfo(partitionInfo)
+      }
+    })
+
+    val rdd = new GrapeEdgeRDDImpl[VD,ED](grapeEdgePartitions)
+    log.info(s"[GrapeEdgeRDD:] Finish Construct EdgeRDD, total edges count ${rdd.count()}")
+    rdd
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/GrapeGraphImpl.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/GrapeGraphImpl.scala
@@ -1,0 +1,428 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.graphx.grape
+
+import com.alibaba.graphscope.graphx.graph.GraphStructureTypes.GraphStructureType
+import com.alibaba.graphscope.graphx.graph.impl.GraphXGraphStructure
+import com.alibaba.graphscope.graphx.store.VertexDataStore
+import com.alibaba.graphscope.graphx.store.impl.{InHeapEdgeDataStore, InHeapVertexDataStore, OffHeapEdgeDataStore}
+import com.alibaba.graphscope.graphx.utils.{BitSetWithOffset, ExecutorUtils, GrapeUtils, ScalaFFIFactory}
+import org.apache.spark.SparkContext
+import org.apache.spark.graphx._
+import org.apache.spark.graphx.grape.impl.{GrapeEdgeRDDImpl, GrapeVertexRDDImpl}
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{GSSparkSession, SparkSession}
+import org.apache.spark.storage.StorageLevel
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.reflect.{ClassTag, classTag}
+
+object GrapeGraphBackend extends Enumeration{
+  val GraphXFragment, ArrowProjectedFragment = GrapeGraphBackend
+}
+/**
+ * Creating a graph abstraction by combining vertex RDD and edge RDD together.
+ * Before doing this construction:
+ *   - Both vertex RDD and edge RDD are available for map,fliter operators.
+ *   - Both vertex RDD and edge RDD stores data in partitions
+ *     When construct this graph, we will
+ *   - copy data out to shared-memory
+ *   - create mpi processes to load into fragment.
+ *   - Wrap fragment as GrapeGraph when doing pregel computation.
+ *     When changes made to graphx graph, it will not directly take effect on grape-graph. To apply these
+ *     changes to grape-graph. Invoke to grape graph directly.
+ *
+ *
+ * @param vertices vertex rdd
+ * @param edges    edge rdd
+ * @tparam VD vd
+ * @tparam ED ed
+ */
+class GrapeGraphImpl[VD: ClassTag, ED: ClassTag] protected(
+                                                            @transient val vertices: GrapeVertexRDD[VD],
+                                                            @transient val edges: GrapeEdgeRDD[ED]) extends Graph[VD, ED] with Serializable {
+  val logger: Logger = LoggerFactory.getLogger(classOf[GrapeGraphImpl[_,_]].toString)
+
+  lazy val backend: GraphStructureType = vertices.grapePartitionsRDD.mapPartitions(iter => {
+    val part = iter.next()
+    Iterator(part.graphStructure.structureType)
+  }).collect().distinct(0)
+
+  val vdClass: Class[VD] = classTag[VD].runtimeClass.asInstanceOf[java.lang.Class[VD]]
+  val edClass: Class[ED] = classTag[ED].runtimeClass.asInstanceOf[java.lang.Class[ED]]
+  val grapeEdges: GrapeEdgeRDDImpl[VD, ED] = edges.asInstanceOf[GrapeEdgeRDDImpl[VD,ED]]
+  val grapeVertices: GrapeVertexRDDImpl[VD] = vertices.asInstanceOf[GrapeVertexRDDImpl[VD]]
+
+  def numVertices: Long = grapeVertices.count()
+
+  def numEdges: Long = edges.count()
+
+  lazy val fragmentIds : RDD[String] = {
+    val syncedGrapeVertices = grapeVertices.syncOuterVertex.cache()
+    syncedGrapeVertices.grapePartitionsRDD.foreachPartition(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        logger.debug("Empty run just invoking sync outer vertices")
+      }
+    })
+    logger.debug(s"synced grape vertices ${syncedGrapeVertices.count()}")
+
+    //we only use numFrags partitions, each with number of `numThread` for parallelization.
+    PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(),
+      edges.grapePartitionsRDD,
+      syncedGrapeVertices.grapePartitionsRDD){(edgeIter, vertexIter) => {
+      val ePart = edgeIter.next()
+      val vPart = vertexIter.next()
+      require(ePart.pid == vPart.pid)
+      if (ePart.localId != 0){
+        Iterator.empty
+      }
+      else {
+        ePart.graphStructure match {
+          case casted: GraphXGraphStructure =>
+            val vm = casted.vm
+            val csr = casted.csr
+            val localNum = ePart.localNum
+
+            var fragId = null.asInstanceOf[Long]
+            if (GrapeUtils.isPrimitive[VD] && GrapeUtils.isPrimitive[ED]) {
+              require(vPart.vertexData.isInstanceOf[InHeapVertexDataStore[VD]], "current only support in heap vd")
+              val vertexData = GrapeUtils.array2PrimitiveVertexData(vPart.vertexData.asInstanceOf[InHeapVertexDataStore[VD]].array, ePart.client)
+              val edataStore = ePart.edatas
+              require(edataStore.size == ePart.totalFragEdgeNum)
+              val edgeData = GrapeUtils.buildPrimitiveEdgeData(edataStore.asInstanceOf[OffHeapEdgeDataStore[ED]], ePart.client, localNum)
+              val fragBuilder = ScalaFFIFactory.newGraphXFragmentBuilder[VD, ED](ePart.client, vm, csr, vertexData, edgeData)
+              fragId = fragBuilder.seal(ePart.client).get().id()
+            }
+            else if (GrapeUtils.isPrimitive[VD]) {
+              require(vPart.vertexData.isInstanceOf[InHeapVertexDataStore[VD]], "current only support in heap vd")
+              val vertexData = GrapeUtils.array2PrimitiveVertexData(vPart.vertexData.asInstanceOf[InHeapVertexDataStore[VD]].array, ePart.client)
+              val edataArray = ePart.edatas
+              require(edataArray.size == ePart.totalFragEdgeNum)
+              val edgeData = GrapeUtils.array2StringEdgeData(edataArray.asInstanceOf[InHeapEdgeDataStore[ED]].edataArray, ePart.client)
+              val fragBuilder = ScalaFFIFactory.newGraphXStringEDFragmentBuilder[VD](ePart.client, vm, csr, vertexData, edgeData)
+              fragId = fragBuilder.seal(ePart.client).get().id()
+            }
+            else if (GrapeUtils.isPrimitive[ED]) {
+              require(vPart.vertexData.isInstanceOf[InHeapVertexDataStore[VD]], "current only support in heap vd")
+              val vertexData = GrapeUtils.array2StringVertexData(vPart.vertexData.asInstanceOf[InHeapVertexDataStore[VD]].array, ePart.client)
+              val edataStore = ePart.edatas
+              require(edataStore.size == ePart.totalFragEdgeNum)
+              val edgeData = GrapeUtils.buildPrimitiveEdgeData(edataStore.asInstanceOf[OffHeapEdgeDataStore[ED]], ePart.client, localNum)
+              val fragBuilder = ScalaFFIFactory.newGraphXStringVDFragmentBuiler[ED](ePart.client, vm, csr, vertexData, edgeData)
+              fragId = fragBuilder.seal(ePart.client).get().id()
+            }
+            else {
+              require(vPart.vertexData.isInstanceOf[InHeapVertexDataStore[VD]], "current only support in heap vd")
+              val vertexData = GrapeUtils.array2StringVertexData(vPart.vertexData.asInstanceOf[InHeapVertexDataStore[VD]].array, ePart.client)
+              val edataArray = ePart.edatas
+              require(edataArray.size == ePart.totalFragEdgeNum)
+              val edgeData = GrapeUtils.array2StringEdgeData(edataArray.asInstanceOf[InHeapEdgeDataStore[ED]].edataArray, ePart.client)
+              val fragBuilder = ScalaFFIFactory.newGraphXStringVEDFragmentBuilder(ePart.client, vm, csr, vertexData, edgeData)
+              fragId = fragBuilder.seal(ePart.client).get().id()
+            }
+            logger.info(s"Got built frag: ${fragId}")
+            Iterator(ExecutorUtils.getHostName + ":" + ePart.pid + ":" + fragId)
+          case _ =>
+            throw new IllegalStateException("Not implemented now!")
+        }
+      }
+    }}
+  }
+
+  def generateGlobalVMIds() : Array[String] = {
+    edges.grapePartitionsRDD.mapPartitions(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        part.graphStructure match {
+          case casted: GraphXGraphStructure =>
+            Iterator(ExecutorUtils.getHostName + ":" + part.pid + ":" + casted.vm.id())
+          case _ =>
+            throw new IllegalStateException("Not implemented now!")
+        }
+      }
+      else {
+        Iterator.empty
+      }
+    }).collect()
+  }
+
+
+  @transient override lazy val triplets: RDD[EdgeTriplet[VD, ED]] = {
+    PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), grapeEdges.grapePartitionsRDD, grapeVertices.grapePartitionsRDD){
+      (edgeIter, vertexIter) => {
+        val edgePart = edgeIter.next()
+        val vertexPart = vertexIter.next()
+        edgePart.tripletIterator(vertexPart.vertexData)
+      }
+    }
+  }
+
+  override def persist(newLevel: StorageLevel): Graph[VD, ED] = {
+    vertices.persist(newLevel)
+    edges.persist(newLevel)
+    this
+  }
+
+  override def cache(): Graph[VD, ED] = {
+    vertices.cache()
+    edges.cache()
+    this
+  }
+
+  override def checkpoint(): Unit = {
+    vertices.checkpoint()
+    edges.checkpoint()
+  }
+
+  override def isCheckpointed: Boolean = {
+    vertices.isCheckpointed && edges.isCheckpointed
+  }
+
+  override def getCheckpointFiles: Seq[String] = {
+    Seq(vertices.getCheckpointFile, edges.getCheckpointFile).flatMap {
+      case Some(path) => Seq(path)
+      case None => Seq.empty
+    }
+  }
+
+  override def unpersist(blocking: Boolean): Graph[VD, ED] = {
+    vertices.unpersist(blocking)
+    edges.unpersist(blocking)
+    this
+  }
+
+  override def unpersistVertices(blocking: Boolean): Graph[VD, ED] = {
+    vertices.unpersist(blocking)
+    this
+  }
+
+  override def partitionBy(partitionStrategy: PartitionStrategy): Graph[VD, ED] = {
+    logger.warn("Currently grape graph doesn't support partition")
+    this
+  }
+
+  override def partitionBy(partitionStrategy: PartitionStrategy, numPartitions: PartitionID): Graph[VD, ED] = {
+    logger.warn("Currently grape graph doesn't support partition")
+    this
+  }
+  def mapVertices[VD2: ClassTag](map: (VertexId, VD) => VD2)
+                                (implicit eq: VD =:= VD2 = null): Graph[VD2, ED] = {
+    new GrapeGraphImpl[VD2,ED](vertices.mapVertices[VD2](map), edges)
+  }
+  override def mapEdges[ED2: ClassTag](map: Edge[ED] => ED2): Graph[VD, ED2] = {
+    val newEdgePartitions = grapeEdges.grapePartitionsRDD.mapPartitions(
+      iter => {
+        if (iter.hasNext){
+          val part = iter.next()
+          Iterator(part.map(map))
+        }
+        else {
+          Iterator.empty
+        }
+      }
+    )
+    new GrapeGraphImpl[VD,ED2](vertices, grapeEdges.withPartitionsRDD(newEdgePartitions))
+  }
+
+  override def mapEdges[ED2](f: (PartitionID, Iterator[Edge[ED]]) => Iterator[ED2])(implicit evidence$5: ClassTag[ED2]): Graph[VD, ED2] = {
+    val newEdges = grapeEdges.mapEdgePartitions(part => part.map(f))
+    new GrapeGraphImpl[VD,ED2](vertices,newEdges)
+  }
+
+  override def mapTriplets[ED2: ClassTag](map: EdgeTriplet[VD, ED] => ED2): Graph[VD, ED2] = {
+    mapTriplets(map, TripletFields.All)
+  }
+
+  override def mapTriplets[ED2: ClassTag](
+                                  map: EdgeTriplet[VD, ED] => ED2,
+                                  tripletFields: TripletFields): Graph[VD, ED2] = {
+    //broadcast outer vertex data
+    //After map vertices, broadcast new inner vertex data to outer vertex data
+    var newVertices = vertices
+    if (!grapeVertices.outerVertexSynced){
+      newVertices = grapeVertices.syncOuterVertex
+    }
+    else {
+      logger.info(s"${grapeVertices} has done outer vertex data sync, just go to map triplets")
+    }
+
+    val newEdgePartitions = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(),grapeEdges.grapePartitionsRDD, newVertices.grapePartitionsRDD){
+      (eIter,vIter) => {
+        if (vIter.hasNext){
+          val vPart = vIter.next()
+          val epart = eIter.next()
+          Iterator(epart.mapTriplets(map,vPart.bitSet, vPart.vertexData, tripletFields))
+        }
+        else Iterator.empty
+      }
+    }
+    val newEdges = grapeEdges.withPartitionsRDD(newEdgePartitions)
+    new GrapeGraphImpl[VD,ED2](newVertices,newEdges)
+  }
+
+  override def mapTriplets[ED2](f: (PartitionID, Iterator[EdgeTriplet[VD, ED]]) => Iterator[ED2], tripletFields: TripletFields)(implicit evidence$8: ClassTag[ED2]): Graph[VD, ED2] = {
+    var newVertices = vertices
+    if (!grapeVertices.outerVertexSynced){
+      newVertices = grapeVertices.syncOuterVertex
+    }
+    else {
+      logger.info(s"${grapeVertices} has done outer vertex data sync, just go to map triplets")
+    }
+    val newEdgePartitions = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(),grapeEdges.grapePartitionsRDD, newVertices.grapePartitionsRDD){
+      (eIter,vIter) => {
+        if (vIter.hasNext) {
+          val vPart = vIter.next()
+          val epart = eIter.next()
+          Iterator(epart.mapTriplets(f, vPart.vertexData, true, true))
+        }
+        else Iterator.empty
+      }
+    }
+    val newEdges = grapeEdges.withPartitionsRDD(newEdgePartitions)
+    new GrapeGraphImpl[VD,ED2](newVertices,newEdges)
+  }
+
+  override def reverse: Graph[VD, ED] = {
+    new GrapeGraphImpl(vertices, grapeEdges.reverse)
+  }
+
+  override def subgraph(epred: EdgeTriplet[VD, ED] => Boolean, vpred: (VertexId, VD) => Boolean): Graph[VD, ED] = {
+    var newVertices = vertices
+    if (!grapeVertices.outerVertexSynced){
+      newVertices = grapeVertices.syncOuterVertex
+    }
+    else {
+      logger.info(s"${grapeVertices} has done outer vertex data sync, just go to map triplets")
+    }
+    newVertices = newVertices.mapGrapeVertexPartitions(_.filter(vpred))
+
+    val newEdgePartitions = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(),grapeEdges.grapePartitionsRDD, newVertices.grapePartitionsRDD){
+      (eIter,vIter) => {
+        if (vIter.hasNext) {
+          val vPart = vIter.next()
+          val ePart = eIter.next()
+          Iterator(ePart.filter(epred, vpred, vPart.vertexData))
+        }
+        else Iterator.empty
+      }
+    }
+    val newEdges = grapeEdges.withPartitionsRDD(newEdgePartitions)
+    new GrapeGraphImpl(newVertices, newEdges)
+  }
+
+  override def mask[VD2 : ClassTag, ED2 : ClassTag](other: Graph[VD2, ED2]): Graph[VD, ED] = {
+    val newVertices = grapeVertices.innerJoin(other.asInstanceOf[GrapeGraphImpl[VD,ED]].grapeVertices){ (oid, v1, v2)=> v1}
+    val newEdges = grapeEdges.innerJoin(other.asInstanceOf[GrapeGraphImpl[VD,ED]].grapeEdges){ (src,dst,e1,e2) => e1}
+    new GrapeGraphImpl(newVertices,newEdges)
+  }
+
+  override def groupEdges(merge: (ED, ED) => ED): Graph[VD, ED] = {
+    new GrapeGraphImpl(vertices, grapeEdges.withPartitionsRDD(
+      grapeEdges.grapePartitionsRDD.mapPartitions(iter => {
+        if (iter.hasNext) {
+          val part = iter.next()
+          Iterator(part.groupEdges(merge))
+        }
+        else Iterator.empty
+      })
+    ))
+  }
+
+  override private[graphx] def aggregateMessagesWithActiveSet[A: ClassTag](
+                                          sendMsg: EdgeContext[VD, ED, A] => Unit,
+                                          mergeMsg: (A, A) => A,
+                                          tripletFields: TripletFields,
+                                          activeSetOpt: Option[(VertexRDD[_], EdgeDirection)]) : VertexRDD[A] = {
+    vertices.cache()
+    val newVertices = activeSetOpt match {
+      case Some((activeSet, _)) => {
+        throw new IllegalStateException("Currently not supported aggregate with active vertex set")
+      }
+      case None => vertices.syncOuterVertex
+    }
+
+    val activeDirection = activeSetOpt.map(_._2)
+    val preAgg = grapeEdges.grapePartitionsRDD.zipPartitions(newVertices.grapePartitionsRDD){(eiter,viter) => {
+      val epart = eiter.next()
+      val vpart = viter.next()
+      epart.scanEdgeTriplet(vpart.vertexData,sendMsg,mergeMsg, tripletFields, activeDirection)
+    }}.setName("GraphImpl.aggregateMessages - preAgg")
+
+    newVertices.aggregateUsingIndex(preAgg, mergeMsg)
+  }
+
+  override def outerJoinVertices[U : ClassTag, VD2 : ClassTag](other: RDD[(VertexId, U)])(mapFunc: (VertexId, VD, Option[U]) => VD2)(implicit eq: VD =:= VD2 = null): Graph[VD2, ED] = {
+    val newVertices = vertices.leftJoin[U,VD2](other)(mapFunc)
+    new GrapeGraphImpl[VD2,ED](newVertices,edges)
+  }
+
+  def generateDegreeRDD(edgeDirection: EdgeDirection) : GrapeVertexRDD[Int] = {
+      val newVertexPartitionRDD = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), grapeEdges.grapePartitionsRDD, grapeVertices.grapePartitionsRDD){
+      (thisIter, otherIter) => {
+        if (thisIter.hasNext) {
+          val ePart = thisIter.next()
+          val otherVPart = otherIter.next()
+          //VertexPartition id range should be same with edge partition
+          val newVdArray = ePart.getDegreeArray(edgeDirection)
+          val vertexData = otherVPart.vertexData
+          if (otherVPart.localId == 0){
+            val newValues = vertexData.mapToNew[Int].asInstanceOf[VertexDataStore[Int]]
+            for (dstPid <- otherVPart.siblingPid){
+              VertexDataStore.enqueue(dstPid, newValues)
+            }
+          }
+          val newValues = VertexDataStore.dequeue(otherVPart.pid).asInstanceOf[VertexDataStore[Int]]
+          require((otherVPart.endLid - otherVPart.startLid) == newVdArray.length)
+          //IN native graphx impl, the vertex with degree 0 is not returned. But we return them as well.
+          //to make the result same, we set all vertices with zero degree to inactive.
+          val startLid = otherVPart.startLid
+          val endLid = otherVPart.endLid
+          val activeSet = new BitSetWithOffset(startLid,endLid)
+          activeSet.setRange(startLid, endLid)
+          var i = startLid
+          while (i < endLid) {
+            newValues.set(i, newVdArray(i - startLid))
+            i += 1
+          }
+          if (ePart.localNum==0) {
+            i = otherVPart.ivnum
+            while (i < newValues.size) {
+              newValues.set(i, 0) // for outer data, set 0.
+              i += 1
+            }
+          }
+          val newVPart = otherVPart.withNewValues(newValues)
+          Iterator(newVPart.withMask(activeSet))
+        }
+        else Iterator.empty
+      }
+    }
+    val degreeRDD = grapeVertices.withGrapePartitionsRDD(newVertexPartitionRDD).cache()
+    logger.info(s"degree rdd size ${degreeRDD.count()}") // invoke calculation here to make sure the
+    degreeRDD
+  }
+}
+
+
+object GrapeGraphImpl extends Logging{
+
+  def fromExistingRDDs[VD: ClassTag,ED :ClassTag](vertices: GrapeVertexRDD[VD], edges: GrapeEdgeRDD[ED]): GrapeGraphImpl[VD,ED] ={
+    new GrapeGraphImpl[VD,ED](vertices.cache(), edges.cache())
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/GrapeVertexRDD.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/GrapeVertexRDD.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.graphx.grape
+
+import com.alibaba.graphscope.ds.Vertex
+import com.alibaba.graphscope.fragment.IFragment
+import com.alibaba.graphscope.graphx.graph.impl.FragmentStructure
+import com.alibaba.graphscope.graphx.rdd.RoutingTable
+import com.alibaba.graphscope.graphx.rdd.impl.GrapeVertexPartition
+import com.alibaba.graphscope.graphx.store.impl.InHeapVertexDataStore
+import com.alibaba.graphscope.utils.FFITypeFactoryhelper
+import org.apache.spark.graphx._
+import org.apache.spark.graphx.grape.impl.GrapeVertexRDDImpl
+import org.apache.spark.graphx.scheduler.cluster.ExecutorInfoHelper
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.{Dependency, SparkContext}
+
+import scala.reflect.ClassTag
+
+/**
+ * Act as the base class of gs related rdds.
+ */
+abstract class GrapeVertexRDD[VD](
+                                   sc: SparkContext, deps: Seq[Dependency[_]]) extends VertexRDD[VD](sc, deps) {
+  private[graphx] def grapePartitionsRDD: RDD[GrapeVertexPartition[VD]]
+
+  override def partitionsRDD = null
+
+  private[graphx] def mapGrapeVertexPartitions[VD2: ClassTag](
+                                                               f: GrapeVertexPartition[VD] => GrapeVertexPartition[VD2])
+  : GrapeVertexRDD[VD2];
+
+  private[graphx] def withGrapePartitionsRDD[VD2: ClassTag](partitionsRDD: RDD[GrapeVertexPartition[VD2]])
+  : GrapeVertexRDD[VD2]
+
+  def mapVertices[VD2: ClassTag](map: (VertexId, VD) => VD2): GrapeVertexRDD[VD2]
+
+  override def innerZipJoin[U: ClassTag, VD2: ClassTag](other: VertexRDD[U])
+                                              (f: (VertexId, VD, U) => VD2): GrapeVertexRDD[VD2]
+
+  override def innerJoin[U : ClassTag, VD2 : ClassTag](other: RDD[(VertexId, U)])(f: (VertexId, VD, U) => VD2): GrapeVertexRDD[VD2]
+
+  override def leftJoin[VD2: ClassTag, VD3: ClassTag](other: RDD[(VertexId, VD2)])(f: (VertexId, VD, Option[VD2]) => VD3)
+  : GrapeVertexRDD[VD3]
+
+  override def leftZipJoin[VD2: ClassTag, VD3: ClassTag]
+  (other: VertexRDD[VD2])(f: (VertexId, VD, Option[VD2]) => VD3): VertexRDD[VD3]
+
+  def syncOuterVertex : GrapeVertexRDD[VD]
+
+  def collectNbrIds(direction : EdgeDirection) : GrapeVertexRDD[Array[VertexId]]
+
+  def updateAfterPIE() : GrapeVertexRDD[VD]
+}
+
+object GrapeVertexRDD extends Logging{
+
+  def fromVertexPartitions[VD : ClassTag](vertexPartition : RDD[GrapeVertexPartition[VD]]): GrapeVertexRDDImpl[VD] ={
+    new GrapeVertexRDDImpl[VD](vertexPartition)
+  }
+
+  def fromGrapeEdgeRDD[VD: ClassTag](edgeRDD: GrapeEdgeRDD[_], routingTable : RDD[RoutingTable], numPartitions : Int, defaultVal : VD, storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY) : GrapeVertexRDDImpl[VD] = {
+    log.info(s"Driver: Creating vertex rdd from graphx edgeRDD of numPartition ${numPartitions}, default val ${defaultVal}")
+    val grapeVertexPartition = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), edgeRDD.grapePartitionsRDD, routingTable)((epartIter, routingIter) => {
+      if (epartIter.hasNext){
+        val ePart = epartIter.next()
+        require(routingIter.hasNext)
+        val routingTable = routingIter.next()
+        //vertex partition include the all the vertices in this frag, including inner vertices and outer vertices.
+        log.debug(s"Vertex partition ${ePart.pid} doing initialization with default value ${defaultVal}, from ${ePart.startLid} to ${ePart.endLid}")
+        val grapeVertexPartition = GrapeVertexPartition.fromEdgePartition(defaultVal,ePart.pid, ePart.startLid, ePart.endLid, ePart.localId, ePart.localNum, ePart.siblingPid, ePart.client, ePart.graphStructure,routingTable)
+        Iterator(grapeVertexPartition)
+      }
+      else Iterator.empty
+    }).cache()
+    new GrapeVertexRDDImpl[VD](grapeVertexPartition, storageLevel)
+  }
+
+  def fromFragmentEdgeRDD[VD: ClassTag](edgeRDD: GrapeEdgeRDD[_],routingTable : RDD[RoutingTable], numPartitions : Int, storageLevel: StorageLevel = StorageLevel.MEMORY_ONLY) : GrapeVertexRDDImpl[VD] = {
+    log.info(s"Driver: Creating vertex rdd from fragment edgeRDD of numPartition ${numPartitions}")
+    val grapeVertexPartitions = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), edgeRDD.grapePartitionsRDD, routingTable)((epartIter, routingIter) => {
+      val ePart = epartIter.next()
+      val routingTable = routingIter.next()
+      val vertexDataStore = new InHeapVertexDataStore[VD](ePart.graphStructure.getVertexSize.toInt, ePart.localNum, ePart.client)
+      val actualStructure = ePart.graphStructure.asInstanceOf[FragmentStructure]
+        val frag = actualStructure.fragment.asInstanceOf[IFragment[Long,Long,VD,_]]
+        val vertex = FFITypeFactoryhelper.newVertexLong().asInstanceOf[Vertex[Long]]
+        for (i <- 0 until ePart.graphStructure.getInnerVertexSize.toInt){
+          vertex.SetValue(i)
+          vertexDataStore.set(i,frag.getData(vertex))
+        }
+        //only set inner vertices
+        val partition = new GrapeVertexPartition[VD](ePart.pid, 0,frag.getInnerVerticesNum.toInt, ePart.localId, ePart.localNum, ePart.siblingPid, actualStructure, vertexDataStore, ePart.client, routingTable)
+        Iterator(partition)
+    }).cache()
+    new GrapeVertexRDDImpl[VD](grapeVertexPartitions,storageLevel)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/PartitionAwareZippedPartitionRDD.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/PartitionAwareZippedPartitionRDD.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.graphx.grape
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.util.Utils
+import org.apache.spark.{OneToOneDependency, Partition, SparkContext, TaskContext}
+
+import java.io.{IOException, ObjectOutputStream}
+import scala.reflect.ClassTag
+
+/** In spark, we need use zipPartition to combine two rdd together. In Spark default impl, partitions
+ * of two rdd will be scheduled to same host. However, in our cases, we don't want data to move cross
+ * machines. So we create this rdd to make all partitions located on first rdd's preference.*/
+class ZippedPartitionsPartition(
+                                                idx: Int,
+                                                @transient private val rdds: Seq[RDD[_]],
+                                                @transient val preferredLocations: Seq[String])
+  extends Partition with Logging {
+
+  override val index: Int = idx
+  var partitionValues = rdds.map(rdd => rdd.partitions(idx))
+  def partitions: Seq[Partition] = partitionValues
+
+  @throws(classOf[IOException])
+  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    // Update the reference to parent split at the time of task serialization
+    partitionValues = rdds.map(rdd => rdd.partitions(idx))
+    oos.defaultWriteObject()
+  }
+}
+
+abstract class PartitionAwareZippedBaseRDD[V: ClassTag](
+                                                                    sc: SparkContext,
+                                                                    var rdds: Seq[RDD[_]],
+                                                                    preservesPartitioning: Boolean = false)
+  extends RDD[V](sc, rdds.map(x => new OneToOneDependency(x))) {
+
+  override val partitioner =
+    if (preservesPartitioning) firstParent[Any].partitioner else None
+
+  override def getPartitions: Array[Partition] = {
+    val numParts = rdds.head.partitions.length
+    if (!rdds.forall(rdd => rdd.partitions.length == numParts)) {
+      throw new IllegalArgumentException(
+        s"Can't zip RDDs with unequal numbers of partitions: ${rdds.map(_.partitions.length)}")
+    }
+    Array.tabulate[Partition](numParts) { i =>
+      val firstPartition = rdds(0).partitions(i)
+      new ZippedPartitionsPartition(i, rdds, rdds(0).preferredLocations(firstPartition))
+    }
+  }
+
+  override def getPreferredLocations(s: Partition): Seq[String] = {
+    s.asInstanceOf[ZippedPartitionsPartition].preferredLocations
+  }
+
+  override def clearDependencies(): Unit = {
+    super.clearDependencies()
+    rdds = null
+  }
+}
+
+class PartitionAwareZippedPartitionRDD2[A: ClassTag, B: ClassTag, V: ClassTag](
+                                                                                  sc: SparkContext,
+                                                                                  var f: (Iterator[A], Iterator[B]) => Iterator[V],
+                                                                                  var rdd1: RDD[A],
+                                                                                  var rdd2: RDD[B],
+                                                                                  preservesPartitioning: Boolean = false)
+  extends PartitionAwareZippedBaseRDD[V](sc, List(rdd1, rdd2), preservesPartitioning) {
+
+  override def compute(s: Partition, context: TaskContext): Iterator[V] = {
+    val partitions = s.asInstanceOf[ZippedPartitionsPartition].partitions
+    f(rdd1.iterator(partitions(0), context), rdd2.iterator(partitions(1), context))
+  }
+
+  override def clearDependencies(): Unit = {
+    super.clearDependencies()
+    rdd1 = null
+    rdd2 = null
+    f = null
+  }
+}
+object PartitionAwareZippedBaseRDD{
+  def zipPartitions[T: ClassTag, B: ClassTag, V: ClassTag](sc : SparkContext,rdd1 : RDD[T], rdd2: RDD[B], preservesPartitioning: Boolean = true)
+  (f: (Iterator[T], Iterator[B]) => Iterator[V]): RDD[V] = {
+    new PartitionAwareZippedPartitionRDD2(sc, sc.clean(f), rdd1, rdd2, preservesPartitioning)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/impl/GrapeEdgeRDDImpl.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/impl/GrapeEdgeRDDImpl.scala
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.graphx.grape.impl
+
+import com.alibaba.graphscope.graphx.rdd.impl.GrapeEdgePartition
+import org.apache.spark.graphx._
+import org.apache.spark.graphx.grape.{GrapeEdgeRDD, PartitionAwareZippedBaseRDD}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.{OneToOneDependency, Partition, Partitioner, TaskContext}
+
+import scala.reflect.ClassTag
+
+class GrapeEdgeRDDImpl [VD: ClassTag, ED: ClassTag] private[graphx](@transient override val grapePartitionsRDD: RDD[GrapeEdgePartition[VD, ED]],
+                                                                     val targetStorageLevel: StorageLevel = StorageLevel.MEMORY_ONLY)
+  extends GrapeEdgeRDD[ED](grapePartitionsRDD.context, List(new OneToOneDependency(grapePartitionsRDD))) {
+
+  override protected def getPartitions: Array[Partition] = grapePartitionsRDD.partitions
+
+  override val partitioner: Option[Partitioner] = grapePartitionsRDD.partitioner
+
+  override def compute(part: Partition, context: TaskContext): Iterator[Edge[ED]] = {
+    val p = firstParent[GrapeEdgePartition[VD, ED]].iterator(part, context)
+    if (p.hasNext) {
+      p.next().iterator.map(_.copy())
+    } else {
+      Iterator.empty
+    }
+  }
+
+  override def setName(_name: String): this.type = {
+    if (grapePartitionsRDD.name != null) {
+      grapePartitionsRDD.setName(grapePartitionsRDD.name + ", " + _name)
+    } else {
+      grapePartitionsRDD.setName(_name)
+    }
+    this
+  }
+  setName("GrapeEdgeRDDImpl")
+
+  override def collect(): Array[Edge[ED]] = this.map(_.copy()).collect()
+
+  override def persist(newLevel: StorageLevel): this.type = {
+    grapePartitionsRDD.persist(newLevel)
+    this
+  }
+
+  override def unpersist(blocking: Boolean = false): this.type = {
+    grapePartitionsRDD.unpersist(blocking)
+    this
+  }
+
+  override def cache(): this.type = {
+    grapePartitionsRDD.persist(targetStorageLevel)
+    this
+  }
+
+  override def getStorageLevel: StorageLevel = grapePartitionsRDD.getStorageLevel
+
+  override def checkpoint(): Unit = {
+    grapePartitionsRDD.checkpoint()
+  }
+
+  override def isCheckpointed: Boolean = {
+    firstParent[(PartitionID, GrapeEdgePartition[VD, ED])].isCheckpointed
+  }
+
+  override def getCheckpointFile: Option[String] = {
+    grapePartitionsRDD.getCheckpointFile
+  }
+
+  override def count(): Long = {
+    grapePartitionsRDD.map(_.activeEdgeNum).fold(0)(_ + _)
+  }
+
+  override def mapValues[ED2 :ClassTag](f: Edge[ED] => ED2): GrapeEdgeRDDImpl[VD,ED2] = {
+    mapEdgePartitions((part) => part.map(f))
+  }
+
+  override def reverse: GrapeEdgeRDD[ED] = {
+    mapEdgePartitions(partition => partition.reverse)
+  }
+
+  override def innerJoin[ED2: ClassTag, ED3: ClassTag]
+  (other: EdgeRDD[ED2])
+  (f: (VertexId, VertexId, ED, ED2) => ED3): GrapeEdgeRDD[ED3] = {
+  val newPartitions = PartitionAwareZippedBaseRDD.zipPartitions(context, grapePartitionsRDD, other.asInstanceOf[GrapeEdgeRDD[ED2]].grapePartitionsRDD)({
+      (thisIter, otherIter) => {
+        if (thisIter.hasNext) {
+          val thisEpart = thisIter.next()
+          val otherEpart = otherIter.next()
+          Iterator(thisEpart.innerJoin(otherEpart)(f))
+        }
+        else Iterator.empty
+      }
+    })
+    this.withPartitionsRDD[VD,ED3](newPartitions)
+  }
+
+  override def withTargetStorageLevel(newTargetStorageLevel: StorageLevel) : GrapeEdgeRDDImpl[VD,ED] = {
+    new GrapeEdgeRDDImpl[VD,ED](grapePartitionsRDD, newTargetStorageLevel)
+  }
+
+  def mapEdgePartitions[VD2: ClassTag, ED2: ClassTag](
+           f: GrapeEdgePartition[VD, ED] => GrapeEdgePartition[VD2, ED2]): GrapeEdgeRDDImpl[VD2, ED2] = {
+    this.withPartitionsRDD[VD2, ED2](grapePartitionsRDD.mapPartitions({ iter =>
+      if (iter.hasNext) {
+        val ep = iter.next()
+        Iterator(f(ep))
+      } else {
+        Iterator.empty
+      }
+    }, preservesPartitioning = true))
+  }
+
+  def withPartitionsRDD[VD2: ClassTag, ED2: ClassTag](
+          partitionsRDD: RDD[GrapeEdgePartition[VD2, ED2]]): GrapeEdgeRDDImpl[VD2, ED2] = {
+    new GrapeEdgeRDDImpl[VD2,ED2](partitionsRDD, this.targetStorageLevel)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/impl/GrapeVertexRDDImpl.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/grape/impl/GrapeVertexRDDImpl.scala
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.graphx.grape.impl
+
+import com.alibaba.graphscope.context.GraphXParallelAdaptorContext
+import com.alibaba.graphscope.graphx.GraphXParallelPIE
+import com.alibaba.graphscope.graphx.rdd.impl.GrapeVertexPartition
+import org.apache.spark._
+import org.apache.spark.graphx.{grape, _}
+import org.apache.spark.graphx.grape.{GrapeVertexRDD, PartitionAwareZippedBaseRDD}
+import org.apache.spark.graphx.impl.ShippableVertexPartition
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+
+import java.util
+import scala.reflect.ClassTag
+
+/**
+ * This class should be construct from off heap memories, which is provided by graphscope.
+ * @param partitionsRDD
+ * @param targetStorageLevel
+ * @param vdTag
+ * @tparam VD
+ */
+class GrapeVertexRDDImpl[VD] private[graphx](
+                                              @transient override val grapePartitionsRDD: RDD[GrapeVertexPartition[VD]],
+                                              val targetStorageLevel: StorageLevel = StorageLevel.MEMORY_ONLY,
+                                              val outerVertexSynced : Boolean = false) // indicate whether we have done outer vertex shuffling.
+                                            (implicit override protected val vdTag: ClassTag[VD])
+  extends GrapeVertexRDD[VD](grapePartitionsRDD.context, List(new OneToOneDependency(grapePartitionsRDD))) {
+
+  setName("GrapeVertexRDDImpl")
+  override def reindex(): VertexRDD[VD] = {
+    this
+  }
+
+  override protected def getPartitions: Array[Partition] = grapePartitionsRDD.partitions
+
+  override val partitioner: Option[Partitioner] = grapePartitionsRDD.partitioner
+
+  override def compute(part: Partition, context: TaskContext): Iterator[(VertexId,VD)] = {
+    val p = firstParent[GrapeVertexPartition[VD]].iterator(part, context)
+    if (p.hasNext) {
+      p.next().iterator.map(_.copy())
+    } else {
+      Iterator.empty
+    }
+  }
+
+  def mapVertices[VD2: ClassTag](map: (VertexId, VD) => VD2) : GrapeVertexRDD[VD2] = {
+    this.mapGrapeVertexPartitions(_.map(map))
+  }
+
+  override def count(): Long = {
+    grapePartitionsRDD.map(_.bitSet.cardinality()).reduce(_ + _)
+  }
+
+  override private[graphx] def mapGrapeVertexPartitions[VD2: ClassTag](f: GrapeVertexPartition[VD] => GrapeVertexPartition[VD2])
+  : GrapeVertexRDD[VD2] = {
+  val newPartitionsRDD  = grapePartitionsRDD.mapPartitions(
+      iter => {
+        if (iter.hasNext){
+          val part = iter.next();
+          Iterator(f.apply(part))
+        }
+        else {
+          Iterator.empty
+        }
+      },preservesPartitioning = true
+    )
+  this.withGrapePartitionsRDD(newPartitionsRDD)
+  }
+
+  override def mapValues[VD2](f: VD => VD2)(implicit evidence$2: ClassTag[VD2]): VertexRDD[VD2] = {
+    this.mapGrapeVertexPartitions(_.map((vid, attr) => f(attr)))
+  }
+
+  override def mapValues[VD2](f: (VertexId, VD) => VD2)(implicit evidence$3: ClassTag[VD2]): VertexRDD[VD2] = {
+    this.mapGrapeVertexPartitions(_.map(f))
+  }
+
+  override def minus(other: RDD[(VertexId, VD)]): VertexRDD[VD] = {
+    minus(this.aggregateUsingIndex(other, (a: VD, b: VD) => a))
+  }
+
+  override def minus(other: VertexRDD[VD]): VertexRDD[VD] = {
+    other match{
+      case other : GrapeVertexRDDImpl[VD] if this.partitioner == other.partitioner => {
+        this.withGrapePartitionsRDD[VD](
+          PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(),grapePartitionsRDD, other.grapePartitionsRDD){
+            (thisIter, otherIter) =>
+              if (thisIter.hasNext) {
+                val thisPartition = thisIter.next()
+                val otherPartition = otherIter.next()
+                require(thisPartition.pid == otherPartition.pid, "partition id should match")
+                Iterator(thisPartition.minus(otherPartition))
+              }
+              else Iterator.empty
+          })
+      }
+      case _ =>  throw new IllegalArgumentException("can only minus a grape vertex rdd now")
+    }
+  }
+
+  override def diff(other: RDD[(VertexId, VD)]): VertexRDD[VD] = {
+    diff(this.aggregateUsingIndex(other, (a: VD, b: VD) => a))
+  }
+
+  override def diff(other: VertexRDD[VD]): VertexRDD[VD] = {
+    val otherPartition = other match {
+      case other: GrapeVertexRDDImpl[VD] if this.partitioner == other.partitioner =>
+        other.grapePartitionsRDD
+      case _ =>  throw new IllegalArgumentException("can only minus a grape vertex rdd now")
+    }
+    val newPartitionsRDD = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), grapePartitionsRDD,otherPartition) { (thisIter, otherIter) =>
+      val thisTuple = thisIter.next()
+      val otherTuple = otherIter.next()
+      require(thisTuple.pid == otherTuple.pid, "partition id should match")
+      Iterator( thisTuple.diff(otherTuple))
+    }
+    this.withGrapePartitionsRDD(newPartitionsRDD)
+  }
+
+  override def leftZipJoin[VD2 : ClassTag, VD3 : ClassTag](other: VertexRDD[VD2])(f: (VertexId, VD, Option[VD2]) => VD3): GrapeVertexRDD[VD3] = {
+    val newPartitionsRDD = other match {
+      case other : GrapeVertexRDDImpl[VD2] => {
+        PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), grapePartitionsRDD, other.grapePartitionsRDD) { (thisIter, otherIter) =>
+          val thisTuple = thisIter.next()
+          val otherTuple = otherIter.next()
+          Iterator(thisTuple.leftJoin[VD2,VD3](otherTuple)(f))
+        }
+      }
+    }
+    this.withGrapePartitionsRDD(newPartitionsRDD)
+  }
+
+  override def leftJoin[VD2 : ClassTag, VD3 : ClassTag](other: RDD[(VertexId, VD2)])(f: (VertexId, VD, Option[VD2]) => VD3): GrapeVertexRDD[VD3] = {
+    other match {
+      case other: GrapeVertexRDDImpl[VD2] =>
+        leftZipJoin[VD2,VD3](other)(f)
+      case _ =>
+        throw new IllegalArgumentException("currently not support to join with non-grape vertex rdd")
+    }
+  }
+
+  override def innerZipJoin[U : ClassTag, VD2 : ClassTag](other: VertexRDD[U])(f: (VertexId, VD, U) => VD2): GrapeVertexRDD[VD2] = {
+    val newPartitionsRDD = other match {
+      case other : GrapeVertexRDDImpl[U] => {
+          PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(),grapePartitionsRDD,other.grapePartitionsRDD
+        ) { (thisIter, otherIter) =>
+          val thisTuple = thisIter.next()
+          val otherTuple = otherIter.next()
+          Iterator(thisTuple.innerJoin(otherTuple)(f))
+        }
+      }
+    }
+    this.withGrapePartitionsRDD(newPartitionsRDD)
+  }
+
+  override def innerJoin[U: ClassTag, VD2: ClassTag](other: RDD[(VertexId, U)])(f: (VertexId, VD, U) => VD2): GrapeVertexRDD[VD2] = {
+    other match {
+      case other: GrapeVertexRDDImpl[U] => innerZipJoin(other)(f)
+      case _ =>
+          throw new IllegalArgumentException("Current only support join with grape vertex rdd");
+    }
+  }
+
+  /**
+   * To aggregate with us, the input rdd can be a offheap vertexRDDImpl or a common one.
+   * - For offHeap rdd ,just do the aggregation, since its partitioner is same with use, i.e. hashPartition
+   *   with fnum = num of workers.
+   * - For common one, we need to make sure they share the same num of partitions. and then we repartition to size of excutors.
+   * @param messages
+   * @param reduceFunc
+   * @tparam VD2
+   * @return
+   */
+  override def aggregateUsingIndex[VD2: ClassTag](messages: RDD[(VertexId, VD2)], reduceFunc: (VD2, VD2) => VD2)
+                                       : VertexRDD[VD2] = {
+    val executorStatus = sparkContext.getExecutorMemoryStatus
+    log.info(s"Current available executors ${executorStatus}")
+    val numExecutors = executorStatus.size
+    val shuffled = messages.partitionBy(new HashPartitioner(numExecutors))
+    val newPartitionsRDD = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), grapePartitionsRDD, shuffled){
+      (thisIter, msgIter) =>{
+        if (thisIter.hasNext){
+          val tuple = thisIter.next();
+          val newPartition = tuple.aggregateUsingIndex(msgIter, reduceFunc)
+          Iterator(newPartition)
+        }
+        else {
+          Iterator.empty
+        }
+      }
+    }
+    this.withGrapePartitionsRDD[VD2](newPartitionsRDD)
+  }
+
+
+  override def syncOuterVertex : GrapeVertexRDD[VD] = {
+    if (outerVertexSynced){
+      log.info("Outer vertex already synced")
+      return this
+    }
+    val time0 = System.nanoTime()
+    val updateMessage = this.grapePartitionsRDD.mapPartitions(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        part.generateVertexDataMessage
+      }
+      else {
+        Iterator.empty
+      }
+    }).partitionBy(new HashPartitioner(this.grapePartitionsRDD.getNumPartitions)).cache()
+
+    val updatedVertexPartition = PartitionAwareZippedBaseRDD.zipPartitions(SparkContext.getOrCreate(), grapePartitionsRDD, updateMessage){
+    (vIter, msgIter) => {
+      if (vIter.hasNext) {
+        val vpart = vIter.next()
+         Iterator(vpart.updateOuterVertexData(msgIter))
+      } else Iterator.empty
+    }
+    }.cache()
+
+    val test = updatedVertexPartition.barrier().mapPartitions(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        log.info("inside barrier execution")
+        Iterator(1)
+      }
+      else {
+        Iterator.empty
+      }
+    }).collect()
+    val time1 = System.nanoTime()
+    log.info(s"[Perf: ]Sync vertices cost ${(time1 - time0)/1000000} ms")
+    updateMessage.unpersist()
+    this.withGrapePartitionsRDD(updatedVertexPartition, true)
+  }
+
+  override def reverseRoutingTables(): VertexRDD[VD] = {
+    throw new IllegalStateException("Inherited but not implemented, should not be used")
+  }
+
+  override def withEdges(edges: EdgeRDD[_]): VertexRDD[VD] = {
+    throw new IllegalStateException("Inherited but not implemented, should not be used")
+  }
+
+  override private[graphx] def withPartitionsRDD[VD2](partitionsRDD: RDD[ShippableVertexPartition[VD2]])(implicit evidence$13: ClassTag[VD2]) = {
+    throw new IllegalStateException("Inherited but not implemented, should not be used, use withGrapePartitionsRDD instead")
+  }
+
+  override private[graphx] def withGrapePartitionsRDD[VD2 : ClassTag](partitionsRDD: RDD[GrapeVertexPartition[VD2]]) : GrapeVertexRDD[VD2] = {
+    new GrapeVertexRDDImpl[VD2](partitionsRDD,this.targetStorageLevel)
+  }
+  private[graphx] def withGrapePartitionsRDD[VD2 : ClassTag](partitionsRDD: RDD[GrapeVertexPartition[VD2]], synced : Boolean) : GrapeVertexRDD[VD2] = {
+    new GrapeVertexRDDImpl[VD2](partitionsRDD,this.targetStorageLevel, synced)
+  }
+
+  override private[graphx] def withTargetStorageLevel(newTargetStorageLevel: StorageLevel) = {
+    new GrapeVertexRDDImpl[VD](grapePartitionsRDD, newTargetStorageLevel)
+  }
+
+  override private[graphx] def shipVertexAttributes(shipSrc: Boolean, shipDst: Boolean) = {
+    throw new IllegalStateException("Inherited but not implemented, should not be used")
+  }
+
+  override private[graphx] def shipVertexIds() = {
+    throw new IllegalStateException("Inherited but not implemented, should not be used")
+    }
+
+  override def collectNbrIds(direction : EdgeDirection): GrapeVertexRDD[Array[VertexId]] = {
+    val part = grapePartitionsRDD.mapPartitions(iter => {
+      val part = iter.next()
+      Iterator(part.collectNbrIds(direction))
+    })
+    this.withGrapePartitionsRDD(part)
+  }
+
+  override private[graphx] def mapVertexPartitions[VD2](f: ShippableVertexPartition[VD] => ShippableVertexPartition[VD2])(implicit evidence$1: ClassTag[VD2]) = {
+    throw new IllegalStateException("Not implemented")
+  }
+
+  override def updateAfterPIE(): GrapeVertexRDD[VD] = {
+    val filePathPrefix = GraphXParallelAdaptorContext.pathPrefix
+    val partitions = grapePartitionsRDD.mapPartitions(iter => {
+      if (iter.hasNext){
+        val part = iter.next()
+        Iterator(part.updateAfterPIE(filePathPrefix))
+      }
+      else Iterator.empty
+    }).cache()
+    this.withGrapePartitionsRDD(partitions)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/lib/PageRank.scala
@@ -1,0 +1,536 @@
+/*
+ * The file GiraphConfiguration.java is referred and derived from
+ * project apache/spark,
+ *
+ *    https://github.com/apache/spark.git
+ *
+ * which has the following license:
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.graphx.lib
+
+import scala.reflect.ClassTag
+import breeze.linalg.{Vector => BV}
+import com.alibaba.graphscope.graphx.utils.DoubleDouble
+import org.apache.spark.graphx._
+import org.apache.spark.internal.Logging
+import org.apache.spark.ml.linalg.{Vector, Vectors}
+
+/**
+ * PageRank algorithm implementation. There are two implementations of PageRank implemented.
+ *
+ * The first implementation uses the standalone `Graph` interface and runs PageRank
+ * for a fixed number of iterations:
+ * {{{
+ * var PR = Array.fill(n)( 1.0 )
+ * val oldPR = Array.fill(n)( 1.0 )
+ * for( iter <- 0 until numIter ) {
+ *   swap(oldPR, PR)
+ *   for( i <- 0 until n ) {
+ *     PR[i] = alpha + (1 - alpha) * inNbrs[i].map(j => oldPR[j] / outDeg[j]).sum
+ *   }
+ * }
+ * }}}
+ *
+ * The second implementation uses the `Pregel` interface and runs PageRank until
+ * convergence:
+ *
+ * {{{
+ * var PR = Array.fill(n)( 1.0 )
+ * val oldPR = Array.fill(n)( 0.0 )
+ * while( max(abs(PR - oldPr)) > tol ) {
+ *   swap(oldPR, PR)
+ *   for( i <- 0 until n if abs(PR[i] - oldPR[i]) > tol ) {
+ *     PR[i] = alpha + (1 - \alpha) * inNbrs[i].map(j => oldPR[j] / outDeg[j]).sum
+ *   }
+ * }
+ * }}}
+ *
+ * `alpha` is the random reset probability (typically 0.15), `inNbrs[i]` is the set of
+ * neighbors which link to `i` and `outDeg[j]` is the out degree of vertex `j`.
+ *
+ * @note This is not the "normalized" PageRank and as a consequence pages that have no
+ * inlinks will have a PageRank of alpha.
+ */
+object PageRank extends Logging {
+
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph
+   * with vertex attributes containing the PageRank and edge
+   * attributes the normalized edge weight.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param numIter the number of iterations of PageRank to run
+   * @param resetProb the random reset probability (alpha)
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   */
+  def run[VD: ClassTag, ED: ClassTag](
+                                       graph: Graph[VD, ED], numIter: Int, resetProb: Double = 0.15): Graph[Double, Double] =
+  {
+    runWithOptions(graph, numIter, resetProb, None)
+  }
+
+  /**
+   * Run an update pass of PageRank algorithm. Update the values of every node in the
+   * pageRank
+   *
+   * @param rankGraph the current PageRank
+   * @param personalized True if personalized pageRank
+   * @param resetProb the random reset probability (alpha)
+   * @param src the source vertex for a Personalized Page Rank
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight after a single update step.
+   *
+   */
+  private def runUpdate(rankGraph: Graph[Double, Double], personalized: Boolean,
+                        resetProb: Double, src: VertexId): Graph[Double, Double] = {
+
+    def delta(u: VertexId, v: VertexId): Double = { if (u == v) 1.0 else 0.0 }
+    // Compute the outgoing rank contributions of each vertex, perform local preaggregation, and
+    // do the final aggregation at the receiving vertices. Requires a shuffle for aggregation.
+    val rankUpdates = rankGraph.aggregateMessages[Double](
+      ctx => ctx.sendToDst(ctx.srcAttr * ctx.attr), _ + _, TripletFields.Src)
+
+    // Apply the final rank updates to get the new ranks, using join to preserve ranks of vertices
+    // that didn't receive a message. Requires a shuffle for broadcasting updated ranks to the
+    // edge partitions.
+    val rPrb = if (personalized) {
+      (src: VertexId, id: VertexId) => resetProb * delta(src, id)
+    } else {
+      (src: VertexId, id: VertexId) => resetProb
+    }
+
+    rankGraph.outerJoinVertices(rankUpdates) {
+      (id, oldRank, msgSumOpt) => rPrb(src, id) + (1.0 - resetProb) * msgSumOpt.getOrElse(0.0)
+    }
+  }
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph
+   * with vertex attributes containing the PageRank and edge
+   * attributes the normalized edge weight.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param numIter the number of iterations of PageRank to run
+   * @param resetProb the random reset probability (alpha)
+   * @param srcId the source vertex for a Personalized Page Rank (optional)
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   *
+   */
+  def runWithOptions[VD: ClassTag, ED: ClassTag](
+                                                  graph: Graph[VD, ED], numIter: Int, resetProb: Double = 0.15,
+                                                  srcId: Option[VertexId] = None): Graph[Double, Double] = {
+    runWithOptions(graph, numIter, resetProb, srcId, normalized = true)
+  }
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph
+   * with vertex attributes containing the PageRank and edge
+   * attributes the normalized edge weight.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param numIter the number of iterations of PageRank to run
+   * @param resetProb the random reset probability (alpha)
+   * @param srcId the source vertex for a Personalized Page Rank (optional)
+   * @param normalized whether or not to normalize rank sum
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   *
+   * @since 3.2.0
+   */
+  def runWithOptions[VD: ClassTag, ED: ClassTag](
+                                                  graph: Graph[VD, ED], numIter: Int, resetProb: Double,
+                                                  srcId: Option[VertexId], normalized: Boolean): Graph[Double, Double] = {
+    require(numIter > 0, "Number of iterations must be greater than 0," +
+      s" but got ${numIter}")
+    require(resetProb >= 0 && resetProb <= 1, "Random reset probability must belong" +
+      s" to [0, 1], but got ${resetProb}")
+
+    val personalized = srcId.isDefined
+    val src: VertexId = srcId.getOrElse(-1L)
+
+    // Initialize the PageRank graph with each edge attribute having
+    // weight 1/outDegree and each vertex with attribute 1.0.
+    // When running personalized pagerank, only the source vertex
+    // has an attribute 1.0. All others are set to 0.
+    var rankGraph: Graph[Double, Double] = graph
+      // Associate the degree with each vertex
+      .outerJoinVertices(graph.outDegrees) { (vid, vdata, deg) => deg.getOrElse(0) }
+      // Set the weight on the edges based on the degree
+      .mapTriplets( e => 1.0 / e.srcAttr, TripletFields.Src )
+      // Set the vertex attributes to the initial pagerank values
+      .mapVertices { (id, attr) =>
+        if (!(id != src && personalized)) 1.0 else 0.0
+      }
+
+    var iteration = 0
+    var prevRankGraph: Graph[Double, Double] = null
+    while (iteration < numIter) {
+      rankGraph.cache()
+      prevRankGraph = rankGraph
+
+      rankGraph = runUpdate(rankGraph, personalized, resetProb, src)
+      rankGraph.cache()
+      rankGraph.edges.foreachPartition(x => {}) // also materializes rankGraph.vertices
+      logInfo(s"PageRank finished iteration $iteration.")
+      prevRankGraph.vertices.unpersist()
+      prevRankGraph.edges.unpersist()
+      iteration += 1
+    }
+
+    if (normalized) {
+      // SPARK-18847 If the graph has sinks (vertices with no outgoing edges),
+      // correct the sum of ranks
+      normalizeRankSum(rankGraph, personalized)
+    } else {
+      rankGraph
+    }
+  }
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph
+   * with vertex attributes containing the PageRank and edge
+   * attributes the normalized edge weight.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param numIter the number of iterations of PageRank to run
+   * @param resetProb the random reset probability (alpha)
+   * @param srcId the source vertex for a Personalized Page Rank (optional)
+   * @param preRankGraph PageRank graph from which to keep iterating
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   *
+   */
+  def runWithOptionsWithPreviousPageRank[VD: ClassTag, ED: ClassTag](
+                                                                      graph: Graph[VD, ED], numIter: Int, resetProb: Double, srcId: Option[VertexId],
+                                                                      preRankGraph: Graph[Double, Double]): Graph[Double, Double] = {
+    runWithOptionsWithPreviousPageRank(
+      graph, numIter, resetProb, srcId, normalized = true, preRankGraph
+    )
+  }
+
+  /**
+   * Run PageRank for a fixed number of iterations returning a graph
+   * with vertex attributes containing the PageRank and edge
+   * attributes the normalized edge weight.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param numIter the number of iterations of PageRank to run
+   * @param resetProb the random reset probability (alpha)
+   * @param srcId the source vertex for a Personalized Page Rank (optional)
+   * @param normalized whether or not to normalize rank sum
+   * @param preRankGraph PageRank graph from which to keep iterating
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   *
+   * @since 3.2.0
+   */
+  def runWithOptionsWithPreviousPageRank[VD: ClassTag, ED: ClassTag](
+                                                                      graph: Graph[VD, ED], numIter: Int, resetProb: Double, srcId: Option[VertexId],
+                                                                      normalized: Boolean, preRankGraph: Graph[Double, Double]): Graph[Double, Double] = {
+    require(numIter > 0, "Number of iterations must be greater than 0," +
+      s" but got ${numIter}")
+    require(resetProb >= 0 && resetProb <= 1, "Random reset probability must belong" +
+      s" to [0, 1], but got ${resetProb}")
+    val graphVertices = graph.numVertices
+    val prePageRankVertices = preRankGraph.numVertices
+    require(graphVertices == prePageRankVertices, "Graph and previous pageRankGraph" +
+      s" must have the same number of vertices but got ${graphVertices} and ${prePageRankVertices}")
+
+    val personalized = srcId.isDefined
+    val src: VertexId = srcId.getOrElse(-1L)
+
+    // Initialize the PageRank graph with each edge attribute having
+    // weight 1/outDegree and each vertex with attribute 1.0.
+    // When running personalized pagerank, only the source vertex
+    // has an attribute 1.0. All others are set to 0.
+    var rankGraph: Graph[Double, Double] = preRankGraph
+
+    var iteration = 0
+    var prevRankGraph: Graph[Double, Double] = null
+
+    while (iteration < numIter) {
+      rankGraph.cache()
+      prevRankGraph = rankGraph
+
+      rankGraph = runUpdate(rankGraph, personalized, resetProb, src)
+      rankGraph.cache()
+      rankGraph.edges.foreachPartition(x => {}) // also materializes rankGraph.vertices
+      logInfo(s"PageRank finished iteration $iteration.")
+      prevRankGraph.vertices.unpersist()
+      prevRankGraph.edges.unpersist()
+      iteration += 1
+    }
+
+    if (normalized) {
+      // SPARK-18847 If the graph has sinks (vertices with no outgoing edges),
+      // correct the sum of ranks
+      normalizeRankSum(rankGraph, personalized)
+    } else {
+      rankGraph
+    }
+  }
+
+  /**
+   * Run Personalized PageRank for a fixed number of iterations, for a
+   * set of starting nodes in parallel. Returns a graph with vertex attributes
+   * containing the pagerank relative to all starting nodes (as a sparse vector) and
+   * edge attributes the normalized edge weight
+   *
+   * @tparam VD The original vertex attribute (not used)
+   * @tparam ED The original edge attribute (not used)
+   *
+   * @param graph The graph on which to compute personalized pagerank
+   * @param numIter The number of iterations to run
+   * @param resetProb The random reset probability
+   * @param sources The list of sources to compute personalized pagerank from
+   * @return the graph with vertex attributes
+   *         containing the pagerank relative to all starting nodes (as a sparse vector
+   *         indexed by the position of nodes in the sources list) and
+   *         edge attributes the normalized edge weight
+   */
+  def runParallelPersonalizedPageRank[VD: ClassTag, ED: ClassTag](
+                                                                   graph: Graph[VD, ED],
+                                                                   numIter: Int,
+                                                                   resetProb: Double = 0.15,
+                                                                   sources: Array[VertexId]): Graph[Vector, Double] = {
+    require(numIter > 0, "Number of iterations must be greater than 0," +
+      s" but got ${numIter}")
+    require(resetProb >= 0 && resetProb <= 1, "Random reset probability must belong" +
+      s" to [0, 1], but got ${resetProb}")
+    require(sources.nonEmpty, "The list of sources must be non-empty," +
+      s" but got ${sources.mkString("[", ",", "]")}")
+
+    val zero = Vectors.sparse(sources.size, List()).asBreeze
+    // map of vid -> vector where for each vid, the _position of vid in source_ is set to 1.0
+    val sourcesInitMap = sources.zipWithIndex.map { case (vid, i) =>
+      val v = Vectors.sparse(sources.size, Array(i), Array(1.0)).asBreeze
+      (vid, v)
+    }.toMap
+
+    val sc = graph.vertices.sparkContext
+    val sourcesInitMapBC = sc.broadcast(sourcesInitMap)
+    // Initialize the PageRank graph with each edge attribute having
+    // weight 1/outDegree and each source vertex with attribute 1.0.
+    var rankGraph = graph
+      // Associate the degree with each vertex
+      .outerJoinVertices(graph.outDegrees) { (vid, vdata, deg) => deg.getOrElse(0) }
+      // Set the weight on the edges based on the degree
+      .mapTriplets(e => 1.0 / e.srcAttr, TripletFields.Src)
+      .mapVertices((vid, _) => sourcesInitMapBC.value.getOrElse(vid, zero))
+
+    var i = 0
+    while (i < numIter) {
+      val prevRankGraph = rankGraph
+      // Propagates the message along outbound edges
+      // and adding start nodes back in with activation resetProb
+      val rankUpdates = rankGraph.aggregateMessages[BV[Double]](
+        ctx => ctx.sendToDst(ctx.srcAttr *:* ctx.attr),
+        (a : BV[Double], b : BV[Double]) => a +:+ b, TripletFields.Src)
+
+      rankGraph = rankGraph.outerJoinVertices(rankUpdates) {
+        (vid, oldRank, msgSumOpt) =>
+          val popActivations: BV[Double] = msgSumOpt.getOrElse(zero) *:* (1.0 - resetProb)
+          val resetActivations = if (sourcesInitMapBC.value contains vid) {
+            sourcesInitMapBC.value(vid) *:* resetProb
+          } else {
+            zero
+          }
+          popActivations +:+ resetActivations
+      }.cache()
+
+      rankGraph.edges.foreachPartition(_ => {}) // also materializes rankGraph.vertices
+      prevRankGraph.vertices.unpersist()
+      prevRankGraph.edges.unpersist()
+
+      logInfo(s"Parallel Personalized PageRank finished iteration $i.")
+
+      i += 1
+    }
+
+    // SPARK-18847 If the graph has sinks (vertices with no outgoing edges) correct the sum of ranks
+    val rankSums = rankGraph.vertices.values.fold(zero)(_ +:+ _)
+    rankGraph.mapVertices { (vid, attr) =>
+      Vectors.fromBreeze(attr /:/ rankSums)
+    }
+  }
+
+  /**
+   * Run a dynamic version of PageRank returning a graph with vertex attributes containing the
+   * PageRank and edge attributes containing the normalized edge weight.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param tol the tolerance allowed at convergence (smaller => more accurate).
+   * @param resetProb the random reset probability (alpha)
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   */
+  def runUntilConvergence[VD: ClassTag, ED: ClassTag](
+                                                       graph: Graph[VD, ED], tol: Double, resetProb: Double = 0.15): Graph[Double, Double] =
+  {
+    runUntilConvergenceWithOptions(graph, tol, resetProb)
+  }
+
+  /**
+   * Run a dynamic version of PageRank returning a graph with vertex attributes containing the
+   * PageRank and edge attributes containing the normalized edge weight.
+   *
+   * @tparam VD the original vertex attribute (not used)
+   * @tparam ED the original edge attribute (not used)
+   *
+   * @param graph the graph on which to compute PageRank
+   * @param tol the tolerance allowed at convergence (smaller => more accurate).
+   * @param resetProb the random reset probability (alpha)
+   * @param srcId the source vertex for a Personalized Page Rank (optional)
+   *
+   * @return the graph containing with each vertex containing the PageRank and each edge
+   *         containing the normalized weight.
+   */
+  def runUntilConvergenceWithOptions[VD: ClassTag, ED: ClassTag](
+                                                                  graph: Graph[VD, ED], tol: Double, resetProb: Double = 0.15,
+                                                                  srcId: Option[VertexId] = None): Graph[Double, Double] =
+  {
+    require(tol >= 0, s"Tolerance must be no less than 0, but got ${tol}")
+    require(resetProb >= 0 && resetProb <= 1, "Random reset probability must belong" +
+      s" to [0, 1], but got ${resetProb}")
+
+    val personalized = srcId.isDefined
+    val src: VertexId = srcId.getOrElse(-1L)
+
+    // Initialize the pagerankGraph with each edge attribute
+    // having weight 1/outDegree and each vertex with attribute 0.
+//    val outDegreeRDD = graph.outDegrees.cache()
+//    log.info(s"${outDegreeRDD.collect().mkString("Array(", ", ", ")")}")
+    val time0 = System.nanoTime()
+    val pagerankGraph: Graph[DoubleDouble, Double] = graph
+      // Associate the degree with each vertex
+      .outerJoinVertices(graph.outDegrees) {
+        (vid, vdata, deg) => deg.getOrElse(0)
+      }
+      // Set the weight on the edges based on the degree
+      .mapTriplets( {
+        e => {
+//          System.out.println(s"map triplet ${1.0/e.srcAttr}")
+          1.0 / e.srcAttr
+        }
+      } )
+      // Set the vertex attributes to (initialPR, delta = 0)
+      .mapVertices { (id, attr) =>
+      if (id == src) new DoubleDouble(0.0, Double.NegativeInfinity) else new DoubleDouble()
+    }.cache()
+    val (numVertices,numEdeges) = (pagerankGraph.numVertices,pagerankGraph.numEdges)
+    System.out.println(s"pagerank graph ${numVertices}, ${numEdeges}")
+    val time1 = System.nanoTime()
+    System.out.println(s"[Perf2:] construct pagerank graph cost ${(time1 - time0)/1000000} ms")
+
+//    log.info(s"${pagerankGraph.vertices.collect().mkString("Array(", ", ", ")")}")
+
+    // Define the three functions needed to implement PageRank in the GraphX
+    // version of Pregel
+    def vertexProgram(id: VertexId, attr: DoubleDouble, msgSum: Double): DoubleDouble = {
+      val (oldPR, lastDelta) = (attr.a,attr.b)
+      val newPR = oldPR + (1.0 - resetProb) * msgSum
+//      System.out.println(s"[vertex ${id} old attr ${attr}, new pr ${newPR}, msg ${msgSum}]")
+//      log.info(s"vertex ${id}, prev pr ${oldPR}, new pr ${newPR}, msgSum ${msgSum}")
+      new DoubleDouble(newPR, newPR - oldPR)
+    }
+
+    def personalizedVertexProgram(id: VertexId, attr: DoubleDouble,
+                                  msgSum: Double): DoubleDouble = {
+      val (oldPR, lastDelta) = (attr.a,attr.b)
+      val newPR = if (lastDelta == Double.NegativeInfinity) {
+        1.0
+      } else {
+        oldPR + (1.0 - resetProb) * msgSum
+      }
+      new DoubleDouble(newPR, newPR - oldPR)
+    }
+
+    def sendMessage(edge: EdgeTriplet[DoubleDouble, Double]) = {
+      if (edge.srcAttr.b > tol) {
+//        System.out.println(s"visiting edge ${edge}, sending msg to dst ${edge.dstId} msg ${edge.srcAttr.b * edge.attr}")
+        Iterator((edge.dstId, edge.srcAttr.b * edge.attr))
+      } else {
+       // System.out.println(s"visiting edge ${edge}, no msg to send")
+        Iterator.empty
+      }
+    }
+
+    def messageCombiner(a: Double, b: Double): Double = a + b
+
+    // The initial message received by all vertices in PageRank
+    val initialMessage = if (personalized) 0.0 else resetProb / (1.0 - resetProb)
+
+    // Execute a dynamic version of Pregel.
+    val vp = if (personalized) {
+      (id: VertexId, attr: DoubleDouble, msgSum: Double) =>
+        personalizedVertexProgram(id, attr, msgSum)
+    } else {
+      (id: VertexId, attr: DoubleDouble, msgSum: Double) =>
+        vertexProgram(id, attr, msgSum)
+    }
+
+    val pregelRes = Pregel(pagerankGraph, initialMessage, activeDirection = EdgeDirection.Out)(
+      vp, sendMessage, messageCombiner).cache()
+
+    val rankGraph = pregelRes.mapVertices((vid, attr) => attr.a)
+
+    // SPARK-18847 If the graph has sinks (vertices with no outgoing edges) correct the sum of ranks
+    normalizeRankSum(rankGraph, personalized)
+  }
+
+  // Normalizes the sum of ranks to n (or 1 if personalized)
+  private def normalizeRankSum(rankGraph: Graph[Double, Double], personalized: Boolean) = {
+    val rankSum = rankGraph.vertices.values.sum()
+    if (personalized) {
+      rankGraph.mapVertices((id, rank) => rank / rankSum)
+    } else {
+      val numVertices = rankGraph.numVertices
+      val correctionFactor = numVertices.toDouble / rankSum
+      rankGraph.mapVertices((id, rank) => rank * correctionFactor)
+    }
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/lib/TriangleCount.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/lib/TriangleCount.scala
@@ -1,0 +1,83 @@
+/*
+ * The file GiraphConfiguration.java is referred and derived from
+ * project apache/spark,
+ *
+ *    https://github.com/apache/spark.git
+ *
+ * which has the following license:
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.graphx.lib
+
+import org.apache.spark.graphx._
+import org.apache.spark.internal.Logging
+
+import scala.reflect.ClassTag
+
+object TriangleCount extends Logging with Serializable{
+  var stage = 0
+
+  def run[VD: ClassTag, ED: ClassTag](graph: Graph[VD, ED]): Graph[Int, ED] = {
+
+    val tmp = graph.outerJoinVertices(graph.collectNeighborIds(edgeDirection = EdgeDirection.Either))((vid, vd, nbrIds) => nbrIds.get)
+
+    val triangleGraph = tmp.mapVertices((vid, vd) => (0, vd.toSet))
+    stage = 0
+
+    def vp(id : VertexId, attr : (Int, Set[VertexId]), msg : Array[VertexId]) : (Int,Set[VertexId]) = {
+      if (stage == 0){
+        attr
+      }
+      else if (stage == 1){
+        val prevCnt = attr._1
+        var curCnt = 0
+        var i = 0
+        val size = msg.size
+        while (i < size){
+          if (attr._2.contains(msg(i))){
+            curCnt += 1
+          }
+          i += 1
+        }
+        (prevCnt + curCnt, attr._2)
+      }
+      else {
+        attr
+      }
+    }
+
+    def sendMsg(edge: EdgeTriplet[(Int, Set[VertexId]), ED]) : Iterator[(VertexId,Array[VertexId])] = {
+      if (stage == 0){
+        stage = 1
+        log.info(s"${edge.srcId} send msg to ${edge.dstId}, ${edge.srcAttr._2.toArray.mkString(",")}")
+        Iterator((edge.dstId, edge.srcAttr._2.toArray))
+      }
+      else {
+        Iterator.empty
+      }
+    }
+
+    def mergeMsg(a: Array[VertexId], b: Array[VertexId]): Array[VertexId] = {
+      val res = a ++ b
+      res
+    }
+
+    val initialMsg = new Array[VertexId](1)
+    triangleGraph.pregel(initialMsg)(vp, sendMsg, mergeMsg).mapVertices((vid,vd) => vd._1)
+  }
+}
+

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/scheduler/cluster/ExecutorInfoHelper.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/graphx/scheduler/cluster/ExecutorInfoHelper.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.graphx.scheduler.cluster
+
+import org.apache.spark.SparkContext
+import org.apache.spark.internal.Logging
+import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, StandaloneSchedulerBackend}
+import org.apache.spark.scheduler.cluster.ExecutorInfo
+import org.apache.spark.scheduler.local.LocalSchedulerBackend
+
+import java.net.InetAddress
+import scala.collection.mutable
+
+object ExecutorInfoHelper extends Logging{
+
+  def getExecutors(sc : SparkContext) : mutable.HashMap[String,String] = {
+    val castedBackend = sc.schedulerBackend.asInstanceOf[CoarseGrainedSchedulerBackend]
+    val allFields = castedBackend.getClass.getSuperclass.getDeclaredFields
+    log.info(s"${allFields.mkString(",")}")
+    val field = castedBackend.getClass.getSuperclass.getDeclaredField("org$apache$spark$scheduler$cluster$CoarseGrainedSchedulerBackend$$executorDataMap")
+    require(field != null)
+    field.setAccessible(true)
+    val executorDataMap = field.get(castedBackend).asInstanceOf[mutable.HashMap[String,ExecutorInfo]]
+    require(executorDataMap != null)
+
+    val res = new mutable.HashMap[String,String]()
+    for (tuple <- executorDataMap){
+      val executorId = tuple._1
+      val host = tuple._2.executorHost
+      log.info(s"executor id ${executorId}, host ${host}")
+      //here we got ip, cast to hostname
+      val hostName = InetAddress.getByName(host).getHostName
+      res.+=((executorId,hostName))
+    }
+    res
+  }
+
+  def getExecutorsHost2Id(sc : SparkContext) : mutable.HashMap[String,String] = {
+    //executor backend can be several kinds,
+    sc.schedulerBackend match {
+      case coarseGrainedSchedulerBackend: CoarseGrainedSchedulerBackend => {
+        val castedBackend = sc.schedulerBackend.asInstanceOf[CoarseGrainedSchedulerBackend]
+        val allFields = castedBackend.getClass.getSuperclass.getDeclaredFields
+        //    log.info(s"${allFields.mkString(",")}")
+        val field = castedBackend.getClass.getSuperclass.getDeclaredField("org$apache$spark$scheduler$cluster$CoarseGrainedSchedulerBackend$$executorDataMap")
+        require(field != null)
+        field.setAccessible(true)
+        val executorDataMap = field.get(castedBackend).asInstanceOf[mutable.HashMap[String,ExecutorInfo]]
+        require(executorDataMap != null)
+
+        val res = new mutable.HashMap[String,String]()
+        for (tuple <- executorDataMap){
+          val executorId = tuple._1
+          val host = tuple._2.executorHost
+          log.info(s"executor id ${executorId}, host ${host}")
+          //here we got ip, cast to hostname
+          val hostName = InetAddress.getByName(host).getHostName
+          if (res.contains(hostName)){
+            throw new IllegalStateException(s"host ${hostName} already contains executor ${res.get(hostName)}")
+          }
+          res.+=((hostName,executorId))
+        }
+        res
+      }
+      case local : LocalSchedulerBackend => {
+        val res = new mutable.HashMap[String,String]()
+        res.+=((InetAddress.getLocalHost.getHostName, "0"))
+        res
+      }
+    }
+
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/sql/GSSparkSession.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/sql/GSSparkSession.scala
@@ -1,0 +1,822 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import com.alibaba.graphscope.format.{LongLong, LongLongInputFormat}
+import com.alibaba.graphscope.graphx.GSClientWrapper
+import com.alibaba.graphscope.graphx.GSClientWrapper.VINEYARD_DEFAULT_SHARED_MEM
+import com.alibaba.graphscope.graphx.rdd.{FragmentRDD, LocationAwareRDD}
+import com.alibaba.graphscope.graphx.shuffle.{EdgeShuffle, EdgeShuffleReceived}
+import com.alibaba.graphscope.graphx.utils.{GSPartitioner, GrapeUtils, PrimitiveVector}
+import org.apache.hadoop.io.LongWritable
+import org.apache.spark.annotation.Stable
+import org.apache.spark.graphx.grape.{GrapeEdgeRDD, GrapeGraphImpl, GrapeVertexRDD}
+import org.apache.spark.graphx.impl.GraphImpl
+import org.apache.spark.graphx.scheduler.cluster.ExecutorInfoHelper
+import org.apache.spark.graphx.{Graph, PartitionID, VertexId}
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config.{ConfigEntry, EXECUTOR_ALLOW_SPARK_CONTEXT}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.scheduler.{SparkListener, SparkListenerApplicationEnd}
+import org.apache.spark.sql.GSSparkSession.getFullRDD
+import org.apache.spark.sql.internal.StaticSQLConf.CATALOG_IMPLEMENTATION
+import org.apache.spark.sql.internal._
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.collection.OpenHashSet
+import org.apache.spark.util.{CallSite, Utils}
+import org.apache.spark.{HashPartitioner, SparkConf, SparkContext, TaskContext}
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
+
+class GSSparkSession(sparkContext: SparkContext)
+  extends SparkSession(sparkContext){
+
+  private val creationSite: CallSite = Utils.getCallSite()
+
+  var socketPath: String = {
+    if (sparkContext.getConf.contains("spark.gs.vineyard.sock")){
+      sparkContext.getConf.get("spark.gs.vineyard.sock")
+    }
+    else ""
+  }
+
+  val sharedMemSize : String = {
+    if (sparkContext.getConf.contains("spark.gs.vineyard.memory")){
+      sparkContext.getConf.get("spark.gs.vineyard.memory")
+    }
+    else VINEYARD_DEFAULT_SHARED_MEM
+  }
+
+  val userJarPath :String = {
+    if (sparkContext.getConf.contains("spark.gs.submit.jar")){
+      sparkContext.getConf.get("spark.gs.submit.jar")
+    }
+    else throw new IllegalStateException("please specify spark.gs.submit.jar to your app jar")
+  }
+
+  /**
+   * On the creation of GSSpark session, we will start the python interpreter.
+   */
+  @transient val interpreter = new GSClientWrapper(sparkContext,socketPath, sharedMemSize)
+  if (socketPath.equals("")){
+    log.info(s"Update socket path from GraphScope: ${socketPath}")
+    socketPath = interpreter.startedSocket
+  }
+
+
+  override def stop(): Unit = {
+    super.stop()
+    log.info("closing gs Spark session...")
+    interpreter.close()
+  }
+
+  def loadGraphToGS[VD: ClassTag,ED : ClassTag](vFilePath : String, eFilePath : String, numPartitions : Int) : GrapeGraphImpl[VD,ED] = {
+    interpreter.loadGraph(vFilePath,eFilePath, numPartitions)
+  }
+
+  /**
+   * Similar to methods defined in GraphLoader, same signature but read the edges to GraphScope store.
+   * Although the Graph structure is stored in c++, with wrappers based on JNI, RDD can not differ GS-based
+   * RDD with graphx rdd in java heap.
+   */
+  def edgeListFile(
+                    sc: SparkContext,
+                    path: String,
+                    canonicalOrientation: Boolean = false,
+                    numEdgePartitions: Int = -1,
+                    edgeStorageLevel: StorageLevel = StorageLevel.MEMORY_ONLY,
+                    vertexStorageLevel: StorageLevel = StorageLevel.MEMORY_ONLY)
+  : Graph[Int, Int] = {
+    val lines = {
+      if (numEdgePartitions > 0) {
+        sc.hadoopFile(path, classOf[LongLongInputFormat], classOf[LongWritable], classOf[LongLong]).setName(path) //coalesce(fakeNumPartitions)
+      } else {
+        sc.hadoopFile(path, classOf[LongLongInputFormat], classOf[LongWritable], classOf[LongLong]).setName(path)
+      }
+    }.map(pair => (pair._2.first, pair._2.second)).cache()
+    fromLineRDD(lines, numEdgePartitions, vertexStorageLevel, edgeStorageLevel)
+  }
+
+  def fromLineRDD(lines : RDD[(Long,Long)], numPartitions : Int,
+                  edgeStorageLevel: StorageLevel = StorageLevel.MEMORY_ONLY,
+                  vertexStorageLevel: StorageLevel = StorageLevel.MEMORY_ONLY) : Graph[Int,Int] = {
+    val sc = SparkContext.getOrCreate()
+    val executorInfo = ExecutorInfoHelper.getExecutorsHost2Id(sc)
+    val executorNum = executorInfo.size
+    val partPartitioner = new HashPartitioner(numPartitions)
+    val rangePartitioner1 = new GSPartitioner[Long](numPartitions)
+    val edgeShuffledAfterPartition = lines.mapPartitionsWithIndex (
+      (fromPid, iter) => {
+        //        iter.toArray
+        val pid2src = Array.fill(numPartitions)(new org.apache.spark.util.collection.PrimitiveVector[VertexId](1200))
+        val pid2Dst = Array.fill(numPartitions)(new org.apache.spark.util.collection.PrimitiveVector[VertexId](1200))
+        val pid2Oids = Array.fill(numPartitions)(new OpenHashSet[VertexId](6000))
+        //        val pid2OuterIds = Array.fill(numFrag)(new OpenHashSet[VertexId](6000))
+        val time0 = System.nanoTime();
+        while (iter.hasNext) {
+          val line = iter.next()
+          val srcId = line._1
+          val dstId = line._2
+          val srcPid = partPartitioner.getPartition(srcId)
+          val dstPid = partPartitioner.getPartition(dstId)
+          pid2src(srcPid).+=(srcId)
+          pid2Dst(srcPid).+=(dstId)
+          pid2Oids(srcPid).add(srcId)
+          pid2Oids(dstPid).add(dstId)
+        }
+        val time1 = System.nanoTime()
+        log.info("[edgeListFile: ] iterating over edge cost " + (time1 - time0) / 1000000 + "ms")
+        val res = new ArrayBuffer[(PartitionID,EdgeShuffle[Int,Int])]
+        var ind = 0
+        while (ind < numPartitions){
+          res.+=((ind, new EdgeShuffle(fromPid, ind, null, pid2Oids(ind), pid2src(ind).trim().array, pid2Dst(ind).trim().array)))
+          ind += 1
+        }
+        val resIter = res.toIterator
+        val time2 = System.nanoTime()
+        log.info("[edgeListFile: ] convert to iterator cost " + (time2 - time1) / 1000000 + "ms")
+        resIter
+      }
+    ).partitionBy(rangePartitioner1).cache()
+
+    //construct
+    //gather the host <-> partition id info.
+    val (hostArray,pid2Host) = GrapeUtils.extractHostInfo(edgeShuffledAfterPartition.asInstanceOf[RDD[(Int,_)]], numPartitions)
+    val numWorker = hostArray.length
+    val numFrag = Math.min(numWorker, executorNum)
+    log.info(s"numFrag ${numFrag}, num worker ${numWorker}, executor Num ${executorNum}")
+
+    //gather all received into one
+    val gathered = edgeShuffledAfterPartition.mapPartitions(iter =>{
+      if (iter.hasNext) {
+        val edgeShuffleReceived = new EdgeShuffleReceived[Int]()
+        while (iter.hasNext) {
+          val (pid, shuffle) = iter.next()
+          if (shuffle != null){
+            edgeShuffleReceived.add(shuffle)
+          }
+        }
+        Iterator(edgeShuffleReceived)
+      }
+      else {
+        log.info("In gather encounter empty")
+        Iterator.empty
+      }
+    },preservesPartitioning = true).cache()
+    log.info(s"gather all partition together size ${gathered.count()}")
+
+    val fullRDD = getFullRDD[Int,Int](sc, numPartitions, numPartitions, gathered, numFrag,hostArray,executorInfo,vertexStorageLevel,edgeStorageLevel, 1,1)
+    log.info(s"constructed full graph size${fullRDD.numVertices}, ${fullRDD.numEdges}")
+
+    edgeShuffledAfterPartition.unpersist()
+    gathered.unpersist()
+
+    fullRDD
+  }
+
+  def loadFragmentAsGraph[VD: ClassTag, ED: ClassTag](sc : SparkContext, userNumPartitions : Int, objectIDs : String, fragName : String, vineyardSocket : String) : GrapeGraphImpl[VD,ED] = {
+    val fragmentRDD = new FragmentRDD[VD,ED](sc, ExecutorInfoHelper.getExecutors(sc), fragName,objectIDs, vineyardSocket)
+    val (vertexRDD,edgeRDD) = fragmentRDD.generateRDD(userNumPartitions)
+    GrapeGraphImpl.fromExistingRDDs[VD,ED](vertexRDD,edgeRDD)
+  }
+
+}
+object GSSparkSession extends Logging {
+  /**
+   * Builder for [[GSSparkSession]].
+   */
+  @Stable
+  class Builder extends Logging {
+
+    private[this] val options = new scala.collection.mutable.HashMap[String, String]
+
+    private[this] val extensions = new SparkSessionExtensions
+
+    private[this] var userSuppliedContext: Option[SparkContext] = None
+
+    private[spark] def sparkContext(sparkContext: SparkContext): Builder = synchronized {
+      userSuppliedContext = Option(sparkContext)
+      this
+    }
+
+    /**
+     * Sets a name for the application, which will be shown in the Spark web UI.
+     * If no application name is set, a randomly generated name will be used.
+     *
+     * @since 2.0.0
+     */
+    def appName(name: String): Builder = config("spark.app.name", name)
+
+    /**
+     * Sets a config option. Options set using this method are automatically propagated to
+     * both `SparkConf` and SparkSession's own configuration.
+     *
+     * @since 2.0.0
+     */
+    def config(key: String, value: String): Builder = synchronized {
+      options += key -> value
+      this
+    }
+
+    /**
+     * Sets a config option. Options set using this method are automatically propagated to
+     * both `SparkConf` and SparkSession's own configuration.
+     *
+     * @since 2.0.0
+     */
+    def config(key: String, value: Long): Builder = synchronized {
+      options += key -> value.toString
+      this
+    }
+
+    /**
+     * Sets a config option. Options set using this method are automatically propagated to
+     * both `SparkConf` and SparkSession's own configuration.
+     *
+     * @since 2.0.0
+     */
+    def config(key: String, value: Double): Builder = synchronized {
+      options += key -> value.toString
+      this
+    }
+
+    /**
+     * Sets a config option. Options set using this method are automatically propagated to
+     * both `SparkConf` and SparkSession's own configuration.
+     *
+     * @since 2.0.0
+     */
+    def config(key: String, value: Boolean): Builder = synchronized {
+      options += key -> value.toString
+      this
+    }
+
+    /**
+     * Sets a list of config options based on the given `SparkConf`.
+     *
+     * @since 2.0.0
+     */
+    def config(conf: SparkConf): Builder = synchronized {
+      conf.getAll.foreach { case (k, v) => options += k -> v }
+      this
+    }
+
+    /**
+     * Sets the Spark master URL to connect to, such as "local" to run locally, "local[4]" to
+     * run locally with 4 cores, or "spark://master:7077" to run on a Spark standalone cluster.
+     *
+     * @since 2.0.0
+     */
+    def master(master: String): Builder = config("spark.master", master)
+
+    /**
+     * GraphgScope related param, setting vineyard memroy size.
+     */
+    def vineyardMemory(memoryStr : String)  : Builder = config("spark.gs.vineyard.memory", memoryStr)
+
+    /**
+     * GraphScope vineyard socket file. Vineyard process should be bound on this address on all workers.
+     */
+    def vineyardSock(filePath : String) : Builder = {
+      config("spark.gs.vineyard.sock", filePath)
+    }
+
+    /**
+     * User need to specify the file path to the jar submitted to spark cluster.
+     */
+    def gsSubmitJar(filePath : String) : Builder = {
+      config("spark.gs.submit.jar", filePath)
+    }
+
+    /**
+     * Enables Hive support, including connectivity to a persistent Hive metastore, support for
+     * Hive serdes, and Hive user-defined functions.
+     *
+     * @since 2.0.0
+     */
+    def enableHiveSupport(): Builder = synchronized {
+      if (hiveClassesArePresent) {
+        config(CATALOG_IMPLEMENTATION.key, "hive")
+      } else {
+        throw new IllegalArgumentException(
+          "Unable to instantiate SparkSession with Hive support because " +
+            "Hive classes are not found.")
+      }
+    }
+
+    /**
+     * Inject extensions into the [[SparkSession]]. This allows a user to add Analyzer rules,
+     * Optimizer rules, Planning Strategies or a customized parser.
+     *
+     * @since 2.2.0
+     */
+    def withExtensions(f: SparkSessionExtensions => Unit): Builder = synchronized {
+      f(extensions)
+      this
+    }
+
+    /**
+     * Gets an existing [[SparkSession]] or, if there is no existing one, creates a new
+     * one based on the options set in this builder.
+     *
+     * This method first checks whether there is a valid thread-local SparkSession,
+     * and if yes, return that one. It then checks whether there is a valid global
+     * default SparkSession, and if yes, return that one. If no valid global default
+     * SparkSession exists, the method creates a new SparkSession and assigns the
+     * newly created SparkSession as the global default.
+     *
+     * In case an existing SparkSession is returned, the non-static config options specified in
+     * this builder will be applied to the existing SparkSession.
+     *
+     * @since 2.0.0
+     */
+    def getOrCreate(): GSSparkSession = synchronized {
+      val sparkConf = new SparkConf()
+      options.foreach { case (k, v) => sparkConf.set(k, v) }
+
+      if (!sparkConf.get(EXECUTOR_ALLOW_SPARK_CONTEXT)) {
+        assertOnDriver()
+      }
+
+      // Get the session from current thread's active session.
+      var session = activeThreadSession.get()
+      if ((session ne null) && !session.sparkContext.isStopped) {
+        applyModifiableSettings(session)
+        return session
+      }
+
+      // Global synchronization so we will only set the default session once.
+      GSSparkSession.synchronized {
+        // If the current thread does not have an active session, get it from the global session.
+        session = defaultSession.get()
+        if ((session ne null) && !session.sparkContext.isStopped) {
+          applyModifiableSettings(session)
+          return session
+        }
+
+        // No active nor global default session. Create a new one.
+        val sparkContext = userSuppliedContext.getOrElse {
+          // set a random app name if not given.
+          if (!sparkConf.contains("spark.app.name")) {
+            sparkConf.setAppName(java.util.UUID.randomUUID().toString)
+          }
+
+          SparkContext.getOrCreate(sparkConf)
+          // Do not update `SparkConf` for existing `SparkContext`, as it's shared by all sessions.
+        }
+
+        applyExtensions(
+          sparkContext.getConf.get(StaticSQLConf.SPARK_SESSION_EXTENSIONS).getOrElse(Seq.empty),
+          extensions)
+
+        session = new GSSparkSession(sparkContext) // None, None, extensions, options.toMap
+        GSSparkSession.setExtensionsField(session, extensions, options.toMap)
+        setDefaultSession(session)
+        setActiveSession(session)
+        registerContextListener(sparkContext)
+      }
+
+      return session
+    }
+
+    private def applyModifiableSettings(session: SparkSession): Unit = {
+      val (staticConfs, otherConfs) =
+        options.partition(kv => SQLConf.staticConfKeys.contains(kv._1))
+
+      otherConfs.foreach { case (k, v) => session.sessionState.conf.setConfString(k, v) }
+
+      if (staticConfs.nonEmpty) {
+        logWarning("Using an existing SparkSession; the static sql configurations will not take" +
+          " effect.")
+      }
+      if (otherConfs.nonEmpty) {
+        logWarning("Using an existing SparkSession; some spark core configurations may not take" +
+          " effect.")
+      }
+    }
+  }
+
+  /**
+   * Creates a [[SparkSession.Builder]] for constructing a [[SparkSession]].
+   *
+   * @since 2.0.0
+   */
+  def builder(): Builder = new Builder
+
+  /**
+   * Changes the SparkSession that will be returned in this thread and its children when
+   * SparkSession.getOrCreate() is called. This can be used to ensure that a given thread receives
+   * a SparkSession with an isolated session, instead of the global (first created) context.
+   *
+   * @since 2.0.0
+   */
+  def setActiveSession(session: GSSparkSession): Unit = {
+    activeThreadSession.set(session)
+  }
+
+  /**
+   * Clears the active SparkSession for current thread. Subsequent calls to getOrCreate will
+   * return the first created context instead of a thread-local override.
+   *
+   * @since 2.0.0
+   */
+  def clearActiveSession(): Unit = {
+    activeThreadSession.remove()
+  }
+
+  /**
+   * Sets the default SparkSession that is returned by the builder.
+   *
+   * @since 2.0.0
+   */
+  def setDefaultSession(session: GSSparkSession): Unit = {
+    defaultSession.set(session)
+  }
+
+  /**
+   * Clears the default SparkSession that is returned by the builder.
+   *
+   * @since 2.0.0
+   */
+  def clearDefaultSession(): Unit = {
+    defaultSession.set(null)
+  }
+
+  /**
+   * Returns the active SparkSession for the current thread, returned by the builder.
+   *
+   * @note Return None, when calling this function on executors
+   *
+   * @since 2.2.0
+   */
+  def getActiveSession: Option[GSSparkSession] = {
+    if (TaskContext.get != null) {
+      // Return None when running on executors.
+      None
+    } else {
+      Option(activeThreadSession.get)
+    }
+  }
+
+  /**
+   * Returns the default SparkSession that is returned by the builder.
+   *
+   * @note Return None, when calling this function on executors
+   *
+   * @since 2.2.0
+   */
+  def getDefaultSession: Option[GSSparkSession] = {
+    if (TaskContext.get != null) {
+      // Return None when running on executors.
+      None
+    } else {
+      Option(defaultSession.get)
+    }
+  }
+
+  /**
+   * Returns the currently active SparkSession, otherwise the default one. If there is no default
+   * SparkSession, throws an exception.
+   *
+   * @since 2.4.0
+   */
+  def active: SparkSession = {
+    getActiveSession.getOrElse(getDefaultSession.getOrElse(
+      throw new IllegalStateException("No active or default Spark session found")))
+  }
+
+  /**
+   * Returns a cloned SparkSession with all specified configurations disabled, or
+   * the original SparkSession if all configurations are already disabled.
+   */
+  private[sql] def getOrCloneSessionWithConfigsOff(
+                                                    session: SparkSession,
+                                                    configurations: Seq[ConfigEntry[Boolean]]): SparkSession = {
+    val configsEnabled = configurations.filter(session.sessionState.conf.getConf(_))
+    if (configsEnabled.isEmpty) {
+      session
+    } else {
+      val newSession = session.cloneSession()
+      configsEnabled.foreach(conf => {
+        newSession.sessionState.conf.setConf(conf, false)
+      })
+      newSession
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////
+  // Private methods from now on
+  ////////////////////////////////////////////////////////////////////////////////////////
+
+  private val listenerRegistered: AtomicBoolean = new AtomicBoolean(false)
+
+  /** Register the AppEnd listener onto the Context  */
+  private def registerContextListener(sparkContext: SparkContext): Unit = {
+    if (!listenerRegistered.get()) {
+      sparkContext.addSparkListener(new SparkListener {
+        override def onApplicationEnd(applicationEnd: SparkListenerApplicationEnd): Unit = {
+          defaultSession.set(null)
+          listenerRegistered.set(false)
+        }
+      })
+      listenerRegistered.set(true)
+    }
+  }
+
+  /** The active SparkSession for the current thread. */
+  private val activeThreadSession = new InheritableThreadLocal[GSSparkSession]
+
+  /** Reference to the root SparkSession. */
+  private val defaultSession = new AtomicReference[GSSparkSession]
+
+  private val HIVE_SESSION_STATE_BUILDER_CLASS_NAME =
+    "org.apache.spark.sql.hive.HiveSessionStateBuilder"
+
+  private def sessionStateClassName(conf: SparkConf): String = {
+    conf.get(CATALOG_IMPLEMENTATION) match {
+      case "hive" => HIVE_SESSION_STATE_BUILDER_CLASS_NAME
+      case "in-memory" => classOf[SessionStateBuilder].getCanonicalName
+    }
+  }
+
+  private def assertOnDriver(): Unit = {
+    if (TaskContext.get != null) {
+      // we're accessing it during task execution, fail.
+      throw new IllegalStateException(
+        "SparkSession should only be created and accessed on the driver.")
+    }
+  }
+
+  /**
+   * Helper method to create an instance of `SessionState` based on `className` from conf.
+   * The result is either `SessionState` or a Hive based `SessionState`.
+   */
+  private def instantiateSessionState(
+                                       className: String,
+                                       sparkSession: SparkSession,
+                                       options: Map[String, String]): SessionState = {
+    try {
+      // invoke new [Hive]SessionStateBuilder(
+      //   SparkSession,
+      //   Option[SessionState],
+      //   Map[String, String])
+      val clazz = Utils.classForName(className)
+      val ctor = clazz.getConstructors.head
+      ctor.newInstance(sparkSession, None, options).asInstanceOf[BaseSessionStateBuilder].build()
+    } catch {
+      case NonFatal(e) =>
+        throw new IllegalArgumentException(s"Error while instantiating '$className':", e)
+    }
+  }
+
+  /**
+   * @return true if Hive classes can be loaded, otherwise false.
+   */
+  private[spark] def hiveClassesArePresent: Boolean = {
+    try {
+      Utils.classForName(HIVE_SESSION_STATE_BUILDER_CLASS_NAME)
+      Utils.classForName("org.apache.hadoop.hive.conf.HiveConf")
+      true
+    } catch {
+      case _: ClassNotFoundException | _: NoClassDefFoundError => false
+    }
+  }
+
+  private[spark] def cleanupAnyExistingSession(): Unit = {
+    val session = getActiveSession.orElse(getDefaultSession)
+    if (session.isDefined) {
+      logWarning(
+        s"""An existing Spark session exists as the active or default session.
+           |This probably means another suite leaked it. Attempting to stop it before continuing.
+           |This existing Spark session was created at:
+           |
+           |${session.get.creationSite.longForm}
+           |
+         """.stripMargin)
+      session.get.stop()
+      SparkSession.clearActiveSession()
+      SparkSession.clearDefaultSession()
+    }
+  }
+
+  /**
+   * Initialize extensions for given extension classnames. The classes will be applied to the
+   * extensions passed into this function.
+   */
+  private def applyExtensions(
+                               extensionConfClassNames: Seq[String],
+                               extensions: SparkSessionExtensions): SparkSessionExtensions = {
+    extensionConfClassNames.foreach { extensionConfClassName =>
+      try {
+        val extensionConfClass = Utils.classForName(extensionConfClassName)
+        val extensionConf = extensionConfClass.getConstructor().newInstance()
+          .asInstanceOf[SparkSessionExtensions => Unit]
+        extensionConf(extensions)
+      } catch {
+        // Ignore the error if we cannot find the class or when the class has the wrong type.
+        case e@(_: ClassCastException |
+                _: ClassNotFoundException |
+                _: NoClassDefFoundError) =>
+          logWarning(s"Cannot use $extensionConfClassName to configure session extensions.", e)
+      }
+    }
+    extensions
+  }
+
+  def setExtensionsField(session : SparkSession, extensions: SparkSessionExtensions, initialSessionOptions : Map[String,String]) : SparkSession = {
+    val extensionField = classOf[SparkSession].getDeclaredField("extensions")
+    val initOptionField = classOf[SparkSession].getDeclaredField("initialSessionOptions")
+    require(extensionField != null, "extension field null")
+    require(initOptionField != null, "init option null")
+    extensionField.setAccessible(true)
+    initOptionField.setAccessible(true)
+
+    extensionField.set(session, extensions)
+    initOptionField.set(session, initialSessionOptions)
+    session
+  }
+
+  /**
+   * default vd == null means we will use vertex attr is shuffles.
+   * @return
+   */
+  def getFullRDD[VD : ClassTag, ED : ClassTag](sc : SparkContext, numShuffles : Int, userNumPartitions : Int,
+                                               prevRDD: RDD[EdgeShuffleReceived[ED]], fragNum : Int, hosts : Array[String],
+                                               hostName2ExecutorId : mutable.HashMap[String,String],
+                                               vertexStorageLevel : StorageLevel, edgeStorageLevel : StorageLevel,
+                                               defaultED : ED = null.asInstanceOf[ED], defaultVD : VD = null.asInstanceOf[VD]) : GrapeGraphImpl[VD,ED] = {
+    prevRDD.foreachPartition(iter => {
+      while (iter.hasNext){
+        val part = iter.next()
+        EdgeShuffleReceived.push(part)
+      }
+    })
+    //generate host,location,and partitionIds.
+    val rddHosts = new Array[String](fragNum)
+    val rddLocations = new Array[String](fragNum)
+    val partitionIds = new Array[Int](fragNum)
+    for (i <- 0 until fragNum){
+      rddHosts(i) = hosts(i)
+      rddLocations(i) = "executor_" + hosts(i) + "_" + hostName2ExecutorId(hosts(i))
+      partitionIds(i) = i
+    }
+
+    log.debug(s"rdd hosts ${rddHosts.mkString(",")}")
+    log.debug(s"rdd locations ${rddLocations.mkString(",")}")
+    log.debug(s"rdd partitions id ${partitionIds.mkString(",")}")
+    val emptyRDD = new LocationAwareRDD(sc, rddLocations, rddHosts, partitionIds)
+
+    val edgeRDD = GrapeEdgeRDD.fromEmptyRDD[VD,ED](sc, numShuffles, userNumPartitions, emptyRDD,defaultED)
+    prevRDD.unpersist()
+    val routingTableRDD = GrapeEdgeRDD.edgeRDDToRoutingTable(edgeRDD)
+    val vertexRDD = GrapeVertexRDD.fromGrapeEdgeRDD[VD](edgeRDD, routingTableRDD, edgeRDD.grapePartitionsRDD.getNumPartitions, defaultVD,vertexStorageLevel).cache()
+    log.info(s"num vertices ${vertexRDD.count()}, num edges ${edgeRDD.count()}")
+
+    GrapeGraphImpl.fromExistingRDDs[VD,ED](vertexRDD,edgeRDD)
+  }
+
+  /**
+   * Convert a spark graphx graph to gs fragment-based graph.
+   * @param graph input graphx graph
+   * @tparam VD vertex data type
+   * @tparam ED edge data type
+   * @return graphGraphImpl
+   */
+  def toGSGraph[VD : ClassTag,ED : ClassTag](graph : Graph[VD,ED]) : GrapeGraphImpl[VD,ED] = {
+    graph match {
+      case graphImpl :  GrapeGraphImpl[VD,ED] => {
+        log.info(s"${graph} is already a GS fragment-based graph")
+        graphImpl
+      }
+      case graphImpl: GraphImpl[VD,ED] => {
+        log.info(s"Converting graph of ${graphImpl.numVertices} vertices and ${graphImpl.numEdges} edges to GS fragment-based graph")
+        val time0 = System.nanoTime()
+        val res = graphXtoGSGraph(graphImpl)
+        val time1 = System.nanoTime()
+        log.info(s"[Perf:] Converting graph ${graphImpl} to grapeGraph ${res} cost ${(time1 - time0)/1000000} ms")
+        res
+      }
+    }
+  }
+
+  def graphXtoGSGraph[VD: ClassTag,ED : ClassTag](originGraph: GraphImpl[VD, ED]) : GrapeGraphImpl[VD,ED] = {
+    val numPartitions = originGraph.vertices.getNumPartitions
+    val time0 = System.nanoTime()
+    //Note: Before convert to graphx graph, we need to generate shuffles of vertices and edges.
+    //We can not separate vertex shuffles from edges shuffles, because the result partitions
+    //has inconsistent pids.
+    val executorInfo = ExecutorInfoHelper.getExecutorsHost2Id(SparkContext.getOrCreate())
+    val executorNum = executorInfo.size
+
+    val graphShuffles = generateGraphShuffle(originGraph).cache()
+
+    val edgeShufflesNum = graphShuffles.count()
+    val time1 = System.nanoTime()
+    logInfo(s"It took ${(time1 - time0)/1000000} ms" +
+      s" to generate edge shuffles,shuffle count ${edgeShufflesNum}")
+
+    val (hostArray,pid2Host) = GrapeUtils.extractHostInfo[VD,ED](graphShuffles.asInstanceOf[RDD[(Int,_)]], numPartitions)
+
+    val numWorker = hostArray.length
+    val numFrag = Math.min(numWorker, executorNum)
+    log.info(s"numFrag ${numFrag}, num worker ${numWorker}, executor Num ${executorNum}")
+
+    val time2 = System.nanoTime()
+
+    //gather all received into one
+    val gathered = graphShuffles.mapPartitions(iter =>{
+      if (iter.hasNext) {
+        val edgeShuffleReceived = new EdgeShuffleReceived[ED]()
+        while (iter.hasNext) {
+          val (pid, shuffle) = iter.next()
+          if (shuffle != null){
+            edgeShuffleReceived.add(shuffle)
+          }
+        }
+        Iterator(edgeShuffleReceived)
+      }
+      else {
+        log.info("In gather encounter empty")
+        Iterator.empty
+      }
+    },preservesPartitioning = true).cache()
+    log.info(s"gather all partition together size ${gathered.count()}")
+
+    val (vertexStorageLevel, edgeStorageLevel) = (originGraph.vertices.getStorageLevel,originGraph.edges.getStorageLevel)
+    val fullRDD = getFullRDD[VD,ED](SparkContext.getOrCreate(), numPartitions, numPartitions, gathered,
+      numFrag, hostArray, executorInfo, vertexStorageLevel, edgeStorageLevel)
+    log.info(s"constructed full graph size${fullRDD.numVertices}, ${fullRDD.numEdges}")
+
+    graphShuffles.unpersist()
+    gathered.unpersist()
+
+    fullRDD
+  }
+  def generateGraphShuffle[VD : ClassTag, ED : ClassTag](graph : GraphImpl[VD,ED]) : RDD[(PartitionID, EdgeShuffle[VD,ED])] = {
+    graph.replicatedVertexView.upgrade(graph.vertices,includeSrc = true,includeDst = true)
+    val numPartitions = graph.vertices.getNumPartitions
+    val partPartitioner = new HashPartitioner(numPartitions)
+    val rangePartitioner = new GSPartitioner[Long](numPartitions)
+    graph.replicatedVertexView.edges.partitionsRDD.mapPartitions(iter => {
+      if (iter.hasNext){
+        val (fromPid, part) = iter.next()
+        val edgeIter = part.tripletIterator()
+        val edgeNum = part.size
+        val pid2src = Array.fill(numPartitions)(new PrimitiveVector[VertexId](edgeNum/ numPartitions))
+        val pid2Dst = Array.fill(numPartitions)(new PrimitiveVector[VertexId](edgeNum/ numPartitions))
+        val pid2Attr = Array.fill(numPartitions)(new PrimitiveVector[ED](edgeNum/ numPartitions))
+        val pid2Vertices = Array.fill(numPartitions)(new mutable.HashMap[VertexId,VD]())
+        val time0 = System.nanoTime()
+        while (edgeIter.hasNext){
+          val triplet = edgeIter.next()
+          val srcPid = partPartitioner.getPartition(triplet.srcId)
+          val dstPid = partPartitioner.getPartition(triplet.dstId)
+          if (!pid2Vertices(srcPid).contains(triplet.srcId)){
+            pid2Vertices(srcPid).put(triplet.srcId, triplet.srcAttr)
+          }
+          if (!pid2Vertices(dstPid).contains(triplet.dstId)){
+            pid2Vertices(dstPid).put(triplet.dstId, triplet.dstAttr)
+          }
+          pid2src(srcPid).+=(triplet.srcId)
+          pid2Dst(srcPid).+=(triplet.dstId)
+          pid2Attr(srcPid).+=(triplet.attr)
+        }
+        val time1 = System.nanoTime()
+        val res = new ArrayBuffer[(PartitionID,EdgeShuffle[VD,ED])]
+        var ind = 0
+        while (ind < numPartitions){
+          val shuffle = new EdgeShuffle[VD,ED](fromPid,ind, pid2Vertices(ind).keySet.toArray,null,
+            pid2src(ind).trim().array, pid2Dst(ind).trim().array, pid2Attr(ind).trim().array, pid2Vertices(ind).values.toArray)
+            res.+=((ind, shuffle))
+          ind += 1
+        }
+        val time2 = System.nanoTime()
+        log.info(s"[Perf:] iterating graphx partition size ${edgeNum} cost ${(time1 - time0)/1000000} ms, convert to iterator cost ${(time2 - time1)/1000000}ms")
+        res.toIterator
+      }
+      else {
+        Iterator.empty
+      }
+    }).partitionBy(rangePartitioner).setName("GraphxGraph2Fragment.graphShuffle")
+  }
+
+}
+

--- a/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/util/KnownSizeEstimationPorter.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/main/scala/org/apache/spark/util/KnownSizeEstimationPorter.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.spark.util
+
+/**
+ * The KnownSizeEstimation is private in package. port this out.
+ */
+trait KnownSizeEstimationPorter extends KnownSizeEstimation

--- a/analytical_engine/java/graphx-on-graphscope/src/test/java/com/alibaba/graphscope/utils/CallUtilsTest.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/java/com/alibaba/graphscope/utils/CallUtilsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import org.junit.Test;
+
+public class CallUtilsTest {
+    public static class A {
+        public static void a() {
+            System.out.println(CallUtils.getCallerCallerClassName());
+        }
+    }
+
+    public static class B {
+        public static void b() {
+            A.a();
+        }
+    }
+
+    public static class C {
+        public static void c() {
+            B.b();
+        }
+    }
+
+    @Test
+    public void test() {
+        C.c();
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/java/com/alibaba/graphscope/utils/SubprocessTest.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/java/com/alibaba/graphscope/utils/SubprocessTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+
+public class SubprocessTest {
+
+    @Test
+    public void test2() throws IOException, InterruptedException {
+        PythonInterpreter interpreter = new PythonInterpreter();
+        interpreter.init();
+        interpreter.runCommand("1");
+        String res = interpreter.getResult();
+        System.out.println(res);
+        interpreter.runCommand("1 + 2");
+        res = interpreter.getResult();
+        System.out.println(res);
+        interpreter.close();
+        System.out.println("Finish test2");
+    }
+
+    @Test
+    public void test1()
+            throws IOException, InterruptedException, NoSuchFieldException, IllegalAccessException {
+        ProcessBuilder builder = new ProcessBuilder("/usr/bin/env", "python3", "-i");
+        Process process = builder.start();
+
+        new Thread(
+                        () -> {
+                            String line;
+                            final BufferedReader reader =
+                                    new BufferedReader(
+                                            new InputStreamReader(process.getInputStream()));
+                            // Ignore line, or do something with it
+                            while (true) {
+                                try {
+                                    if ((line = reader.readLine()) == null) {
+                                        break;
+                                    } else {
+                                        System.out.println(line);
+                                    }
+                                } catch (IOException e) {
+                                    e.printStackTrace();
+                                }
+                            }
+                        })
+                .start();
+        new Thread(
+                        () -> {
+                            final PrintWriter writer =
+                                    new PrintWriter(
+                                            new OutputStreamWriter(process.getOutputStream()));
+                            writer.println("1");
+                            writer.println("2 * 2");
+                            writer.println("exit()");
+                            writer.flush();
+                        })
+                .start();
+
+        int res = process.waitFor();
+        if (res != 0) {
+            System.out.println("Terminate unexpectedly");
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/java/com/alibaba/graphscope/utils/ThreadSafeBitSetTest.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/java/com/alibaba/graphscope/utils/ThreadSafeBitSetTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ThreadSafeBitSetTest {
+
+    @Test
+    public void test1() {
+        ThreadSafeBitSet set =
+                new ThreadSafeBitSet(ThreadSafeBitSet.DEFAULT_LOG2_SEGMENT_SIZE_IN_BITS, 16);
+        set.setUntil(10);
+        for (int i = 0; i < 10; ++i) {
+            Assert.assertTrue(set.get(i));
+        }
+        for (int i = 10; i < 16; ++i) {
+            Assert.assertFalse(set.get(i));
+        }
+    }
+
+    @Test
+    public void test2() {
+        ThreadSafeBitSet set =
+                new ThreadSafeBitSet(ThreadSafeBitSet.DEFAULT_LOG2_SEGMENT_SIZE_IN_BITS, 16);
+        set.setUntil(16);
+        for (int i = 0; i < 16; ++i) {
+            Assert.assertTrue(set.get(i));
+        }
+    }
+
+    @Test
+    public void test3() {
+        ThreadSafeBitSet set =
+                new ThreadSafeBitSet(ThreadSafeBitSet.DEFAULT_LOG2_SEGMENT_SIZE_IN_BITS, 100);
+        set.setUntil(65);
+        for (int i = 0; i < 65; ++i) {
+            Assert.assertTrue(set.get(i));
+        }
+        for (int i = 65; i < 100; ++i) {
+            Assert.assertFalse(set.get(i));
+        }
+    }
+
+    @Test
+    public void test4() {
+        ThreadSafeBitSet set =
+                new ThreadSafeBitSet(ThreadSafeBitSet.DEFAULT_LOG2_SEGMENT_SIZE_IN_BITS, 100);
+        set.setUntil(33);
+        for (int i = 0; i < 33; ++i) {
+            Assert.assertTrue(set.get(i));
+        }
+        for (int i = 33; i < 100; ++i) {
+            Assert.assertFalse(set.get(i));
+        }
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/java/com/alibaba/graphscope/utils/WildCardTest.java
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/java/com/alibaba/graphscope/utils/WildCardTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.utils;
+
+import org.junit.Test;
+
+public class WildCardTest {
+
+    public static class Conf<A, B, C> {
+
+        private A a;
+
+        public Conf() {}
+
+        public void setA(A a) {
+            this.a = a;
+        }
+
+        public A getA() {
+            return a;
+        }
+    }
+
+    public static <A, B, C> Conf<A, B, C> create(
+            Class<? super A> clz, Class<? super B> clz2, Class<? super C> clz3) {
+        return new Conf<A, B, C>();
+    }
+
+    @Test
+    public void test1() {
+        Conf<Long, Double, Integer> conf = create(Long.class, Double.class, Integer.class);
+    }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/BitSetTest.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/BitSetTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import com.alibaba.graphscope.graphx.utils.BitSetWithOffset
+import org.apache.spark.util.collection.BitSet
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class BitSetTest extends FunSuite{
+  test("test1"){
+    val bitSet = new BitSet(8546613)
+    bitSet.setUntil(8546612)
+    var ind = 0;
+    val time0 = System.nanoTime()
+    while (ind > 0){
+      ind = bitSet.nextSetBit(ind + 1)
+    }
+    val time1 = System.nanoTime()
+    System.out.println(s"Bitset iter cost ${(time1 - time0) / 1000000} ms")
+  }
+
+  test("test2"){
+    val bitSet = new BitSet(1000)
+    bitSet.setUntil(1000)
+    assert(bitSet.cardinality() == 1000)
+    assert(bitSet.get(999))
+  }
+
+  test("test3"){
+    val myBitSet = new BitSetWithOffset(500,502)
+    assert(myBitSet.cardinality() == 0)
+    assert(myBitSet.bitset.cardinality() == 0)
+    myBitSet.set(500)
+    assert(myBitSet.get(500))
+    assert(!myBitSet.get(501))
+    myBitSet.set(501)
+    assert(myBitSet.get(501))
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/CaseClassTest.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/CaseClassTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+@RunWith(classOf[JUnitRunner])
+class CaseClassTest extends FunSuite{
+  def write[A](obj: A): Array[Byte] = {
+    val bo = new ByteArrayOutputStream()
+    new ObjectOutputStream(bo).writeObject(obj)
+    bo.toByteArray
+  }
+
+  def read(bytes:Array[Byte]): Any = {
+    new ObjectInputStream(new ByteArrayInputStream(bytes)).readObject()
+  }
+
+  test("test1"){
+    println(read(write( {a:Int => a+1} )).asInstanceOf[ Function[Int,Int] ](5)) // == 6
+  }
+
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/FloorTest.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/FloorTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+import java.util
+
+@RunWith(classOf[JUnitRunner])
+class FloorTest extends FunSuite{
+  test("test1"){
+    val map = new util.TreeMap[Long,Int]()
+    val arrays = Array(Array(0,1),Array(2,3,4),Array(5))
+    var tmp = 0;
+    for (ind <- arrays.indices){
+      map.put(tmp, ind)
+      tmp += arrays(ind).length
+    }
+
+    assert(map.floorEntry(0L).getValue.equals(0))
+    assert(map.floorEntry(1L).getValue.equals(0))
+    assert(map.floorEntry(2L).getValue.equals(1))
+    assert(map.floorEntry(4L).getValue.equals(1))
+    assert(map.floorEntry(5L).getValue.equals(2))
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/GSPartitionTest.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/GSPartitionTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import com.alibaba.graphscope.graphx.utils.GSPartitioner
+import org.apache.spark.HashPartitioner
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class GSPartitionTest extends FunSuite{
+  test("test1"){
+    val partitioner = new GSPartitioner[Int](4)
+    assert(partitioner.getPartition(0) == 0)
+    assert(partitioner.getPartition(1) == 1)
+    assert(partitioner.getPartition(2) == 2)
+    assert(partitioner.getPartition(3) == 3)
+  }
+
+  test("test2"){
+    val partitioner = new HashPartitioner(384)
+    assert(partitioner.getPartition(2199025280463L) == (2199025280463L % 384))
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/GrapeUtilsTest.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/GrapeUtilsTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import com.alibaba.graphscope.graphx.utils.GrapeUtils
+import com.alibaba.graphscope.utils.array.PrimitiveArray
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class GrapeUtilsTest extends FunSuite{
+  test("test1") {
+    val array = PrimitiveArray.create(classOf[Long], 5)
+    val index = PrimitiveArray.create(classOf[Long], 5)
+    array.set(0,5)
+    array.set(1,4)
+    array.set(2,3)
+    array.set(3,2)
+    array.set(4,1)
+
+    index.set(0,4)
+    index.set(1,3)
+    index.set(2,2)
+    index.set(3,1)
+    index.set(4,0)
+
+    val res = GrapeUtils.rearrangeArrayWithIndex(array,index)
+    assert(res.get(0) == 1)
+    assert(res.get(1) == 2)
+    assert(res.get(4) == 5)
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/IdParserTest.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/IdParserTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import com.alibaba.graphscope.graphx.utils.IdParser
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class IdParserTest extends FunSuite {
+  test("test1"){
+    val idParser = new IdParser(4)
+    val gid1 = idParser.generateGlobalId(0, 1)
+    val gid2 = idParser.generateGlobalId(3, 101)
+    val gid3 = idParser.generateGlobalId(2, 10000001)
+    println(s"${gid1}, ${gid2}, ${gid3}")
+    assert(idParser.getFragId(gid1) == 0)
+    assert(idParser.getFragId(gid2) == 3)
+    assert(idParser.getFragId(gid3) == 2)
+    assert(idParser.getLocalId(gid1) == 1)
+    assert(idParser.getLocalId(gid2) == 101)
+    assert(idParser.getLocalId(gid3) == 10000001)
+  }
+  test("test2"){
+    val idParser = new IdParser(1)
+    val gid1 = idParser.generateGlobalId(0, 1)
+    val gid2 = idParser.generateGlobalId(0, 2)
+    assert(idParser.getFragId(gid1) == 0)
+    assert(idParser.getFragId(gid2) == 0)
+    assert(idParser.getLocalId(gid1) == 1)
+    assert(idParser.getLocalId(gid2) == 2)
+  }
+
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/IteratorGenerator.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/IteratorGenerator.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+import scala.reflect.ClassTag
+
+@RunWith(classOf[JUnitRunner])
+class IteratorGenerator extends FunSuite{
+  def generateIterator(lid : Long): Iterator[(Long,Long)] = {
+    Iterator((lid, lid))
+  }
+
+  test("test1"){
+    val t1 = System.nanoTime()
+    var i = 0L;
+    var res = 0L;
+    while (i < 100000000) {
+      val iterator = generateIterator(i)
+      while (iterator.hasNext){
+        val tuple = iterator.next()
+        res += tuple._1 + tuple._2
+      }
+      i += 1;
+    }
+    val t2 = System.nanoTime()
+    println("test1 iterate over iterator : "+ (t2 - t1) / 1000000 + "ms")
+  }
+  test("test2"){
+    val t1 = System.nanoTime()
+    var i = 0L;
+    var res = 0L;
+    var iter = Iterator.empty
+    while (i < 100000000) {
+      val iterator = generateIterator(i)
+      iterator.foreach( tuple => res += tuple._1 + tuple._2)
+      i += 1;
+    }
+    val t2 = System.nanoTime()
+    println("test2 iterate over iterator : "+ (t2 - t1) / 1000000 + "ms")
+  }
+  test("test2"){
+    val t1 = System.nanoTime()
+    var i = 0L;
+    var res = 0L;
+    var iter = Iterator.empty
+    var arr = Array.empty[(Long,Long)]
+    while (i < 100000000) {
+      val iterator = generateIterator(i)
+//      val arr = iterator.toArray
+      arr.
+      iterator.foreach( tuple => res += tuple._1 + tuple._2)
+      i += 1;
+    }
+    val t2 = System.nanoTime()
+    println("test2 iterate over iterator : "+ (t2 - t1) / 1000000 + "ms")
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/SerializationTest.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/SerializationTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import com.alibaba.graphscope.graphx.utils.SerializationUtils
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class SerializationTest extends FunSuite{
+  test("test serialization"){
+    val vprog : (Long,Long,Long) => Long = {
+      (a,b,c) => a
+    }
+    SerializationUtils.write("/tmp/vprog-tmp",vprog)
+    println("success in serialization")
+  }
+
+  test("serialization & deserialization"){
+    val value = 1
+    val vprog : (Long,Long,Long) => Long = {
+      (a,b,c) => a + value
+    }
+    val filePath = "/tmp/vprog-tmp"
+    SerializationUtils.write(filePath,vprog)
+
+    val func = SerializationUtils.read(getClass.getClassLoader,"/tmp/vprog-tmp").asInstanceOf[Array[Object]]
+    require(func.length == 1)
+    val funcCasted = func(0).asInstanceOf[(Long,Long,Long)=>Long]
+  }
+}

--- a/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/SessionFieldGetterTest.scala
+++ b/analytical_engine/java/graphx-on-graphscope/src/test/scala/com/alibaba/graphscope/graphx/SessionFieldGetterTest.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.graphscope.graphx
+
+import org.apache.spark.sql.GSSparkSession
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class SessionFieldGetterTest extends FunSuite{
+  test("get"){
+    val session = org.mockito.Mockito.mock(classOf[GSSparkSession])
+
+    GSSparkSession.setExtensionsField(session, null, null)
+  }
+}

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -23,12 +23,13 @@
 
   <packaging>pom</packaging>
 
-  <name>grape-jdk-parent</name>
+  <name>Grape Java SDK</name>
 
   <modules>
     <module>grape-jdk</module>
     <module>grape-demo</module>
     <module>grape-runtime</module>
+    <module>graphx-on-graphscope</module>
     <module>giraph-on-grape</module>
   </modules>
 
@@ -38,10 +39,12 @@
     <compile-testing.version>0.19</compile-testing.version>
     <cupid.sdk.version>3.3.11</cupid.sdk.version>
     <cupid.table.version>1.1.3-SNAPSHOT</cupid.table.version>
+    <fastffi.revision>0.1</fastffi.revision>
     <fastjson.version>1.2.83</fastjson.version>
     <google-java-format.version>1.7</google-java-format.version>
     <javapoet.version>1.13.0</javapoet.version>
     <junit.version>4.13.2</junit.version>
+    <scala.library.version>2.12.10</scala.library.version>
     <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
@@ -56,6 +59,7 @@
     <dep.kryo.version>4.0.0</dep.kryo.version>
     <dep.json.version>20160810</dep.json.version>
     <dep.kryo-serializers.version>0.42</dep.kryo-serializers.version>
+    <spark.version>3.1.3</spark.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -72,6 +76,12 @@
         <version>0.16.0</version>
       </dependency>
       <dependency>
+        <groupId>com.alibaba.graphscope</groupId>
+        <artifactId>graphx-on-graphscope</artifactId>
+        <classifier>shaded</classifier>
+        <version>0.16.0</version>
+      </dependency>
+      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
@@ -79,7 +89,12 @@
       <dependency>
         <groupId>com.alibaba.fastffi</groupId>
         <artifactId>ffi</artifactId>
-        <version>${fastffi.version}</version>
+        <version>${fastffi.revision}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>${scala.library.version}</version>
       </dependency>
       <dependency>
         <groupId>com.alibaba.fastffi</groupId>
@@ -154,6 +169,17 @@
         <version>${dep.kryo-serializers.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-graphx_2.12</artifactId>
+        <version>${spark.version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-sql_2.12</artifactId>
+        <version>${spark.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>
         <version>1.10.19</version>
@@ -165,6 +191,11 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>net.alchim31.maven</groupId>
+          <artifactId>scala-maven-plugin</artifactId>
+          <version>4.3.1</version>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>

--- a/analytical_engine/java/run_graphx.sh
+++ b/analytical_engine/java/run_graphx.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+#
+# Copyright 2022 Alibaba Group Holding Limited.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  	http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+TASK=$1
+shift
+NUM_WORKERS=$1
+shift
+HOST_SLOT=$1
+shift
+VD_CLASS=$1
+shift
+ED_CLASS=$1
+shift
+MSG_CLASS=$1
+shift
+SERIAL_PATH=$1
+shift
+FRAG_IDS=$1
+shift
+MAX_ITERATION=$1
+shift
+NUM_PART=$1
+shift
+IPC_SOCKET=$1
+shift
+USER_JAR_PATH=$1
+shift
+
+echo "task                "${TASK}
+echo "num workers:        "${NUM_WORKERS}
+echo "host file           "${HOST_SLOT} # host name with slots
+echo "vd class            "${VD_CLASS}
+echo "ed class            "${ED_CLASS}
+echo "msg class           "${MSG_CLASS}
+echo "serial path         "${SERIAL_PATH}
+echo "frag ids:           "${FRAG_IDS}
+echo "max iter            "${MAX_ITERATION}
+echo "num part:           "${NUM_PART}
+echo "ipc socket          "${IPC_SOCKET}
+echo "user jar path       "${USER_JAR_PATH}
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+if [ -z "${USER_JAR_PATH}" ]; then
+    echo "USER_JAR_PATH need to be set"
+    exit 1;
+fi
+export USER_JAR_PATH=${USER_JAR_PATH}
+
+if [ -z "${GRAPHSCOPE_HOME}" ]; then
+    export GRAPHSCOPE_HOME=${SCRIPT_DIR}/../
+    echo "using probed GRAPHSCOPE_HOME: "${GRAPHSCOPE_HOME}
+else
+    echo "using GRAPHSCOPE_HOME: "${GRAPHSCOPE_HOME}
+
+fi
+
+GRAPHX_RUNNER=${GRAPHSCOPE_HOME}/bin/graphx_runner
+MPIRUN_EXECUTABLE=${GRAPHSCOPE_HOME}/openmpi/bin/mpirun
+source  ${GRAPHSCOPE_HOME}/conf/grape_jvm_opts
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GRAPHSCOPE_HOME}/lib/:${GRAPHSCOPE_HOME}/lib64
+
+if [ -f "${GRAPHX_RUNNER}" ]; then
+    echo "graphx runner exists."
+else
+    echo "graphx runner doesn't exist"
+    exit 1;
+fi
+
+# 1.first distribute serialization file
+array=($(echo "${HOST_SLOT}" | tr ',' '\n'))
+for host in ${array};
+do
+    echo ${host}
+    splited=($(echo "$host" | tr ':' '\n'))
+    echo "scp to host "${splited[0]}
+    scp ${SERIAL_PATH} ${splited[0]}:${SERIAL_PATH}
+done
+
+cmd="GLOG_v=10 ${MPIRUN_EXECUTABLE} -n ${NUM_WORKERS} -host ${HOST_SLOT} -x GLOG_v \
+-x USER_JAR_PATH -x GRAPE_JVM_OPTS ${GRAPHX_RUNNER} \
+--task ${TASK} \
+--vd_class ${VD_CLASS} --ed_class ${ED_CLASS} --msg_class ${MSG_CLASS} \
+--serial_path ${SERIAL_PATH} --frag_ids ${FRAG_IDS} \
+--max_iterations ${MAX_ITERATION} --num_part ${NUM_PART} --ipc_socket ${IPC_SOCKET}"
+echo "running cmd: "$cmd >&2
+eval $cmd

--- a/analytical_engine/test/app_tests.sh
+++ b/analytical_engine/test/app_tests.sh
@@ -388,6 +388,9 @@ exact_verify "${test_dir}/p2p-31"-triangles
 
 if [[ "${RUN_JAVA_TESTS}" == "ON" ]];
 then
+  run_vy_2 ${np} ./projected_fragment_mapper_test "${socket_file}" 1 "${test_dir}"/projected_property/twitter_property_e "${test_dir}"/projected_property/twitter_property_v 
+  mpirun -n 2 ./graphx_test ${socket_file}
+
   if [[ "${USER_JAR_PATH}"x != ""x ]]
   then
     echo "Running Java tests..."

--- a/analytical_engine/test/graphx_test.cc
+++ b/analytical_engine/test/graphx_test.cc
@@ -1,0 +1,286 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "arrow/array.h"
+#include "arrow/array/builder_primitive.h"
+#include "glog/logging.h"
+
+#include "vineyard/client/client.h"
+
+#include "core/java/graphx/edge_data.h"
+#include "core/java/graphx/graphx_csr.h"
+#include "core/java/graphx/graphx_fragment.h"
+#include "core/java/graphx/local_vertex_map.h"
+#include "core/java/graphx/vertex_data.h"
+
+boost::leaf::result<void> generateData(arrow::Int64Builder& srcBuilder,
+                                       arrow::Int64Builder& dstBuilder,
+                                       arrow::Int64Builder& edataBuilder,
+                                       grape::CommSpec& comm_spec);
+
+vineyard::ObjectID getLocalVM(vineyard::Client& client,
+                              grape::CommSpec& comm_spec) {
+  vineyard::ObjectID vmap_id;
+  {
+    arrow::Int64Builder inner, outer;
+    arrow::Int32Builder pid;
+    CHECK(inner.Reserve(3).ok());
+    CHECK(outer.Reserve(3).ok());
+    CHECK(pid.Reserve(2).ok());
+    pid.UnsafeAppend(0);
+    pid.UnsafeAppend(1);
+    pid.UnsafeAppend(0);
+    pid.UnsafeAppend(1);
+    if (comm_spec.worker_id() == 1) {
+      inner.UnsafeAppend(2);
+      inner.UnsafeAppend(4);
+      inner.UnsafeAppend(6);
+      outer.UnsafeAppend(1);
+      outer.UnsafeAppend(3);
+      outer.UnsafeAppend(5);
+      gs::BasicLocalVertexMapBuilder<int64_t, uint64_t> builder(client, inner,
+                                                                outer, pid);
+      auto vmap =
+          std::dynamic_pointer_cast<gs::LocalVertexMap<int64_t, uint64_t>>(
+              builder.Seal(client));
+
+      VINEYARD_CHECK_OK(client.Persist(vmap->id()));
+      vmap_id = vmap->id();
+      LOG(INFO) << "Worker [" << comm_spec.worker_id()
+                << "Persist local vmap id: " << vmap->id();
+    } else {
+      inner.UnsafeAppend(1);
+      inner.UnsafeAppend(3);
+      inner.UnsafeAppend(5);
+      outer.UnsafeAppend(2);
+      outer.UnsafeAppend(4);
+      outer.UnsafeAppend(6);
+      gs::BasicLocalVertexMapBuilder<int64_t, uint64_t> builder(client, inner,
+                                                                outer, pid);
+      auto vmap =
+          std::dynamic_pointer_cast<gs::LocalVertexMap<int64_t, uint64_t>>(
+              builder.Seal(client));
+
+      VINEYARD_CHECK_OK(client.Persist(vmap->id()));
+      vmap_id = vmap->id();
+      LOG(INFO) << "Worker [" << comm_spec.worker_id()
+                << "Persist local vmap id: " << vmap->id();
+    }
+  }
+  return vmap_id;
+}
+gs::GraphXVertexMap<int64_t, uint64_t> TestGraphXVertexMap(
+    vineyard::Client& client) {
+  grape::CommSpec comm_spec;
+  comm_spec.Init(MPI_COMM_WORLD);
+
+  if (comm_spec.worker_num() != 2) {
+    LOG(FATAL) << "Expect worker num == 2";
+  }
+  vineyard::ObjectID vm_id;
+  {
+    vineyard::ObjectID partial_map = getLocalVM(client, comm_spec);
+    LOG(INFO) << "Worker: " << comm_spec.worker_id()
+              << " local vm: " << partial_map;
+    gs::BasicGraphXVertexMapBuilder<int64_t, uint64_t> builder(
+        client, comm_spec, comm_spec.worker_num() - comm_spec.worker_id() - 1,
+        partial_map);
+    auto graphx_vm =
+        std::dynamic_pointer_cast<gs::GraphXVertexMap<int64_t, uint64_t>>(
+            builder.Seal(client));
+
+    VINEYARD_CHECK_OK(client.Persist(graphx_vm->id()));
+    vm_id = graphx_vm->id();
+    LOG(INFO) << "Persist csr id: " << graphx_vm->id();
+  }
+  std::shared_ptr<gs::GraphXVertexMap<int64_t, uint64_t>> vm =
+      std::dynamic_pointer_cast<gs::GraphXVertexMap<int64_t, uint64_t>>(
+          client.GetObject(vm_id));
+  LOG(INFO) << "worker " << comm_spec.worker_id() << " Got graphx vm "
+            << vm->id();
+  LOG(INFO) << "worker " << comm_spec.worker_id()
+            << " total vnum: " << vm->GetTotalVertexSize();
+  uint64_t gid;
+  for (int64_t i = 1; i <= 6; ++i) {
+    vm->GetGid(i, gid);
+    LOG(INFO) << "worker " << comm_spec.worker_id() << "oid " << i << "gid "
+              << gid;
+  }
+  return *vm;
+}
+
+vineyard::ObjectID TestGraphXCSR(
+    vineyard::Client& client, gs::GraphXVertexMap<int64_t, uint64_t>& graphx_vm,
+    arrow::Int64Builder& srcBuilder, arrow::Int64Builder& dstBuilder) {
+  grape::CommSpec comm_spec;
+  comm_spec.Init(MPI_COMM_WORLD);
+
+  vineyard::ObjectID csr_id;
+  {
+    gs::BasicGraphXCSRBuilder<int64_t, uint64_t> builder(client);
+    std::vector<int64_t> src{1, 2, 3, 4};
+    std::vector<int64_t> dst{2, 3, 4, 5};
+    builder.LoadEdges(src, dst, graphx_vm, comm_spec.local_num());
+    auto csr = std::dynamic_pointer_cast<gs::GraphXCSR<uint64_t>>(
+        builder.Seal(client));
+
+    // VINEYARD_CHECK_OK(client.Persist(csr->id()));
+    auto tmp_id = csr->id();
+    LOG(INFO) << "Persist csr id: " << csr->id();
+    std::shared_ptr<gs::GraphXCSR<uint64_t>> csr_ =
+        std::dynamic_pointer_cast<gs::GraphXCSR<uint64_t>>(
+            client.GetObject(tmp_id));
+    LOG(INFO) << "Got csr " << csr_->id();
+    csr_id = csr_->id();
+  }
+  std::shared_ptr<gs::GraphXCSR<uint64_t>> csr =
+      std::dynamic_pointer_cast<gs::GraphXCSR<uint64_t>>(
+          client.GetObject(csr_id));
+  LOG(INFO) << "Got csr " << csr->id();
+  LOG(INFO) << "in num edges: " << csr->GetInEdgesNum()
+            << "out num edges: " << csr->GetOutEdgesNum() << " vs "
+            << csr->GetPartialOutEdgesNum(
+                   0, graphx_vm.GetInnerVertexSize(comm_spec.fid()));
+  LOG(INFO) << "lid 0 degreee: " << csr->GetOutDegree(0) << ", "
+            << csr->GetPartialOutEdgesNum(0, 1);
+  return csr->id();
+}
+
+vineyard::ObjectID TestGraphXVertexData(vineyard::Client& client) {
+  vineyard::ObjectID id;
+  {
+    gs::VertexDataBuilder<uint64_t, int64_t> builder(client, 6);
+    auto& arrayBuilder = builder.GetArrayBuilder();
+    for (int i = 0; i < 6; ++i) {
+      arrayBuilder[i] = i;
+    }
+    auto vd = builder.MySeal(client);
+    id = vd->id();
+  }
+
+  std::shared_ptr<gs::VertexData<uint64_t, int64_t>> vd =
+      std::dynamic_pointer_cast<gs::VertexData<uint64_t, int64_t>>(
+          client.GetObject(id));
+  LOG(INFO) << "vnum: " << vd->VerticesNum();
+  LOG(INFO) << "vdata : " << vd->GetData(0);
+  auto vdArray = vd->GetVdataArray();
+  LOG(INFO) << "vd length: " << vdArray.GetLength();
+  return vd->id();
+}
+
+vineyard::ObjectID TestGraphXEdgeData(vineyard::Client& client,
+                                      std::vector<int64_t>& edata_builder) {
+  vineyard::ObjectID id;
+  {
+    gs::EdgeDataBuilder<uint64_t, int64_t> builder(client, edata_builder);
+    auto ed = builder.MySeal(client);
+    id = ed->id();
+  }
+
+  std::shared_ptr<gs::EdgeData<uint64_t, int64_t>> ed =
+      std::dynamic_pointer_cast<gs::EdgeData<uint64_t, int64_t>>(
+          client.GetObject(id));
+  LOG(INFO) << "vnum: " << ed->GetEdgeNum();
+  LOG(INFO) << "edata : " << ed->GetEdgeDataByEid(0);
+  auto edArray = ed->GetEdataArray();
+  LOG(INFO) << "ed length: " << edArray.GetLength();
+  return ed->id();
+}
+
+void TestGraphXFragment(vineyard::Client& client, vineyard::ObjectID vm_id,
+                        vineyard::ObjectID csr_id, vineyard::ObjectID vdata_id,
+                        vineyard::ObjectID edata_id) {
+  gs::GraphXFragmentBuilder<int64_t, uint64_t, int64_t, int64_t> builder(
+      client, vm_id, csr_id, vdata_id, edata_id);
+  auto res = std::dynamic_pointer_cast<
+      gs::GraphXFragment<int64_t, uint64_t, int64_t, int64_t>>(
+      builder.Seal(client));
+  LOG(INFO) << "Succesfully construct fragment: " << res->id();
+}
+
+boost::leaf::result<void> generateData(arrow::Int64Builder& srcBuilder,
+                                       arrow::Int64Builder& dstBuilder,
+                                       std::vector<int64_t>& edataBuilder) {
+  grape::CommSpec comm_spec;
+  comm_spec.Init(MPI_COMM_WORLD);
+
+  // if (comm_spec.worker_id() == 0) {
+  ARROW_OK_OR_RAISE(srcBuilder.Reserve(6));
+  ARROW_OK_OR_RAISE(dstBuilder.Reserve(6));
+  edataBuilder.resize(6);
+  srcBuilder.UnsafeAppend(1);
+  srcBuilder.UnsafeAppend(1);
+  srcBuilder.UnsafeAppend(2);
+  srcBuilder.UnsafeAppend(3);
+  srcBuilder.UnsafeAppend(4);
+  srcBuilder.UnsafeAppend(5);
+
+  dstBuilder.UnsafeAppend(2);
+  dstBuilder.UnsafeAppend(3);
+  dstBuilder.UnsafeAppend(3);
+  dstBuilder.UnsafeAppend(4);
+  dstBuilder.UnsafeAppend(6);
+  dstBuilder.UnsafeAppend(4);
+
+  edataBuilder[0] = 1;
+  edataBuilder[1] = 2;
+  edataBuilder[2] = 3;
+  edataBuilder[3] = 4;
+  edataBuilder[4] = 5;
+  edataBuilder[5] = 6;
+  return {};
+}
+void Init() {
+  grape::InitMPIComm();
+  grape::CommSpec comm_spec;
+  comm_spec.Init(MPI_COMM_WORLD);
+}
+
+void Finalize() { grape::FinalizeMPIComm(); }
+
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    printf("usage: ./graphx_test <ipc_socket>\n");
+    return 1;
+  }
+  std::string ipc_socket = std::string(argv[1]);
+  FLAGS_stderrthreshold = 0;
+  google::InitGoogleLogging("graphx_test");
+  google::InstallFailureSignalHandler();
+  vineyard::Client client;
+  VINEYARD_CHECK_OK(client.Connect(ipc_socket));
+  LOG(INFO) << "Connected to IPCServer: ";
+  Init();
+
+  arrow::Int64Builder srcBuilder, dstBuilder;
+  std::vector<int64_t> edataBuilder;
+  generateData(srcBuilder, dstBuilder, edataBuilder);
+
+  // TestLocalVertexMap(client);
+  auto graphx_vm = TestGraphXVertexMap(client);
+  auto csr_id = TestGraphXCSR(client, graphx_vm, srcBuilder, dstBuilder);
+  auto vdata_id = TestGraphXVertexData(client);
+  auto edata_id = TestGraphXEdgeData(client, edataBuilder);
+  TestGraphXFragment(client, graphx_vm.id(), csr_id, vdata_id, edata_id);
+  VLOG(1) << "Finish Querying.";
+  Finalize();
+
+  google::ShutdownGoogleLogging();
+  return 0;
+}

--- a/analytical_engine/test/projected_fragment_mapper_test.cc
+++ b/analytical_engine/test/projected_fragment_mapper_test.cc
@@ -1,0 +1,139 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include <boost/asio.hpp>
+#include "glog/logging.h"
+
+#include "grape/grape.h"
+#include "grape/util.h"
+#include "vineyard/client/client.h"
+#include "vineyard/graph/fragment/arrow_fragment.h"
+
+#include "core/fragment/arrow_projected_fragment.h"
+#include "core/fragment/arrow_projected_fragment_mapper.h"
+#include "core/java/graphx/fragment_getter.h"
+#include "core/loader/arrow_fragment_loader.h"
+
+std::string getHostName() { return boost::asio::ip::host_name(); }
+
+int main(int argc, char** argv) {
+  if (argc < 6) {
+    printf(
+        "usage: ./projected_fragment_mapper_test <ipc_socket> <e_label_num> "
+        "<efiles...> "
+        "<v_label_num> <vfiles...>\n");
+    return 1;
+  }
+  int index = 1;
+  std::string ipc_socket = std::string(argv[index++]);
+
+  int edge_label_num = atoi(argv[index++]);
+  std::vector<std::string> efiles;
+  for (int i = 0; i < edge_label_num; ++i) {
+    efiles.push_back(argv[index++]);
+  }
+
+  int vertex_label_num = atoi(argv[index++]);
+  std::vector<std::string> vfiles;
+  for (int i = 0; i < vertex_label_num; ++i) {
+    vfiles.push_back(argv[index++]);
+  }
+  int directed = 1;
+
+  grape::InitMPIComm();
+  {
+    grape::CommSpec comm_spec;
+    comm_spec.Init(MPI_COMM_WORLD);
+
+    vineyard::Client client;
+    VINEYARD_CHECK_OK(client.Connect(ipc_socket));
+
+    LOG(INFO) << "Connected to IPCServer: " << ipc_socket;
+
+    vineyard::ObjectID fragment_id;
+    {
+      auto loader = std::make_unique<
+          gs::ArrowFragmentLoader<vineyard::property_graph_types::OID_TYPE,
+                                  vineyard::property_graph_types::VID_TYPE>>(
+          client, comm_spec, efiles, vfiles, directed != 0);
+      fragment_id = boost::leaf::try_handle_all(
+          [&loader]() { return loader->LoadFragment(); },
+          [](const vineyard::GSError& e) {
+            LOG(FATAL) << e.error_msg;
+            return 0;
+          },
+          [](const boost::leaf::error_info& unmatched) {
+            LOG(FATAL) << "Unmatched error " << unmatched;
+            return 0;
+          });
+    }
+
+    {
+      using FragmentType =
+          vineyard::ArrowFragment<vineyard::property_graph_types::OID_TYPE,
+                                  vineyard::property_graph_types::VID_TYPE>;
+      using ProjectedFragmentType =
+          gs::ArrowProjectedFragment<int64_t, uint64_t, double, int64_t>;
+
+      LOG(INFO) << "[worker-" << comm_spec.worker_id()
+                << "] loaded graph to vineyard ..." << fragment_id;
+      MPI_Barrier(comm_spec.comm());
+      auto fragment = std::dynamic_pointer_cast<FragmentType>(
+          client.GetObject(fragment_id));
+      LOG(INFO) << "vertex prop num:" << fragment->vertex_property_num(0);
+      LOG(INFO) << "edge prop num:" << fragment->edge_property_num(0);
+      std::shared_ptr<ProjectedFragmentType> projected_fragment =
+          ProjectedFragmentType::Project(fragment, 0, 0, 0, 0);
+      LOG(INFO) << "After projection: " << getHostName() << ":"
+                << projected_fragment->id();
+
+      gs::ArrowProjectedFragmentMapper<int64_t, uint64_t, double, int64_t,
+                                       int64_t, double>
+          mapper;
+      arrow::Int64Builder vdata_builder;
+      arrow::DoubleBuilder edata_builder;
+      vdata_builder.Reserve(projected_fragment->GetInnerVerticesNum());
+      LOG(INFO) << "ivnum: " << projected_fragment->GetInnerVerticesNum()
+                << ",enum: " << projected_fragment->GetOutEdgeNum();
+      {
+        auto ivnum = projected_fragment->GetInnerVerticesNum();
+        for (size_t i = 0; i < ivnum; ++i) {
+          vdata_builder.UnsafeAppend(static_cast<int64_t>(i));
+        }
+        auto edata_array = projected_fragment->get_edata_array_accessor();
+        size_t edge_num = edata_array.GetLength();
+        edata_builder.Reserve(edge_num);
+        for (size_t i = 0; i < edge_num; ++i) {
+          edata_builder.UnsafeAppend(static_cast<double>(i));
+        }
+      }
+      auto mapped_fragment =
+          mapper.Map(*projected_fragment, vdata_builder, edata_builder, client);
+      LOG(INFO) << "Got mapped fragment " << mapped_fragment->id();
+      grape::Vertex<uint64_t> vertex;
+      vertex.SetValue(10);
+      LOG(INFO) << "new data: " << mapped_fragment->GetData(vertex);
+    }
+
+    MPI_Barrier(comm_spec.comm());
+  }
+
+  grape::FinalizeMPIComm();
+  return 0;
+}


### PR DESCRIPTION
## GraphScope for Spark-GraphX

### Functionality 
- Breaking down the barrier of graph storage between `GraphScope` and `GraphX`, Spark Graph `RDD`s can be converted from/to GraphScope `Fragment`
- Running `GraphX Pregel` on GraphScope. `GraphX Pregel` algorithms can be seamlessly run on GraphScope, with up to `6x` performance boost.
- Deploy `GraphScope for Graphx` on exiting Spark clusters.

### For code review

Important changes brought in this pr:
- Add new Executable : `graphx_runner`, used to run spark graphx pregel query.
- install new shell scripts, `run_graphx.sh`, `construct_vertex_map.sh` to `${GRAPHSCOPE_HOME}/bin/`
- Add two test to `app_test.sh`, `graphx_test` and `projected_fragment_mapper_test`
- For CI, one job is added in `ci.yml` for spark-graphx, which runs an end-to-end spark test.
- The majority of contributed code is writen in `scala`, may be scalafmt is needed?

### issue
#1599 
#1482 
