### PR TITLE
Integrate vineyard operator python API with Graphscope

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -401,7 +401,7 @@ jobs:
           git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
 
           # create a kubernetes cluster with 2 nodes
-          minikube start --nodes 2 --cpus='12' --memory='32000mb' --disk-size='40000mb' \
+          minikube start --nodes 2 --cpus='6' --memory='32000mb' --disk-size='40000mb' \
                          --mount=true --mount-string="${GS_TEST_DIR}:${GS_TEST_DIR}"
 
           export GS_REGISTRY=""

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -400,8 +400,8 @@ jobs:
           # download dataset
           git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
 
-          minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.30' \
-                         --cpus='12' --memory='32000mb' --disk-size='40000mb' \
+          # create a kubernetes cluster with 2 nodes
+          minikube start --nodes 2 --cpus='12' --memory='32000mb' --disk-size='40000mb' \
                          --mount=true --mount-string="${GS_TEST_DIR}:${GS_TEST_DIR}"
 
           export GS_REGISTRY=""

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -402,7 +402,7 @@ jobs:
 
           # create a kubernetes cluster with 2 nodes
           minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.32' \
-                         --nodes 2 --cpus='6' --memory='30000mb' --disk-size='40000mb' \
+                         --nodes 2 --cpus='6' --memory='16000mb' --disk-size='20000mb' \
                          --mount=true --mount-string="${GS_TEST_DIR}:${GS_TEST_DIR}"
 
           export GS_REGISTRY=""

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -402,7 +402,7 @@ jobs:
 
           # create a kubernetes cluster with 2 nodes
           minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.32' \
-                         --nodes 2 --cpus='6' --memory='32000mb' --disk-size='40000mb' \
+                         --nodes 2 --cpus='6' --memory='30000mb' --disk-size='40000mb' \
                          --mount=true --mount-string="${GS_TEST_DIR}:${GS_TEST_DIR}"
 
           export GS_REGISTRY=""

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -400,10 +400,14 @@ jobs:
           # download dataset
           git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
 
+          minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.30' \
+                         --cpus='12' --memory='32000mb' --disk-size='40000mb' \
+
           # create a kubernetes cluster with 2 nodes
-          minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.32' \
-                         --nodes 2 --cpus='6' --memory='16000mb' --disk-size='20000mb' \
-                         --mount=true --mount-string="${GS_TEST_DIR}:${GS_TEST_DIR}"
+          #TODO(caoye)
+          #minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.32' \
+          #               --nodes 2 --cpus='6' --memory='16000mb' --disk-size='20000mb' \
+          #               --mount=true --mount-string="${GS_TEST_DIR}:${GS_TEST_DIR}"
 
           export GS_REGISTRY=""
           export GS_TAG=${SHORT_SHA}

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -401,7 +401,8 @@ jobs:
           git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
 
           # create a kubernetes cluster with 2 nodes
-          minikube start --nodes 2 --cpus='6' --memory='32000mb' --disk-size='40000mb' \
+          minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.30' \
+                         --nodes 2 --cpus='6' --memory='32000mb' --disk-size='40000mb' \
                          --mount=true --mount-string="${GS_TEST_DIR}:${GS_TEST_DIR}"
 
           export GS_REGISTRY=""

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -401,7 +401,7 @@ jobs:
           git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
 
           # create a kubernetes cluster with 2 nodes
-          minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.30' \
+          minikube start --base-image='registry-vpc.cn-hongkong.aliyuncs.com/graphscope/kicbase:v0.0.32' \
                          --nodes 2 --cpus='6' --memory='32000mb' --disk-size='40000mb' \
                          --mount=true --mount-string="${GS_TEST_DIR}:${GS_TEST_DIR}"
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -366,7 +366,6 @@ GraphScope 遵循 [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2
 - Wenfei Fan, Tao He, Longbin Lai, Xue Li, Yong Li, Zhao Li, Zhengping Qian, Chao Tian, Lei Wang, Jingbo Xu, Youyang Yao, Qiang Yin, Wenyuan Yu, Jingren Zhou, Diwen Zhu, Rong Zhu. [GraphScope: A Unified Engine For Big Graph Processing](http://vldb.org/pvldb/vol14/p2879-qian.pdf). The 47th International Conference on Very Large Data Bases (VLDB), industry, 2021.
 - Jingbo Xu, Zhanning Bai, Wenfei Fan, Longbin Lai, Xue Li, Zhao Li, Zhengping Qian, Lei Wang, Yanyan Wang, Wenyuan Yu, Jingren Zhou. [GraphScope: A One-Stop Large Graph Processing System](http://vldb.org/pvldb/vol14/p2703-xu.pdf). The 47th International Conference on Very Large Data Bases (VLDB), demo, 2021
 
-
 ## 贡献
 
 我们热忱欢迎和感谢来自社区的各种贡献！

--- a/charts/graphscope/templates/coordinator.yaml
+++ b/charts/graphscope/templates/coordinator.yaml
@@ -82,9 +82,9 @@ spec:
           - {{ printf "%s-%s" "coordinator" $fullname | quote }}
           - "--k8s_coordinator_service_name"
           - {{ printf "%s-%s" "coordinator-service" $fullname | quote }}
-          {{- if .Values.vineyard.daemonset }}
-          - "--k8s_vineyard_daemonset"
-          - {{ .Values.vineyard.daemonset }}
+          {{- if .Values.vineyard.deployment }}
+          - "--k8s_vineyard_deployment"
+          - {{ .Values.vineyard.deployment }}
           {{- end }}
           - "--k8s_vineyard_image"
           - {{ .Values.vineyard.image.name }}:{{ .Values.vineyard.image.tag }}

--- a/charts/graphscope/values.yaml
+++ b/charts/graphscope/values.yaml
@@ -84,12 +84,12 @@ engines:
       memory: 2Gi
 
 vineyard:
-  # When `vineyard.daemonset` is set to the Helm release name, the coordinator will
-  # tries to discover the vineyard DaemonSet in current namespace, then use it if
+  # When `vineyard.deployment` is set to the Helm release name,
+  # the coordinator will try to discover the vineyard deployment in current namespace, then use it if
   # found, and fallback to bundled vineyard container otherwise.
   #
-  # The vineyard IPC socket is placed on host at /var/run/vineyard-{namespace}-{release}.
-  daemonset: ""
+  # The vineyard IPC socket is placed on host at /var/run/vineyard-kubernetes/{namespace}/{deployment}.
+  deployment: ""
   image:
     name: vineyardcloudnative/vineyardd
     # Overrides the image tag whose default is the chart appVersion.

--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -67,7 +67,7 @@ class EngineCluster:
         preemptive,
         service_type,
         vineyard_cpu,
-        vineyard_daemonset,
+        k8s_vineyard_deployment,
         vineyard_image,
         vineyard_mem,
         vineyard_shared_mem,
@@ -126,7 +126,7 @@ class EngineCluster:
         self._image_pull_policy = image_pull_policy
         self._image_pull_secrets = image_pull_secrets
 
-        self._vineyard_daemonset = vineyard_daemonset
+        self._k8s_vineyard_deployment = k8s_vineyard_deployment
 
         self._with_analytical = with_analytical
         self._with_analytical_java = with_analytical_java
@@ -216,11 +216,11 @@ class EngineCluster:
     def get_vineyard_socket_volume(self):
         name = "vineyard-ipc-socket"
         volume = kube_client.V1Volume(name=name)
-        if self._vineyard_daemonset is None:
+        if self._k8s_vineyard_deployment is None:
             empty_dir = kube_client.V1EmptyDirVolumeSource()
             volume.empty_dir = empty_dir
         else:
-            path = f"/var/run/vineyard-{self._namespace}-{self._vineyard_daemonset}"
+            path = f"/var/run/vineyard-kubernetes/{self._namespace}/{self._k8s_vineyard_deployment}"
             host_path = kube_client.V1HostPathVolumeSource(path=path)
             host_path.type = "Directory"
             volume.host_path = host_path
@@ -396,6 +396,7 @@ class EngineCluster:
         socket_volume = self.get_vineyard_socket_volume()
         shm_volume = self.get_shm_volume()
         volumes.extend([socket_volume[0], shm_volume[0]])
+
         engine_volume_mounts = [socket_volume[2], shm_volume[2]]
 
         if self._volumes and self._volumes is not None:
@@ -424,12 +425,13 @@ class EngineCluster:
                 self.get_learning_container(volume_mounts=engine_volume_mounts)
             )
 
-        if self._vineyard_daemonset is None:
+        if self._k8s_vineyard_deployment is None:
             containers.append(
                 self.get_vineyard_container(
                     volume_mounts=[socket_volume[1], shm_volume[1]]
                 )
             )
+
         if self._with_dataset:
             dataset_volume = self.get_dataset_volume()
             volumes.append(dataset_volume[0])
@@ -529,8 +531,11 @@ class EngineCluster:
 
     def get_vineyard_service_endpoint(self, api_client):
         # return f"{self.vineyard_service_name}:{self._vineyard_service_port}"
-        service_type = self._service_type
         service_name = self.vineyard_service_name
+        service_type = self._service_type
+        if self._k8s_vineyard_deployment is not None:
+            service_name = self._k8s_vineyard_deployment + "-rpc"
+            service_type = "ClusterIP"
         endpoints = get_service_endpoints(
             api_client=api_client,
             namespace=self._namespace,
@@ -581,12 +586,22 @@ class EngineCluster:
         container.resources = ResourceBuilder.get_resources(
             self._frontend_requests, None
         )
+        if self._k8s_vineyard_deployment is not None:
+            socket_volume = self.get_vineyard_socket_volume()
+            container.volume_mounts = [socket_volume[2]]
         return container
 
     def get_interactive_frontend_deployment(self, replicas=1):
         name = self.frontend_deployment_name
+        vineyard_volumes = []
+        if self._k8s_vineyard_deployment is not None:
+            socket_volume = self.get_vineyard_socket_volume()
+            vineyard_volumes = [socket_volume[0]]
+
         container = self.get_interactive_frontend_container()
-        pod_spec = ResourceBuilder.get_pod_spec(containers=[container])
+        pod_spec = ResourceBuilder.get_pod_spec(
+            containers=[container], volumes=vineyard_volumes
+        )
         template_spec = ResourceBuilder.get_pod_template_spec(
             pod_spec, self._frontend_labels
         )

--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -183,9 +183,7 @@ class EngineCluster:
         return self._sock
 
     def vineyard_deployment_exists(self):
-        if self._vineyard_deployment is not None:
-            return True
-        return False
+        return self._vineyard_deployment is not None
 
     def base64_decode(self, string):
         return base64.b64decode(string).decode("utf-8", errors="ignore")
@@ -591,21 +589,17 @@ class EngineCluster:
         container.resources = ResourceBuilder.get_resources(
             self._frontend_requests, None
         )
-        if self.self.vineyard_deployment_exists():
+        if self.vineyard_deployment_exists():
             socket_volume = self.get_vineyard_socket_volume()
             container.volume_mounts = [socket_volume[2]]
         return container
 
     def get_interactive_frontend_deployment(self, replicas=1):
         name = self.frontend_deployment_name
-        vineyard_volumes = []
-        if self.vineyard_deployment_exists():
-            socket_volume = self.get_vineyard_socket_volume()
-            vineyard_volumes = [socket_volume[0]]
 
         container = self.get_interactive_frontend_container()
         pod_spec = ResourceBuilder.get_pod_spec(
-            containers=[container], volumes=vineyard_volumes
+            containers=[container],
         )
         template_spec = ResourceBuilder.get_pod_template_spec(
             pod_spec, self._frontend_labels

--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -589,9 +589,6 @@ class EngineCluster:
         container.resources = ResourceBuilder.get_resources(
             self._frontend_requests, None
         )
-        if self.vineyard_deployment_exists():
-            socket_volume = self.get_vineyard_socket_volume()
-            container.volume_mounts = [socket_volume[2]]
         return container
 
     def get_interactive_frontend_deployment(self, replicas=1):

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -925,7 +925,7 @@ def get_launcher(args):
             service_type=args.k8s_service_type,
             timeout_seconds=args.timeout_seconds,
             vineyard_cpu=args.k8s_vineyard_cpu,
-            k8s_vineyard_deployment=args.k8s_vineyard_deployment,
+            vineyard_deployment=args.vineyard_deployment,
             vineyard_image=args.k8s_vineyard_image,
             vineyard_mem=args.k8s_vineyard_mem,
             vineyard_shared_mem=args.vineyard_shared_mem,

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -925,7 +925,7 @@ def get_launcher(args):
             service_type=args.k8s_service_type,
             timeout_seconds=args.timeout_seconds,
             vineyard_cpu=args.k8s_vineyard_cpu,
-            vineyard_deployment=args.vineyard_deployment,
+            vineyard_deployment=args.k8s_vineyard_deployment,
             vineyard_image=args.k8s_vineyard_image,
             vineyard_mem=args.k8s_vineyard_mem,
             vineyard_shared_mem=args.vineyard_shared_mem,

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -697,6 +697,12 @@ def parse_sys_args():
         help="Service type, choose from 'NodePort' or 'LoadBalancer'.",
     )
     parser.add_argument(
+        "--k8s_vineyard_deployment",
+        type=str,
+        default=None,
+        help="The name of vineyard deployment, it should exist as expected.",
+    )
+    parser.add_argument(
         "--k8s_coordinator_name",
         type=str,
         default="",
@@ -719,12 +725,6 @@ def parse_sys_args():
         type=str,
         default="",
         help="A list of comma separated secrets to pull image.",
-    )
-    parser.add_argument(
-        "--k8s_vineyard_daemonset",
-        type=str,
-        default=None,
-        help="Use the existing vineyard DaemonSet with name 'k8s_vineyard_daemonset'.",
     )
     parser.add_argument(
         "--k8s_vineyard_cpu",
@@ -925,7 +925,7 @@ def get_launcher(args):
             service_type=args.k8s_service_type,
             timeout_seconds=args.timeout_seconds,
             vineyard_cpu=args.k8s_vineyard_cpu,
-            vineyard_daemonset=args.k8s_vineyard_daemonset,
+            k8s_vineyard_deployment=args.k8s_vineyard_deployment,
             vineyard_image=args.k8s_vineyard_image,
             vineyard_mem=args.k8s_vineyard_mem,
             vineyard_shared_mem=args.vineyard_shared_mem,

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -593,6 +593,21 @@ class KubernetesClusterLauncher(AbstractLauncher):
             )
             logger.info("Mars service endpoint: %s", self._mars_service_endpoint)
 
+    # the function will add the podAffinity to the engine workload so that the workload
+    # will be scheduled to the same node with vineyard deployment.
+    # e.g. the vineyard deployment is named "vineyard-deployment" and the namespace is "graphscope-system",
+    # the podAffinity will be added to the engine workload as below:
+    # spec:
+    #   affinity:
+    #     podAffinity:
+    #       requiredDuringSchedulingIgnoredDuringExecution:
+    #       - labelSelector:
+    #           matchExpressions:
+    #           - key: app.kubernetes.io/instance
+    #             operator: In
+    #             values:
+    #             - graphscope-system-vineyard-deployment # [vineyard deployment namespace]-[vineyard deployment name]
+    #         topologyKey: kubernetes.io/hostname
     def _add_podAffinity_for_vineyard_deployment(self, workload):
         try:
             import vineyard

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -68,6 +68,13 @@ from gscoordinator.version import __version__
 logger = logging.getLogger("graphscope")
 
 
+class FakeKubeResponse:
+    def __init__(self, obj):
+        import json
+
+        self.data = json.dumps(obj)
+
+
 class KubernetesClusterLauncher(AbstractLauncher):
     def __init__(
         self,
@@ -95,7 +102,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         service_type=None,
         timeout_seconds=None,
         vineyard_cpu=None,
-        vineyard_daemonset=None,
+        k8s_vineyard_deployment=None,
         vineyard_image=None,
         vineyard_mem=None,
         vineyard_shared_mem=None,
@@ -131,15 +138,18 @@ class KubernetesClusterLauncher(AbstractLauncher):
 
         self._num_workers = num_workers
 
-        self._vineyard_daemonset = vineyard_daemonset
-        if vineyard_daemonset is not None:
+        self._k8s_vineyard_deployment = k8s_vineyard_deployment
+
+        if k8s_vineyard_deployment is not None:
             try:
-                self._apps_api.read_namespaced_daemon_set(
-                    vineyard_daemonset, self._namespace
+                self._apps_api.read_namespaced_deployment(
+                    k8s_vineyard_deployment, self._namespace
                 )
             except K8SApiException:
-                logger.error(f"Vineyard daemonset {vineyard_daemonset} not found")
-                self._vineyard_daemonset = None
+                logger.exception(
+                    f"Vineyard deployment {self._namespace}/{k8s_vineyard_deployment} not found"
+                )
+                self._k8s_vineyard_deployment = None
 
         self._engine_cpu = engine_cpu
         self._engine_mem = engine_mem
@@ -230,7 +240,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
             preemptive=preemptive,
             service_type=service_type,
             vineyard_cpu=vineyard_cpu,
-            vineyard_daemonset=vineyard_daemonset,
+            k8s_vineyard_deployment=k8s_vineyard_deployment,
             vineyard_image=vineyard_image,
             vineyard_mem=vineyard_mem,
             vineyard_shared_mem=vineyard_shared_mem,
@@ -244,7 +254,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         )
 
         self._vineyard_service_endpoint = None
-        self.vineyard_internal_service_endpoint = None
+        self._vineyard_internal_service_endpoint = None
         self._mars_service_endpoint = None
         if self._with_mars:
             self._mars_cluster = MarsCluster(
@@ -429,7 +439,14 @@ class KubernetesClusterLauncher(AbstractLauncher):
         response = self._core_api.create_namespaced_service(self._namespace, service)
         self._resource_object.append(response)
         logger.info("Creating engine pods...")
+
         stateful_set = self._engine_cluster.get_engine_stateful_set()
+        if self._k8s_vineyard_deployment is not None:
+            # schedule engine statefulset to the same node with vineyard deployment
+            stateful_set = self._add_podAffinity_for_vineyard_deployment(
+                workload=stateful_set
+            )
+
         stateful_set.metadata.owner_references = self._owner_references
         response = self._apps_api.create_namespaced_stateful_set(
             self._namespace, stateful_set
@@ -439,6 +456,11 @@ class KubernetesClusterLauncher(AbstractLauncher):
     def _create_frontend_deployment(self):
         logger.info("Creating frontend pods...")
         deployment = self._engine_cluster.get_interactive_frontend_deployment()
+        if self._k8s_vineyard_deployment is not None:
+            # schedule frontend deployment to the same node with vineyard deployment
+            deployment = self._add_podAffinity_for_vineyard_deployment(
+                workload=deployment
+            )
         deployment.metadata.owner_references = self._owner_references
         response = self._apps_api.create_namespaced_deployment(
             self._namespace, deployment
@@ -486,7 +508,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         if self._with_mars:
             # scheduler used by Mars
             self._create_mars_scheduler()
-        if self._vineyard_daemonset is None:
+        if self._k8s_vineyard_deployment is None:
             self._create_vineyard_service()
 
     def _waiting_for_services_ready(self):
@@ -560,7 +582,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         self._vineyard_service_endpoint = (
             self._engine_cluster.get_vineyard_service_endpoint(self._api_client)
         )
-        self.vineyard_internal_endpoint = (
+        self._vineyard_internal_endpoint = (
             f"{self._pod_ip_list[0]}:{self._engine_cluster._vineyard_service_port}"
         )
 
@@ -574,6 +596,27 @@ class KubernetesClusterLauncher(AbstractLauncher):
                 self._api_client
             )
             logger.info("Mars service endpoint: %s", self._mars_service_endpoint)
+
+    def _add_podAffinity_for_vineyard_deployment(self, workload):
+        try:
+            import vineyard
+        except ImportError:
+            logger.error("vineyard is not installed, please install vineyard first.")
+
+        workload_json = json.dumps(
+            self._api_client.sanitize_for_serialization(workload)
+        )
+        new_workload_json = vineyard.deploy.vineyardctl.schedule.workload(
+            resource=workload_json,
+            vineyardd_name=self._k8s_vineyard_deployment,
+            vineyardd_namespace=self._namespace,
+            capture=True,
+        )
+
+        normalized_workload_json = json.loads(new_workload_json)
+        fake_kube_response = FakeKubeResponse(normalized_workload_json)
+        new_workload = self._api_client.deserialize(fake_kube_response, type(workload))
+        return new_workload
 
     def _dump_resource_object(self):
         resource = {}

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -70,8 +70,6 @@ logger = logging.getLogger("graphscope")
 
 class FakeKubeResponse:
     def __init__(self, obj):
-        import json
-
         self.data = json.dumps(obj)
 
 
@@ -268,9 +266,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         return types_pb2.K8S
 
     def vineyard_deployment_exists(self):
-        if self._vineyard_deployment is not None:
-            return True
-        return False
+        return self._vineyard_deployment is not None
 
     def get_coordinator_owner_references(self):
         owner_references = []
@@ -461,11 +457,6 @@ class KubernetesClusterLauncher(AbstractLauncher):
     def _create_frontend_deployment(self):
         logger.info("Creating frontend pods...")
         deployment = self._engine_cluster.get_interactive_frontend_deployment()
-        if self.vineyard_deployment_exists():
-            # schedule frontend deployment to the same node with vineyard deployment
-            deployment = self._add_podAffinity_for_vineyard_deployment(
-                workload=deployment
-            )
         deployment.metadata.owner_references = self._owner_references
         response = self._apps_api.create_namespaced_deployment(
             self._namespace, deployment

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -444,7 +444,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         stateful_set = self._engine_cluster.get_engine_stateful_set()
         if self.vineyard_deployment_exists():
             # schedule engine statefulset to the same node with vineyard deployment
-            stateful_set = self._add_podAffinity_for_vineyard_deployment(
+            stateful_set = self._add_pod_affinity_for_vineyard_deployment(
                 workload=stateful_set
             )
 
@@ -608,13 +608,8 @@ class KubernetesClusterLauncher(AbstractLauncher):
     #             values:
     #             - graphscope-system-vineyard-deployment # [vineyard deployment namespace]-[vineyard deployment name]
     #         topologyKey: kubernetes.io/hostname
-    def _add_podAffinity_for_vineyard_deployment(self, workload):
-        try:
-            import vineyard
-        except ImportError:
-            raise RuntimeError(
-                "vineyard is not installed, please install vineyard first."
-            )
+    def _add_pod_affinity_for_vineyard_deployment(self, workload):
+        import vineyard
 
         workload_json = json.dumps(
             self._api_client.sanitize_for_serialization(workload)

--- a/coordinator/gscoordinator/op_executor.py
+++ b/coordinator/gscoordinator/op_executor.py
@@ -680,6 +680,10 @@ class OperationExecutor:
             vineyard_rpc_endpoint = engine_config["vineyard_rpc_endpoint"]
         else:
             vineyard_rpc_endpoint = self._launcher.vineyard_internal_endpoint
+            if self._launcher._k8s_vineyard_deployment is not None:
+                vineyard_rpc_endpoint = self._launcher._vineyard_service_endpoint
+            else:
+                vineyard_rpc_endpoint = self._launcher._vineyard_internal_endpoint
         total_builder_chunks = executor_workers_num * threads_per_executor
 
         (
@@ -749,7 +753,7 @@ class OperationExecutor:
         if self._launcher.type() == types_pb2.HOSTS:
             vineyard_endpoint = engine_config["vineyard_rpc_endpoint"]
         else:
-            vineyard_endpoint = self._launcher.vineyard_internal_endpoint
+            vineyard_endpoint = self._launcher._vineyard_internal_endpoint
         vineyard_ipc_socket = engine_config["vineyard_socket"]
         deployment, hosts = self._launcher.get_vineyard_stream_info()
         dfstream = vineyard.io.open(
@@ -848,7 +852,10 @@ class OperationExecutor:
         if self._launcher.type() == types_pb2.HOSTS:
             vineyard_endpoint = engine_config["vineyard_rpc_endpoint"]
         else:
-            vineyard_endpoint = self._launcher.vineyard_internal_endpoint
+            if self._launcher._k8s_vineyard_deployment is not None:
+                vineyard_endpoint = self._launcher._vineyard_service_endpoint
+            else:
+                vineyard_endpoint = self._launcher._vineyard_internal_endpoint
         vineyard_ipc_socket = engine_config["vineyard_socket"]
 
         for loader in op.large_attr.chunk_meta_list.items:

--- a/coordinator/gscoordinator/op_executor.py
+++ b/coordinator/gscoordinator/op_executor.py
@@ -680,7 +680,7 @@ class OperationExecutor:
             vineyard_rpc_endpoint = engine_config["vineyard_rpc_endpoint"]
         else:
             vineyard_rpc_endpoint = self._launcher.vineyard_internal_endpoint
-            if self._launcher._k8s_vineyard_deployment is not None:
+            if self._launcher.vineyard_deployment_exists():
                 vineyard_rpc_endpoint = self._launcher._vineyard_service_endpoint
             else:
                 vineyard_rpc_endpoint = self._launcher._vineyard_internal_endpoint
@@ -852,7 +852,7 @@ class OperationExecutor:
         if self._launcher.type() == types_pb2.HOSTS:
             vineyard_endpoint = engine_config["vineyard_rpc_endpoint"]
         else:
-            if self._launcher._k8s_vineyard_deployment is not None:
+            if self._launcher.vineyard_deployment_exists():
                 vineyard_endpoint = self._launcher._vineyard_service_endpoint
             else:
                 vineyard_endpoint = self._launcher._vineyard_internal_endpoint

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -301,7 +301,7 @@ class Session(object):
         etcd_listening_client_port=gs_config.etcd_listening_client_port,
         etcd_listening_peer_port=gs_config.etcd_listening_peer_port,
         k8s_vineyard_image=gs_config.k8s_vineyard_image,
-        k8s_vineyard_daemonset=gs_config.k8s_vineyard_daemonset,
+        k8s_vineyard_deployment=gs_config.k8s_vineyard_deployment,
         k8s_vineyard_cpu=gs_config.k8s_vineyard_cpu,
         k8s_vineyard_mem=gs_config.k8s_vineyard_mem,
         vineyard_shared_mem=gs_config.vineyard_shared_mem,
@@ -373,8 +373,8 @@ class Session(object):
 
             k8s_vineyard_image (str, optional): The image of vineyard.
 
-            k8s_vineyard_daemonset (str, optional): The name of vineyard Helm deployment to use. GraphScope will try to
-                discovery the daemonset from kubernetes cluster, then use it if exists, and fallback to launching
+            k8s_vineyard_deployment (str, optional): The name of vineyard deployment to use. GraphScope will try to
+                discovery the deployment from kubernetes cluster, then use it if exists, and fallback to launching
                 a bundled vineyard container otherwise.
 
             k8s_vineyard_cpu (float, optional): Minimum number of CPU cores request for vineyard container. Defaults to 0.5.
@@ -544,7 +544,7 @@ class Session(object):
             "etcd_listening_client_port",
             "etcd_listening_peer_port",
             "k8s_vineyard_image",
-            "k8s_vineyard_daemonset",
+            "k8s_vineyard_deployment",
             "k8s_vineyard_cpu",
             "k8s_vineyard_mem",
             "vineyard_shared_mem",
@@ -1315,7 +1315,7 @@ def set_option(**kwargs):
         - k8s_image_pull_secrets
         - k8s_coordinator_cpu
         - k8s_coordinator_mem
-        - k8s_vineyard_daemonset
+        - k8s_vineyard_deployment
         - k8s_vineyard_cpu
         - k8s_vineyard_mem
         - k8s_engine_cpu
@@ -1370,7 +1370,7 @@ def get_option(key):
         - k8s_image_pull_secrets
         - k8s_coordinator_cpu
         - k8s_coordinator_mem
-        - k8s_vineyard_daemonset
+        - k8s_vineyard_deployment
         - k8s_vineyard_cpu
         - k8s_vineyard_mem
         - k8s_engine_cpu

--- a/python/graphscope/config.py
+++ b/python/graphscope/config.py
@@ -69,7 +69,7 @@ class GSConfig(object):
     # vineyard resource configuration
     # image for vineyard container
     k8s_vineyard_image = "vineyardcloudnative/vineyardd:v0.13.3"
-    k8s_vineyard_daemonset = None
+    k8s_vineyard_deployment = None
     k8s_vineyard_cpu = 0.5
     k8s_vineyard_mem = "512Mi"
     vineyard_shared_mem = "4Gi"

--- a/python/graphscope/deploy/kubernetes/cluster.py
+++ b/python/graphscope/deploy/kubernetes/cluster.py
@@ -75,7 +75,7 @@ class KubernetesClusterLauncher(Launcher):
         k8s_image_pull_policy=None,
         k8s_image_pull_secrets=None,
         k8s_vineyard_image=None,
-        k8s_vineyard_daemonset=None,
+        k8s_vineyard_deployment=None,
         k8s_vineyard_cpu=None,
         k8s_vineyard_mem=None,
         vineyard_shared_mem=None,
@@ -419,11 +419,11 @@ class KubernetesClusterLauncher(Launcher):
                     f"{self.base64_encode(json.dumps(volumes))}",
                 ]
             )
-        if self._saved_locals["k8s_vineyard_daemonset"] is not None:
+        if self._saved_locals["k8s_vineyard_deployment"] is not None:
             args.extend(
                 [
-                    "--k8s_vineyard_daemonset",
-                    str(self._saved_locals["k8s_vineyard_daemonset"]),
+                    "--k8s_vineyard_deployment",
+                    str(self._saved_locals["k8s_vineyard_deployment"]),
                 ]
             )
 
@@ -525,10 +525,12 @@ class KubernetesClusterLauncher(Launcher):
         try:
             self._create_namespace()
             self._create_role_and_binding()
-
+            logger.info("Creating services...")
             self._create_services()
             time.sleep(1)
+            logger.info("Waiting for coordinator service ready ...")
             self._waiting_for_services_ready()
+            logger.info("coordinator service ready haha")
             self._coordinator_endpoint = self._get_coordinator_endpoint()
             logger.info(
                 "Coordinator pod start successful with address %s, connecting to service ...",

--- a/python/graphscope/deploy/kubernetes/cluster.py
+++ b/python/graphscope/deploy/kubernetes/cluster.py
@@ -525,12 +525,12 @@ class KubernetesClusterLauncher(Launcher):
         try:
             self._create_namespace()
             self._create_role_and_binding()
-            logger.info("Creating services...")
+
             self._create_services()
             time.sleep(1)
-            logger.info("Waiting for coordinator service ready ...")
+
             self._waiting_for_services_ready()
-            logger.info("coordinator service ready haha")
+
             self._coordinator_endpoint = self._get_coordinator_endpoint()
             logger.info(
                 "Coordinator pod start successful with address %s, connecting to service ...",

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -100,10 +100,6 @@ def gs_session_distributed():
 
 @pytest.fixture
 def create_vineyard_deployment_on_single_node():
-    try:
-        import vineyard
-    except ImportError:
-        logger.error("vineyard is not installed, please install vineyard first.")
     # create vineyard deployment on single node
     # set the replicas of vineyard and etcd to 1 as there is only one node in the cluster
     vineyard.deploy.vineyardctl.deploy.vineyard_deployment(
@@ -137,10 +133,6 @@ def gs_session_with_vineyard_deployment(create_vineyard_deployment_on_single_nod
 
 @pytest.fixture
 def create_vineyard_deployment_on_multiple_nodes(create_graphscope_namesapce):
-    try:
-        import vineyard
-    except ImportError:
-        logger.error("vineyard is not installed, please install vineyard first.")
     # create vineyard deployment on multiple nodes
     # set the replicas of vineyard and etcd to 2 as there are 2 nodes in the kubernetes cluster
     vineyard.deploy.vineyardctl.deploy.vineyard_deployment(

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -24,8 +24,6 @@ import tempfile
 
 import numpy as np
 import pytest
-from kubernetes import client
-from kubernetes import config
 
 import graphscope
 from graphscope import Graph

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -241,6 +241,7 @@ def test_demo_on_hdfs(gs_session_distributed):
     )
 
 
+@pytest.mark.skip(reason="(caoye)skip for testing")
 def test_vineyard_deployment_on_single_node(
     gs_session_with_vineyard_deployment, data_dir, modern_graph_data_dir
 ):
@@ -249,6 +250,7 @@ def test_vineyard_deployment_on_single_node(
     )
 
 
+@pytest.mark.skip(reason="(caoye)skip for testing")
 def test_vineyard_deployment_on_multiple_nodes(
     gs_session_distributed_with_vineyard_deployment, data_dir, modern_graph_data_dir
 ):

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -100,10 +100,7 @@ def gs_session_distributed():
 
 @pytest.fixture
 def create_vineyard_deployment_on_single_node():
-    try:
-        import vineyard
-    except ImportError:
-        raise RuntimeError("vineyard is not installed, please install vineyard first.")
+    import vineyard
 
     # create vineyard deployment on single node
     # set the replicas of vineyard and etcd to 1 as there is only one node in the cluster
@@ -138,10 +135,8 @@ def gs_session_with_vineyard_deployment(create_vineyard_deployment_on_single_nod
 
 @pytest.fixture
 def create_vineyard_deployment_on_multiple_nodes():
-    try:
-        import vineyard
-    except ImportError:
-        raise RuntimeError("vineyard is not installed, please install vineyard first.")
+    import vineyard
+
     # create vineyard deployment on multiple nodes
     # set the replicas of vineyard and etcd to 2 as there are 2 nodes in the kubernetes cluster
     vineyard.deploy.vineyardctl.deploy.vineyard_deployment(

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -24,6 +24,8 @@ import tempfile
 
 import numpy as np
 import pytest
+from kubernetes import client
+from kubernetes import config
 
 import graphscope
 from graphscope import Graph
@@ -99,6 +101,82 @@ def gs_session_distributed():
 
 
 @pytest.fixture
+def create_vineyard_deployment_on_single_node():
+    try:
+        import vineyard
+    except ImportError:
+        logger.error("vineyard is not installed, please install vineyard first.")
+    # create vineyard deployment on single node
+    # set the replicas of vineyard and etcd to 1 as there is only one node in the cluster
+    vineyard.deploy.vineyardctl.deploy.vineyard_deployment(
+        vineyard_replicas=1,
+        vineyard_etcd_replicas=1,
+        namespace="graphscope-system",
+        create_namespace=True,
+    )
+
+
+@pytest.fixture
+def gs_session_with_vineyard_deployment(create_vineyard_deployment_on_single_node):
+    sess = graphscope.session(
+        num_workers=2,
+        k8s_namespace="graphscope-system",
+        k8s_image_registry=get_gs_registry_on_ci_env(),
+        k8s_image_tag=get_gs_tag_on_ci_env(),
+        k8s_coordinator_cpu=2,
+        k8s_coordinator_mem="4Gi",
+        k8s_vineyard_cpu=2,
+        k8s_vineyard_mem="1Gi",
+        k8s_engine_cpu=2,
+        k8s_engine_mem="4Gi",
+        vineyard_shared_mem="4Gi",
+        k8s_vineyard_deployment="vineyardd-sample",
+        k8s_volumes=get_k8s_volumes(),
+    )
+    yield sess
+    sess.close()
+
+
+@pytest.fixture
+def create_vineyard_deployment_on_multiple_nodes(create_graphscope_namesapce):
+    try:
+        import vineyard
+    except ImportError:
+        logger.error("vineyard is not installed, please install vineyard first.")
+    # create vineyard deployment on multiple nodes
+    # set the replicas of vineyard and etcd to 2 as there are 2 nodes in the kubernetes cluster
+    vineyard.deploy.vineyardctl.deploy.vineyard_deployment(
+        vineyard_replicas=2,
+        vineyard_etcd_replicas=2,
+        namespace="graphscope-system",
+        create_namespace=True,
+    )
+
+
+@pytest.fixture
+def gs_session_distributed_with_vineyard_deployment(
+    create_vineyard_deployment_on_multiple_nodes,
+):
+    sess = graphscope.session(
+        num_workers=2,
+        k8s_namespace="graphscope-system",
+        k8s_image_registry=get_gs_registry_on_ci_env(),
+        k8s_image_tag=get_gs_tag_on_ci_env(),
+        k8s_coordinator_cpu=2,
+        k8s_coordinator_mem="4Gi",
+        k8s_vineyard_cpu=2,
+        k8s_vineyard_mem="1Gi",
+        k8s_engine_cpu=2,
+        k8s_engine_mem="4Gi",
+        vineyard_shared_mem="4Gi",
+        k8s_vineyard_deployment="vineyardd-sample",
+        k8s_volumes=get_k8s_volumes(),
+    )
+    yield sess
+    sess.close()
+
+
+@pytest.fixture
 def data_dir():
     return "/testingdata/ldbc_sample"
 
@@ -166,6 +244,22 @@ def test_demo_on_hdfs(gs_session_distributed):
         selector={"id": "v.id", "rank": "r"},
         host=os.environ["HDFS_HOST"],
         port=9000,
+    )
+
+
+def test_vineyard_deployment_on_single_node(
+    gs_session_with_vineyard_deployment, data_dir, modern_graph_data_dir
+):
+    test_demo_distribute(
+        gs_session_with_vineyard_deployment, data_dir, modern_graph_data_dir
+    )
+
+
+def test_vineyard_deployment_on_multiple_nodes(
+    gs_session_distributed_with_vineyard_deployment, data_dir, modern_graph_data_dir
+):
+    test_demo_distribute(
+        gs_session_distributed_with_vineyard_deployment, data_dir, modern_graph_data_dir
     )
 
 

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -100,6 +100,11 @@ def gs_session_distributed():
 
 @pytest.fixture
 def create_vineyard_deployment_on_single_node():
+    try:
+        import vineyard
+    except ImportError:
+        raise RuntimeError("vineyard is not installed, please install vineyard first.")
+
     # create vineyard deployment on single node
     # set the replicas of vineyard and etcd to 1 as there is only one node in the cluster
     vineyard.deploy.vineyardctl.deploy.vineyard_deployment(
@@ -132,7 +137,11 @@ def gs_session_with_vineyard_deployment(create_vineyard_deployment_on_single_nod
 
 
 @pytest.fixture
-def create_vineyard_deployment_on_multiple_nodes(create_graphscope_namesapce):
+def create_vineyard_deployment_on_multiple_nodes():
+    try:
+        import vineyard
+    except ImportError:
+        raise RuntimeError("vineyard is not installed, please install vineyard first.")
     # create vineyard deployment on multiple nodes
     # set the replicas of vineyard and etcd to 2 as there are 2 nodes in the kubernetes cluster
     vineyard.deploy.vineyardctl.deploy.vineyard_deployment(


### PR DESCRIPTION
## What do these changes do?

The pr uses Deployment to replace the original Daemonset as the vineyard operator uses `Deployment` to install the vineyard cluster. Also, after specifying the vineyard deployment, we need to use the vineyard operator python API to deploy the engines to vineyard nodes.

BTW, the pr needs to wait for the https://github.com/v6d-io/v6d/pull/1183 ready.



