### PR TITLE
[pegasus] update contains_source in progress

### DIFF
--- a/interactive_engine/executor/engine/pegasus/pegasus/src/communication/decorator/exchange.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/communication/decorator/exchange.rs
@@ -796,7 +796,7 @@ impl<D: Data> Push<MicroBatch<D>> for ExchangeByBatchPush<D> {
         } else {
             assert!(batch.is_empty());
             if let Some(end) = batch.take_end() {
-                if end.contains_source(self.src) {
+                if end.peers_contains(self.src) {
                     for p in self.pushes.iter_mut() {
                         let mut new_end = end.clone();
                         new_end.total_send = 0;

--- a/interactive_engine/executor/engine/pegasus/pegasus/src/progress.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/progress.rs
@@ -268,7 +268,8 @@ impl EndOfScope {
     }
 
     pub(crate) fn contains_source(&self, src: u32) -> bool {
-        self.peers.value() > 0 && self.peers.contains_source(src)
+        (self.tag.is_root() && src == 0)
+            || (!self.tag.is_root() && self.peers.value() > 0 && self.peers.contains_source(src))
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Update method `contains_source` in progress.rs to avoid bug in https://github.com/alibaba/GraphScope/issues/1999. The operators count, any, etc. in dataflow with aggregate will no longer output multi results.
Apply commit in https://github.com/bmmcq/fork-pegasus/commit/2ca02e401a09ba62aa9fa859e38a0700db781ac1#diff-0db0ad0daf508cf2b957808eefe7445c43d66a8621b538e5b15ac36866832a71 . 


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes https://github.com/alibaba/GraphScope/issues/1999
