### PR TITLE
[BugFix] GAE JavaDoc not generated

### DIFF
--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -78,7 +78,6 @@
     <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
-    <maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
     <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
@@ -94,7 +93,7 @@
     <dep.json.version>20160810</dep.json.version>
     <dep.kryo-serializers.version>0.42</dep.kryo-serializers.version>
     <spark.version>3.1.3</spark.version>
-    <maven.javadoc.version>3.3.1</maven.javadoc.version>
+    <maven.javadoc.version>3.4.0</maven.javadoc.version>
     <javadoc.output.directory>grape-jdk-javadoc</javadoc.output.directory>
     <javadoc.output.destDir>grape-jdk-javadoc</javadoc.output.destDir>
     <grpc.version>1.47.0</grpc.version>
@@ -312,7 +311,7 @@
                 <packages>com.alibaba.graphscope*</packages>
               </group>
             </groups>
-            <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>
+            <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
             <sourceFileExcludes>
               <sourceFileExclude>**/*GenGen.java</sourceFileExclude>
               <sourceFileExclude>**/Unused*.java</sourceFileExclude>

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,7 +39,7 @@ clean:
 	@echo "Building Java doc to $(BUILDDIR)/${TAG}/$@/reference/gae_java"
 
 	cd ${WORKING_DIR}/../analytical_engine/java && \
-	mvn -P javadoc javadoc:aggregate -Dmaven.antrun.skip=true -DskipTests -Djavadoc.output.directory=${WORKING_DIR}/$(BUILDDIR)/${TAG}/$@/reference -Djavadoc.output.destDir=gae_java \
+	mvn -P javadoc javadoc:aggregate -Dmaven.antrun.skip=true -DskipTests -Djavadoc.output.directory=${WORKING_DIR}/$(BUILDDIR)/${TAG}/$@/reference -Djavadoc.output.destDir=gae_java --quiet \
 
 doxygen:
 	@mkdir -p _build


### PR DESCRIPTION
The GAE Java doc not generated due to `javadoc` path error.