### PR TITLE
[GAE-Java] Fix : can not compile the submodule of GAE Java SDK

### DIFF
--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -423,7 +423,7 @@ if(ENABLE_JAVA_SDK)
     set(GAE_JAVA_GRAPHX_JAR "${GAE_JAVA_DIR}/graphx-on-graphscope/target/graphx-on-graphscope-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
     add_custom_command(
         OUTPUT "${GAE_JAVA_RUNTIME_DIR}/target/native/libgrape-jni.so"
-        COMMAND mvn clean install -DskipTests --quiet
+        COMMAND mvn -Drevision=${GRAPHSCOPE_ANALYTICAL_JAR_VERSION} clean install -DskipTests --quiet
         DEPENDS gs_proto
         WORKING_DIRECTORY ${GAE_JAVA_DIR}
         COMMENT "Building GAE-java..."

--- a/analytical_engine/java/giraph-on-grape/pom.xml
+++ b/analytical_engine/java/giraph-on-grape/pom.xml
@@ -20,7 +20,8 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.18.0</version>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>giraph-on-grape</artifactId>

--- a/analytical_engine/java/giraph-on-grape/pom.xml
+++ b/analytical_engine/java/giraph-on-grape/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.18.0</version>
   </parent>
 
   <artifactId>giraph-on-grape</artifactId>
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>
       <artifactId>grape-jdk</artifactId>
-      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/analytical_engine/java/grape-annotation/pom.xml
+++ b/analytical_engine/java/grape-annotation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>grape-jdk-parent</artifactId>
     <groupId>com.alibaba.graphscope</groupId>
-    <version>${revision}</version>
+    <version>0.18.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/analytical_engine/java/grape-annotation/pom.xml
+++ b/analytical_engine/java/grape-annotation/pom.xml
@@ -6,6 +6,7 @@
     <artifactId>grape-jdk-parent</artifactId>
     <groupId>com.alibaba.graphscope</groupId>
     <version>0.18.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/analytical_engine/java/grape-annotation/pom.xml
+++ b/analytical_engine/java/grape-annotation/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>grape-jdk-parent</artifactId>
     <groupId>com.alibaba.graphscope</groupId>
-    <version>0.18.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/analytical_engine/java/grape-demo/pom.xml
+++ b/analytical_engine/java/grape-demo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.18.0</version>
   </parent>
 
   <artifactId>grape-demo</artifactId>
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>
       <artifactId>grape-jdk</artifactId>
-      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>

--- a/analytical_engine/java/grape-demo/pom.xml
+++ b/analytical_engine/java/grape-demo/pom.xml
@@ -22,6 +22,7 @@
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
     <version>0.18.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>grape-demo</artifactId>

--- a/analytical_engine/java/grape-demo/pom.xml
+++ b/analytical_engine/java/grape-demo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.18.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.18.0</version>
   </parent>
 
   <artifactId>grape-jdk</artifactId>

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -21,6 +21,7 @@
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
     <version>0.18.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>grape-jdk</artifactId>

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.18.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.18.0</version>
   </parent>
 
   <artifactId>grape-runtime</artifactId>
@@ -54,7 +54,6 @@
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>
       <artifactId>grape-jdk</artifactId>
-      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.18.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -22,6 +22,7 @@
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
     <version>0.18.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>grape-runtime</artifactId>

--- a/analytical_engine/java/graphx-on-graphscope/pom.xml
+++ b/analytical_engine/java/graphx-on-graphscope/pom.xml
@@ -20,6 +20,7 @@
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
     <version>0.18.0</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>graphx-on-graphscope</artifactId>

--- a/analytical_engine/java/graphx-on-graphscope/pom.xml
+++ b/analytical_engine/java/graphx-on-graphscope/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.18.0</version>
   </parent>
 
   <artifactId>graphx-on-graphscope</artifactId>
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>com.alibaba.graphscope</groupId>
       <artifactId>grape-jdk</artifactId>
-      <classifier>shaded</classifier>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/analytical_engine/java/graphx-on-graphscope/pom.xml
+++ b/analytical_engine/java/graphx-on-graphscope/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.alibaba.graphscope</groupId>
     <artifactId>grape-jdk-parent</artifactId>
-    <version>0.18.0</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -75,13 +75,13 @@
       </dependency>
       <dependency>
         <groupId>com.alibaba.graphscope</groupId>
-        <artifactId>graphx-on-graphscope</artifactId>
+        <artifactId>giraph-on-grape</artifactId>
         <classifier>shaded</classifier>
         <version>${revision}</version>
       </dependency>
       <dependency>
         <groupId>com.alibaba.graphscope</groupId>
-        <artifactId>giraph-on-grape</artifactId>
+        <artifactId>graphx-on-graphscope</artifactId>
         <classifier>shaded</classifier>
         <version>${revision}</version>
       </dependency>

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -18,8 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.alibaba.graphscope</groupId>
   <artifactId>grape-jdk-parent</artifactId>
-
-  <version>${revision}</version>
+  <version>0.18.0</version>
 
   <packaging>pom</packaging>
 
@@ -72,18 +71,17 @@
       <dependency>
         <groupId>com.alibaba.graphscope</groupId>
         <artifactId>grape-jdk</artifactId>
+        <version>${revision}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.alibaba.graphscope</groupId>
+        <artifactId>graphx-on-graphscope</artifactId>
         <classifier>shaded</classifier>
         <version>${revision}</version>
       </dependency>
       <dependency>
         <groupId>com.alibaba.graphscope</groupId>
         <artifactId>giraph-on-grape</artifactId>
-        <classifier>shaded</classifier>
-        <version>${revision}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.alibaba.graphscope</groupId>
-        <artifactId>graphx-on-graphscope</artifactId>
         <classifier>shaded</classifier>
         <version>${revision}</version>
       </dependency>

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -17,8 +17,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.alibaba.graphscope</groupId>
-  <version>${revision}</version>
   <artifactId>grape-jdk-parent</artifactId>
+  <version>${revision}</version>
 
   <packaging>pom</packaging>
 

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -17,8 +17,8 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.alibaba.graphscope</groupId>
+  <version>${revision}</version>
   <artifactId>grape-jdk-parent</artifactId>
-  <version>0.18.0</version>
 
   <packaging>pom</packaging>
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

Fix the problem that user can not compile only the submodule of GAE Java SDK
