### PR TITLE
Implement ToArrowArrays method for TensorContext

### DIFF
--- a/analytical_engine/core/context/i_context.h
+++ b/analytical_engine/core/context/i_context.h
@@ -333,6 +333,12 @@ class ITensorContextWrapper : public IContextWrapper {
 
   virtual bl::result<vineyard::ObjectID> ToVineyardDataframe(
       const grape::CommSpec& comm_spec, vineyard::Client& client) = 0;
+
+  virtual bl::result<
+      std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>>
+    ToArrowArrays(
+      const grape::CommSpec& comm_spec,
+      const std::vector<std::pair<std::string, Selector>>& selectors) = 0;
 };
 
 }  // namespace gs

--- a/analytical_engine/core/context/i_context.h
+++ b/analytical_engine/core/context/i_context.h
@@ -336,7 +336,7 @@ class ITensorContextWrapper : public IContextWrapper {
 
   virtual bl::result<
       std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>>
-    ToArrowArrays(
+  ToArrowArrays(
       const grape::CommSpec& comm_spec,
       const std::vector<std::pair<std::string, Selector>>& selectors) = 0;
 };

--- a/analytical_engine/core/context/tensor_context.h
+++ b/analytical_engine/core/context/tensor_context.h
@@ -545,7 +545,8 @@ class TensorContextWrapper : public ITensorContextWrapper {
       switch (selector.type()) {
       case SelectorType::kResult: {
         typename vineyard::ConvertToArrowType<data_t>::BuilderType builder;
-        std::shared_ptr<typename vineyard::ConvertToArrowType<data_t>::ArrayType> arr_ptr;
+        std::shared_ptr<
+            typename vineyard::ConvertToArrowType<data_t>::ArrayType> arr_ptr;
         for (size_t offset = 0; offset < tensor.size(); offset++) {
           ARROW_OK_OR_RAISE(builder.Append(tensor.data()[offset]));
         }
@@ -554,10 +555,10 @@ class TensorContextWrapper : public ITensorContextWrapper {
         break;
       }
       default:
-        RETURN_GS_ERROR(
-            vineyard::ErrorCode::kUnsupportedOperationError,
-            "Unsupported operation, available selector type: result. selector: " +
-                selector.str());
+        RETURN_GS_ERROR(vineyard::ErrorCode::kUnsupportedOperationError,
+                        "Unsupported operation, available selector type: "
+                        "result. selector: " +
+                            selector.str());
       }
       arrow_arrays.emplace_back(col_name, arr);
     }
@@ -714,10 +715,10 @@ class TensorContextWrapper<FRAG_T, std::string> : public ITensorContextWrapper {
         break;
       }
       default:
-        RETURN_GS_ERROR(
-            vineyard::ErrorCode::kUnsupportedOperationError,
-            "Unsupported operation, available selector type: result. selector: " +
-                selector.str());
+        RETURN_GS_ERROR(vineyard::ErrorCode::kUnsupportedOperationError,
+                        "Unsupported operation, available selector type: "
+                        "result. selector: " +
+                            selector.str());
       }
       arrow_arrays.emplace_back(col_name, arr);
     }

--- a/analytical_engine/core/context/tensor_context.h
+++ b/analytical_engine/core/context/tensor_context.h
@@ -530,6 +530,40 @@ class TensorContextWrapper : public ITensorContextWrapper {
     return vy_obj->id();
   }
 
+  bl::result<std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>>
+  ToArrowArrays(
+      const grape::CommSpec& comm_spec,
+      const std::vector<std::pair<std::string, Selector>>& selectors) override {
+    auto& frag = ctx_->fragment();
+    auto& tensor = ctx_->tensor();
+    std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>
+        arrow_arrays;
+    for (auto& pair : selectors) {
+      auto& col_name = pair.first;
+      auto& selector = pair.second;
+      std::shared_ptr<arrow::Array> arr;
+      switch (selector.type()) {
+      case SelectorType::kResult: {
+        typename vineyard::ConvertToArrowType<data_t>::BuilderType builder;
+        std::shared_ptr<typename vineyard::ConvertToArrowType<data_t>::ArrayType> arr_ptr;
+        for (size_t offset = 0; offset < tensor.size(); offset++) {
+          ARROW_OK_OR_RAISE(builder.Append(tensor.data()[offset]));
+        }
+        CHECK_ARROW_ERROR(builder.Finish(&arr_ptr));
+        arr = std::dynamic_pointer_cast<arrow::Array>(arr_ptr);
+        break;
+      }
+      default:
+        RETURN_GS_ERROR(
+            vineyard::ErrorCode::kUnsupportedOperationError,
+            "Unsupported operation, available selector type: result. selector: " +
+                selector.str());
+      }
+      arrow_arrays.emplace_back(col_name, arr);
+    }
+    return arrow_arrays;
+  }
+
  private:
   std::shared_ptr<IFragmentWrapper> frag_wrapper_;
   std::shared_ptr<context_t> ctx_;
@@ -660,6 +694,34 @@ class TensorContextWrapper<FRAG_T, std::string> : public ITensorContextWrapper {
       const grape::CommSpec& comm_spec, vineyard::Client& client) override {
     RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
                     "Not implemented ToVineyardDataframe for string type");
+  }
+
+  bl::result<std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>>
+  ToArrowArrays(
+      const grape::CommSpec& comm_spec,
+      const std::vector<std::pair<std::string, Selector>>& selectors) override {
+    auto& frag = ctx_->fragment();
+    auto& tensor = ctx_->tensor();
+    std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>
+        arrow_arrays;
+    for (auto& pair : selectors) {
+      auto& col_name = pair.first;
+      auto& selector = pair.second;
+      std::shared_ptr<arrow::Array> arr;
+      switch (selector.type()) {
+      case SelectorType::kResult: {
+        arr = std::dynamic_pointer_cast<arrow::Array>(tensor.data());
+        break;
+      }
+      default:
+        RETURN_GS_ERROR(
+            vineyard::ErrorCode::kUnsupportedOperationError,
+            "Unsupported operation, available selector type: result. selector: " +
+                selector.str());
+      }
+      arrow_arrays.emplace_back(col_name, arr);
+    }
+    return arrow_arrays;
   }
 
  private:
@@ -974,6 +1036,14 @@ class TensorContextWrapper<
     builder.AddChunk(df_chunk_id);
 
     return builder.Seal(client)->id();
+  }
+
+  bl::result<std::vector<std::pair<std::string, std::shared_ptr<arrow::Array>>>>
+  ToArrowArrays(
+      const grape::CommSpec& comm_spec,
+      const std::vector<std::pair<std::string, Selector>>& selectors) override {
+    RETURN_GS_ERROR(vineyard::ErrorCode::kInvalidOperationError,
+                    "Not implemented ToArrowArrays for dynamic type");
   }
 
  private:

--- a/analytical_engine/core/context/tensor_context.h
+++ b/analytical_engine/core/context/tensor_context.h
@@ -546,7 +546,8 @@ class TensorContextWrapper : public ITensorContextWrapper {
       case SelectorType::kResult: {
         typename vineyard::ConvertToArrowType<data_t>::BuilderType builder;
         std::shared_ptr<
-            typename vineyard::ConvertToArrowType<data_t>::ArrayType> arr_ptr;
+            typename vineyard::ConvertToArrowType<data_t>::ArrayType>
+            arr_ptr;
         for (size_t offset = 0; offset < tensor.size(); offset++) {
           ARROW_OK_OR_RAISE(builder.Append(tensor.data()[offset]));
         }

--- a/analytical_engine/core/context/tensor_context.h
+++ b/analytical_engine/core/context/tensor_context.h
@@ -43,6 +43,7 @@
 #include "core/config.h"
 #include "core/context/context_protocols.h"
 #include "core/context/i_context.h"
+#include "core/context/selector.h"
 #include "core/context/tensor_dataframe_builder.h"
 #include "core/error.h"
 #include "core/utils/mpi_utils.h"


### PR DESCRIPTION

## What do these changes do?
These changes add implementation of ToArrowArrays method for TensorContext to enable convert tensor context to arrow::Table.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

