### PR TITLE
fix(sec): upgrade netty-all to 4.1.44.Final

### DIFF
--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -54,7 +54,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>2.19.0</log4j.version>
-    <dep.netty.version>4.1.36.Final</dep.netty.version>
+    <dep.netty.version>4.1.44.Final</dep.netty.version>
     <dep.fastutil.version>6.5.4</dep.fastutil.version>
     <dep.kryo.version>4.0.0</dep.kryo.version>
     <dep.json.version>20160810</dep.json.version>


### PR DESCRIPTION
Upgrade netty-all 4.1.36.Final to 4.1.44.Final for vulnerability fix:
         - [CVE-2019-16869](https://www.oscs1024.com/hd/MPS-2019-12064)
         - [CVE-2020-7238](https://www.oscs1024.com/hd/MPS-2020-1320)
         - [CVE-2019-20444](https://www.oscs1024.com/hd/MPS-2020-1526)