### PR TITLE
fix src label and dst label of edge kinds may be empty

### DIFF
--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/SnapshotCache.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/SnapshotCache.java
@@ -63,7 +63,7 @@ public class SnapshotCache {
      *
      * <p>Discussion:
      *
-     * <p>We need to decide whether should the write framework coupled with the implementation of
+     * <p>We need to decide whether should the writing framework coupled with the implementation of
      * schema synchronization. Options are discussed here:
      * https://yuque.antfin-inc.com/graphscope/project/eibfty#EQGg9 This interface assumes write
      * framework isn't coupled with schema synchronization.

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/ClientDdlService.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/ClientDdlService.java
@@ -148,11 +148,15 @@ public class ClientDdlService extends ClientDdlGrpc.ClientDdlImplBase {
                                 .setEdgeLabelId(
                                         LabelIdPb.newBuilder()
                                                 .setId(edgeKind.getEdgeLabelId().getId()))
-                                .setSrcVertexLabel(graphDef.getTypeDef(edgeKind.getSrcVertexLabelId()).getLabel())
+                                .setSrcVertexLabel(
+                                        graphDef.getTypeDef(edgeKind.getSrcVertexLabelId())
+                                                .getLabel())
                                 .setSrcVertexLabelId(
                                         LabelIdPb.newBuilder()
                                                 .setId(edgeKind.getSrcVertexLabelId().getId()))
-                                .setDstVertexLabel(graphDef.getTypeDef(edgeKind.getDstVertexLabelId()).getLabel())
+                                .setDstVertexLabel(
+                                        graphDef.getTypeDef(edgeKind.getDstVertexLabelId())
+                                                .getLabel())
                                 .setDstVertexLabelId(
                                         LabelIdPb.newBuilder()
                                                 .setId(edgeKind.getDstVertexLabelId().getId()))

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/ClientDdlService.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/ClientDdlService.java
@@ -17,12 +17,8 @@ import com.alibaba.graphscope.groot.SnapshotCache;
 import com.alibaba.graphscope.groot.schema.request.DdlRequestBatch;
 import com.alibaba.graphscope.proto.ddl.*;
 import com.alibaba.maxgraph.compiler.api.schema.DataType;
-import com.alibaba.maxgraph.sdkcommon.schema.EdgeKind;
+import com.alibaba.maxgraph.sdkcommon.schema.*;
 import com.alibaba.maxgraph.sdkcommon.schema.GraphDef;
-import com.alibaba.maxgraph.sdkcommon.schema.PropertyDef;
-import com.alibaba.maxgraph.sdkcommon.schema.PropertyValue;
-import com.alibaba.maxgraph.sdkcommon.schema.TypeDef;
-import com.alibaba.maxgraph.sdkcommon.schema.TypeEnum;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 
@@ -152,11 +148,11 @@ public class ClientDdlService extends ClientDdlGrpc.ClientDdlImplBase {
                                 .setEdgeLabelId(
                                         LabelIdPb.newBuilder()
                                                 .setId(edgeKind.getEdgeLabelId().getId()))
-                                .setSrcVertexLabel(edgeKind.getSrcVertexLabel())
+                                .setSrcVertexLabel(graphDef.getTypeDef(edgeKind.getSrcVertexLabelId()).getLabel())
                                 .setSrcVertexLabelId(
                                         LabelIdPb.newBuilder()
                                                 .setId(edgeKind.getSrcVertexLabelId().getId()))
-                                .setDstVertexLabel(edgeKind.getDstVertexLabel())
+                                .setDstVertexLabel(graphDef.getTypeDef(edgeKind.getDstVertexLabelId()).getLabel())
                                 .setDstVertexLabelId(
                                         LabelIdPb.newBuilder()
                                                 .setId(edgeKind.getDstVertexLabelId().getId()))


### PR DESCRIPTION
The graph def is read from rust side after restarting.
And the edge kinds proto in rust only has label ID.

Fixes #2154