### PR TITLE
[Pegasus] Avoid get iter.next() when it is None already in sending batches

### DIFF
--- a/interactive_engine/executor/engine/pegasus/pegasus/src/communication/output/output.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/communication/output/output.rs
@@ -399,7 +399,7 @@ impl<D: Data> OutputHandle<D> {
                 }
                 Ok(None) => {
                     // all data in iter should be send;
-                    assert!(iter.next().is_none());
+                    debug_assert!(iter.next().is_none());
                     break;
                 }
                 Err(e) => return if let Some(item) = e.0 { Ok(Some(item)) } else { would_block!("") },


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As titled. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2114 

