### PR TITLE
[GIE-IR] fix expand fusion strategy

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/strategy/ExpandFusionStepStrategy.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/strategy/ExpandFusionStepStrategy.java
@@ -71,8 +71,9 @@ public class ExpandFusionStepStrategy
                 // fuse outE + inV
                 currentStep = expandFusionStep.getNextStep();
                 if (expandFusionStep.getLabels().isEmpty()
-                        && currentStep instanceof EdgeVertexStep
-                        && canFuseExpandWithGetV(expandFusionStep, (EdgeVertexStep) currentStep)) {
+                        && (currentStep instanceof EdgeVertexStep
+                                || currentStep instanceof EdgeOtherVertexStep)
+                        && canFuseExpandWithGetV(expandFusionStep, currentStep)) {
                     expandFusionStep.setExpandOpt(FfiExpandOpt.Vertex);
                     TraversalHelper.copyLabels(currentStep, currentStep.getPreviousStep(), false);
                     traversal.removeStep(currentStep);
@@ -106,13 +107,14 @@ public class ExpandFusionStepStrategy
                 || parent instanceof NotStep;
     }
 
-    private boolean canFuseExpandWithGetV(
-            ExpandFusionStep expandFusionStep, EdgeVertexStep edgeVertexStep) {
+    private boolean canFuseExpandWithGetV(ExpandFusionStep expandFusionStep, Step getVStep) {
         return expandFusionStep.getDirection() == Direction.OUT
-                        && edgeVertexStep.getDirection() == Direction.IN
+                        && (getVStep instanceof EdgeVertexStep)
+                        && ((EdgeVertexStep) getVStep).getDirection() == Direction.IN
                 || expandFusionStep.getDirection() == Direction.IN
-                        && edgeVertexStep.getDirection() == Direction.OUT
+                        && (getVStep instanceof EdgeVertexStep)
+                        && ((EdgeVertexStep) getVStep).getDirection() == Direction.OUT
                 || expandFusionStep.getDirection() == Direction.BOTH
-                        && edgeVertexStep.getDirection() == Direction.BOTH;
+                        && getVStep instanceof EdgeOtherVertexStep;
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
fuse bothE() with otherV instead of bothV()
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

