### PR TITLE
[GIE POM] Make the version of GIE compiler consistent with the default value in interactive_engine pom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,7 +789,7 @@ jobs:
           cd interactive_engine/compiler && make build rpc.target=${RPC_TARGET}
           cd ${GITHUB_WORKSPACE}
           tar -czf artifacts.tar.gz interactive_engine/compiler/target/libs \
-            interactive_engine/compiler/target/compiler-1.0-SNAPSHOT.jar \
+            interactive_engine/compiler/target/compiler-0.0.1-SNAPSHOT.jar \
             interactive_engine/compiler/conf \
             interactive_engine/compiler/set_properties.sh \
             interactive_engine/executor/ir/target/release/libir_core.so \

--- a/charts/ir-standalone/templates/frontend/statefulset.yaml
+++ b/charts/ir-standalone/templates/frontend/statefulset.yaml
@@ -89,7 +89,7 @@ spec:
             - -c
             - |
               cd /opt/GraphScope/interactive_engine/compiler && ./set_properties.sh
-              java -cp ".:./target/libs/*:./target/compiler-1.0-SNAPSHOT.jar" \
+              java -cp ".:./target/libs/*:./target/compiler-0.0.1-SNAPSHOT.jar" \
                 -Djna.library.path=../executor/ir/target/release \
                 -Dgraph.schema=/etc/graphscope-store/config/$GRAPH_SCHEMA com.alibaba.graphscope.gremlin.service.GraphServiceMain
           {{- end }}

--- a/interactive_engine/compiler/Makefile
+++ b/interactive_engine/compiler/Makefile
@@ -16,7 +16,7 @@ graph.schema:=
 
 rpc.target:=start_rpc_server
 
-target.revision:=1.0-SNAPSHOT
+target.revision:=0.0.1-SNAPSHOT
 
 ifeq ($(UNAME_S),Darwin)
     ifeq ($(UNAME_M),arm64)
@@ -46,14 +46,14 @@ gremlin_test:
 
 submit:
 	cd $(CUR_DIR) && $(java) \
-	  -cp ".:./target/libs/*:./target/compiler-1.0-SNAPSHOT.jar" \
+	  -cp ".:./target/libs/*:./target/compiler-0.0.1-SNAPSHOT.jar" \
 	  -Djna.library.path=../executor/ir/target/release \
 	  com.alibaba.graphscope.common.SubmitPlanServiceMain \
 	  $(OPT)
 
 run:
 	cd $(CUR_DIR) && $(java) \
-	  -cp ".:./target/libs/*:./target/compiler-1.0-SNAPSHOT.jar" \
+	  -cp ".:./target/libs/*:./target/compiler-0.0.1-SNAPSHOT.jar" \
 	  -Djna.library.path=../executor/ir/target/release \
 	  -Dgraph.schema=${graph.schema} \
 	  -Dpegasus.hosts=${pegasus.hosts} \


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->
set the version of compiler as 0.0.1-SNAPSHOT (default value in pom of interactive_engine) to fix the ci issue reported by @siyuan0322 
## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

