### PR TITLE
[Bug Fix]Update the DefaultTag to .Chart.AppVersion

### DIFF
--- a/charts/graphscope-store/templates/_helpers.tpl
+++ b/charts/graphscope-store/templates/_helpers.tpl
@@ -75,7 +75,7 @@ Return the proper graphscope-store image name
 
 {{/*
 Return the proper image name
-{{ include "graphscope-store.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" $ "DefaultTag" .Chart.AppVersion ) }}
+{{ include "graphscope-store.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" $ "DefaultTag" .DefaultTag ) }}
 */}}
 {{- define "graphscope-store.images.image" -}}
 {{- $registryName := .imageRoot.registry -}}
@@ -87,8 +87,8 @@ Return the proper image name
     {{- end -}}
 {{- end -}}
 {{- if not $tag }}
-{{- if .imageRoot.DefaultTag }}
-{{- $tag = .imageRoot.DefaultTag -}}
+{{- if .DefaultTag }}
+{{- $tag = .DefaultTag -}}
 {{- else -}}
 {{- $tag = "latest" -}}
 {{- end -}}


### PR DESCRIPTION
Thanks for @siyuan0322 , https://github.com/alibaba/GraphScope/pull/2205 doesn't use the `.Chart.AppVersion`.

I have tested it with the pr and works as expected.

```shell
$ kubectl create ns graphscope-store
namespace/graphscope-store created
$ helm install graphscope-store "./graphscope-store" -n graphscope-store
NAME: graphscope-store
LAST DEPLOYED: Tue Nov  8 12:29:11 2022
NAMESPACE: graphscope-store
STATUS: deployed
REVISION: 1
NOTES:
1. Get the application URL by running these commands:
  export NODE_IP=$(kubectl -n graphscope-store get pod graphscope-store-frontend-0  -o jsonpath="{.status.hostIP}")
  export GRPC_PORT=$(kubectl -n graphscope-store get services graphscope-store-frontend -o jsonpath="{.spec.ports[0].nodePort}")
  export GREMLIN_PORT=$(kubectl -n graphscope-store get services graphscope-store-frontend -o jsonpath="{.spec.ports[1].nodePort}")
  echo "GRPC endpoint is: ${NODE_IP}:${GRPC_PORT}"
  echo "GREMLIN endpoint is: ${NODE_IP}:${GREMLIN_PORT}"
$ kubectl get pod -l app.kubernetes.io/instance=graphscope-store -n graphscope-store -oyaml | grep image 
              f:image: {}
              f:imagePullPolicy: {}
      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0
      imagePullPolicy: IfNotPresent
    - image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0
      imageID: ""
          message: 'rpc error: code = NotFound desc = failed to pull and unpack image
              f:image: {}
              f:imagePullPolicy: {}
      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0
      imagePullPolicy: IfNotPresent
    - image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0
      imageID: ""
          message: 'rpc error: code = NotFound desc = failed to pull and unpack image
              f:image: {}
              f:imagePullPolicy: {}
      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0
      imagePullPolicy: IfNotPresent
    - image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0
      imageID: ""
          message: Back-off pulling image "registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0"
              f:image: {}
              f:imagePullPolicy: {}
      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0
      imagePullPolicy: IfNotPresent
    - image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0
      imageID: ""
          message: Back-off pulling image "registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0"
``` 

BTW, it looks like the image `registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:0.18.0` doesn't exist. Is there something I missed?
 
/cc @sighingnow  @siyuan0322 