### PR TITLE
Ensure the correctness of retry (in the RunStep request) to avoid the strange "has no attribute" error

### DIFF
--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -654,7 +654,7 @@ class CoordinatorServiceServicer(
                 responses[0].head.results.extend(head.head.results)
                 responses.extend(bodies)
             except grpc.RpcError as exc:
-                # Not raised by graphscope, maybe socket closed, etc
+                # Not raised by graphscope, maybe socket closed, etc.
                 context.set_code(exc.code())
                 context.set_details(exc.details())
                 for response in responses:


### PR DESCRIPTION
## What do these changes do?

- Don't reuse the "generator" during retry
- Some operation shouldn't be retried

## Related issue number

Fixes #2093

