### PR TITLE
fix bug in extract_needed_columns

### DIFF
--- a/interactive_engine/executor/ir/graph_proxy/src/adapters/gs_store/read_graph.rs
+++ b/interactive_engine/executor/ir/graph_proxy/src/adapters/gs_store/read_graph.rs
@@ -711,6 +711,13 @@ fn extract_needed_columns(
 
     use crate::utils::expr::eval_pred::zip_option_vecs;
 
+    // Some(vec[]) means need all props, so can't merge it with props needed in filter
+    if let Some(out_columns) = out_columns {
+        if out_columns.is_empty() {
+            return Ok(Some(Vec::with_capacity(0)))
+        }
+    }
+
     let filter_needed = if let Some(filter) = filter { filter.as_ref().extract_prop_ids() } else { None };
     let columns = zip_option_vecs(filter_needed, out_columns.cloned());
     // remove duplicated prop ids


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
`Some(vec[])` means need all props,  so can't merge it with props needed in filter

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#1530 
