### PR TITLE
fix(sec): upgrade org.apache.tinkerpop:gremlin-core to 3.5.2

### DIFF
--- a/interactive_engine/compiler/pom.xml
+++ b/interactive_engine/compiler/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,7 +24,7 @@
         <exec.maven.version>3.0.0</exec.maven.version>
         <junit.version>4.13.2</junit.version>
         <maven.surefire.version>2.22.2</maven.surefire.version>
-        <tinkerpop.version>3.5.1</tinkerpop.version>
+        <tinkerpop.version>3.5.2</tinkerpop.version>
         <common.io.version>2.6</common.io.version>
         <antlr4.version>4.9.1</antlr4.version>
     </properties>

--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.alibaba.maxgraph</groupId>
@@ -71,7 +69,7 @@
     <log4j2.version>[2.17.1,)</log4j2.version>
     <hadoop.version>3.2.4</hadoop.version>
     <grpc.version>1.34.1</grpc.version>
-    <tinkerpop.version>3.5.1</tinkerpop.version>
+    <tinkerpop.version>3.5.2</tinkerpop.version>
     <slf4j.version>1.7.21</slf4j.version>
     <groovy.version>2.5.14</groovy.version>
     <curator.new.version>5.1.0</curator.new.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.tinkerpop:gremlin-core 3.5.1
- [MPS-2022-12129](https://www.oscs1024.com/hd/MPS-2022-12129)


### What did I do？
Upgrade org.apache.tinkerpop:gremlin-core from 3.5.1 to 3.5.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS