### PR TITLE
fix(sec): upgrade commons-codec:commons-codec to 1.13

### DIFF
--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.alibaba.maxgraph</groupId>
@@ -92,7 +90,7 @@
     <rocksdb.version>5.15.10</rocksdb.version>
     <maven.clean.plugin.version>3.1.0</maven.clean.plugin.version>
     <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
-    <commons.codec.version>1.11</commons.codec.version>
+    <commons.codec.version>1.13</commons.codec.version>
     <metrics.core.version>3.2.5</metrics.core.version>
     <aliyun.oss.version>3.14.1</aliyun.oss.version>
     <skip.tests>true</skip.tests>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-codec:commons-codec 1.11
- [MPS-2022-11853](https://www.oscs1024.com/hd/MPS-2022-11853)


### What did I do？
Upgrade commons-codec:commons-codec from 1.11 to 1.13 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS