### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka-clients to 2.7.2

### DIFF
--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.alibaba.maxgraph</groupId>
@@ -84,7 +82,7 @@
     <protobuf.version>3.19.6</protobuf.version>
     <logback.version>1.2.3</logback.version>
     <zookeeper.version>3.6.3</zookeeper.version>
-    <kafka.version>2.5.0</kafka.version>
+    <kafka.version>2.7.2</kafka.version>
     <kafka.junit.version>3.2.1</kafka.junit.version>
     <jna.version>5.5.0</jna.version>
     <junit.jupiter.version>5.6.3</junit.jupiter.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.kafka:kafka-clients 2.5.0
- [CVE-2021-38153](https://www.oscs1024.com/hd/CVE-2021-38153)


### What did I do？
Upgrade org.apache.kafka:kafka-clients from 2.5.0 to 2.7.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS