### PR TITLE
Tensorflow requires lower version of pandas

### DIFF
--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -199,7 +199,7 @@ jobs:
         popd
 
         # install tensorflow
-        python3 -m pip install pytest "tensorflow<=2.5.2" --user
+        python3 -m pip install pytest "tensorflow<=2.5.2" "pandas<1.5.0" --user
         # install java
         sudo apt update -y && sudo apt install openjdk-11-jdk -y
 
@@ -255,7 +255,7 @@ jobs:
         popd
 
         # install tensorflow
-        python3 -m pip install pytest "tensorflow<=2.5.2" --user
+        python3 -m pip install pytest "tensorflow<=2.5.2" "pandas<1.5.0" --user
         # install jdk
         dnf install -y java-11-openjdk-devel
 

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -191,7 +191,7 @@ jobs:
         popd
 
         # install tensorflow
-        python3 -m pip install pytest "tensorflow<=2.5.2" --user
+        python3 -m pip install pytest "tensorflow<=2.5.2" "pandas<1.5.0" --user
 
     - name: Run Minimum Test
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,7 @@ jobs:
           popd
 
           # install tensorflow
-          python3 -m pip install pytest "tensorflow<=2.5.2" --user
+          python3 -m pip install pytest "tensorflow<=2.5.2" "pandas<1.5.0" --user
           # install java
           sudo apt update -y && sudo apt install openjdk-11-jdk -y
 

--- a/Makefile
+++ b/Makefile
@@ -156,13 +156,13 @@ unittest:
 .PHONY: minitest
 minitest:
 	cd $(WORKING_DIR)/python && \
-	pip3 install tensorflow==2.5.2 && \
+	pip3 install tensorflow==2.5.2 "pandas<1.5.0" && \
 	python3 -m pytest --cov=graphscope --cov-config=.coveragerc --cov-report=xml --cov-report=term -s -v ./graphscope/tests/minitest
 
 .PHONY: k8stest
 k8stest:
 	cd $(WORKING_DIR)/python && \
-	pip3 install tensorflow==2.5.2 && \
+	pip3 install tensorflow==2.5.2 "pandas<1.5.0" && \
 	python3 -m pytest --cov=graphscope --cov-config=.coveragerc --cov-report=xml --cov-report=term -s -v ./graphscope/tests/kubernetes
 
 .PHONY: clean

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -182,7 +182,7 @@ graphscope-client-manylinux2014-py3-nodocker:
 		cd $(WORKING_DIR)/../python; \
 		export PATH=/opt/python/$$py/bin:$$PATH; \
 		pip3 install -U pip; \
-		pip3 install "numpy==1.18.5" "grpcio<=1.43.0,>=1.40.0" "grpcio-tools<=1.43.0,>=1.40.0" wheel "auditwheel==5.0.0"; \
+		pip3 install "numpy==1.18.5" "pandas<1.5.0" "grpcio<=1.43.0,>=1.40.0" "grpcio-tools<=1.43.0,>=1.40.0" wheel "auditwheel==5.0.0"; \
 		rm -rf build; \
 		rm -rf dist/*.whl; \
 		python3 setup.py bdist_wheel; \
@@ -201,7 +201,7 @@ graphscope-client-darwin-py3:
 		export DYLD_LIBRARY_PATH=$(WORKING_DIR)/../learning_engine/graph-learn/built/lib:/usr/local/lib:$$DYLD_LIBRARY_PATH && \
 		cd $(WORKING_DIR)/../python && \
 		pip3 install -U pip && \
-		pip3 install "numpy==1.18.5" "grpcio<=1.43.0,>=1.40.0" "grpcio-tools<=1.43.0,>=1.40.0" delocate wheel && \
+		pip3 install "numpy==1.18.5" "pandas<1.5.0" "grpcio<=1.43.0,>=1.40.0" "grpcio-tools<=1.43.0,>=1.40.0" delocate wheel && \
 		rm -fr build dist/*.whl || true && \
 		python3 setup.py bdist_wheel --plat=macosx_10_9_x86_64 && \
 		for wheel in `ls dist/*.whl`; do \


### PR DESCRIPTION

## What do these changes do?

pandas v1.5.0 releases last night and doesn't support lower version of numpy anymore.

## Related issue number

N/A, see failure on CI: https://github.com/alibaba/GraphScope/actions/runs/3086602666/jobs/4991491718