### PR TITLE
Use ownerReferences to replace finalizers during helm uninstall

### DIFF
--- a/charts/graphscope/templates/coordinator.yaml
+++ b/charts/graphscope/templates/coordinator.yaml
@@ -46,14 +46,13 @@ spec:
                 - /bin/bash
                 - -c
                 - |
+                  export uid=$(kubectl get deployment coordinator-{{ include "graphscope.fullname" . }} -n {{ .Release.Namespace }} -o jsonpath='{.metadata.uid}') &&
                   kubectl patch role/{{ include "graphscope.fullname" . }}-role \
                   -n {{ .Release.Namespace }} \
-                  --type json \
-                  --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]' && \
+                  --patch '{"metadata": {"ownerReferences": {"apiVersion": "apps/v1", "kind": "Deployment","name": "coordinator-{{ include "graphscope.fullname" . }}","uid": $uid}}}' &&
                   kubectl patch rolebinding/{{ include "graphscope.fullname" . }}-role-binding \
                   -n {{ .Release.Namespace }} \
-                  --type json \
-                  --patch='[ { "op": "remove", "path": "/metadata/finalizers" } ]' && \
+                  --patch '{"metadata": {"ownerReferences": {"apiVersion": "apps/v1", "kind": "Deployment","name": "coordinator-{{ include "graphscope.fullname" . }}","uid": $uid}}}' &&
                   /opt/rh/rh-python38/root/usr/bin/python3 -m gscoordinator.hook.prestop
         args:
           - python3

--- a/charts/graphscope/templates/role_and_binding.yaml
+++ b/charts/graphscope/templates/role_and_binding.yaml
@@ -3,8 +3,6 @@ kind: Role
 metadata:
   name: {{ include "graphscope.fullname" . }}-role
   namespace: {{ .Release.Namespace }}
-  finalizers:
-  - kubernetes
 rules:
 - apiGroups: ["apps", "extensions", ""]
   resources: ["configmaps", "deployments", "deployments/status", "statefulsets", "statefulsets/status", "endpoints", "events", "pods", "pods/log", "pods/exec", "pods/status", "services", "replicasets"]
@@ -18,8 +16,6 @@ kind: RoleBinding
 metadata:
   name: {{ include "graphscope.fullname" . }}-role-binding
   namespace: {{ .Release.Namespace }}
-  finalizers:
-  - kubernetes
 subjects:
 - kind: ServiceAccount
   name: default


### PR DESCRIPTION
## What do these changes do?

In a real k8s cluster, we find the finalizers can't work as expected, and using ownerReferences to perform cascade deletion of role and rolebinding works fine.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Related https://github.com/alibaba/GraphScope/pull/2208
Related https://github.com/alibaba/GraphScope/pull/2324

