### PR TITLE
Enable running multiple GIE instances on a same vineyardd server

### DIFF
--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -347,12 +347,16 @@ class CoordinatorServiceServicer(
                 response_head = responses[0]
                 response_head.head.code = error_code
                 response_head.head.error_msg = f"Error occurred during RunStep. The traceback is: {traceback.format_exc()}"
+                if hasattr(exc, "status_message"):
+                    exc_message = exc.status_message
+                else:
+                    exc_message = str(exc)
                 response_head.head.full_exception = pickle.dumps(
                     (
                         GremlinServerError,
                         {
                             "code": exc.status_code,
-                            "message": exc.status_message,
+                            "message": exc_message,
                             "attributes": exc.status_attributes,
                         },
                     )

--- a/coordinator/gscoordinator/op_executor.py
+++ b/coordinator/gscoordinator/op_executor.py
@@ -505,15 +505,24 @@ class OperationExecutor:
             instances = [key for key in vineyard_client.meta]
 
             # duplicate each instances for each thread per worker.
+            if len(instances) == num_workers:
+                local_stream_chunks = threads_per_executor
+            else:
+                assert (
+                    num_workers % len(instances) == 0
+                ), f"Unable to distribute {num_workers} workers to {len(instances)} instances"
+                local_stream_chunks = (
+                    num_workers // len(instances) * threads_per_executor
+                )
             chunk_instances = [
-                key for key in instances for _ in range(threads_per_executor)
+                key for key in instances for _ in range(local_stream_chunks)
             ]
 
             # build the vineyard::GlobalPGStream
             metadata = vineyard.ObjectMeta()
             metadata.set_global(True)
             metadata["typename"] = "vineyard::htap::GlobalPGStream"
-            metadata["local_stream_chunks"] = threads_per_executor
+            metadata["local_stream_chunks"] = local_stream_chunks
             metadata["total_stream_chunks"] = len(chunk_instances)
 
             # build the parallel stream for edge
@@ -656,15 +665,20 @@ class OperationExecutor:
             os.environ.get("THREADS_PER_WORKER", INTERACTIVE_ENGINE_THREADS_PER_WORKER)
         )
 
-        if self._launcher.type() == types_pb2.HOSTS:
-            # only 1 GIE executor on local cluster
+        if (
+            self._launcher.type() == types_pb2.HOSTS
+            and os.environ.get("PARALLEL_INTERACTIVE_EXECUTOR_ON_VINEYARD", "OFF")
+            != "ON"
+        ):
             executor_workers_num = 1
             threads_per_executor = self._launcher.num_workers * threads_per_worker
-            engine_config = self.get_analytical_engine_config()
-            vineyard_rpc_endpoint = engine_config["vineyard_rpc_endpoint"]
         else:
             executor_workers_num = self._launcher.num_workers
             threads_per_executor = threads_per_worker
+        if self._launcher.type() == types_pb2.HOSTS:
+            engine_config = self.get_analytical_engine_config()
+            vineyard_rpc_endpoint = engine_config["vineyard_rpc_endpoint"]
+        else:
             vineyard_rpc_endpoint = self._launcher.vineyard_internal_endpoint
         total_builder_chunks = executor_workers_num * threads_per_executor
 

--- a/interactive_engine/assembly/src/bin/graphscope/giectl
+++ b/interactive_engine/assembly/src/bin/graphscope/giectl
@@ -157,16 +157,16 @@ start_executor() {
       -e "s@SERVER_SIZE@${server_size}@g" \
       -e "s@NETWORK_SERVERS@${network_servers}@g" \
       -e "s@THREADS_PER_WORKER@${threads_per_worker}@g" \
-      ${GRAPHSCOPE_HOME}/conf/executor.vineyard.properties > ${config_dir}/executor.vineyard.properties
+      ${GRAPHSCOPE_HOME}/conf/executor.vineyard.properties > ${config_dir}/executor.$server_id.vineyard.properties
 
   cp ${GRAPHSCOPE_HOME}/conf/log4rs.yml  ${config_dir}/log4rs.yml
 
   declare executor_binary="gaia_executor"
 
   # launch executor
-  declare flag="gaia_${object_id}executor"  # Flag is used to kill process
-  RUST_BACKTRACE=full ${GRAPHSCOPE_HOME}/bin/gaia_executor ${config_dir}/log4rs.yml ${config_dir}/executor.vineyard.properties ${flag} \
-    >> ${log_dir}/executor.log 2>&1 &
+  declare flag="gaia_${object_id}executor.${server_id}"  # Flag is used to kill process
+  RUST_BACKTRACE=full ${GRAPHSCOPE_HOME}/bin/gaia_executor ${config_dir}/log4rs.yml ${config_dir}/executor.$server_id.vineyard.properties ${flag} \
+    >> ${log_dir}/executor.$server_id.log 2>&1 &
   echo $! >> ${pid_dir}/executor.pid
 }
 
@@ -188,7 +188,7 @@ create_gremlin_instance_on_local() {
   declare -r GRAPHSCOPE_RUNTIME=$1
   declare -r object_id=$2
   declare -r schema_path=$3
-  declare -r server_id=$4
+  declare -r server_size=$4
   declare -r executor_port=$5
   declare -r executor_rpc_port=$6
   declare -r frontend_port=$7
@@ -210,18 +210,30 @@ create_gremlin_instance_on_local() {
   unlink ${GS_LOG}/current || true
   ln -s ${log_dir} ${GS_LOG}/current
 
-  server_size="1"
   # Frontend use executor rpc port
-  pegasus_hosts="127.0.0.1:${executor_rpc_port}"
+  network_servers=""
+  pegasus_hosts=""
+  for server_id in $(seq 0 $(($server_size - 1))); do
+    current_executor_port=$(($executor_port + 2 * $server_id))
+    current_executor_rpc_port=$(($executor_rpc_port + 2 * $server_id))
+    network_servers="${network_servers},127.0.0.1:$current_executor_port"
+    pegasus_hosts="${pegasus_hosts},127.0.0.1:$current_executor_rpc_port"
+  done
+  network_servers=${network_servers:1}
+  pegasus_hosts=${pegasus_hosts:1}
 
   start_frontend ${GRAPHSCOPE_RUNTIME} ${object_id} ${schema_path} ${pegasus_hosts} \
                  ${frontend_port}
 
   log "FRONTEND_ENDPOINT:127.0.0.1:${frontend_port}"
+
   # executor use executor inner port
-  network_servers="127.0.0.1:${executor_port}"
-  start_executor ${GRAPHSCOPE_RUNTIME} ${object_id} ${server_id} ${server_size} ${executor_rpc_port} \
-                 ${network_servers}
+  for server_id in $(seq 0 $(($server_size - 1))); do
+    current_executor_port=$(($executor_port + 2 * $server_id))
+    current_executor_rpc_port=$(($executor_rpc_port + 2 * $server_id))
+    start_executor ${GRAPHSCOPE_RUNTIME} ${object_id} ${server_id} ${server_size} ${current_executor_rpc_port} \
+                   ${network_servers}
+  done
 }
 
 ##########################

--- a/interactive_engine/executor/ir/integrated/src/assemble/vineyard.rs
+++ b/interactive_engine/executor/ir/integrated/src/assemble/vineyard.rs
@@ -27,6 +27,9 @@ pub struct QueryVineyard<V, VI, E, EI> {
     graph_query: Arc<dyn GlobalGraphQuery<V = V, VI = VI, E = E, EI = EI>>,
     graph_partitioner: Arc<dyn GraphPartitionManager>,
     partition_server_index_mapping: HashMap<u32, u32>,
+    // computed partition ids after split fragments on same vineyard instance to
+    // multiple GIE worker processes
+    computed_process_partition_list: Vec<u32>,
 }
 
 #[allow(dead_code)]
@@ -34,9 +37,14 @@ impl<V, VI, E, EI> QueryVineyard<V, VI, E, EI> {
     pub fn new(
         graph_query: Arc<dyn GlobalGraphQuery<V = V, VI = VI, E = E, EI = EI>>,
         graph_partitioner: Arc<dyn GraphPartitionManager>,
-        partition_server_index_mapping: HashMap<u32, u32>,
+        partition_server_index_mapping: HashMap<u32, u32>, computed_process_partition_list: Vec<u32>,
     ) -> Self {
-        QueryVineyard { graph_query, graph_partitioner, partition_server_index_mapping }
+        QueryVineyard {
+            graph_query,
+            graph_partitioner,
+            partition_server_index_mapping,
+            computed_process_partition_list,
+        }
     }
 }
 
@@ -53,6 +61,7 @@ where
         let partitioner = VineyardMultiPartition::new(
             self.graph_partitioner.clone(),
             self.partition_server_index_mapping.clone(),
+            self.computed_process_partition_list.clone(),
         );
         IRJobAssembly::new(partitioner)
     }

--- a/interactive_engine/executor/store/global_query/src/store_impl/v6d/native/global_store_ffi.h
+++ b/interactive_engine/executor/store/global_query/src/store_impl/v6d/native/global_store_ffi.h
@@ -262,8 +262,8 @@ PartitionId v6d_get_partition_id(GraphHandle graph, VertexId v);
 // key是\0结束的字符串，如果 key 不存在，返回 -1
 // 否则返回0，结果存在 internal_id 和 partition_id 中
 int v6d_get_vertex_id_from_primary_key(GraphHandle graph, LabelId label_id,
-                                   const char* key, VertexId* internal_id,
-                                   PartitionId* partition_id);
+                                       const char* key, VertexId* internal_id,
+                                       PartitionId* partition_id);
 
 // 返回本地的partition列表。
 //
@@ -273,8 +273,9 @@ int v6d_get_vertex_id_from_primary_key(GraphHandle graph, LabelId label_id,
 // 接收返回值，调用者（GIE）负责使用free_partition_list释放内存
 // partition_id_size: partition_ids的长度
 //
-void v6d_get_process_partition_list(GraphHandle graph, PartitionId** partition_ids,
-                                int* partition_id_size);
+void v6d_get_process_partition_list(GraphHandle graph,
+                                    PartitionId** partition_ids,
+                                    int* partition_id_size);
 
 // 释放partition_ids对应的内存
 void v6d_free_partition_list(PartitionId* partition_ids);


### PR DESCRIPTION
## What do these changes do?

We will decouple the deploy of vineyard and graphscope (see also #2458) where vineyard and graphscope workers may not aligned. After that, on one kubernetes node, there might be only 1 vineyardd instance and more than one graphscope workers (specially GIE executors) on it.

Before this pull request, that workable, but yields wrong (duplication) query results. This pull fixed that by first sync process partition list and splitted the partitions to "local" work processes.

To avoid disturbe existing users, the new feature is only availbel when the environment variable `PARALLEL_INTERACTIVE_EXECUTOR_ON_VINEYARD ` is set to `OFF` (both `ON` and `OFF` are covered by CI). 

## Related issue number

N/A

