### PR TITLE
[GIE/Docs] update path_expand examples in docs

### DIFF
--- a/docs/supported_gremlin_steps.md
+++ b/docs/supported_gremlin_steps.md
@@ -759,10 +759,17 @@ The following steps will remain unsupported.
 * repeat().times() </br>
 In graph pattern scenarios, `repeat().times()` can be replaced equivalently by the `PathExpand`-step.
     ```bash
-    # = g.V().out("1..3", "knows").endV()
+    # = g.V().out("2..3", "knows").endV()
     g.V().repeat(out("knows")).times(2)
-    # = g.V().out("1..3", "knows").with('PATH_OPT', 'SIMPLE').endV()
+  
+    # = g.V().out("1..3", "knows").endV()
+    g.V().repeat(out("knows")).emit().times(2)
+  
+    # = g.V().out("2..3", "knows").with('PATH_OPT', 'SIMPLE').endV()
     g.V().repeat(out("knows").simplePath()).times(2)
+  
+    # = g.V().out("1..3", "knows").with('PATH_OPT', 'SIMPLE').endV()
+    g.V().repeat(out("knows").simplePath()).emit().times(2)
     ```
 * repeat().until() </br>
 It is a imperative syntax, not declarative.

--- a/tutorials/07_interactive_query_with_gremlin.ipynb
+++ b/tutorials/07_interactive_query_with_gremlin.ipynb
@@ -113,11 +113,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q3 = interactive.execute(\"g.V().group().by().by(bothE().count())\").all()\n",
+    "q3 = interactive.execute(\"g.V().as('a').bothE().groupCount().by(select('a'))\").all()\n",
     "for p in q3:\n",
     "    print(p)\n",
     "\n",
-    "q4 = interactive.execute(\"g.V().group().by().by(inE().count())\").all()\n",
+    "q4 = interactive.execute(\"g.V().as('a').inE().groupCount().by(select('a'))\").all()\n",
     "for p in q4:\n",
     "    print(p)"
    ]
@@ -137,7 +137,7 @@
    "outputs": [],
    "source": [
     "q5 = interactive.execute(\n",
-    "    'g.V().as(\"u\").repeat(out().simplePath()).times(2).where(out().where(eq(\"u\"))).count()'\n",
+    "    'g.V().as(\"u\").out('2..3').with('PATH_OPT', 'SIMPLE').endV().where(out().where(eq(\"u\"))).count()'\n",
     ")\n",
     "print(q5.one())"
    ]


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. rewrite `repeat.times(..)` (unsupported in GIE currently) as `path_expand` in jupyter docs.
2. rewrite examples of illustrating transformations between `repeat` and `path_expand` in docs.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

