### PR TITLE
Use a self-hosted public image to avoid reaching the download limits

### DIFF
--- a/charts/graphscope-store/templates/test/test-rpc.yaml
+++ b/charts/graphscope-store/templates/test/test-rpc.yaml
@@ -10,7 +10,7 @@ spec:
   {{- end }}
   containers:
     - name: python
-      image: registry.hub.docker.com/library/python:3.9.9-alpine3.14
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:python-3.9.9-alpine3.14
       env:
         - name: frontend
           value: {{ include "graphscope-store.frontend.fullname" . }}.{{ .Release.Namespace }}
@@ -36,7 +36,7 @@ spec:
   {{- end }}
   containers:
     - name: python
-      image: registry.hub.docker.com/library/python:3.9.9-alpine3.14
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-store:python-3.9.9-alpine3.14
       env:
         - name: frontend
           value: {{ include "graphscope-store.frontend.fullname" . }}.{{ .Release.Namespace }}


### PR DESCRIPTION

## What do these changes do?

as titled.

## Related issue number

See also: https://github.com/alibaba/GraphScope/actions/runs/3627042971/jobs/6117279514
