### PR TITLE
The `ExceptionUtils.getRootCause()` may returns null, record the error and backtrace in such cases

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/script/AntlrToJavaScriptEngine.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/script/AntlrToJavaScriptEngine.java
@@ -43,8 +43,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSo
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Reader;
 import java.io.PrintWriter;
+import java.io.Reader;
 import java.io.StringWriter;
 
 import javax.script.*;
@@ -102,7 +102,9 @@ public class AntlrToJavaScriptEngine extends AbstractScriptEngine implements Gre
                     StringWriter sw = new StringWriter();
                     PrintWriter pw = new PrintWriter(sw);
                     e.printStackTrace(pw);
-                    error += String.format("message: %s, stacktrace: %s.", e.toString(), sw.toString());
+                    error +=
+                            String.format(
+                                    "message: %s, stacktrace: %s.", e.toString(), sw.toString());
                 } else {
                     error += String.format("message: %s.", t.getMessage());
                 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/script/AntlrToJavaScriptEngine.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/script/AntlrToJavaScriptEngine.java
@@ -44,6 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Reader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 import javax.script.*;
 
@@ -96,7 +98,14 @@ public class AntlrToJavaScriptEngine extends AbstractScriptEngine implements Gre
                                 "token: %s.",
                                 ((NoViableAltException) t).getStartToken().toString());
             } else {
-                error += String.format("message: %s.", t.getMessage());
+                if (t == null) {
+                    StringWriter sw = new StringWriter();
+                    PrintWriter pw = new PrintWriter(sw);
+                    e.printStackTrace(pw);
+                    error += String.format("message: %s, stacktrace: %s.", e.toString(), sw.toString());
+                } else {
+                    error += String.format("message: %s.", t.getMessage());
+                }
             }
             throw new InvalidGremlinScriptException(error);
         }


### PR DESCRIPTION
## What do these changes do?

We receive the following error report from end user, from the documentation of apache common, we know that `t` might be null: https://commons.apache.org/proper/commons-lang/javadocs/api-3.4/org/apache/commons/lang3/exception/ExceptionUtils.html#getRootCause(java.lang.Throwable)


```java
[2022-09-20 11:55:37,018][INFO][gremlin-server-exec-2][com.alibaba.graphscope.gremlin.plugin.processor.IrStandardOpProcessor:131] query "g.V().limit(1)" total execution time is 669.3701 ms
[2022-09-20 11:55:37,019][INFO][gremlin-server-exec-2][MetricLog:136] 1 | g.V().limit(1) | true | 669.3701 | 1663646136347
[2022-09-20 11:55:37,158][INFO][gremlin-server-exec-3][com.alibaba.graphscope.gremlin.plugin.processor.IrStandardOpProcessor:131] query "g.V().has('year', inside(2014, 2020)).outE('cites').subgraph('subgraph-20220920115537-9001454')" total execution time is 10.262539 ms
[2022-09-20 11:55:37,159][INFO][gremlin-server-exec-3][MetricLog:136] 2 | g.V().has('year', inside(2014, 2020)).outE('cites').subgraph('subgraph-20220920115537-9001454') | false | 10.262539 | 1663646137148
[2022-09-20 11:55:37,162][WARN][gremlin-server-exec-3][com.alibaba.graphscope.gremlin.plugin.processor.IrStandardOpProcessor:219] Exception processing a script on request [RequestMessage{, requestId=7f0266ff-8eac-4a22-b91b-4f166bc08c2f, op='eval', processor='', args={gremlin=g.V().has('year', inside(2014, 2020)).outE('cites').subgraph('subgraph-20220920115537-9001454'), aliases={g=g}}}].
java.lang.NullPointerException: null
	at com.alibaba.graphscope.gremlin.plugin.script.AntlrToJavaScriptEngine.eval(AntlrToJavaScriptEngine.java:99)
	at java.scripting/javax.script.AbstractScriptEngine.eval(AbstractScriptEngine.java:233)
	at org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor.lambda$eval$0(GremlinExecutor.java:272)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
[2022-09-20 11:55:38,844][INFO][gremlin-server-shutdown][org.apache.tinkerpop.gremlin.server.GremlinServer:239] Shutting down OpProcessor[]
[2022-09-20 11:55:38,844][INFO][gremlin-server-shutdown][org.apache.tinkerpop.gremlin.server.GremlinServer:239] Shutting down OpProcessor[session]
[2022-09-20 11:55:38,846][INFO][gremlin-server-shutdown][org.apache.tinkerpop.gremlin.server.GremlinServer:239] Shutting down OpProcessor[traversal]
[2022-09-20 11:55:38,848][INFO][gremlin-server-shutdown][org.apache.tinkerpop.gremlin.server.GremlinServer:254] Shutting down thread pools.
[2022-09-20 11:55:40,857][INFO][gremlin-server-stop][org.apache.tinkerpop.gremlin.server.GremlinServer:311] Closed Graph instance [graph]
```

