### PR TITLE
Add pytest-timeout to requirements-dev.txt and fixes a deprecated warnings when running tests

### DIFF
--- a/python/graphscope/nx/utils/compat.py
+++ b/python/graphscope/nx/utils/compat.py
@@ -24,12 +24,16 @@ to make the graph algorithms runs on grape-engine.
 
 import copy
 import functools
-import imp
 import inspect
+import warnings
 from enum import Enum
 from types import FunctionType
 from types import LambdaType
 from types import ModuleType
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    import imp
 
 __all__ = [
     "internal_name",

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -7,6 +7,7 @@ m2r2
 pylint
 pytest
 pytest-cov
+pytest-timeout
 Pygments>=2.4.1
 recommonmark
 sphinx==4.0.3


### PR DESCRIPTION

## What do these changes do?

- add pytest-timeout to the dependency list
- filter out the deprecated warning when importing imp.

## Related issue number

n/a