### PR TITLE
fix create interactive engine failure on helm installed graphscope

### DIFF
--- a/charts/graphscope/README.md
+++ b/charts/graphscope/README.md
@@ -44,8 +44,8 @@ Note that it may take a few minutes for pulling image at first time, you can wat
 $ helm test [RELEASE_NAME]
 
 # Default, with kubernetes `NodePort` service type, you can get service endpoint by:
-$ export NODE_IP=$(kubectl --namespace [NAMESPACE] get pod -o jsonpath="{.status.hostIP}" [GRAPHSCOPE-FULLNAME]-coordinator)
-$ export NODE_PORT=$(kubectl --namespace [NAMESPACE] get services -o jsonpath="{.spec.ports[0].nodePort}" [GRAPHSCOPE-FULLNAME]-coordinator-service)
+$ export NODE_IP=$(kubectl --namespace [NAMESPACE] get pod -o jsonpath="{.status.hostIP}" coordinator-[GRAPHSCOPE-FULLNAME])
+$ export NODE_PORT=$(kubectl --namespace [NAMESPACE] get services -o jsonpath="{.spec.ports[0].nodePort}" coordinator-service-[GRAPHSCOPE-FULLNAME])
 $ echo "GraphScope service listen on ${NODE_IP}:${NODE_PORT}"
 ```
 

--- a/charts/graphscope/templates/NOTES.txt
+++ b/charts/graphscope/templates/NOTES.txt
@@ -5,13 +5,13 @@ The GraphScope has been deployed.
 {{- if contains "NodePort" .Values.coordinator.service.type }}
 
   export NODE_IP=$(kubectl --namespace {{ .Release.Namespace }}  get pod -l {{ template "graphscope.coordinator.labelSelector" . }} --no-headers=true | awk '/ /{print $1}' | xargs kubectl --namespace {{ .Release.Namespace }} get pod -o jsonpath="{.status.hostIP}")
-  export NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" {{ template "graphscope.fullname" . }}-coordinator-service)
+  export NODE_PORT=$(kubectl --namespace {{ .Release.Namespace }} get services -o jsonpath="{.spec.ports[0].nodePort}" coordinator-service-{{ template "graphscope.fullname" . }})
   echo "GraphScope service listen on ${NODE_IP}:${NODE_PORT}"
 
 {{- else if contains "LoadBalancer" .Values.coordinator.service.type }}
 
   It may take a few minutes for the LoadBalancer IP to be available.
-  You can watch the status by executing 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w {{ template "graphscope.fullname" . }}-coordinator-service'
+  You can watch the status by executing 'kubectl --namespace {{ .Release.Namespace }} get services -o wide -w coordinator-service-{{ template "graphscope.fullname" . }}'
 
 {{- end }}
 

--- a/charts/graphscope/templates/_helpers.tpl
+++ b/charts/graphscope/templates/_helpers.tpl
@@ -4,11 +4,7 @@ We truncate at 30 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "graphscope.fullname" -}}
-{{- if contains .Chart.Name .Release.Name }}
 {{- .Release.Name | trunc 30 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name .Chart.Name  | trunc 30 | trimSuffix "-" }}
-{{- end }}
 {{- end }}
 
 
@@ -47,14 +43,14 @@ Transform the Docker Image Registry Secret Names to string with comma separated.
 Unique Label of GraphScope Coordinator.
 */}}
 {{- define "graphscope.coordinator.uniqueLabel" -}}
-graphscope.coordinator.name: {{ include "graphscope.fullname" . }}-coordinator
+graphscope.coordinator.name: coordinator-{{ include "graphscope.fullname" . }}
 {{- end }}
 
 {{/*
 Label Selector Corresponding to Unique Label of GraphScope Coordinator
 */}}
 {{- define "graphscope.coordinator.labelSelector" -}}
-graphscope.coordinator.name={{ include "graphscope.fullname" . }}-coordinator
+graphscope.coordinator.name=coordinator-{{ include "graphscope.fullname" . }}
 {{- end }}
 
 {{/*

--- a/charts/graphscope/templates/coordinator.yaml
+++ b/charts/graphscope/templates/coordinator.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "graphscope.fullname" . }}-coordinator
+  name: coordinator-{{ include "graphscope.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
@@ -87,9 +87,9 @@ spec:
           - {{ include "graphscope.imagePullSecretsStr" . | default (printf "''") | trimAll "\n" | quote }}
           - "--k8s_coordinator_name"
           {{- $fullname := include "graphscope.fullname" . }}
-          - {{ printf "%s-%s" $fullname "coordinator" | quote }}
+          - {{ printf "%s-%s" "coordinator" $fullname | quote }}
           - "--k8s_coordinator_service_name"
-          - {{ printf "%s-%s" $fullname "coordinator-service" | quote }}
+          - {{ printf "%s-%s" "coordinator-service" $fullname | quote }}
           - "--k8s_etcd_cpu"
           - {{ .Values.etcd.resources.requests.cpu | quote }}
           - "--k8s_etcd_mem"

--- a/charts/graphscope/templates/service.yaml
+++ b/charts/graphscope/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "graphscope.fullname" . }}-coordinator-service
+  name: coordinator-service-{{ include "graphscope.fullname" . }}
   namespace: {{ .Release.Namespace }}
 {{- include "graphscope.service.annotations" . | nindent 2 }}
   labels:

--- a/charts/graphscope/templates/test/test-rpc.yaml
+++ b/charts/graphscope/templates/test/test-rpc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "graphscope.fullname" . }}-test-rpc-service
+  name: test-rpc-service-{{ include "graphscope.fullname" . }}
   annotations:
     "helm.sh/hook": test
 spec:
@@ -9,5 +9,5 @@ spec:
     - name: curl
       image: curlimages/curl:7.65.3
       command: ['sh']
-      args: ['-c', 'while ! curl {{ include "graphscope.fullname" . }}-coordinator-service.{{ .Release.Namespace }}:59001 --output -; do sleep 1 && echo -n .; done']
+      args: ['-c', 'while ! curl coordinator-service-{{ include "graphscope.fullname" . }}.{{ .Release.Namespace }}:59001 --output -; do sleep 1 && echo -n .; done']
   restartPolicy: Never


### PR DESCRIPTION
In helm installed cluster the names of coordinator and coordinator service are prefixed by instance id, whereas in python launched cluster the names are suffixed by instance id.

Reported by #2161