### PR TITLE
Fixes the GAE jar name when we have a alpha in version number

### DIFF
--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -386,7 +386,12 @@ add_custom_target(gsa_clformat
 if(ENABLE_JAVA_SDK)
     set(GAE_JAVA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/java/")
     set(GAE_JAVA_RUNTIME_DIR "${GAE_JAVA_DIR}/grape-runtime/")
-    set(GAE_JAVA_RUNTIME_JAR "${GAE_JAVA_RUNTIME_DIR}/target/grape-runtime-${GRAPHSCOPE_ANALYTICAL_VERSION}-shaded.jar")
+    set(GRAPHSCOPE_ANALYTICAL_JAR_VERSION ${GRAPHSCOPE_ANALYTICAL_VERSION})
+    string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1.\\2.\\3"
+        GRAPHSCOPE_ANALYTICAL_JAR_VERSION
+        "${GRAPHSCOPE_ANALYTICAL_VERSION}"
+    )
+    set(GAE_JAVA_RUNTIME_JAR "${GAE_JAVA_RUNTIME_DIR}/target/grape-runtime-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
     add_custom_command(
         OUTPUT "${GAE_JAVA_RUNTIME_DIR}/target/native/libgrape-jni.so"
         COMMAND mvn clean install -DskipTests --quiet


### PR DESCRIPTION
## What do these changes do?

The GAE jar looks have a fixed and won't respect the `GRAPHSCOPE_ANALYTICAL_VERSION` as well as the out-most `VERSION` file.

## Related issue number

Fixes the nightly build failure on Linux: https://github.com/alibaba/GraphScope/actions/runs/3084935220

