### PR TITLE
Fix kafka version

### DIFF
--- a/charts/graphscope-store/Chart.yaml
+++ b/charts/graphscope-store/Chart.yaml
@@ -16,4 +16,5 @@ version: 0.19.0
 dependencies:
   - condition: kafka.enabled
     name: kafka
+    version: "20.*.*"
     repository: https://charts.bitnami.com/bitnami

--- a/charts/graphscope-store/Chart.yaml
+++ b/charts/graphscope-store/Chart.yaml
@@ -16,5 +16,4 @@ version: 0.19.0
 dependencies:
   - condition: kafka.enabled
     name: kafka
-    version: 16.*.*
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Fix `Error: can't get a valid version for repositories kafka. Try changing the version constraint in Chart.yaml`
See https://github.com/alibaba/GraphScope/actions/runs/3736733548/jobs/6341482973