### PR TITLE
[GAE-Java] Make GAE Java SDK version align with GraphScope

### DIFF
--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -91,7 +91,8 @@ jobs:
         mvn test -Dmaven.antrun.skip=true --quiet
 
         source ${GRAPHSCOPE_HOME}/conf/grape_jvm_opts
-        export USER_JAR_PATH=${GITHUB_WORKSPACE}/analytical_engine/java/grape-demo/target/grape-demo-0.16.0-shaded.jar
+        version=$(cat ${GITHUB_WORKSPACE}/VERSION)
+        export USER_JAR_PATH=${GITHUB_WORKSPACE}/analytical_engine/java/grape-demo/target/grape-demo-${version}-shaded.jar
         cd ${GITHUB_WORKSPACE}/analytical_engine/build
         ../test/app_tests.sh --test_dir ${GS_TEST_DIR}
 
@@ -101,7 +102,8 @@ jobs:
         RUN_JAVA_TESTS: ON
         GRAPHSCOPE_HOME: /opt/graphscope
       run: |
-        export USER_JAR_PATH=${GITHUB_WORKSPACE}/analytical_engine/java/grape-demo/target/grape-demo-0.16.0-shaded.jar
+        version=$(cat ${GITHUB_WORKSPACE}/VERSION)
+        export USER_JAR_PATH=${GITHUB_WORKSPACE}/analytical_engine/java/grape-demo/target/grape-demo-${version}-shaded.jar
         source ${GRAPHSCOPE_HOME}/conf/grape_jvm_opts
 
         cd ${GITHUB_WORKSPACE}/python

--- a/analytical_engine/java/giraph-on-grape/pom.xml
+++ b/analytical_engine/java/giraph-on-grape/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.16.0</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>giraph-on-grape</artifactId>

--- a/analytical_engine/java/grape-demo/pom.xml
+++ b/analytical_engine/java/grape-demo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.16.0</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>grape-demo</artifactId>

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.16.0</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>grape-jdk</artifactId>

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.16.0</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>grape-runtime</artifactId>

--- a/analytical_engine/java/grape_jvm_opts
+++ b/analytical_engine/java/grape_jvm_opts
@@ -27,14 +27,15 @@ then
     echo "[warn] No SPARK_HOME found!"
 fi
 
-GRAPHX_GRAPE_SDK=${GRAPHSCOPE_HOME}/lib/graphx-on-graphscope-0.16.0-shaded.jar
+GRAPHX_GRAPE_SDK=`ls ${GRAPHSCOPE_HOME}/lib/graphx-on-graphscope-*.jar`
+GRAPE_RUNTIME_JAR=`ls ${GRAPHSCOPE_HOME}/lib/grape-runtime-*.jar`
 # This env point to the directory where the output for llvm4jni run.sh on Grape-runtime.jar resides
 if [[ "${RUNTIME_LLVM4JNI_OUTPUT}"x != x ]];
 then
     echo "find env RUNTIME_LLVM4JNI_OUTPUT, append to init java class path"
-    class_path=${RUNTIME_LLVM4JNI_OUTPUT}:${GRAPHSCOPE_HOME}/lib/grape-runtime-0.16.0-shaded.jar:${GRAPHX_GRAPE_SDK}
+    class_path=${RUNTIME_LLVM4JNI_OUTPUT}:${GRAPE_RUNTIME_JAR}:${GRAPHX_GRAPE_SDK}
 else 
-    class_path=${GRAPHSCOPE_HOME}/lib/grape-runtime-0.16.0-shaded.jar:${GRAPHX_GRAPE_SDK}
+    class_path=${GRAPE_RUNTIME_JAR}:${GRAPHX_GRAPE_SDK}
 fi
 
 #include jars in spark/jars

--- a/analytical_engine/java/graphx-on-graphscope/pom.xml
+++ b/analytical_engine/java/graphx-on-graphscope/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.16.0</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>graphx-on-graphscope</artifactId>

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -19,7 +19,7 @@
   <groupId>com.alibaba.graphscope</groupId>
   <artifactId>grape-jdk-parent</artifactId>
 
-  <version>0.16.0</version>
+  <version>${revision}</version>
 
   <packaging>pom</packaging>
 
@@ -34,7 +34,7 @@
   </modules>
 
   <properties>
-    <gae.java.version>0.16.0</gae.java.version>
+    <revision>0.16.0</revision>
     <fastffi.version>0.1.2</fastffi.version>
     <compile-testing.version>0.19</compile-testing.version>
     <cupid.sdk.version>3.3.11</cupid.sdk.version>
@@ -67,19 +67,19 @@
         <groupId>com.alibaba.graphscope</groupId>
         <artifactId>grape-jdk</artifactId>
         <classifier>shaded</classifier>
-        <version>0.16.0</version>
+        <version>${revision}</version>
       </dependency>
       <dependency>
         <groupId>com.alibaba.graphscope</groupId>
         <artifactId>giraph-on-grape</artifactId>
         <classifier>shaded</classifier>
-        <version>0.16.0</version>
+        <version>${revision}</version>
       </dependency>
       <dependency>
         <groupId>com.alibaba.graphscope</groupId>
         <artifactId>graphx-on-graphscope</artifactId>
         <classifier>shaded</classifier>
-        <version>0.16.0</version>
+        <version>${revision}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -121,14 +121,21 @@ if not os.path.isfile(ANALYTICAL_ENGINE_PATH):
 
 # ANALYTICAL_ENGINE_JAVA_HOME
 ANALYTICAL_ENGINE_JAVA_HOME = ANALYTICAL_ENGINE_HOME
-# ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH=os.path.join(ANALYTICAL_ENGINE_JAVA_HOME, "lib/*")
-# There should be only grape-runtime.jar we need
-ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH = (
-    ANALYTICAL_ENGINE_JAVA_HOME + "/lib/grape-runtime-0.16.0-shaded.jar"
+
+ANALYTICAL_ENGINE_JAVA_RUNTIME_JAR = glob.glob(
+    ANALYTICAL_ENGINE_JAVA_HOME + "/lib/grape-runtime*.jar"
+)[0]
+ANALYTICAL_ENGINE_JAVA_GRAPHX_JAR = glob.glob(
+    ANALYTICAL_ENGINE_JAVA_HOME + "/lib/graphx-on-graphscope*.jar"
+)[0]
+ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH = "{}:{}".format(
+    ANALYTICAL_ENGINE_JAVA_RUNTIME_JAR, ANALYTICAL_ENGINE_JAVA_GRAPHX_JAR
 )
+
 ANALYTICAL_ENGINE_JAVA_JVM_OPTS = (
     "-Djava.library.path={}/lib -Djava.class.path={}".format(
-        GRAPHSCOPE_HOME, ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH
+        GRAPHSCOPE_HOME,
+        ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH,
     )
 )
 
@@ -157,9 +164,8 @@ LLVM4JNI_HOME = os.environ.get("LLVM4JNI_HOME", None)
 LLVM4JNI_USER_OUT_DIR_BASE = "user-llvm4jni-output"
 PROCESSOR_MAIN_CLASS = "com.alibaba.graphscope.annotation.Main"
 JAVA_CODEGNE_OUTPUT_PREFIX = "gs-ffi"
-GRAPE_PROCESSOR_JAR = os.path.join(
-    GRAPHSCOPE_HOME, "lib", "grape-runtime-0.16.0-shaded.jar"
-)
+GRAPE_PROCESSOR_JAR = glob.glob(GRAPHSCOPE_HOME + "/lib/grape-runtime*.jar")[0]
+
 GIRAPH_DIRVER_CLASS = "com.alibaba.graphscope.app.GiraphComputationAdaptor"
 
 

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -58,6 +58,8 @@ from graphscope.proto import graph_def_pb2
 from graphscope.proto import op_def_pb2
 from graphscope.proto import types_pb2
 
+from gscoordinator.version import __version__
+
 logger = logging.getLogger("graphscope")
 
 RESOURCE_DIR_NAME = "resource"
@@ -122,15 +124,10 @@ if not os.path.isfile(ANALYTICAL_ENGINE_PATH):
 # ANALYTICAL_ENGINE_JAVA_HOME
 ANALYTICAL_ENGINE_JAVA_HOME = ANALYTICAL_ENGINE_HOME
 
-ANALYTICAL_ENGINE_JAVA_RUNTIME_JAR = glob.glob(
-    ANALYTICAL_ENGINE_JAVA_HOME + "/lib/grape-runtime*.jar"
-)[0]
-ANALYTICAL_ENGINE_JAVA_GRAPHX_JAR = glob.glob(
-    ANALYTICAL_ENGINE_JAVA_HOME + "/lib/graphx-on-graphscope*.jar"
-)[0]
-ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH = "{}:{}".format(
-    ANALYTICAL_ENGINE_JAVA_RUNTIME_JAR, ANALYTICAL_ENGINE_JAVA_GRAPHX_JAR
+ANALYTICAL_ENGINE_JAVA_RUNTIME_JAR = os.path.join(
+    ANALYTICAL_ENGINE_JAVA_HOME, "lib", "grape-runtime-{}.jar".format(__version__)
 )
+ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH = "{}".format(ANALYTICAL_ENGINE_JAVA_RUNTIME_JAR)
 
 ANALYTICAL_ENGINE_JAVA_JVM_OPTS = (
     "-Djava.library.path={}/lib -Djava.class.path={}".format(

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -125,7 +125,9 @@ if not os.path.isfile(ANALYTICAL_ENGINE_PATH):
 ANALYTICAL_ENGINE_JAVA_HOME = ANALYTICAL_ENGINE_HOME
 
 ANALYTICAL_ENGINE_JAVA_RUNTIME_JAR = os.path.join(
-    ANALYTICAL_ENGINE_JAVA_HOME, "lib", "grape-runtime-{}.jar".format(__version__)
+    ANALYTICAL_ENGINE_JAVA_HOME,
+    "lib",
+    "grape-runtime-{}-shaded.jar".format(__version__),
 )
 ANALYTICAL_ENGINE_JAVA_INIT_CLASS_PATH = "{}".format(ANALYTICAL_ENGINE_JAVA_RUNTIME_JAR)
 
@@ -161,7 +163,9 @@ LLVM4JNI_HOME = os.environ.get("LLVM4JNI_HOME", None)
 LLVM4JNI_USER_OUT_DIR_BASE = "user-llvm4jni-output"
 PROCESSOR_MAIN_CLASS = "com.alibaba.graphscope.annotation.Main"
 JAVA_CODEGNE_OUTPUT_PREFIX = "gs-ffi"
-GRAPE_PROCESSOR_JAR = glob.glob(GRAPHSCOPE_HOME + "/lib/grape-runtime*.jar")[0]
+GRAPE_PROCESSOR_JAR = os.path.join(
+    GRAPHSCOPE_HOME, "lib", "grape-runtime-{}-shaded.jar".format(__version__)
+)
 
 GIRAPH_DIRVER_CLASS = "com.alibaba.graphscope.app.GiraphComputationAdaptor"
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Make GAE Java SDK version not fixed in code/configuration. BUT we still need to change `analytical_engine/java/pom.xml` for GraphScope version change.

