### PR TITLE
Get the exception type in correct way, both on Linux and on MacOS.

### DIFF
--- a/analytical_engine/core/error.h
+++ b/analytical_engine/core/error.h
@@ -78,10 +78,10 @@ inline rpc::Code ErrorCodeToProto(vineyard::ErrorCode ec) {
 
 #ifndef __FRAME_CURRENT_EXCEPTION_TYPENAME
 #if defined(__GLIBCXX__) || defined(__GLIBCPP__)
-#define __FRAME_CURRENT_EXCEPTION_TYPENAME(var)                 \
-  do {                                                          \
-    std::exception_ptr __p = std::current_exception();          \
-    var = p ? p.__cxa_exception_type()->name() : "unknow type"; \
+#define __FRAME_CURRENT_EXCEPTION_TYPENAME(var)                     \
+  do {                                                              \
+    std::exception_ptr __p = std::current_exception();              \
+    var = __p ? __p.__cxa_exception_type()->name() : "unknow type"; \
   } while (0)
 #else
 #define __FRAME_CURRENT_EXCEPTION_TYPENAME(var)                               \

--- a/k8s/precompile.py
+++ b/k8s/precompile.py
@@ -45,12 +45,21 @@ WORKSPACE = Path(os.path.join("/", tempfile.gettempprefix(), "gs", "builtin"))
 def cmake_and_make(cmake_commands):
     try:
         cmake_process = subprocess.run(
-            cmake_commands, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True
+            cmake_commands,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding="utf-8",
+            errors="replace",
+            universal_newlines=True,
+            check=True
         )
         make_process = subprocess.run(
             [shutil.which("make"), "-j4"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            encoding="utf-8",
+            errors="replace",
+            universal_newlines=True,
             check=True,
         )
         shutil.rmtree("CMakeFiles")


### PR DESCRIPTION
## What do these changes do?

Fixes the CI failure on MacOS in: https://github.com/alibaba/GraphScope/actions/runs/3142684408/jobs/5109428900
