### PR TITLE
upgrade actions version to use node 16

### DIFF
--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -64,7 +64,7 @@ jobs:
         mv ${GITHUB_WORKSPACE}/coordinator/dist/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheel-${{ github.sha }}
         path: |
@@ -96,11 +96,11 @@ jobs:
     needs: [build-wheels]
 
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         path: artifacts
 
@@ -146,7 +146,7 @@ jobs:
     - name: Extract Tag Name
       if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope' }}
       id: tag
-      run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/v}
+      run: echo "TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
     - name: Release Image
       if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope' }}
@@ -174,7 +174,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         path: artifacts
 
@@ -225,7 +225,7 @@ jobs:
         --shm-size 4096m
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         path: artifacts
 

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -16,7 +16,7 @@ jobs:
     if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -53,7 +53,7 @@ jobs:
         tar -zcf graphscope.tar.gz coordinator/dist/wheelhouse/*.whl
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheel-macos-${{ github.sha }}
         path: graphscope.tar.gz
@@ -67,7 +67,7 @@ jobs:
         python-version: ['3.7', '3.8', '3.9']
 
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -104,7 +104,7 @@ jobs:
         tar -zcf client.tar.gz python/dist/
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheel-macos-${{ github.sha }}-${{ matrix.python-version }}
         path: client.tar.gz
@@ -120,7 +120,7 @@ jobs:
         python-version: ['3.7', '3.8', '3.9']
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         path: artifacts
 
@@ -167,7 +167,7 @@ jobs:
         python-version: ['3.7', '3.8', '3.9']
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         path: artifacts
 

--- a/.github/workflows/ci-dummy.yml
+++ b/.github/workflows/ci-dummy.yml
@@ -37,7 +37,7 @@ jobs:
       gie-function-test: ${{ steps.filter.outputs.gie-function-test }}
     steps:
     # For push it's necessary to checkout the code
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # For pull requests it's not necessary to checkout the code
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       gie-function-test: ${{ steps.filter.outputs.gie-function-test }}
     steps:
     # For push it's necessary to checkout the code
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     # For pull requests it's not necessary to checkout the code
     - uses: dorny/paths-filter@v2
       id: filter
@@ -129,7 +129,7 @@ jobs:
         python3 -m flake8 .
 
     - name: Setup Java11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
          distribution: 'zulu'
          java-version: '11'
@@ -174,7 +174,7 @@ jobs:
     needs: [changes]
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -255,7 +255,7 @@ jobs:
         tar -zcf graphscope.tar.gz coordinator/dist/
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: wheel-${{ github.sha }}
         path: |
@@ -268,9 +268,9 @@ jobs:
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     needs: [build-wheels]
     steps:
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: artifacts
 
@@ -311,7 +311,7 @@ jobs:
 
       - name: Upload GIE log
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: gie-log
           path: ~/.local/log/graphscope
@@ -328,10 +328,10 @@ jobs:
         deployment: ["standalone", "distributed"]
 
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
       if: ${{ needs.changes.outputs.gae-python == 'true' }}
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       if: ${{ needs.changes.outputs.gae-python == 'true' }}
       with:
         path: artifacts
@@ -377,7 +377,7 @@ jobs:
 
     - name: Upload Coverage
       if: ${{ needs.changes.outputs.gae-python == 'true' || github.ref == 'refs/heads/main' }}
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
@@ -393,7 +393,7 @@ jobs:
       matrix:
         deployment: ["standalone", "distributed"]
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
       if: ${{ needs.changes.outputs.networkx == 'true' }}
 
     - uses: dorny/paths-filter@v2
@@ -414,7 +414,7 @@ jobs:
             - 'python/graphscope/nx/convert_matrix.py'
             - 'python/graphscope/nx/tests/convert/**'
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       if: ${{ needs.changes.outputs.networkx == 'true' }}
       with:
         path: artifacts
@@ -479,7 +479,7 @@ jobs:
       matrix:
         deployment: ["standalone", "distributed"]
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
       if: ${{ needs.changes.outputs.networkx == 'true' }}
 
     - uses: dorny/paths-filter@v2
@@ -499,7 +499,7 @@ jobs:
           io:
             - 'python/graphscope/nx/readwrite/**'
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       if: ${{ needs.changes.outputs.networkx == 'true' }}
       with:
         path: artifacts
@@ -564,7 +564,7 @@ jobs:
     needs: [build-wheels, changes]
     if: ${{ needs.changes.outputs.gie-function-test == 'true' && github.repository == 'alibaba/GraphScope' }}
     steps:
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v3
 
       - uses: actions/cache@v3
         with:
@@ -580,7 +580,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: artifacts
 
@@ -626,7 +626,7 @@ jobs:
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     needs: [build-wheels]
     steps:
-      - uses: actions/checkout@v2.3.2
+      - uses: actions/checkout@v3
 
       - uses: actions/cache@v3
         with:
@@ -635,7 +635,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: artifacts
 
@@ -703,7 +703,7 @@ jobs:
         if: false
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ./python/coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0
 
     - name: Setup Java11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
          distribution: 'zulu'
          java-version: '11'

--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -33,7 +33,7 @@ jobs:
       options:
         --shm-size 4096m
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
 
     - name: Install latest libgrape-lite and vineyard
       if: false
@@ -109,7 +109,7 @@ jobs:
           --cov-report=term --exitfirst -s -v graphscope/tests/unittest/test_java_app.py
 
     - name: Upload Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: ./python/coverage.xml
         fail_ci_if_error: true

--- a/.github/workflows/gaia.yml
+++ b/.github/workflows/gaia.yml
@@ -23,7 +23,7 @@ jobs:
   gaia-test:
     runs-on: [self-hosted, manylinux2014]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -98,7 +98,7 @@ jobs:
 
     - name: Upload GIE log
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: gie-log
         path: /var/log/graphscope

--- a/.github/workflows/gss.yml
+++ b/.github/workflows/gss.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: [self-hosted, manylinux2014]
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/cache@v3
       with:
         path: ~/.m2/repository
@@ -107,7 +107,7 @@ jobs:
         mvn test -P gremlin-test
 
     - name: Upload tools for helm test to Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: groot.tar.gz
         path: interactive_engine/assembly/target/groot.tar.gz
@@ -127,11 +127,11 @@ jobs:
         find ./ -name "*.whl" | xargs sudo rm -rf || true
         find ./ -name "*_pb2.py" | xargs sudo rm -rf || true
         find ./ -name "*_pb2_grpc.py" | xargs sudo rm -rf || true
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: groot.tar.gz
         path: artifacts

--- a/.github/workflows/networkx-forward-algo-nightly.yml
+++ b/.github/workflows/networkx-forward-algo-nightly.yml
@@ -21,7 +21,7 @@ jobs:
         --shm-size 4096m
 
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
 
     - name: Build GAE and coordinator
       run: |
@@ -40,7 +40,7 @@ jobs:
           --cov-report=term -s -v -m "not slow" graphscope/nx/algorithms/tests/forward
 
     - name: Upload Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: ./python/coverage.xml
         fail_ci_if_error: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-10.15]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -50,7 +50,7 @@ jobs:
         make unittest
 
     - name: Upload Coverage
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       if: matrix.os == 'ubuntu-20.04'
       with:
         file: ./python/coverage.xml

--- a/.github/workflows/pegasus.yml
+++ b/.github/workflows/pegasus.yml
@@ -22,7 +22,7 @@ jobs:
   peagsus-build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build & Test
       run: |
@@ -50,7 +50,7 @@ jobs:
   k8s-test:
     runs-on: [self-hosted, ubuntu2004]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name : Prepare Image
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
 
     - name: Add envs to GITHUB_ENV
       run: |
@@ -52,7 +52,7 @@ jobs:
     - name: Extract Tag Name
       if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope' }}
       id: tag
-      run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/v}
+      run: echo "TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
     - name: Release Image
       if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope' }}
@@ -68,7 +68,7 @@ jobs:
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2.3.2
+    - uses: actions/checkout@v3
 
     # this step is needed for update index.yaml
     - name: Download Released Charts
@@ -104,7 +104,8 @@ jobs:
 
     - name: Extract Tag Name
       id: tag
-      run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/v}
+      run: echo "TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+      
 
     - name: Upload Charts to OSS
       uses: tvrcgo/upload-to-oss@master


### PR DESCRIPTION
As github have deprecated the use of node 12 and will gives warning in every CI.