### PR TITLE
Add proxy support to the dataset container #2512

### DIFF
--- a/charts/graphscope/templates/coordinator.yaml
+++ b/charts/graphscope/templates/coordinator.yaml
@@ -114,6 +114,10 @@ spec:
           - {{ .Values.engines.enabled_engines }}
           - "--k8s_with_dataset"
           - {{ .Values.engines.dataset.enabled | quote }}
+          {{- if .Values.engines.dataset.proxy }}
+          - "--dataset_proxy"
+          - {{ .Values.engines.dataset.proxy | toJson | squote }}
+          {{- end }}
 
       {{- if .Values.withJupyter }}
       - name: jupyter

--- a/charts/graphscope/templates/coordinator.yaml
+++ b/charts/graphscope/templates/coordinator.yaml
@@ -114,9 +114,9 @@ spec:
           - {{ .Values.engines.enabled_engines }}
           - "--k8s_with_dataset"
           - {{ .Values.engines.dataset.enabled | quote }}
-          {{- if .Values.engines.dataset.proxy }}
+          {{- if and .Values.engines.dataset.enabled .Values.engines.dataset.proxy }}
           - "--dataset_proxy"
-          - {{ .Values.engines.dataset.proxy | toJson | squote }}
+          - {{ mustToJson .Values.engines.dataset.proxy | b64enc | quote }}
           {{- end }}
 
       {{- if .Values.withJupyter }}

--- a/charts/graphscope/values.yaml
+++ b/charts/graphscope/values.yaml
@@ -70,9 +70,10 @@ engines:
     enabled: False
     image:
       name: dataset
-#    proxy:
-#      http_proxy: "http://*.*.*.*:*"
-#      https_proxy: "http://*.*.*.*:*"
+  # Running Behind a Forward Proxy
+  # Environment variables that get added to the dataset container
+  # Available options of proxy: http_proxy, https_proxy, no_proxy
+    proxy:
 
   resources:
     requests:

--- a/charts/graphscope/values.yaml
+++ b/charts/graphscope/values.yaml
@@ -70,6 +70,9 @@ engines:
     enabled: False
     image:
       name: dataset
+#    proxy:
+#      http_proxy: "http://*.*.*.*:*"
+#      https_proxy: "http://*.*.*.*:*"
 
   resources:
     requests:

--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -145,8 +145,6 @@ class EngineCluster:
         self._preemptive = preemptive
         self._vineyard_shared_mem = vineyard_shared_mem
 
-        self._dataset_proxy = dataset_proxy
-
         self._node_selector = (
             json.loads(self.base64_decode(engine_pod_node_selector))
             if engine_pod_node_selector
@@ -154,6 +152,7 @@ class EngineCluster:
         )
         self._num_workers = num_workers
         self._volumes = json.loads(self.base64_decode(volumes)) if volumes else None
+        self._dataset_proxy = json.loads(self.base64_decode(dataset_proxy)) if dataset_proxy else None
 
         self._sock = "/tmp/vineyard_workspace/vineyard.sock"
 

--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -78,7 +78,7 @@ class EngineCluster:
         with_interactive,
         with_learning,
         with_mars,
-        dataset_proxy
+        dataset_proxy,
     ):
         self._gs_prefix = "gs-engine-"
         self._analytical_prefix = "gs-analytical-"
@@ -200,7 +200,10 @@ class EngineCluster:
         return env
 
     def get_dataset_proxy_env(self):
-        return [kube_client.V1EnvVar(name=k, value=v) for k, v in self._dataset_proxy.items()]
+        return [
+            kube_client.V1EnvVar(name=k, value=v)
+            for k, v in self._dataset_proxy.items()
+        ]
 
     def get_base_machine_env(self):
         env = [
@@ -379,7 +382,6 @@ class EngineCluster:
         )
 
         container.volume_mounts = volume_mounts
-        container.env = self.get_dataset_proxy_env()
 
         container.security_context = kube_client.V1SecurityContext(privileged=True)
         return container

--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -152,7 +152,9 @@ class EngineCluster:
         )
         self._num_workers = num_workers
         self._volumes = json.loads(self.base64_decode(volumes)) if volumes else None
-        self._dataset_proxy = json.loads(self.base64_decode(dataset_proxy)) if dataset_proxy else None
+        self._dataset_proxy = (
+            json.loads(self.base64_decode(dataset_proxy)) if dataset_proxy else None
+        )
 
         self._sock = "/tmp/vineyard_workspace/vineyard.sock"
 

--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -78,6 +78,7 @@ class EngineCluster:
         with_interactive,
         with_learning,
         with_mars,
+        dataset_proxy
     ):
         self._gs_prefix = "gs-engine-"
         self._analytical_prefix = "gs-analytical-"
@@ -144,6 +145,8 @@ class EngineCluster:
         self._preemptive = preemptive
         self._vineyard_shared_mem = vineyard_shared_mem
 
+        self._dataset_proxy = dataset_proxy
+
         self._node_selector = (
             json.loads(self.base64_decode(engine_pod_node_selector))
             if engine_pod_node_selector
@@ -195,6 +198,9 @@ class EngineCluster:
         put_if_exists(env, "OPAL_BINDIR")
         env = [kube_client.V1EnvVar(name=k, value=v) for k, v in env.items()]
         return env
+
+    def get_dataset_proxy_env(self):
+        return [kube_client.V1EnvVar(name=k, value=v) for k, v in self._dataset_proxy.items()]
 
     def get_base_machine_env(self):
         env = [
@@ -373,6 +379,7 @@ class EngineCluster:
         )
 
         container.volume_mounts = volume_mounts
+        container.env = self.get_dataset_proxy_env()
 
         container.security_context = kube_client.V1SecurityContext(privileged=True)
         return container

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -886,7 +886,7 @@ def parse_sys_args():
         nargs="?",
         const="{}",
         default="{}",
-        help="Proxy for worker dataset."
+        help="Proxy for worker dataset.",
     )
     return parser.parse_args()
 
@@ -932,7 +932,7 @@ def get_launcher(args):
             waiting_for_delete=args.waiting_for_delete,
             with_mars=args.k8s_with_mars,
             enabled_engines=args.k8s_enabled_engines,
-            dataset_proxy=args.dataset_proxy
+            dataset_proxy=args.dataset_proxy,
         )
     elif args.cluster_type == "hosts":
         launcher = LocalLauncher(

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -880,6 +880,14 @@ def parse_sys_args():
         default=9968,
         help="Coordinator prometheus exporter service port.",
     )
+    parser.add_argument(
+        "--dataset_proxy",
+        type=str,
+        nargs="?",
+        const="{}",
+        default="{}",
+        help="Proxy for worker dataset."
+    )
     return parser.parse_args()
 
 
@@ -924,6 +932,7 @@ def get_launcher(args):
             waiting_for_delete=args.waiting_for_delete,
             with_mars=args.k8s_with_mars,
             enabled_engines=args.k8s_enabled_engines,
+            dataset_proxy=args.dataset_proxy
         )
     elif args.cluster_type == "hosts":
         launcher = LocalLauncher(

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -884,9 +884,10 @@ def parse_sys_args():
         "--dataset_proxy",
         type=str,
         nargs="?",
-        const="{}",
-        default="{}",
-        help="Proxy for worker dataset.",
+        const="",
+        default="",
+        help="A json string specifies the dataset proxy info."
+             "Available options of proxy: http_proxy, https_proxy, no_proxy.",
     )
     return parser.parse_args()
 

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -887,7 +887,7 @@ def parse_sys_args():
         const="",
         default="",
         help="A json string specifies the dataset proxy info."
-             "Available options of proxy: http_proxy, https_proxy, no_proxy.",
+        "Available options of proxy: http_proxy, https_proxy, no_proxy.",
     )
     return parser.parse_args()
 

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -240,7 +240,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
             with_analytical_java=self._with_analytical_java,
             with_interactive=self._with_interactive,
             with_learning=self._with_learning,
-            dataset_proxy=json.loads(dataset_proxy)
+            dataset_proxy=json.loads(dataset_proxy),
         )
 
         self._vineyard_service_endpoint = None

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -103,6 +103,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         waiting_for_delete=None,
         with_mars=False,
         enabled_engines="",
+        dataset_proxy="{}",
         **kwargs,
     ):
 
@@ -239,6 +240,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
             with_analytical_java=self._with_analytical_java,
             with_interactive=self._with_interactive,
             with_learning=self._with_learning,
+            dataset_proxy=json.loads(dataset_proxy)
         )
 
         self._vineyard_service_endpoint = None

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -103,7 +103,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         waiting_for_delete=None,
         with_mars=False,
         enabled_engines="",
-        dataset_proxy="{}",
+        dataset_proxy=None,
         **kwargs,
     ):
 
@@ -240,7 +240,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
             with_analytical_java=self._with_analytical_java,
             with_interactive=self._with_interactive,
             with_learning=self._with_learning,
-            dataset_proxy=json.loads(dataset_proxy),
+            dataset_proxy=dataset_proxy,
         )
 
         self._vineyard_service_endpoint = None


### PR DESCRIPTION
This PR adds an option of configuring the proxy service address for the dataset container should be added to the configuration file of helm

The dataset container of graphscope provides the function of obtaining sample dataset online, but there are many inconveniences in accessing the external network to obtain data in many Intranet environments. 

Fixes #2512 


