### PR TITLE
Ensure session close work when triggered not in main thread

### DIFF
--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -810,7 +810,10 @@ class Session(object):
 
         Note that closing will ignore SIGINT and SIGTERM signal and recover later.
         """
-        with SignalIgnore([signal.SIGINT, signal.SIGTERM]):
+        if threading.currentThread() is threading.main_thread():
+            with SignalIgnore([signal.SIGINT, signal.SIGTERM]):
+                self._close()
+        else:
             self._close()
 
     def _close(self):


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Signal is not working when the running program is not in python main thread. ensure session close can work in above case.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

