### PR TITLE
[GIE POM] Unify GIE version by the global flag 'revision'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,7 +789,7 @@ jobs:
           cd interactive_engine/compiler && make build rpc.target=${RPC_TARGET}
           cd ${GITHUB_WORKSPACE}
           tar -czf artifacts.tar.gz interactive_engine/compiler/target/libs \
-            interactive_engine/compiler/target/compiler-1.0-SNAPSHOT.jar \
+            interactive_engine/compiler/target/compiler-0.0.1-SNAPSHOT.jar \
             interactive_engine/compiler/conf \
             interactive_engine/compiler/set_properties.sh \
             interactive_engine/executor/ir/target/release/libir_core.so \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,7 +789,7 @@ jobs:
           cd interactive_engine/compiler && make build rpc.target=${RPC_TARGET}
           cd ${GITHUB_WORKSPACE}
           tar -czf artifacts.tar.gz interactive_engine/compiler/target/libs \
-            interactive_engine/compiler/target/compiler-0.0.1-SNAPSHOT.jar \
+            interactive_engine/compiler/target/compiler-1.0-SNAPSHOT.jar \
             interactive_engine/compiler/conf \
             interactive_engine/compiler/set_properties.sh \
             interactive_engine/executor/ir/target/release/libir_core.so \

--- a/interactive_engine/assembly/pom.xml
+++ b/interactive_engine/assembly/pom.xml
@@ -39,12 +39,12 @@
       <dependency>
         <groupId>com.alibaba.maxgraph</groupId>
         <artifactId>frontend</artifactId>
-        <version>${project.parent.version}</version>
+        <version>${project.version}</version>
       </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>executor</artifactId>
-          <version>${project.parent.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -68,22 +68,22 @@
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>groot-server</artifactId>
-          <version>${project.parent.version}</version>
+          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>data_load_tools</artifactId>
-          <version>${project.parent.version}</version>
+          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>executor</artifactId>
-          <version>${project.parent.version}</version>
+          <version>${project.version}</version>
         </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>c-end-lgraph</artifactId>
-          <version>${project.parent.version}</version>
+          <version>${project.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/interactive_engine/assembly/pom.xml
+++ b/interactive_engine/assembly/pom.xml
@@ -39,10 +39,12 @@
       <dependency>
         <groupId>com.alibaba.maxgraph</groupId>
         <artifactId>frontend</artifactId>
+        <version>${project.parent.version}</version>
       </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>executor</artifactId>
+          <version>${project.parent.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -66,6 +68,7 @@
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>groot-server</artifactId>
+          <version>${project.parent.version}</version>
         </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
@@ -75,10 +78,12 @@
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>executor</artifactId>
+          <version>${project.parent.version}</version>
         </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>c-end-lgraph</artifactId>
+          <version>${project.parent.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/interactive_engine/assembly/pom.xml
+++ b/interactive_engine/assembly/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -39,12 +39,10 @@
       <dependency>
         <groupId>com.alibaba.maxgraph</groupId>
         <artifactId>frontend</artifactId>
-        <version>${project.parent.version}</version>
       </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>executor</artifactId>
-          <version>${project.parent.version}</version>
         </dependency>
       </dependencies>
     </profile>
@@ -68,7 +66,6 @@
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>groot-server</artifactId>
-          <version>${project.parent.version}</version>
         </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
@@ -78,12 +75,10 @@
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>executor</artifactId>
-          <version>${project.parent.version}</version>
         </dependency>
         <dependency>
           <groupId>com.alibaba.maxgraph</groupId>
           <artifactId>c-end-lgraph</artifactId>
-          <version>${project.parent.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/interactive_engine/common/pom.xml
+++ b/interactive_engine/common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/interactive_engine/compiler/Makefile
+++ b/interactive_engine/compiler/Makefile
@@ -23,10 +23,8 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 build:
-	cd $(CUR_DIR)/../executor/engine/pegasus/clients/java/client && \
-		mvn clean install -DskipTests --quiet $(OSFLAG) && \
-		cd $(CUR_DIR)/../executor/ir/integrated && cargo build --release --bin $(rpc.target) && \
-		cd $(CUR_DIR) && mvn clean package -DskipTests --quiet $(OSFLAG)
+	cd $(CUR_DIR)/.. && mvn clean install -DskipTests -Pjava-release --quiet $(OSFLAG) && \
+	cd $(CUR_DIR)/../executor/ir/integrated && cargo build --release --bin $(rpc.target)
 
 clean:
 	cd $(CUR_DIR)/../executor/engine/pegasus/clients/java/client && mvn clean && \

--- a/interactive_engine/compiler/Makefile
+++ b/interactive_engine/compiler/Makefile
@@ -44,14 +44,14 @@ gremlin_test:
 
 submit:
 	cd $(CUR_DIR) && $(java) \
-	  -cp ".:./target/libs/*:./target/compiler-1.0-SNAPSHOT.jar" \
+	  -cp ".:./target/libs/*:./target/compiler-0.0.1-SNAPSHOT.jar" \
 	  -Djna.library.path=../executor/ir/target/release \
 	  com.alibaba.graphscope.common.SubmitPlanServiceMain \
 	  $(OPT)
 
 run:
 	cd $(CUR_DIR) && $(java) \
-	  -cp ".:./target/libs/*:./target/compiler-1.0-SNAPSHOT.jar" \
+	  -cp ".:./target/libs/*:./target/compiler-0.0.1-SNAPSHOT.jar" \
 	  -Djna.library.path=../executor/ir/target/release \
 	  -Dgraph.schema=${graph.schema} \
 	  -Dpegasus.hosts=${pegasus.hosts} \

--- a/interactive_engine/compiler/Makefile
+++ b/interactive_engine/compiler/Makefile
@@ -23,8 +23,8 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 build:
-	cd $(CUR_DIR)/../executor/engine/pegasus/clients/java/client && \
-		mvn clean install -DskipTests --quiet $(OSFLAG) && \
+	cd $(CUR_DIR)/.. && \
+		mvn clean package -DskipTests -Pexperimental --quiet $(OSFLAG) && \
 		cd $(CUR_DIR)/../executor/ir/integrated && cargo build --release --bin $(rpc.target) && \
 		cd $(CUR_DIR) && mvn clean package -DskipTests --quiet $(OSFLAG)
 
@@ -36,7 +36,7 @@ clean:
 test:
 	cd $(CUR_DIR)/../executor/ir && cargo test && \
 	cd $(CUR_DIR)/../executor/ir && cargo test --features with_v6d && \
-	cd $(CUR_DIR) && mvn test
+	cd $(CUR_DIR) && mvn test -Pexperimental
 
 # start rpc server
 # make run

--- a/interactive_engine/compiler/Makefile
+++ b/interactive_engine/compiler/Makefile
@@ -44,14 +44,14 @@ gremlin_test:
 
 submit:
 	cd $(CUR_DIR) && $(java) \
-	  -cp ".:./target/libs/*:./target/compiler-0.0.1-SNAPSHOT.jar" \
+	  -cp ".:./target/libs/*:./target/compiler-1.0-SNAPSHOT.jar" \
 	  -Djna.library.path=../executor/ir/target/release \
 	  com.alibaba.graphscope.common.SubmitPlanServiceMain \
 	  $(OPT)
 
 run:
 	cd $(CUR_DIR) && $(java) \
-	  -cp ".:./target/libs/*:./target/compiler-0.0.1-SNAPSHOT.jar" \
+	  -cp ".:./target/libs/*:./target/compiler-1.0-SNAPSHOT.jar" \
 	  -Djna.library.path=../executor/ir/target/release \
 	  -Dgraph.schema=${graph.schema} \
 	  -Dpegasus.hosts=${pegasus.hosts} \

--- a/interactive_engine/compiler/Makefile
+++ b/interactive_engine/compiler/Makefile
@@ -24,9 +24,8 @@ endif
 
 build:
 	cd $(CUR_DIR)/.. && \
-		mvn clean package -DskipTests -Pexperimental --quiet $(OSFLAG) && \
-		cd $(CUR_DIR)/../executor/ir/integrated && cargo build --release --bin $(rpc.target) && \
-		cd $(CUR_DIR) && mvn clean package -DskipTests --quiet $(OSFLAG)
+		mvn clean install -DskipTests -Pexperimental --quiet $(OSFLAG) && \
+		cd $(CUR_DIR)/../executor/ir/integrated && cargo build --release --bin $(rpc.target)
 
 clean:
 	cd $(CUR_DIR)/../executor/engine/pegasus/clients/java/client && mvn clean && \
@@ -36,7 +35,7 @@ clean:
 test:
 	cd $(CUR_DIR)/../executor/ir && cargo test && \
 	cd $(CUR_DIR)/../executor/ir && cargo test --features with_v6d && \
-	cd $(CUR_DIR) && mvn test -Pexperimental
+	cd $(CUR_DIR) && mvn test
 
 # start rpc server
 # make run

--- a/interactive_engine/compiler/Makefile
+++ b/interactive_engine/compiler/Makefile
@@ -23,8 +23,10 @@ ifeq ($(UNAME_S),Darwin)
 endif
 
 build:
-	cd $(CUR_DIR)/.. && mvn clean install -DskipTests -Pjava-release --quiet $(OSFLAG) && \
-	cd $(CUR_DIR)/../executor/ir/integrated && cargo build --release --bin $(rpc.target)
+	cd $(CUR_DIR)/../executor/engine/pegasus/clients/java/client && \
+		mvn clean install -DskipTests --quiet $(OSFLAG) && \
+		cd $(CUR_DIR)/../executor/ir/integrated && cargo build --release --bin $(rpc.target) && \
+		cd $(CUR_DIR) && mvn clean package -DskipTests --quiet $(OSFLAG)
 
 clean:
 	cd $(CUR_DIR)/../executor/engine/pegasus/clients/java/client && mvn clean && \

--- a/interactive_engine/compiler/Makefile
+++ b/interactive_engine/compiler/Makefile
@@ -16,6 +16,8 @@ graph.schema:=
 
 rpc.target:=start_rpc_server
 
+target.revision:=1.0-SNAPSHOT
+
 ifeq ($(UNAME_S),Darwin)
     ifeq ($(UNAME_M),arm64)
         OSFLAG += -Dos.detected.classifier=osx-x86_64
@@ -24,7 +26,7 @@ endif
 
 build:
 	cd $(CUR_DIR)/.. && \
-		mvn clean install -DskipTests -Pexperimental --quiet $(OSFLAG) && \
+		mvn clean install -DskipTests -Drevision=${target.revision} -Pexperimental --quiet $(OSFLAG) && \
 		cd $(CUR_DIR)/../executor/ir/integrated && cargo build --release --bin $(rpc.target)
 
 clean:

--- a/interactive_engine/compiler/pom.xml
+++ b/interactive_engine/compiler/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.alibaba.pegasus</groupId>
             <artifactId>pegasus-client</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/interactive_engine/compiler/pom.xml
+++ b/interactive_engine/compiler/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>com.alibaba.pegasus</groupId>
             <artifactId>pegasus-client</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/interactive_engine/compiler/pom.xml
+++ b/interactive_engine/compiler/pom.xml
@@ -5,9 +5,15 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <artifactId>maxgraph-parent</artifactId>
+        <groupId>com.alibaba.maxgraph</groupId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>compiler</artifactId>
     <groupId>com.alibaba.graphscope</groupId>
-    <version>1.0-SNAPSHOT</version>
 
     <properties>
         <jackson.version>2.14.0-rc1</jackson.version>

--- a/interactive_engine/data_load_tools/pom.xml
+++ b/interactive_engine/data_load_tools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
@@ -42,7 +42,7 @@
           <artifactId>hadoop-common</artifactId>
         </exclusion>
       </exclusions>
-      <version>${project.parent.version}</version>
+      <version>${revision}</version>
     </dependency>
     <dependency>
       <groupId>org.rocksdb</groupId>

--- a/interactive_engine/executor/engine/pegasus/clients/java/client/pom.xml
+++ b/interactive_engine/executor/engine/pegasus/clients/java/client/pom.xml
@@ -4,14 +4,18 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <artifactId>maxgraph-parent</artifactId>
+        <groupId>com.alibaba.maxgraph</groupId>
+        <version>${revision}</version>
+        <relativePath>../../../../../../pom.xml</relativePath>
+    </parent>
+
     <groupId>com.alibaba.pegasus</groupId>
     <artifactId>pegasus-client</artifactId>
-    <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <protobuf.version>3.19.6</protobuf.version>
-        <protoc.grpc.version>1.42.1</protoc.grpc.version>
-        <grpc.version>1.42.1</grpc.version>
+        <protoc.grpc.version>${grpc.version}</protoc.grpc.version>
     </properties>
 
     <dependencies>

--- a/interactive_engine/executor/pom.xml
+++ b/interactive_engine/executor/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/interactive_engine/frontend/pom.xml
+++ b/interactive_engine/frontend/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <artifactId>compiler</artifactId>
             <groupId>com.alibaba.graphscope</groupId>
-            <version>1.0-SNAPSHOT</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.maxgraph</groupId>

--- a/interactive_engine/frontend/pom.xml
+++ b/interactive_engine/frontend/pom.xml
@@ -15,12 +15,12 @@
         <dependency>
             <artifactId>compiler</artifactId>
             <groupId>com.alibaba.graphscope</groupId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba.maxgraph</groupId>
             <artifactId>maxgraph-common</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/interactive_engine/frontend/pom.xml
+++ b/interactive_engine/frontend/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>maxgraph-parent</artifactId>
         <groupId>com.alibaba.maxgraph</groupId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/interactive_engine/groot-module/pom.xml
+++ b/interactive_engine/groot-module/pom.xml
@@ -16,12 +16,12 @@
     <dependency>
       <groupId>com.alibaba.maxgraph</groupId>
       <artifactId>maxgraph-common</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.alibaba.maxgraph</groupId>
       <artifactId>maxgraph-sdk-common</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
         <groupId>io.grpc</groupId>

--- a/interactive_engine/groot-module/pom.xml
+++ b/interactive_engine/groot-module/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/interactive_engine/groot-server/pom.xml
+++ b/interactive_engine/groot-server/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>com.alibaba.maxgraph</groupId>
       <artifactId>sdk</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.alibaba.maxgraph</groupId>
       <artifactId>groot-module</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.logging.log4j</groupId>
@@ -42,7 +42,7 @@
     <dependency>
       <artifactId>compiler</artifactId>
       <groupId>com.alibaba.graphscope</groupId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/interactive_engine/groot-server/pom.xml
+++ b/interactive_engine/groot-server/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <artifactId>compiler</artifactId>
       <groupId>com.alibaba.graphscope</groupId>
-      <version>1.0-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/interactive_engine/groot-server/pom.xml
+++ b/interactive_engine/groot-server/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/interactive_engine/lgraph/pom.xml
+++ b/interactive_engine/lgraph/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>com.alibaba.maxgraph</groupId>
       <artifactId>executor</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 

--- a/interactive_engine/lgraph/pom.xml
+++ b/interactive_engine/lgraph/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -56,9 +56,6 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
-      <properties>
-        <revision>0.0.1-SNAPSHOT</revision>
-      </properties>
       <modules>
         <module>assembly</module>
         <module>common</module>

--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -5,7 +5,7 @@
   <groupId>com.alibaba.maxgraph</groupId>
   <artifactId>maxgraph-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>${revision}</version>
 
   <name>MaxGraph</name>
   <profiles>
@@ -68,6 +68,7 @@
   </profiles>
 
   <properties>
+    <revision>0.0.1-SNAPSHOT</revision>
     <rust.compile.skip>false</rust.compile.skip>
     <rust.compile.mode>debug</rust.compile.mode>
     <rust.compile.target>v6d</rust.compile.target>

--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -49,6 +49,9 @@
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
+      <properties>
+        <revision>0.0.1-SNAPSHOT</revision>
+      </properties>
       <modules>
         <module>assembly</module>
         <module>common</module>

--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -11,6 +11,13 @@
   <profiles>
     <!-- DO NOT CHANGE THE *ORDER* IN WHICH THESE PROFILES ARE DEFINED! -->
     <profile>
+      <id>experimental</id>
+      <modules>
+        <module>executor/engine/pegasus/clients/java/client</module>
+        <module>compiler</module>
+      </modules>
+    </profile>
+    <profile>
       <id>graphscope</id>
       <properties>
         <rust.compile.target>v6d</rust.compile.target>
@@ -105,6 +112,7 @@
     <metrics.core.version>3.2.5</metrics.core.version>
     <aliyun.oss.version>3.14.1</aliyun.oss.version>
     <skip.tests>true</skip.tests>
+    <flatten.maven.plugin>1.1.0</flatten.maven.plugin>
   </properties>
 
   <dependencyManagement>
@@ -717,5 +725,32 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>${flatten.maven.plugin}</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/interactive_engine/sdk-common/pom.xml
+++ b/interactive_engine/sdk-common/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/interactive_engine/sdk/pom.xml
+++ b/interactive_engine/sdk/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/interactive_engine/sdk/pom.xml
+++ b/interactive_engine/sdk/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.alibaba.maxgraph</groupId>
       <artifactId>maxgraph-sdk-common</artifactId>
-      <version>${project.parent.version}</version>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/interactive_engine/tests/pom.xml
+++ b/interactive_engine/tests/pom.xml
@@ -7,13 +7,12 @@
   <parent>
     <artifactId>maxgraph-parent</artifactId>
     <groupId>com.alibaba.maxgraph</groupId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>com.alibaba.maxgraph</groupId>
   <artifactId>maxgraph-tests</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->
Build a GIE target with a unified version by running `mvn clean package -Drevision=<XXX>`, default  is https://github.com/shirly121/GraphScope/blob/ir_unify_version/interactive_engine/pom.xml#L71
## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2164 

