### PR TITLE
Fixes the performance issue in `Project()`

### DIFF
--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.11.6
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.11.7
       options:
         --shm-size 4096m
     steps:

--- a/.github/workflows/networkx-forward-algo-nightly.yml
+++ b/.github/workflows/networkx-forward-algo-nightly.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.11.6
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.11.7
       options:
         --shm-size 4096m
 

--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -234,7 +234,7 @@ else()
 endif()
 
 # find vineyard after arrow to avoid duplicate target names
-find_package(vineyard 0.11.6 REQUIRED)
+find_package(vineyard 0.11.7 REQUIRED)
 include_directories(${VINEYARD_INCLUDE_DIRS})
 add_compile_options(-DENABLE_SELECTOR)
 

--- a/analytical_engine/test/app_tests.sh
+++ b/analytical_engine/test/app_tests.sh
@@ -184,9 +184,9 @@ function run_vy() {
     if [ "$first" = true ]
         then
           first=false
-          cmd="${cmd}${e_prefix}_${src}_${dst}_${e}#src_label=v${src}&dst_label=v${dst}&label=e${e}"
+          cmd="${cmd}${e_prefix}_${src}_${dst}_${e}#header_row=True#src_label=v${src}&dst_label=v${dst}&label=e${e}"
         else
-          cmd="${cmd};${e_prefix}_${src}_${dst}_${e}#src_label=v${src}&dst_label=v${dst}&label=e${e}"
+          cmd="${cmd};${e_prefix}_${src}_${dst}_${e}#header_row=True#src_label=v${src}&dst_label=v${dst}&label=e${e}"
     fi
       done
     done
@@ -195,7 +195,7 @@ function run_vy() {
 
   cmd="${cmd} ${v_label_num}"
   for ((i = 0; i < v_label_num; i++)); do
-    cmd="${cmd} ${v_prefix}_${i}#label=v${i}"
+    cmd="${cmd} ${v_prefix}_${i}#header_row=True#label=v${i}"
   done
 
   cmd="${cmd} $*"
@@ -230,12 +230,12 @@ function run_vy_2() {
 
   cmd="${cmd} ${label_num}"
   for ((i = 0; i < label_num; i++)); do
-    cmd="${cmd} '${e_prefix}_${i}#src_label=v${i}&dst_label=v${i}&label=e${i}'"
+    cmd="${cmd} '${e_prefix}_${i}#header_row=True#src_label=v${i}&dst_label=v${i}&label=e${i}'"
   done
 
   cmd="${cmd} ${label_num}"
   for ((i = 0; i < label_num; i++)); do
-    cmd="${cmd} '${v_prefix}_${i}#label=v${i}'"
+    cmd="${cmd} '${v_prefix}_${i}#header_row=True#label=v${i}'"
   done
 
   cmd="${cmd} $*"
@@ -260,16 +260,16 @@ function run_sampling_path() {
   cmd="${cmd_prefix} -n ${num_procs} --host localhost:${num_procs} ${executable} ${socket_file}"
 
   cmd="${cmd} 5"
-  cmd="${cmd} '${data_dir}/sampling_path_1000_e_0#src_label=v0&dst_label=v1&label=e0'"
-  cmd="${cmd} '${data_dir}/sampling_path_1000_e_1#src_label=v0&dst_label=v2&label=e1'"
-  cmd="${cmd} '${data_dir}/sampling_path_1000_e_2#src_label=v0&dst_label=v2&label=e2'"
-  cmd="${cmd} '${data_dir}/sampling_path_1000_e_3#src_label=v0&dst_label=v2&label=e3'"
-  cmd="${cmd} '${data_dir}/sampling_path_1000_e_4#src_label=v1&dst_label=v2&label=e4'"
+  cmd="${cmd} '${data_dir}/sampling_path_1000_e_0#header_row=True#src_label=v0&dst_label=v1&label=e0'"
+  cmd="${cmd} '${data_dir}/sampling_path_1000_e_1#header_row=True#src_label=v0&dst_label=v2&label=e1'"
+  cmd="${cmd} '${data_dir}/sampling_path_1000_e_2#header_row=True#src_label=v0&dst_label=v2&label=e2'"
+  cmd="${cmd} '${data_dir}/sampling_path_1000_e_3#header_row=True#src_label=v0&dst_label=v2&label=e3'"
+  cmd="${cmd} '${data_dir}/sampling_path_1000_e_4#header_row=True#src_label=v1&dst_label=v2&label=e4'"
 
   cmd="${cmd} 3"
-  cmd="${cmd} '${data_dir}/sampling_path_1000_v_0#label=v0'"
-  cmd="${cmd} '${data_dir}/sampling_path_1000_v_1#label=v1'"
-  cmd="${cmd} '${data_dir}/sampling_path_1000_v_2#label=v2'"
+  cmd="${cmd} '${data_dir}/sampling_path_1000_v_0#header_row=True#label=v0'"
+  cmd="${cmd} '${data_dir}/sampling_path_1000_v_1#header_row=True#label=v1'"
+  cmd="${cmd} '${data_dir}/sampling_path_1000_v_2#header_row=True#label=v2'"
 
   cmd="${cmd} $*"
 
@@ -298,12 +298,12 @@ function run_lpa() {
 
   cmd="${cmd} ${e_label_num}"
   for ((i = 0; i < e_label_num; i++)); do
-    cmd="${cmd} '${e_prefix}_${i}#src_label=v0&dst_label=v1&label=e${i}'"
+    cmd="${cmd} '${e_prefix}_${i}#header_row=True#src_label=v0&dst_label=v1&label=e${i}'"
   done
 
   cmd="${cmd} ${v_label_num}"
   for ((i = 0; i < v_label_num; i++)); do
-    cmd="${cmd} '${v_prefix}_${i}#label=v${i}'"
+    cmd="${cmd} '${v_prefix}_${i}#header_row=True#label=v${i}'"
   done
 
   cmd="${cmd} $*"
@@ -333,12 +333,12 @@ function run_local_vertex_map() {
 
   cmd="${cmd} ${e_label_num}"
   for ((i = 0; i < e_label_num; i++)); do
-    cmd="${cmd} '${e_prefix}_${i}#src_label=v0&dst_label=v0&label=e${i}'"
+    cmd="${cmd} '${e_prefix}_${i}#header_row=True#src_label=v0&dst_label=v0&label=e${i}'"
   done
 
   cmd="${cmd} ${v_label_num}"
   for ((i = 0; i < v_label_num; i++)); do
-    cmd="${cmd} '${v_prefix}_${i}#label=v${i}'"
+    cmd="${cmd} '${v_prefix}_${i}#header_row=True#label=v${i}'"
   done
 
   cmd="${cmd} $*"
@@ -433,8 +433,8 @@ then
     echo "Running Java tests..."
     run_vy_2 ${np} ./run_java_app "${socket_file}" 1 "${test_dir}"/projected_property/twitter_property_e "${test_dir}"/projected_property/twitter_property_v 1 0 1 com.alibaba.graphscope.example.bfs.BFS
     GLOG_v=10 ./run_java_string_app /tmp/vineyard.sock \
-        1 "${test_dir}/projected_property/twitter_property_e_0#src_label=v&dst_label=v&label=e&include_all_columns=true&column_types=int64_t,int64_t,int32_t,int32_t,std::string" \
-        1 "${test_dir}/projected_property/twitter_property_v_0#label=v&include_all_columns=true&column_types=int64_t,std::string" \
+        1 "${test_dir}/projected_property/twitter_property_e_0#header_row=True#src_label=v&dst_label=v&label=e&include_all_columns=true&column_types=int64_t,int64_t,int32_t,int32_t,std::string" \
+        1 "${test_dir}/projected_property/twitter_property_v_0#header_row=True#label=v&include_all_columns=true&column_types=int64_t,std::string" \
         com.alibaba.graphscope.example.stringApp.StringApp
 
     echo "Running girpah tests..."

--- a/interactive_engine/executor/store/global_query/src/store_impl/v6d/native/CMakeLists.txt
+++ b/interactive_engine/executor/store/global_query/src/store_impl/v6d/native/CMakeLists.txt
@@ -57,7 +57,7 @@ find_package(Threads REQUIRED)
 #  we need edge src/dst ids in etable.
 add_definitions(-DENDPOINT_LISTS)
 
-find_package(vineyard 0.11.6 REQUIRED)
+find_package(vineyard 0.11.7 REQUIRED)
 add_library(v6d_native_store global_store_ffi.cc
                          htap_ds_impl.cc
                          graph_builder_ffi.cc

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -7,7 +7,7 @@ ifeq ($(REGISTRY),)
 endif
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.11.6
+VINEYARD_VERSION ?= v0.11.7
 # This is the version of builder base image in most cases, except for graphscope-dev
 BUILDER_VERSION ?= $(VINEYARD_VERSION)
 # This is the version of runtime base image

--- a/k8s/actions-runner-controller/manylinux/Makefile
+++ b/k8s/actions-runner-controller/manylinux/Makefile
@@ -12,7 +12,7 @@ TARGETPLATFORM ?= $(shell arch)
 RUNNER_VERSION ?= 2.287.1
 DOCKER_VERSION ?= 20.10.12
 
-VINEYARD_VERSION ?= v0.11.6
+VINEYARD_VERSION ?= v0.11.7
 BUILDER_VERSION ?= $(VINEYARD_VERSION)
 
 # default list of platforms for which multiarch image is built

--- a/k8s/build_scripts/build_vineyard.sh
+++ b/k8s/build_scripts/build_vineyard.sh
@@ -17,7 +17,7 @@ cd ${WORKDIR} && \
 # Vineyard
 echo "Installing vineyard"
 cd ${WORKDIR} && \
-    git clone -b v0.11.6 https://github.com/v6d-io/v6d.git --depth=1 && \
+    git clone -b v0.11.7 https://github.com/v6d-io/v6d.git --depth=1 && \
     pushd v6d && \
     git submodule update --init && \
     cmake . -DCMAKE_PREFIX_PATH=/opt/vineyard \

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -31,7 +31,7 @@ else
 endif
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.11.6
+VINEYARD_VERSION ?= v0.11.7
 PROFILE ?= release
 CI ?= false
 

--- a/python/graphscope/config.py
+++ b/python/graphscope/config.py
@@ -68,7 +68,7 @@ class GSConfig(object):
 
     # vineyard resource configuration
     # image for vineyard container
-    k8s_vineyard_image = "vineyardcloudnative/vineyardd:v0.11.6"
+    k8s_vineyard_image = "vineyardcloudnative/vineyardd:v0.11.7"
     k8s_vineyard_daemonset = None
     k8s_vineyard_cpu = 0.5
     k8s_vineyard_mem = "512Mi"

--- a/python/graphscope/learning/__init__.py
+++ b/python/graphscope/learning/__init__.py
@@ -23,6 +23,9 @@ import sys
 try:
     sys.path.insert(0, os.path.dirname(__file__))
 
+    # adapt to latest graph-learn where "import ego_data_loader" is directly used
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "examples", "tf"))
+
     import vineyard
 
     # suppress the warnings of tensorflow
@@ -78,3 +81,6 @@ except ImportError:
     pass
 finally:
     sys.path.pop(sys.path.index(os.path.dirname(__file__)))
+    sys.path.pop(
+        sys.path.index(os.path.join(os.path.dirname(__file__), "examples", "tf"))
+    )

--- a/python/graphscope/tests/unittest/test_context.py
+++ b/python/graphscope/tests/unittest/test_context.py
@@ -82,15 +82,26 @@ def test_context_output(simple_context):
     )
 
 
-def test_add_column_after_computation(arrow_property_graph):
-    sg = arrow_property_graph.project(vertices={"v0": ["id"]}, edges={"e0": ["weight"]})
+@pytest.mark.parametrize(
+    "v_label,e_label",
+    [
+        ("v0", "e0"),
+        ("v0", "e1"),
+        ("v1", "e0"),
+        ("v1", "e1"),
+    ],
+)
+def test_add_column_after_computation(arrow_property_graph, v_label, e_label):
+    sg = arrow_property_graph.project(
+        vertices={v_label: ["id"]}, edges={e_label: ["weight"]}
+    )
     ret = sssp(sg, 20)
     g2 = arrow_property_graph.add_column(
         ret, {"id_col": "v.id", "data_col": "v.data", "result_col": "r"}
     )
-    assert "id_col" in [p.name for p in g2.schema.get_vertex_properties("v0")]
-    assert "data_col" in [p.name for p in g2.schema.get_vertex_properties("v0")]
-    assert "result_col" in [p.name for p in g2.schema.get_vertex_properties("v0")]
+    assert "id_col" in [p.name for p in g2.schema.get_vertex_properties(v_label)]
+    assert "data_col" in [p.name for p in g2.schema.get_vertex_properties(v_label)]
+    assert "result_col" in [p.name for p in g2.schema.get_vertex_properties(v_label)]
 
 
 def test_lpa_u2i(arrow_property_graph_lpa_u2i):

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.11.6"  # vineyard version
-readonly V6D_BRANCH="v0.11.6" # vineyard branch
+readonly V6D_VERSION="0.11.7"  # vineyard version
+readonly V6D_BRANCH="v0.11.7" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true


### PR DESCRIPTION
## What do these changes do?

`ProjectToSimple()` requires scan all edges to establish the new offset ranges. The previous implements runs slow (slower than scan edges for many times in pagerank) because

- It use a scan implementation to find the start and end point for a given label. As the CSR is internally sorted, a bisect could be enough, the complexity is `O(E)`.
- It use a single-thread implementation for vertices
- The method `getRangeOfLabel` takes `std::shared_ptr` as argument, the shared ptr would be constructed and destructed for `O(V)` times. 

This PR optimize the implementation. Benchmark shows that it improve the `Project()` operation from `2~3 seconds` to `0.02~0.1 seconds` (consider the overhead of creating threads for parallelism) on an internal datasets. (PageRank requires about `0.02~0.03 seconds` to scan the edges).

## Related issue number

Part of #1300

