### PR TITLE
Use a `getaddrinfo` resolvable hostname as the local hostname (will be used as the etcd endpoint further).

### DIFF
--- a/coordinator/gscoordinator/launcher.py
+++ b/coordinator/gscoordinator/launcher.py
@@ -357,8 +357,15 @@ class LocalLauncher(Launcher):
         else:
             self._etcd_peer_port = get_free_port()
         if len(self._hosts) > 1:
+            try:
+                local_hostname = socket.gethostname()
+                socket.gethostbyname(
+                    local_hostname
+                )  # make sure the hostname is dns-resolvable
+            except Exception:
+                local_hostname = "127.0.0.1"  # fallback to a must-correct hostname
             self._etcd_endpoint = "http://{0}:{1}".format(
-                socket.gethostname(), str(self._etcd_client_port)
+                local_hostname, str(self._etcd_client_port)
             )
         else:
             self._etcd_endpoint = "http://127.0.0.1:{0}".format(


### PR DESCRIPTION

## What do these changes do?

As titled. On macOS the `socket.gethostname()` is not always resolvable by `getaddrinfo()`.

## Related issue number

n/a, we received the bug report from our end users.

