### PR TITLE
Accept a filetype arguments in loader for reading orc/parquet using prefix

### DIFF
--- a/coordinator/gscoordinator/op_executor.py
+++ b/coordinator/gscoordinator/op_executor.py
@@ -774,6 +774,20 @@ class OperationExecutor:
             # loader is type of attr_value_pb2.Chunk
             protocol = loader.attr[types_pb2.PROTOCOL].s.decode()
             source = loader.attr[types_pb2.SOURCE].s.decode()
+            try:
+                storage_options = json.loads(
+                    loader.attr[types_pb2.STORAGE_OPTIONS].s.decode()
+                )
+                read_options = json.loads(
+                    loader.attr[types_pb2.READ_OPTIONS].s.decode()
+                )
+            except:  # noqa: E722, pylint: disable=bare-except
+                storage_options = {}
+                read_options = {}
+            filetype = storage_options.get("filetype", None)
+            if filetype is None:
+                filetype = read_options.get("filetype", None)
+            filetype = str(filetype).upper()
             if (
                 protocol in ("hdfs", "hive", "oss", "s3")
                 or protocol == "file"
@@ -782,13 +796,8 @@ class OperationExecutor:
                     or source.endswith(".parquet")
                     or source.endswith(".pq")
                 )
+                or filetype in ["ORC", "PARQUET"]
             ):
-                storage_options = json.loads(
-                    loader.attr[types_pb2.STORAGE_OPTIONS].s.decode()
-                )
-                read_options = json.loads(
-                    loader.attr[types_pb2.READ_OPTIONS].s.decode()
-                )
                 new_protocol, new_source = _spawn_vineyard_io_stream(
                     source,
                     storage_options,

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -1672,7 +1672,7 @@ def parse_as_glog_level(log_level):
             log_level = -1
         else:
             log_level = getattr(logging, log_level.upper())
-    python_to_glog = {10: 10, 20: 1}
+    python_to_glog = {0: 100, 10: 10, 20: 1}
     return python_to_glog.get(log_level, 1)
 
 


### PR DESCRIPTION


## What do these changes do?

See changes in `loader.py`.

## Related issue number

Fixes #2328
Requires https://github.com/v6d-io/v6d/pull/1104
