### PR TITLE
[GIE pegasus] Support cancelling query. 

### DIFF
--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -1090,7 +1090,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         )
         setattr(self._analytical_engine_process, "stdout_watcher", stdout_watcher)
         setattr(self._analytical_engine_process, "stderr_watcher", stderr_watcher)
-        time.sleep(2)  # TODO: monitor engine process instead of sleep
+        time.sleep(4)  # TODO: monitor engine process instead of sleep
 
     def _delete_dangling_coordinator(self):
         # delete service

--- a/interactive_engine/executor/engine/pegasus/pegasus/src/operator/primitives/sink.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/operator/primitives/sink.rs
@@ -46,7 +46,6 @@ where
         let mut input = new_input_session::<D>(&inputs[0]);
         input.for_each_batch(|dataset| {
             for d in dataset.drain() {
-                println!("called by sink");
                 self.collector.on_next(d)?;
             }
             Ok(())
@@ -76,7 +75,6 @@ where
         let mut input = new_input_session::<Single<D>>(&inputs[0]);
         input.for_each_batch(|dataset| {
             for d in dataset.drain() {
-                println!("called by single sink");
                 self.sender.on_next(d.0)?;
             }
             Ok(())

--- a/interactive_engine/executor/engine/pegasus/pegasus/src/operator/primitives/sink.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/operator/primitives/sink.rs
@@ -46,6 +46,7 @@ where
         let mut input = new_input_session::<D>(&inputs[0]);
         input.for_each_batch(|dataset| {
             for d in dataset.drain() {
+                println!("called by sink");
                 self.collector.on_next(d)?;
             }
             Ok(())
@@ -75,6 +76,7 @@ where
         let mut input = new_input_session::<Single<D>>(&inputs[0]);
         input.for_each_batch(|dataset| {
             for d in dataset.drain() {
+                println!("called by single sink");
                 self.sender.on_next(d.0)?;
             }
             Ok(())

--- a/interactive_engine/executor/engine/pegasus/pegasus/src/result.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/result.rs
@@ -49,13 +49,15 @@ impl<T: 'static> ResultSink<T> {
 
     pub fn set_cancel_hook(&mut self, is_canceled: bool) {
         self.cancel.store(is_canceled, Ordering::SeqCst);
-        match &mut self.kind {
-            ResultSinkKind::Customized(tx) => {
-                let msg = "Job is canceled".to_string();
-                let err = JobExecError::from(msg);
-                tx.on_error(Box::new(err));
+        if is_canceled {
+            match &mut self.kind {
+                ResultSinkKind::Customized(tx) => {
+                    let msg = "Job is canceled".to_string();
+                    let err = JobExecError::from(msg);
+                    tx.on_error(Box::new(err));
+                }
+                _ => (),
             }
-            _ => (),
         }
     }
 

--- a/interactive_engine/executor/engine/pegasus/pegasus/src/result.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/result.rs
@@ -153,6 +153,11 @@ impl<T> ResultStream<T> {
 
     fn pull_next(&mut self) -> Option<Result<T, Box<dyn Error + Send>>> {
         if self.is_exhaust.load(Ordering::SeqCst) {
+            if self.is_cancel() {
+                let err_msg = "Job is canceled;".to_owned();
+                let err: Box<dyn Error + Send + Sync> = err_msg.into();
+                return Some(Err(err));
+            }
             return None;
         }
 
@@ -171,6 +176,11 @@ impl<T> ResultStream<T> {
             }
             Err(_) => {
                 self.is_exhaust.store(true, Ordering::SeqCst);
+                if self.is_cancel() {
+                    let err_msg = "Job is canceled;".to_owned();
+                    let err: Box<dyn Error + Send + Sync> = err_msg.into();
+                    return Some(Err(err));
+                }
                 None
             }
         }

--- a/interactive_engine/executor/engine/pegasus/pegasus/src/result.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/result.rs
@@ -8,7 +8,7 @@ use dyn_clonable::*;
 
 use crate::api::function::FnResult;
 use crate::api::FromStream;
-use crate::errors::{ErrorKind, JobExecError};
+use crate::errors::JobExecError;
 
 #[clonable]
 pub trait FromStreamExt<T>: FromStream<T> + Clone {
@@ -50,12 +50,12 @@ impl<T: 'static> ResultSink<T> {
     pub fn set_cancel_hook(&mut self, is_canceled: bool) {
         self.cancel.store(is_canceled, Ordering::SeqCst);
         match &mut self.kind {
-            ResultSinkKind::Default(tx) => (),
             ResultSinkKind::Customized(tx) => {
                 let msg = "Job is canceled".to_string();
                 let err = JobExecError::from(msg);
                 tx.on_error(Box::new(err));
             }
+            _ => (),
         }
     }
 

--- a/interactive_engine/executor/engine/pegasus/pegasus/src/worker.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/worker.rs
@@ -119,6 +119,12 @@ impl<D: Data, T: Debug + Send + 'static> Worker<D, T> {
     }
 
     fn check_cancel(&self) -> bool {
+        if self.conf.time_limit > 0 {
+            let elapsed = self.start.elapsed().as_millis() as u64;
+            if elapsed >= self.conf.time_limit {
+                return true;
+            }
+        }
         // TODO: check cancel impl;
         false
     }

--- a/interactive_engine/executor/engine/pegasus/pegasus/tests/fold_test.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/tests/fold_test.rs
@@ -14,7 +14,7 @@
 //! limitations under the License.
 //
 
-use pegasus::api::{Collect, CorrelatedSubTask, Count, Filter, Fold, FoldByKey, KeyBy, Map, Sink};
+use pegasus::api::{Collect, CorrelatedSubTask, Count, Filter, Fold, FoldByKey, KeyBy, Map, Sink, SortBy};
 use pegasus::JobConf;
 
 #[test]

--- a/interactive_engine/executor/engine/pegasus/pegasus/tests/timeout_test.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/tests/timeout_test.rs
@@ -1,0 +1,96 @@
+//
+//! Copyright 2020 Alibaba Group Holding Limited.
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//! http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+
+use pegasus::api::{Binary, IterCondition, Iteration, Map, Sink};
+use pegasus::JobConf;
+use std::time::Duration;
+
+/// test binary merge pipeline;
+#[test]
+fn timeout_test_01() {
+    let mut conf = JobConf::new("timeout_test_01");
+    conf.time_limit = 5000;
+    let mut result = pegasus::run(conf, || {
+        |input, output| {
+            input
+                .input_from(vec![0u32])?
+                .iterate_until(IterCondition::max_iters(20), |iter| {
+                    iter.map(|input| {
+                        std::thread::sleep(Duration::from_secs(1));
+                        Ok(input + 1)
+                    })
+                })?
+                .sink_into(output)
+        }
+    })
+    .expect("submit job failure;");
+
+    let mut count = 0;
+    while let Some(Ok(data)) = result.next() {
+        count += data;
+    }
+    if result.is_cancel() {
+        println!("the task is canceled");
+        assert_eq!(0, count);
+    } else {
+        assert_eq!(20, count);
+    }
+}
+
+/// test binary merge with shuffle between two workers;
+#[test]
+fn timeout_test_02() {
+    let mut conf = JobConf::new("binary_test_02");
+    conf.set_workers(2);
+    let mut result = pegasus::run(conf, || {
+        |input, output| {
+            let stream = input.input_from(0..1000)?;
+            let (left, right) = stream.copied()?;
+            let left = left.map(|item| Ok(item + 1))?;
+            let right = right
+                .map(|item| Ok(item + 2))?
+                .repartition(|item: &u32| Ok(*item as u64));
+            left.binary("merge", right, |_info| {
+                |left, right, output| {
+                    left.for_each_batch(|dataset| {
+                        let mut session = output.new_session(&dataset.tag)?;
+                        for item in dataset.drain() {
+                            session.give(item)?;
+                        }
+                        Ok(())
+                    })?;
+
+                    right.for_each_batch(|dataset| {
+                        let mut session = output.new_session(&dataset.tag)?;
+                        for item in dataset.drain() {
+                            session.give(item)?;
+                        }
+                        Ok(())
+                    })
+                }
+            })?
+            .sink_into(output)
+        }
+    })
+    .expect("submit job failure;");
+
+    let mut count = 0;
+    while let Some(Ok(data)) = result.next() {
+        assert!(data > 0 && data < 1002);
+        count += 1;
+    }
+
+    assert_eq!(4000, count);
+}

--- a/interactive_engine/executor/engine/pegasus/pegasus/tests/timeout_test.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/tests/timeout_test.rs
@@ -50,7 +50,7 @@ fn timeout_test_02() {
     let mut conf = JobConf::new("timeout_test_2");
     conf.time_limit = 5000;
     conf.set_workers(2);
-    let mut result = pegasus::run(conf, || {
+    let mut results = pegasus::run(conf, || {
         |input, output| {
             let worker_id = input.get_worker_index();
             input
@@ -68,8 +68,12 @@ fn timeout_test_02() {
     })
     .expect("submit job failure;");
     let mut count = 0;
-    while let Some(Ok(data)) = result.next() {
-        count += data;
+    while let Some(result) = results.next() {
+        if let Ok(data) = result {
+            count += data;
+        } else {
+            break;
+        }
     }
-    assert!(result.is_cancel());
+    assert!(results.is_cancel());
 }

--- a/interactive_engine/executor/engine/pegasus/pegasus/tests/timeout_test.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/tests/timeout_test.rs
@@ -57,7 +57,7 @@ fn timeout_test_02() {
                 .input_from(vec![0u32])?
                 .iterate_until(IterCondition::max_iters(20), move |iter| {
                     iter.map(move |input| {
-                        if worker_id == 0 {
+                        if worker_id == 1 {
                             std::thread::sleep(Duration::from_millis(1000));
                         }
                         Ok(input + 1)
@@ -72,6 +72,8 @@ fn timeout_test_02() {
         if let Ok(data) = result {
             count += data;
         } else {
+            let err = result.err().unwrap();
+            assert_eq!(err.to_string(), "Job is canceled;".to_string());
             break;
         }
     }

--- a/interactive_engine/executor/engine/pegasus/server/config/tests/standalone2/server_config.toml
+++ b/interactive_engine/executor/engine/pegasus/server/config/tests/standalone2/server_config.toml
@@ -44,10 +44,10 @@ heartbeat_sec = 5
 # If the cluster is standalone, the size of addresses should be equal to [server_size] set above, and the addresses
 # should be in order, the fisrt address would be server 0.
 [[network.servers]]
-ip = '192.168.1.1'
+hostname = '192.168.1.1'
 port = 8080
 
 [[network.servers]]
-ip = '192.168.1.2'
+hostname = '192.168.1.2'
 port = 8080
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

1. Query will be cancelled when timeout
2. User can cancel running job by set cancel hook in ResultSink
3. ResultSink will call method `on_error` when query is cancelled

## Related issue number
Resolves https://github.com/alibaba/GraphScope/issues/1867

