### PR TITLE
Fixes louvain on projected fragment when v label is not 0

### DIFF
--- a/analytical_engine/apps/pregel/louvain/louvain.h
+++ b/analytical_engine/apps/pregel/louvain/louvain.h
@@ -122,6 +122,7 @@ class PregelLouvain
     if (current_super_step == phase_one_start_step && v.edge_size() == 0) {
       // isolated nodes send themselves a message on the phase_1 start step
       md_t message;
+      message.dst_id = v.get_gid();
       v.send_by_gid(v.get_gid(), message);
       v.vote_to_halt();
       return;
@@ -376,7 +377,7 @@ class PregelLouvain
     md_t message;
     message.internal_weight = state.internal_weight;
     std::map<vid_t, edata_t> edges;
-    assert(vertex.use_fake_edges());
+    assert((vertex.edge_size() == 0) || vertex.use_fake_edges());
     edges = vertex.fake_edges();
     message.edges = std::move(edges);
     if (vertex.get_gid() != state.community) {

--- a/python/graphscope/tests/conftest.py
+++ b/python/graphscope/tests/conftest.py
@@ -137,9 +137,8 @@ def twitter_e_1_1_1():
     return "{}/twitter_e_1_1_1".format(new_property_dir)
 
 
-@pytest.fixture(scope="module")
-def arrow_property_graph(graphscope_session):
-    g = graphscope_session.load_from(
+def load_arrow_property_graph(session, directed=True):
+    return session.load_from(
         edges={
             "e0": [
                 (
@@ -232,7 +231,20 @@ def arrow_property_graph(graphscope_session):
         },
         generate_eid=False,
         retain_oid=True,
+        directed=directed,
     )
+
+
+@pytest.fixture(scope="module")
+def arrow_property_graph(graphscope_session):
+    g = load_arrow_property_graph(graphscope_session, directed=True)
+    yield g
+    del g
+
+
+@pytest.fixture(scope="module")
+def arrow_property_graph_undirected(graphscope_session):
+    g = load_arrow_property_graph(graphscope_session, directed=False)
     yield g
     del g
 
@@ -329,58 +341,6 @@ def arrow_property_graph_only_from_efile(graphscope_session):
         generate_eid=False,
         retain_oid=True,
     )
-    yield g
-    del g
-
-
-# @pytest.fixture(scope="module")
-# def arrow_property_graph(graphscope_session):
-# g = graphscope_session.g(generate_eid=False, retain_oid=False)
-# g = g.add_vertices(f"{new_property_dir}/twitter_v_0", "v0")
-# g = g.add_vertices(f"{new_property_dir}/twitter_v_1", "v1")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_0_0_0", "e0", ["weight"], "v0", "v0")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_0_1_0", "e0", ["weight"], "v0", "v1")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_1_0_0", "e0", ["weight"], "v1", "v0")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_0", "e0", ["weight"], "v1", "v1")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_0_0_1", "e1", ["weight"], "v0", "v0")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_0_1_1", "e1", ["weight"], "v0", "v1")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_1_0_1", "e1", ["weight"], "v1", "v0")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_1", "e1", ["weight"], "v1", "v1")
-
-# yield g
-# del g
-
-
-# @pytest.fixture(scope="module")
-# def arrow_property_graph_only_from_efile(graphscope_session):
-# g = graphscope_session.g(generate_eid=False, retain_oid=False)
-# g = g.add_edges(f"{new_property_dir}/twitter_e_0_0_0", "e0", ["weight"], "v0", "v0")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_0_1_0", "e0", ["weight"], "v0", "v1")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_1_0_0", "e0", ["weight"], "v1", "v0")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_0", "e0", ["weight"], "v1", "v1")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_0_0_1", "e1", ["weight"], "v0", "v0")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_0_1_1", "e1", ["weight"], "v0", "v1")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_1_0_1", "e1", ["weight"], "v1", "v0")
-# g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_1", "e1", ["weight"], "v1", "v1")
-
-# yield g
-# del g
-
-
-@pytest.fixture(scope="module")
-def arrow_property_graph_undirected(graphscope_session):
-    g = graphscope_session.g(directed=False, generate_eid=False, retain_oid=False)
-    g = g.add_vertices(f"{new_property_dir}/twitter_v_0", "v0")
-    g = g.add_vertices(f"{new_property_dir}/twitter_v_1", "v1")
-    g = g.add_edges(f"{new_property_dir}/twitter_e_0_0_0", "e0", ["weight"], "v0", "v0")
-    g = g.add_edges(f"{new_property_dir}/twitter_e_0_1_0", "e0", ["weight"], "v0", "v1")
-    g = g.add_edges(f"{new_property_dir}/twitter_e_1_0_0", "e0", ["weight"], "v1", "v0")
-    g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_0", "e0", ["weight"], "v1", "v1")
-    g = g.add_edges(f"{new_property_dir}/twitter_e_0_0_1", "e1", ["weight"], "v0", "v0")
-    g = g.add_edges(f"{new_property_dir}/twitter_e_0_1_1", "e1", ["weight"], "v0", "v1")
-    g = g.add_edges(f"{new_property_dir}/twitter_e_1_0_1", "e1", ["weight"], "v1", "v0")
-    g = g.add_edges(f"{new_property_dir}/twitter_e_1_1_1", "e1", ["weight"], "v1", "v1")
-
     yield g
     del g
 

--- a/python/graphscope/tests/unittest/test_app.py
+++ b/python/graphscope/tests/unittest/test_app.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import itertools
 import os
 
 import networkx as nx
@@ -453,3 +454,12 @@ def test_wcc_on_flatten_graph(arrow_modern_graph):
     df = ctx.to_dataframe({"node": "v.id", "r": "r"})
     # The component id is all 0
     assert sum(df.r.values) == 0
+
+
+def test_louvain_on_projected_graph(arrow_property_graph_undirected):
+    for v, e in itertools.product(["v0", "v1"], ["e0", "e1"]):
+        g = arrow_property_graph_undirected.project(
+            vertices={v: []}, edges={e: ["weight"]}
+        )
+        ctx = louvain(g)
+        ctx.to_dataframe({"node": "v.id", "r": "r"})


### PR DESCRIPTION
## What do these changes do?

With projected fragment, `0` may not be in the range of `Vertices()/InnerVertices` thus cannot be used as the index of vertex arrays.

## Related issue number

Fixes #2446 

