### PR TITLE
[GIE/IR] Fix the bug when fuse filter in `Auxilia`

### DIFF
--- a/interactive_engine/executor/ir/graph_proxy/src/apis/graph/mod.rs
+++ b/interactive_engine/executor/ir/graph_proxy/src/apis/graph/mod.rs
@@ -64,15 +64,15 @@ impl From<algebra_pb::edge_expand::Direction> for Direction {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct QueryParams {
-    pub labels: Vec<LabelId>,
+    pub labels: Arc<Vec<LabelId>>,
     pub limit: Option<usize>,
     pub columns: Option<Vec<NameOrId>>,
-    pub partitions: Option<Vec<u64>>,
+    pub partitions: Option<Arc<Vec<u64>>>,
     pub filter: Option<Arc<PEvaluator>>,
     pub sample_ratio: Option<f64>,
-    pub extra_params: Option<HashMap<String, String>>,
+    pub extra_params: Option<Arc<HashMap<String, String>>>,
 }
 
 impl TryFrom<Option<algebra_pb::QueryParams>> for QueryParams {
@@ -97,10 +97,11 @@ impl TryFrom<Option<algebra_pb::QueryParams>> for QueryParams {
 
 impl QueryParams {
     fn with_labels(mut self, labels_pb: Vec<common_pb::NameOrId>) -> Result<Self, ParsePbError> {
-        self.labels = labels_pb
+        let labels = labels_pb
             .into_iter()
             .map(|label| label.try_into())
             .collect::<Result<Vec<_>, _>>()?;
+        self.labels = Arc::new(labels);
         Ok(self)
     }
 
@@ -162,7 +163,7 @@ impl QueryParams {
     // Extra query params for different storages
     fn with_extra_params(mut self, extra_params_pb: HashMap<String, String>) -> Result<Self, ParsePbError> {
         if !extra_params_pb.is_empty() {
-            self.extra_params = Some(extra_params_pb);
+            self.extra_params = Some(Arc::new(extra_params_pb));
         }
         Ok(self)
     }

--- a/interactive_engine/executor/ir/runtime/src/process/operator/source.rs
+++ b/interactive_engine/executor/ir/runtime/src/process/operator/source.rs
@@ -112,7 +112,11 @@ impl SourceOperator {
         match res {
             Ok(partition_list) => {
                 debug!("Assign worker {:?} to scan partition list: {:?}", worker_index, partition_list);
-                self.query_params.partitions = partition_list;
+                self.query_params.partitions = if let Some(partition_list) = partition_list {
+                    Some(Arc::new(partition_list))
+                } else {
+                    None
+                };
             }
             Err(err) => {
                 debug!("get partition list failed in graph_partition_manager in source op {:?}", err);

--- a/interactive_engine/executor/ir/runtime/src/process/record.rs
+++ b/interactive_engine/executor/ir/runtime/src/process/record.rs
@@ -402,8 +402,8 @@ impl Encode for Record {
                 entry.write_to(writer)?;
             }
         }
-        writer.write_u64(self.columns.len() as u64)?;
-        for (k, v) in self.columns.iter() {
+        writer.write_u32(self.columns.len() as u32)?;
+        for (k, v) in &self.columns {
             (k as KeyId).write_to(writer)?;
             v.write_to(writer)?;
         }
@@ -415,7 +415,7 @@ impl Decode for Record {
     fn read_from<R: ReadExt>(reader: &mut R) -> std::io::Result<Self> {
         let opt = reader.read_u8()?;
         let curr = if opt == 0 { None } else { Some(Arc::new(<Entry>::read_from(reader)?)) };
-        let size = <u64>::read_from(reader)? as usize;
+        let size = <u32>::read_from(reader)? as usize;
         let mut columns = VecMap::with_capacity(size);
         for _i in 0..size {
             let k = <KeyId>::read_from(reader)? as usize;
@@ -429,8 +429,8 @@ impl Decode for Record {
 impl Encode for RecordKey {
     fn write_to<W: WriteExt>(&self, writer: &mut W) -> std::io::Result<()> {
         writer.write_u32(self.key_fields.len() as u32)?;
-        for key in self.key_fields.iter() {
-            (&**key).write_to(writer)?
+        for key in &self.key_fields {
+            key.write_to(writer)?
         }
         Ok(())
     }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As titled. Currently, in `Auxilia`, we will try to evaluate the filter expression before pushing down to the storage, in case that some computed values of variables are missing. Specially, if all the values of variables can be pre-fetched, we will evaluate directly without pushdown the filter.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2021 

