### PR TITLE
Delegate parquet/orc files to vineyard io adaptors

### DIFF
--- a/coordinator/gscoordinator/op_executor.py
+++ b/coordinator/gscoordinator/op_executor.py
@@ -754,8 +754,16 @@ class OperationExecutor:
         def _process_loader_func(loader, vineyard_endpoint, vineyard_ipc_socket):
             # loader is type of attr_value_pb2.Chunk
             protocol = loader.attr[types_pb2.PROTOCOL].s.decode()
-            if protocol in ("hdfs", "hive", "oss", "s3"):
-                source = loader.attr[types_pb2.SOURCE].s.decode()
+            source = loader.attr[types_pb2.SOURCE].s.decode()
+            if (
+                protocol in ("hdfs", "hive", "oss", "s3")
+                or protocol == "file"
+                and (
+                    source.endswith(".orc")
+                    or source.endswith(".parquet")
+                    or source.endswith(".pq")
+                )
+            ):
                 storage_options = json.loads(
                     loader.attr[types_pb2.STORAGE_OPTIONS].s.decode()
                 )

--- a/k8s/graphscope.Dockerfile
+++ b/k8s/graphscope.Dockerfile
@@ -55,9 +55,6 @@ WORKDIR /home/graphscope
 # set the CLASSPATH for hadoop
 RUN bash -l -c 'echo export CLASSPATH="$($HADOOP_HOME/bin/hdfs classpath --glob)" >> /home/graphscope/.profile'
 
-# ensure ~/.profile is sourced, see also: https://stackoverflow.com/a/46239286/5080177
-SHELL ["/bin/bash", "-lc"]
-
 ENV PATH=${PATH}:/home/graphscope/.local/bin
 
 COPY . /home/graphscope/gs

--- a/python/graphscope/framework/loader.py
+++ b/python/graphscope/framework/loader.py
@@ -245,8 +245,22 @@ class Loader(object):
         # doesn't add an additional stream layer.
         # Maybe handled by vineyard in the near future
         if self.protocol == "file":
-            source = "{}#{}".format(self.source, self.options)
-            config[types_pb2.SOURCE] = utils.s_to_attr(source)
+            if (
+                self.source.endswith(".orc")
+                or self.source.endswith(".parquet")
+                or self.source.endswith(".pq")
+            ):
+                # orc and parquet: handled by vineyard
+                config[types_pb2.SOURCE] = utils.s_to_attr(self.source)
+                config[types_pb2.STORAGE_OPTIONS] = utils.s_to_attr(
+                    json.dumps(self.storage_options)
+                )
+                config[types_pb2.READ_OPTIONS] = utils.s_to_attr(
+                    json.dumps(self.options.to_dict())
+                )
+            else:
+                source = "{}#{}".format(self.source, self.options)
+                config[types_pb2.SOURCE] = utils.s_to_attr(source)
         elif self.protocol == "pandas":
             config[types_pb2.VALUES] = self.source
         else:  # Let vineyard handle other data source.


### PR DESCRIPTION

## What do these changes do?

Vineyard supports ORC and Parquet files in its IO adaptors, see also: https://github.com/v6d-io/v6d/pull/1052

## Related issue number

Fixes #1041 

