### PR TITLE
Fix compile error under newer toolchain and arrow 10

### DIFF
--- a/analytical_engine/core/server/analytical_server.h
+++ b/analytical_engine/core/server/analytical_server.h
@@ -20,9 +20,7 @@
 #include <string>
 #include <utility>
 
-namespace grpc {
-class Server;
-}  // namespace grpc
+#include "grpcpp/server.h"
 
 namespace gs {
 class Dispatcher;

--- a/analytical_engine/core/server/graphscope_service.cc
+++ b/analytical_engine/core/server/graphscope_service.cc
@@ -32,9 +32,6 @@
 #include "graphscope/proto/message.pb.h"
 #include "graphscope/proto/op_def.pb.h"
 
-namespace grpc {
-class ServerContext;
-}  // namespace grpc
 
 namespace gs {
 struct CommandDetail;

--- a/analytical_engine/core/server/graphscope_service.cc
+++ b/analytical_engine/core/server/graphscope_service.cc
@@ -32,7 +32,6 @@
 #include "graphscope/proto/message.pb.h"
 #include "graphscope/proto/op_def.pb.h"
 
-
 namespace gs {
 struct CommandDetail;
 

--- a/analytical_engine/core/server/graphscope_service.h
+++ b/analytical_engine/core/server/graphscope_service.h
@@ -23,16 +23,15 @@
 #include <vector>
 
 #include "boost/lexical_cast.hpp"
+#include "grpcpp/server_context.h"
 #include "grpcpp/support/status.h"
 #include "grpcpp/support/status_code_enum.h"
 #include "grpcpp/support/sync_stream.h"
-#include "grpcpp/server_context.h"
 
 #include "core/server/dispatcher.h"
 #include "graphscope/proto/engine_service.grpc.pb.h"
 #include "graphscope/proto/message.pb.h"
 #include "graphscope/proto/op_def.pb.h"
-
 
 namespace gs {
 namespace rpc {

--- a/analytical_engine/core/server/graphscope_service.h
+++ b/analytical_engine/core/server/graphscope_service.h
@@ -25,17 +25,14 @@
 #include "boost/lexical_cast.hpp"
 #include "grpcpp/support/status.h"
 #include "grpcpp/support/status_code_enum.h"
+#include "grpcpp/support/sync_stream.h"
+#include "grpcpp/server_context.h"
 
 #include "core/server/dispatcher.h"
 #include "graphscope/proto/engine_service.grpc.pb.h"
 #include "graphscope/proto/message.pb.h"
 #include "graphscope/proto/op_def.pb.h"
 
-namespace grpc {
-class ServerContext;
-template <class W, class R>
-class ServerReaderWriter;
-}  // namespace grpc
 
 namespace gs {
 namespace rpc {

--- a/interactive_engine/executor/store/global_query/build.rs
+++ b/interactive_engine/executor/store/global_query/build.rs
@@ -30,6 +30,7 @@ fn codegen_inplace() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("cargo:rustc-link-search=/usr/local/lib");
     println!("cargo:rustc-link-search=/usr/local/lib64");
+    println!("cargo:rustc-link-search=/opt/vineyard/lib");
     println!("cargo:rustc-link-search=/opt/homebrew/lib");
     println!("cargo:rustc-link-search={}/build", dst.display());
     println!("cargo:rustc-link-lib=v6d_native_store");

--- a/interactive_engine/executor/store/global_query/src/store_impl/v6d/native/CMakeLists.txt
+++ b/interactive_engine/executor/store/global_query/src/store_impl/v6d/native/CMakeLists.txt
@@ -5,7 +5,14 @@ if(POLICY CMP0025)
   cmake_policy(SET CMP0025 NEW)
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++17" HAS_STDCXX_17)
+if (HAS_STDCXX_17)
+    set(CMAKE_CXX_STANDARD 14)
+else()
+    set(CMAKE_CXX_STANDARD 14)
+endif()
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 SET(DEFAULT_BUILD_TYPE "Release")
@@ -41,7 +48,7 @@ macro(install_vineyard_target target)
 endmacro()
 
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wno-deprecated-declarations")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations")
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)


### PR DESCRIPTION
Fix several build failures
- Fix build gae with grpc 1.30 (which is the default version of ubuntu:latest)
- Fix build gie and gle with arrow10 and gcc11