### PR TITLE
GAE java build refactor

### DIFF
--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -91,7 +91,7 @@ jobs:
         mvn install -Dmaven.antrun.skip=true --quiet
 
         source ${GRAPHSCOPE_HOME}/conf/grape_jvm_opts
-        export USER_JAR_PATH=${GITHUB_WORKSPACE}/analytical_engine/java/grape-demo/target/grape-demo-0.1-shaded.jar
+        export USER_JAR_PATH=${GITHUB_WORKSPACE}/analytical_engine/java/grape-demo/target/grape-demo-0.16.0-shaded.jar
         cd ${GITHUB_WORKSPACE}/analytical_engine/build
         ../test/app_tests.sh --test_dir ${GS_TEST_DIR}
 
@@ -101,7 +101,7 @@ jobs:
         RUN_JAVA_TESTS: ON
         GRAPHSCOPE_HOME: /opt/graphscope
       run: |
-        export USER_JAR_PATH=${GITHUB_WORKSPACE}/analytical_engine/java/grape-demo/target/grape-demo-0.1-shaded.jar
+        export USER_JAR_PATH=${GITHUB_WORKSPACE}/analytical_engine/java/grape-demo/target/grape-demo-0.16.0-shaded.jar
         source ${GRAPHSCOPE_HOME}/conf/grape_jvm_opts
 
         cd ${GITHUB_WORKSPACE}/python

--- a/Makefile
+++ b/Makefile
@@ -98,14 +98,6 @@ ifneq ($(INSTALL_PREFIX), /usr/local)
 		sudo ln -sfn ${INSTALL_PREFIX}/lib/cmake/graphscope-analytical /usr/local/lib/cmake/graphscope-analytical; \
 	fi
 endif
-# ifeq (${ENABLE_JAVA_SDK}, ON)
-# 	cd $(WORKING_DIR)/analytical_engine/java && \
-# 	mvn clean install -DskipTests --quiet && \
-# 	sudo cp ${WORKING_DIR}/analytical_engine/java/grape-runtime/target/native/libgrape-jni.* ${INSTALL_PREFIX}/lib/ && \
-# 	sudo cp ${WORKING_DIR}/analytical_engine/java/grape-runtime/target/grape-runtime-0.1-shaded.jar ${INSTALL_PREFIX}/lib/ && \
-# 	sudo mkdir -p ${INSTALL_PREFIX}/conf/ && \
-# 	sudo cp ${WORKING_DIR}/analytical_engine/java/grape_jvm_opts ${INSTALL_PREFIX}/conf/
-# endif
 
 .PHONY: gie
 gie:

--- a/Makefile
+++ b/Makefile
@@ -98,14 +98,14 @@ ifneq ($(INSTALL_PREFIX), /usr/local)
 		sudo ln -sfn ${INSTALL_PREFIX}/lib/cmake/graphscope-analytical /usr/local/lib/cmake/graphscope-analytical; \
 	fi
 endif
-ifeq (${ENABLE_JAVA_SDK}, ON)
-	cd $(WORKING_DIR)/analytical_engine/java && \
-	mvn clean install -DskipTests --quiet && \
-	sudo cp ${WORKING_DIR}/analytical_engine/java/grape-runtime/target/native/libgrape-jni.* ${INSTALL_PREFIX}/lib/ && \
-	sudo cp ${WORKING_DIR}/analytical_engine/java/grape-runtime/target/grape-runtime-0.1-shaded.jar ${INSTALL_PREFIX}/lib/ && \
-	sudo mkdir -p ${INSTALL_PREFIX}/conf/ && \
-	sudo cp ${WORKING_DIR}/analytical_engine/java/grape_jvm_opts ${INSTALL_PREFIX}/conf/
-endif
+# ifeq (${ENABLE_JAVA_SDK}, ON)
+# 	cd $(WORKING_DIR)/analytical_engine/java && \
+# 	mvn clean install -DskipTests --quiet && \
+# 	sudo cp ${WORKING_DIR}/analytical_engine/java/grape-runtime/target/native/libgrape-jni.* ${INSTALL_PREFIX}/lib/ && \
+# 	sudo cp ${WORKING_DIR}/analytical_engine/java/grape-runtime/target/grape-runtime-0.1-shaded.jar ${INSTALL_PREFIX}/lib/ && \
+# 	sudo mkdir -p ${INSTALL_PREFIX}/conf/ && \
+# 	sudo cp ${WORKING_DIR}/analytical_engine/java/grape_jvm_opts ${INSTALL_PREFIX}/conf/
+# endif
 
 .PHONY: gie
 gie:

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -374,6 +374,7 @@ add_custom_target(gsa_clformat
     COMMENT "Running clang-format, using clang-format-8 from https://github.com/muttleyxd/clang-tools-static-binaries/releases"
     VERBATIM)
 
+# Install GAE Java SDK
 set(GAE_JAVA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/java/")
 set(GAE_JAVA_RUNTIME_DIR "${GAE_JAVA_DIR}/grape-runtime/")
 set(GAE_JAVA_RUNTIME_JAR "${GAE_JAVA_RUNTIME_DIR}/target/grape-runtime-${GRAPHSCOPE_ANALYTICAL_VERSION}-shaded.jar") 
@@ -384,9 +385,9 @@ add_custom_command(
     COMMENT "Building GAE-java..."
     VERBATIM
 )
-
 install(FILES DESTINATION lib)
 install(FILES "${GAE_JAVA_RUNTIME_DIR}/target/native/libgrape-jni.so" DESTINATION lib)
+install(FILES "${GAE_JAVA_RUNTIME_JAR}" DESTINATION lib)
 install(FILES "${GAE_JAVA_DIR}/grape_jvm_opts" DESTINATION conf)
 
 # Install binaries

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -374,6 +374,19 @@ add_custom_target(gsa_clformat
     COMMENT "Running clang-format, using clang-format-8 from https://github.com/muttleyxd/clang-tools-static-binaries/releases"
     VERBATIM)
 
+set(GAE_JAVA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/java/")
+set(GAE_JAVA_RUNTIME_DIR "${GAE_JAVA_DIR}/grape-runtime/")
+add_custom_command(
+    COMMAND mvn clean install -DskipTests --quiet
+    WORKING_DIRECTORY ${GAE_JAVA_DIR}
+    COMMENT "Building GAE-java..."
+    VERBATIM
+)
+
+install(FILES "${GAE_JAVA_RUNTIME_DIR}/target/grape-runtime-${GRAPHSCOPE_ANALYTICAL_VERSION}-shaded.jar" DESTINATION lib)
+install(FILES "${GAE_JAVA_RUNTIME_DIR}/target/native/libgrape-jni.so" DESTINATION lib)
+install(FILES "${GAE_JAVA_DIR}/grape_jvm_opts" DESTINATION conf)
+
 # Install binaries
 macro(install_gsa_binary target)
     install(TARGETS ${target}

--- a/analytical_engine/java/giraph-on-grape/pom.xml
+++ b/analytical_engine/java/giraph-on-grape/pom.xml
@@ -1,21 +1,97 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.alibaba.graphscope</groupId>
+    <artifactId>grape-jdk-parent</artifactId>
+    <version>${gae.java.version}</version>
+  </parent>
+
   <artifactId>giraph-on-grape</artifactId>
+  <version>${gae.java.version}</version>
+  <packaging>jar</packaging>
+  <name>giraph-on-grape</name>
+
+  <properties>
+    <benchmark.filter>org.apache.hadoop.io.StdVectorTest.write*</benchmark.filter>
+    <benchmark.forks>1</benchmark.forks>
+    <benchmark.jvmargs></benchmark.jvmargs>
+    <benchmark.jvmargs>-Darrow.enable_null_check_for_get=false
+      -Darrow.enable_unsafe_memory_access=true
+      -Djava.library.path=${project.build.directory}/native:${project.build.directory}/../../grape-runtime/target/native
+      -XX:CompileCommandFile=/home/graphscope/compile-commands.txt</benchmark.jvmargs>
+    <benchmark.list></benchmark.list>
+    <benchmark.resultfile>jmh-result.json</benchmark.resultfile>
+    <benchmark.resultformat>json</benchmark.resultformat>
+    <benchmark.runs>1</benchmark.runs>
+    <benchmark.warmups>0</benchmark.warmups>
+    <hadoop-core.version>1.2.1</hadoop-core.version>
+    <jmh.version>1.21</jmh.version>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <skip.perf.benchmarks>true</skip.perf.benchmarks>
+    <uberjar.name>giraph-on-grape-shaded</uberjar.name>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-core</artifactId>
+      <version>${hadoop-core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.fastffi</groupId>
+      <artifactId>llvm4jni-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.graphscope</groupId>
+      <artifactId>grape-jdk</artifactId>
+      <version>${gae.java.version}</version>
+      <classifier>shaded</classifier>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <version>${dep.netty.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.giraph</groupId>
+      <artifactId>giraph-core</artifactId>
+      <version>1.3.0-hadoop2</version>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skipTests>true</skipTests>
         </configuration>
-        <groupId>org.apache.maven.plugins</groupId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>2.2</version>
         <executions>
           <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
             <configuration>
               <filters>
                 <filter>
@@ -30,98 +106,17 @@
 
               <finalName>${uberjar.name}</finalName>
             </configuration>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <phase>package</phase>
           </execution>
         </executions>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>2.2</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>
-            -Djava.library.path=${project.build.directory}/native:${project.build.directory}/../../grape-runtime/target/native
-          </argLine>
+          <argLine>-Djava.library.path=${project.build.directory}/native:${project.build.directory}/../../grape-runtime/target/native</argLine>
         </configuration>
-        <groupId>org.apache.maven.plugins</groupId>
       </plugin>
     </plugins>
   </build>
-  <dependencies>
-    <dependency>
-      <artifactId>hadoop-core</artifactId>
-      <groupId>org.apache.hadoop</groupId>
-      <version>${hadoop-core.version}</version>
-    </dependency>
-    <dependency>
-      <artifactId>llvm4jni-runtime</artifactId>
-      <groupId>com.alibaba.fastffi</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>grape-jdk</artifactId>
-      <classifier>shaded</classifier>
-      <groupId>com.alibaba.graphscope</groupId>
-      <version>0.1</version>
-    </dependency>
-    <dependency>
-      <artifactId>logback-classic</artifactId>
-      <groupId>ch.qos.logback</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>netty-all</artifactId>
-      <groupId>io.netty</groupId>
-      <version>${dep.netty.version}</version>
-    </dependency>
-    <dependency>
-      <artifactId>fastutil</artifactId>
-      <groupId>it.unimi.dsi</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>mockito-core</artifactId>
-      <groupId>org.mockito</groupId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.giraph</groupId>
-      <artifactId>giraph-core</artifactId>
-      <version>1.3.0-hadoop2</version>
-    </dependency>
-  </dependencies>
-  <modelVersion>4.0.0</modelVersion>
-  <name>giraph-on-grape</name>
-  <packaging>jar</packaging>
-
-  <parent>
-    <artifactId>grape-jdk-parent</artifactId>
-    <groupId>com.alibaba.graphscope</groupId>
-    <version>0.1</version>
-  </parent>
-
-  <properties>
-    <benchmark.filter>org.apache.hadoop.io.StdVectorTest.write*</benchmark.filter>
-    <benchmark.forks>1</benchmark.forks>
-    <benchmark.jvmargs></benchmark.jvmargs>
-    <benchmark.jvmargs>-Darrow.enable_null_check_for_get=false
-      -Darrow.enable_unsafe_memory_access=true
-      -Djava.library.path=${project.build.directory}/native:${project.build.directory}/../../grape-runtime/target/native
-      -XX:CompileCommandFile=/home/graphscope/compile-commands.txt
-    </benchmark.jvmargs>
-    <benchmark.list></benchmark.list>
-    <benchmark.resultfile>jmh-result.json</benchmark.resultfile>
-    <benchmark.resultformat>json</benchmark.resultformat>
-    <benchmark.runs>1</benchmark.runs>
-    <benchmark.warmups>0</benchmark.warmups>
-    <hadoop-core.version>1.2.1</hadoop-core.version>
-    <jmh.version>1.21</jmh.version>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-    <skip.perf.benchmarks>true</skip.perf.benchmarks>
-    <uberjar.name>giraph-on-grape-shaded</uberjar.name>
-  </properties>
-
-  <version>0.1</version>
 
 </project>

--- a/analytical_engine/java/giraph-on-grape/pom.xml
+++ b/analytical_engine/java/giraph-on-grape/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${gae.java.version}</version>
+    <version>0.16.0</version>
   </parent>
 
   <artifactId>giraph-on-grape</artifactId>
-  <version>${gae.java.version}</version>
+  <version>0.16.0</version>
   <packaging>jar</packaging>
   <name>giraph-on-grape</name>
 
@@ -46,8 +46,6 @@
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>
       <artifactId>grape-jdk</artifactId>
-      <version>${gae.java.version}</version>
-      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
@@ -75,6 +73,10 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/analytical_engine/java/grape-demo/pom.xml
+++ b/analytical_engine/java/grape-demo/pom.xml
@@ -14,17 +14,68 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.alibaba.graphscope</groupId>
+    <artifactId>grape-jdk-parent</artifactId>
+    <version>${gae.java.version}</version>
+  </parent>
   <artifactId>grape-demo</artifactId>
+
+  <version>${gae.java.version}</version>
+  <packaging>jar</packaging>
+
+  <name>grape-demo</name>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba</groupId>
+      <artifactId>fastjson</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.graphscope</groupId>
+      <artifactId>grape-jdk</artifactId>
+      <version>${gae.java.version}</version>
+      <classifier>shaded</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.graphscope</groupId>
+      <artifactId>giraph-on-grape</artifactId>
+      <version>${gae.java.version}</version>
+      <classifier>shaded</classifier>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.fastffi</groupId>
+      <artifactId>annotation-processor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <phase>package</phase>
             <configuration>
               <artifactSet>
                 <excludes>
@@ -32,73 +83,20 @@
                 </excludes>
               </artifactSet>
             </configuration>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <phase>package</phase>
           </execution>
         </executions>
-        <groupId>org.apache.maven.plugins</groupId>
       </plugin>
       <plugin>
-        <artifactId>spotless-maven-plugin</artifactId>
         <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skipTests>true</skipTests>
         </configuration>
-        <groupId>org.apache.maven.plugins</groupId>
       </plugin>
     </plugins>
   </build>
-  <dependencies>
-    <dependency>
-      <artifactId>junit</artifactId>
-      <groupId>junit</groupId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <artifactId>fastjson</artifactId>
-      <groupId>com.alibaba</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>grape-jdk</artifactId>
-      <classifier>shaded</classifier>
-      <groupId>com.alibaba.graphscope</groupId>
-      <version>0.1</version>
-    </dependency>
-    <dependency>
-      <artifactId>giraph-on-grape</artifactId>
-      <classifier>shaded</classifier>
-      <groupId>com.alibaba.graphscope</groupId>
-      <version>0.1</version>
-    </dependency>
-    <dependency>
-      <artifactId>annotation-processor</artifactId>
-      <groupId>com.alibaba.fastffi</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>slf4j-api</artifactId>
-      <groupId>org.slf4j</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>logback-classic</artifactId>
-      <groupId>ch.qos.logback</groupId>
-    </dependency>
-  </dependencies>
-
-  <modelVersion>4.0.0</modelVersion>
-
-  <name>grape-demo</name>
-  <packaging>jar</packaging>
-
-  <parent>
-    <artifactId>grape-jdk-parent</artifactId>
-    <groupId>com.alibaba.graphscope</groupId>
-    <version>0.1</version>
-  </parent>
-
-  <version>0.1</version>
 </project>

--- a/analytical_engine/java/grape-demo/pom.xml
+++ b/analytical_engine/java/grape-demo/pom.xml
@@ -21,11 +21,11 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${gae.java.version}</version>
+    <version>0.16.0</version>
   </parent>
   <artifactId>grape-demo</artifactId>
 
-  <version>${gae.java.version}</version>
+  <version>0.16.0</version>
   <packaging>jar</packaging>
 
   <name>grape-demo</name>
@@ -42,14 +42,10 @@
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>
       <artifactId>grape-jdk</artifactId>
-      <version>${gae.java.version}</version>
-      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>
       <artifactId>giraph-on-grape</artifactId>
-      <version>${gae.java.version}</version>
-      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>com.alibaba.fastffi</groupId>
@@ -69,6 +65,10 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
@@ -85,10 +85,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -20,16 +20,15 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.1</version>
+    <version>${gae.java.version}</version>
   </parent>
 
   <artifactId>grape-jdk</artifactId>
-  <version>0.1</version>
+  <version>${gae.java.version}</version>
   <packaging>jar</packaging>
   <name>grape-jdk</name>
 
   <properties>
-    <alibaba-grape-sdk.version>0.1</alibaba-grape-sdk.version>
     <jacoco.version>0.8.7</jacoco.version>
     <jni.library.name>grape-jni</jni.library.name>
     <jni.library.path>${project.basedir}/target/native/</jni.library.path>

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${gae.java.version}</version>
+    <version>0.16.0</version>
   </parent>
 
   <artifactId>grape-jdk</artifactId>
-  <version>${gae.java.version}</version>
+  <version>0.16.0</version>
   <packaging>jar</packaging>
   <name>grape-jdk</name>
 
@@ -80,10 +80,6 @@
           <failOnError>false</failOnError>
           <locale>en_US</locale>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/analytical_engine/java/grape-runtime/CMakeLists.txt
+++ b/analytical_engine/java/grape-runtime/CMakeLists.txt
@@ -67,13 +67,14 @@ include_directories(SYSTEM ${LIBGRAPELITE_INCLUDE_DIRS})
 find_package(vineyard 0.2.6 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 
-# find graphscope analytical engine---------------------------------------------
-find_package(graphscope-analytical)
-include_directories(SYSTEM ${GRAPHSCOPE_ANALYTICAL_INCLUDE_DIRS})
-include_directories(SYSTEM ${GRAPHSCOPE_ANALYTICAL_INCLUDE_DIRS}/proto)
+# # find graphscope analytical engine---------------------------------------------
+# find_package(graphscope-analytical)
+# include_directories(SYSTEM ${GRAPHSCOPE_ANALYTICAL_INCLUDE_DIRS})
+# include_directories(SYSTEM ${GRAPHSCOPE_ANALYTICAL_INCLUDE_DIRS}/proto)
 
 add_library(grape-jni SHARED ${SOURCES})
 target_compile_definitions(grape-jni PUBLIC ENABLE_JAVA_SDK)
+target_include_directories(grape-jni PRIVATE "${PROJECT_SOURCE_DIR}/../../")
 target_link_libraries(grape-jni ${CMAKE_JNI_LINKER_FLAGS}  ${LIBGRAPELITE_LIBRARIES} ${VINEYARD_LIBRARIES})
 set_target_properties(grape-jni PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_features(grape-jni PRIVATE cxx_std_14)

--- a/analytical_engine/java/grape-runtime/CMakeLists.txt
+++ b/analytical_engine/java/grape-runtime/CMakeLists.txt
@@ -67,11 +67,6 @@ include_directories(SYSTEM ${LIBGRAPELITE_INCLUDE_DIRS})
 find_package(vineyard 0.2.6 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 
-# # find graphscope analytical engine---------------------------------------------
-# find_package(graphscope-analytical)
-# include_directories(SYSTEM ${GRAPHSCOPE_ANALYTICAL_INCLUDE_DIRS})
-# include_directories(SYSTEM ${GRAPHSCOPE_ANALYTICAL_INCLUDE_DIRS}/proto)
-
 add_library(grape-jni SHARED ${SOURCES})
 target_compile_definitions(grape-jni PUBLIC ENABLE_JAVA_SDK)
 target_include_directories(grape-jni PRIVATE "${PROJECT_SOURCE_DIR}/../../")

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -14,29 +14,84 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://maven.apache.org/POM/4.0.0"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.alibaba.graphscope</groupId>
+    <artifactId>grape-jdk-parent</artifactId>
+    <version>${gae.java.version}</version>
+  </parent>
   <artifactId>grape-runtime</artifactId>
+
+  <version>${gae.java.version}</version>
+  <packaging>jar</packaging>
+  <name>grape-runtime</name>
+
+  <properties>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.alibaba.fastffi</groupId>
+      <artifactId>ffi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.fastffi</groupId>
+      <artifactId>annotation-processor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>javapoet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.testing.compile</groupId>
+      <artifactId>compile-testing</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.alibaba.graphscope</groupId>
+      <artifactId>grape-jdk</artifactId>
+      <version>${gae.java.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>
-        <artifactId>spotless-maven-plugin</artifactId>
         <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <!-- Disable annotation processing for ourselves -->
           <!--          <compilerArgument>-proc:none</compilerArgument>-->
         </configuration>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>${maven-compiler-plugin.version}</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
         <executions>
           <execution>
+            <id>make</id>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <phase>compile</phase>
             <configuration>
               <target>
                 <ant antfile="${basedir}/build.xml">
@@ -44,89 +99,32 @@
                 </ant>
               </target>
             </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <id>make</id>
-            <phase>compile</phase>
           </execution>
         </executions>
-        <groupId>org.apache.maven.plugins</groupId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skipTests>true</skipTests>
         </configuration>
-        <groupId>org.apache.maven.plugins</groupId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
+        <version>${maven-shade-plugin.version}</version>
         <executions>
           <execution>
-            <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-            </configuration>
             <goals>
               <goal>shade</goal>
             </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+            </configuration>
           </execution>
         </executions>
-        <groupId>org.apache.maven.plugins</groupId>
-        <version>${maven-shade-plugin.version}</version>
       </plugin>
     </plugins>
   </build>
-
-  <dependencies>
-    <dependency>
-      <artifactId>ffi</artifactId>
-      <groupId>com.alibaba.fastffi</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>annotation-processor</artifactId>
-      <groupId>com.alibaba.fastffi</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>javapoet</artifactId>
-      <groupId>com.squareup</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>compile-testing</artifactId>
-      <groupId>com.google.testing.compile</groupId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <artifactId>grape-jdk</artifactId>
-      <groupId>com.alibaba.graphscope</groupId>
-      <scope>compile</scope>
-      <version>0.1</version>
-    </dependency>
-    <dependency>
-      <artifactId>slf4j-api</artifactId>
-      <groupId>org.slf4j</groupId>
-    </dependency>
-    <dependency>
-      <artifactId>logback-classic</artifactId>
-      <groupId>ch.qos.logback</groupId>
-    </dependency>
-  </dependencies>
-
-  <modelVersion>4.0.0</modelVersion>
-  <name>grape-runtime</name>
-  <packaging>jar</packaging>
-
-  <parent>
-    <artifactId>grape-jdk-parent</artifactId>
-    <groupId>com.alibaba.graphscope</groupId>
-    <version>0.1</version>
-  </parent>
-
-  <properties>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
-  </properties>
-
-  <version>0.1</version>
 
 </project>

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -21,11 +21,11 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${gae.java.version}</version>
+    <version>0.16.0</version>
   </parent>
   <artifactId>grape-runtime</artifactId>
 
-  <version>${gae.java.version}</version>
+  <version>0.16.0</version>
   <packaging>jar</packaging>
   <name>grape-runtime</name>
 
@@ -55,8 +55,6 @@
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>
       <artifactId>grape-jdk</artifactId>
-      <version>${gae.java.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -70,17 +68,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven-compiler-plugin.version}</version>
-        <configuration>
-          <!-- Disable annotation processing for ourselves -->
-          <!--          <compilerArgument>-proc:none</compilerArgument>-->
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/analytical_engine/java/grape_jvm_opts
+++ b/analytical_engine/java/grape_jvm_opts
@@ -23,9 +23,9 @@ fi
 if [[ "${RUNTIME_LLVM4JNI_OUTPUT}"x != x ]];
 then
     echo "find env RUNTIME_LLVM4JNI_OUTPUT, append to init java class path"
-    class_path=${RUNTIME_LLVM4JNI_OUTPUT}:${GRAPHSCOPE_HOME}/lib/grape-runtime-0.1-shaded.jar
+    class_path=${RUNTIME_LLVM4JNI_OUTPUT}:${GRAPHSCOPE_HOME}/lib/grape-runtime-0.16.0-shaded.jar
 else 
-    class_path=${GRAPHSCOPE_HOME}/lib/grape-runtime-0.1-shaded.jar:
+    class_path=${GRAPHSCOPE_HOME}/lib/grape-runtime-0.16.0-shaded.jar:
 fi
 
 jvm_version=$(${JAVA_HOME}/bin/javac -version 2>&1 | awk -F ' ' '{print $2}' | awk -F '.' '{print $1}')

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <gae.java.version>0.16.0</gae.java.version>
-    <fastffi.version>0.1.1</fastffi.version>
+    <fastffi.version>0.1</fastffi.version>
     <compile-testing.version>0.19</compile-testing.version>
     <cupid.sdk.version>3.3.11</cupid.sdk.version>
     <cupid.table.version>1.1.3-SNAPSHOT</cupid.table.version>

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -19,7 +19,7 @@
   <groupId>com.alibaba.graphscope</groupId>
   <artifactId>grape-jdk-parent</artifactId>
 
-  <version>0.1</version>
+  <version>${gae.java.version}</version>
 
   <packaging>pom</packaging>
 
@@ -33,12 +33,11 @@
   </modules>
 
   <properties>
+    <gae.java.version>0.16.0</gae.java.version>
+    <fastffi.version>0.1.1</fastffi.version>
     <compile-testing.version>0.19</compile-testing.version>
     <cupid.sdk.version>3.3.11</cupid.sdk.version>
     <cupid.table.version>1.1.3-SNAPSHOT</cupid.table.version>
-    <fastffi.annotation-processor.version>0.1</fastffi.annotation-processor.version>
-    <fastffi.ffi.version>0.1</fastffi.ffi.version>
-    <fastffi.llvm4jni-runtime.version>0.1</fastffi.llvm4jni-runtime.version>
     <fastjson.version>1.2.83</fastjson.version>
     <google-java-format.version>1.7</google-java-format.version>
     <javapoet.version>1.13.0</javapoet.version>
@@ -71,17 +70,17 @@
       <dependency>
         <groupId>com.alibaba.fastffi</groupId>
         <artifactId>ffi</artifactId>
-        <version>${fastffi.ffi.version}</version>
+        <version>${fastffi.version}</version>
       </dependency>
       <dependency>
         <groupId>com.alibaba.fastffi</groupId>
         <artifactId>annotation-processor</artifactId>
-        <version>${fastffi.annotation-processor.version}</version>
+        <version>${fastffi.version}</version>
       </dependency>
       <dependency>
         <groupId>com.alibaba.fastffi</groupId>
         <artifactId>llvm4jni-runtime</artifactId>
-        <version>${fastffi.llvm4jni-runtime.version}</version>
+        <version>${fastffi.version}</version>
       </dependency>
       <dependency>
         <groupId>com.squareup</groupId>

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -19,7 +19,7 @@
   <groupId>com.alibaba.graphscope</groupId>
   <artifactId>grape-jdk-parent</artifactId>
 
-  <version>${gae.java.version}</version>
+  <version>0.16.0</version>
 
   <packaging>pom</packaging>
 
@@ -34,7 +34,7 @@
 
   <properties>
     <gae.java.version>0.16.0</gae.java.version>
-    <fastffi.version>0.1</fastffi.version>
+    <fastffi.version>0.1.2</fastffi.version>
     <compile-testing.version>0.19</compile-testing.version>
     <cupid.sdk.version>3.3.11</cupid.sdk.version>
     <cupid.table.version>1.1.3-SNAPSHOT</cupid.table.version>
@@ -48,8 +48,6 @@
     <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
     <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <maven-spotless-plugin.version>2.17.0</maven-spotless-plugin.version>
-    <!--        <maven-assemly-plugin.version>3.3.0</maven-assemly-plugin.version>-->
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <odps.sdk.version>0.36.4</odps.sdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -62,6 +60,16 @@
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.alibaba.graphscope</groupId>
+        <artifactId>grape-jdk</artifactId>
+        <version>0.16.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.alibaba.graphscope</groupId>
+        <artifactId>giraph-on-grape</artifactId>
+        <version>0.16.0</version>
+      </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -124,7 +124,7 @@ ANALYTICAL_ENGINE_JAVA_HOME = ANALYTICAL_ENGINE_HOME
 # ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH=os.path.join(ANALYTICAL_ENGINE_JAVA_HOME, "lib/*")
 # There should be only grape-runtime.jar we need
 ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH = (
-    ANALYTICAL_ENGINE_JAVA_HOME + "/lib/grape-runtime-0.1-shaded.jar"
+    ANALYTICAL_ENGINE_JAVA_HOME + "/lib/grape-runtime-0.16.0-shaded.jar"
 )
 ANALYTICAL_ENGINE_JAVA_JVM_OPTS = (
     "-Djava.library.path={}/lib -Djava.class.path={}".format(
@@ -158,7 +158,7 @@ LLVM4JNI_USER_OUT_DIR_BASE = "user-llvm4jni-output"
 PROCESSOR_MAIN_CLASS = "com.alibaba.graphscope.annotation.Main"
 JAVA_CODEGNE_OUTPUT_PREFIX = "gs-ffi"
 GRAPE_PROCESSOR_JAR = os.path.join(
-    GRAPHSCOPE_HOME, "lib", "grape-runtime-0.1-shaded.jar"
+    GRAPHSCOPE_HOME, "lib", "grape-runtime-0.16.0-shaded.jar"
 )
 GIRAPH_DIRVER_CLASS = "com.alibaba.graphscope.app.GiraphComputationAdaptor"
 

--- a/docs/analytics_engine.rst
+++ b/docs/analytics_engine.rst
@@ -525,7 +525,7 @@ To pass params to your contex, put them in ``params`` like ``src=6,threadNum=1``
 
     cd ${GRAPHSCOPE_REPO}/analytical_engine/java/
     python3 java-app-runner.py --app com.alibaba.graphscope.example.traverse.Traverse 
-                --jar_path /home/graphscope/GraphScope/analytical_engine/java/grape-demo/target/grape-demo-0.1-shaded.jar 
+                --jar_path /home/graphscope/GraphScope/analytical_engine/java/grape-demo/target/grape-demo-0.16.0-shaded.jar 
                 --arguments "maxIteration=10"
 
 After verifying your algorithm locally, you may try to run your algorithms on GraphScope analytical engine. 

--- a/docs/zh/analytics_engine.rst
+++ b/docs/zh/analytics_engine.rst
@@ -503,7 +503,7 @@ GraphScope图分析引擎上运行这些示例算法。
 
     cd ${GRAPHSCOPE_REPO}/analytical_engine/java/
     python3 java-app-runner.py --app com.alibaba.graphscope.example.traverse.Traverse 
-                --jar_path /home/graphscope/GraphScope/analytical_engine/java/grape-demo/target/grape-demo-0.1-shaded.jar 
+                --jar_path /home/graphscope/GraphScope/analytical_engine/java/grape-demo/target/grape-demo-0.16.0-shaded.jar 
                 --arguments "maxIteration=10"
 
 在本地验证自定义算法的正确性之后，你可以通过GraphScope的python client来提交运行jar包。一个jar包中可以包含不同的app实现，用户可以多次提交相同的jar包但是运行不同


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- Refactor the building procedure of GAE Java SDK.
    - Currently the Java SDK is built after GAE building, however, the building of Java SDK should be a part of GAE Building.
- GAE Java SDK version keep same with c++(currently 0.16)
- Format `pom.xml`

