### PR TITLE
[BUG Fix] fix bug when fetch properties of tags generated by a `Project`

### DIFF
--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/integration/IrGremlinQueryTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/integration/IrGremlinQueryTest.java
@@ -42,6 +42,8 @@ public abstract class IrGremlinQueryTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Object> get_g_V_hasLabel_hasId_values();
 
+    public abstract Traversal<Vertex, Object> get_g_V_out_as_a_in_select_a_as_b_select_b_by_values();
+
     @Test
     public void g_V_group_by_by_dedup_count_test() {
         Traversal<Vertex, Map<Object, Long>> traversal =
@@ -114,6 +116,23 @@ public abstract class IrGremlinQueryTest extends AbstractGremlinProcessTest {
         Assert.assertEquals(1, counter);
     }
 
+    @Test
+    public void g_V_out_as_a_in_select_a_as_b_select_b_by_valueMap() {
+        Traversal<Vertex, Object> traversal = this.get_g_V_out_as_a_in_select_a_as_b_select_b_by_values();
+        this.printTraversalForm(traversal);
+        int counter = 0;
+
+        List<String> expected = Arrays.asList("lop", "vadas", "josh", "ripple");
+
+        while (traversal.hasNext()) {
+            Object result = traversal.next();
+            Assert.assertTrue(expected.contains(result.toString()));
+            ++counter;
+        }
+
+        Assert.assertEquals(12, counter);
+    }
+
     public static class Traversals extends IrGremlinQueryTest {
 
         @Override
@@ -140,6 +159,11 @@ public abstract class IrGremlinQueryTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Object> get_g_V_hasLabel_hasId_values() {
             return g.V().hasLabel("person").has("id", 1).values("name");
+        }
+
+        @Override
+        public Traversal<Vertex, Object> get_g_V_out_as_a_in_select_a_as_b_select_b_by_values() {
+            return g.V().out().as("a").in().select("a").as("b").select("b").values("name");
         }
     }
 }

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/integration/IrGremlinQueryTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/integration/IrGremlinQueryTest.java
@@ -42,7 +42,8 @@ public abstract class IrGremlinQueryTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Object> get_g_V_hasLabel_hasId_values();
 
-    public abstract Traversal<Vertex, Object> get_g_V_out_as_a_in_select_a_as_b_select_b_by_values();
+    public abstract Traversal<Vertex, Object>
+            get_g_V_out_as_a_in_select_a_as_b_select_b_by_values();
 
     @Test
     public void g_V_group_by_by_dedup_count_test() {
@@ -118,7 +119,8 @@ public abstract class IrGremlinQueryTest extends AbstractGremlinProcessTest {
 
     @Test
     public void g_V_out_as_a_in_select_a_as_b_select_b_by_valueMap() {
-        Traversal<Vertex, Object> traversal = this.get_g_V_out_as_a_in_select_a_as_b_select_b_by_values();
+        Traversal<Vertex, Object> traversal =
+                this.get_g_V_out_as_a_in_select_a_as_b_select_b_by_values();
         this.printTraversalForm(traversal);
         int counter = 0;
 

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/integration/pattern/PatternQueryTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/integration/pattern/PatternQueryTest.java
@@ -57,6 +57,8 @@ public abstract class PatternQueryTest extends AbstractGremlinProcessTest {
 
     public abstract Traversal<Vertex, Long> get_pattern_15_test();
 
+    public abstract Traversal<Vertex, Long> get_pattern_16_test();
+
     @Test
     public void run_pattern_1_test() {
         Traversal<Vertex, Long> traversal = this.get_pattern_1_test();
@@ -297,6 +299,22 @@ public abstract class PatternQueryTest extends AbstractGremlinProcessTest {
         Assert.assertEquals(1, counter);
     }
 
+    @Test
+    public void run_pattern_16_test() {
+        Traversal<Vertex, Long> traversal = this.get_pattern_16_test();
+        this.printTraversalForm(traversal);
+        int counter = 0;
+
+        String expected = "33380";
+        while (traversal.hasNext()) {
+            Long bindings = traversal.next();
+            Assert.assertTrue(bindings.toString().equals(expected));
+            ++counter;
+        }
+
+        Assert.assertEquals(1, counter);
+    }
+
     public static class Traversals extends PatternQueryTest {
 
         // PM1
@@ -499,6 +517,18 @@ public abstract class PatternQueryTest extends AbstractGremlinProcessTest {
                             __.as("a").out("KNOWS").as("c"))
                     .select("a", "b", "c")
                     .by("firstName")
+                    .by("firstName")
+                    .by("firstName")
+                    .count();
+        }
+
+        // support project properties when project (implicitly) user-given tags after pattern match
+        @Override
+        public Traversal<Vertex, Long> get_pattern_16_test() {
+            return g.V().match(
+                            __.as("a").out("KNOWS").out("KNOWS").as("c"),
+                            __.as("a").out("KNOWS").as("c"))
+                    .select("a", "c")
                     .by("firstName")
                     .by("firstName")
                     .count();

--- a/interactive_engine/executor/store/global_query/src/store_impl/v6d/read_ffi.rs
+++ b/interactive_engine/executor/store/global_query/src/store_impl/v6d/read_ffi.rs
@@ -1,8 +1,6 @@
 use std::ffi::{CStr, CString};
 use std::sync::Arc;
 
-use itertools::Itertools;
-
 use crate::store_api::*;
 pub type GraphId = i64;
 type GetVertexIterator = *const ::libc::c_void;
@@ -950,7 +948,7 @@ impl GlobalGraphQuery for FFIGraphStore {
             .iter()
             .map(|v| *v as FfiLabelId)
             .collect();
-        partition_ids.iter().foreach(|partition_id| {
+        partition_ids.iter().for_each(|partition_id| {
             let label_count = labels.len() as i32;
             let iter = unsafe {
                 v6d_get_all_vertices(


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. Fix the bug when we want to fetch properties of tags that generated by `Project` opr,
e.g., `g.V().out().as("a").in().select("a").as("b").select("b").by("name")`
2. Further replace `Auxilia` (to remove unnecessary system-given tags) by `Project` (to project necessary user-given tags) in `Pattern`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2401

