### PR TITLE
Add connected() in session.py to figure out session status

### DIFF
--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -802,6 +802,14 @@ class Session(object):
                 else:
                     self._disconnected = False
             time.sleep(self._heartbeat_interval_seconds)
+            
+    def connected(self) -> bool:
+        """Check if the session is still connected and available.
+
+        Returns: True or False
+
+        """
+        return not self._disconnected
 
     def close(self):
         """Closes this session.

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -802,6 +802,7 @@ class Session(object):
                 else:
                     self._disconnected = False
             time.sleep(self._heartbeat_interval_seconds)
+
     def connected(self) -> bool:
         """Check if the session is still connected and available.
 

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -802,7 +802,6 @@ class Session(object):
                 else:
                     self._disconnected = False
             time.sleep(self._heartbeat_interval_seconds)
-            
     def connected(self) -> bool:
         """Check if the session is still connected and available.
 


### PR DESCRIPTION
GAE add connected() in session.py to indicate if the session is still valid and available for the graph computing work. In some case analytical engine cannot be connected, with this new function, client side can check the session status and process this special case(try to restart runtime or close session etc).

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

GAE add connected() in session.py to indicate if the session is still valid and available for the graph computing work.
In some case analytical engine cannot be connected, with this new function, client side can check the session status and process this special case(try to restart runtime or close session etc).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

