### PR TITLE
Fix: Gremlin startup error when k8s release name contains' - '. #2524

### DIFF
--- a/interactive_engine/assembly/src/bin/graphscope/giectl
+++ b/interactive_engine/assembly/src/bin/graphscope/giectl
@@ -265,7 +265,7 @@ create_gremlin_instance_on_k8s() {
   declare -r frontend_port=$8
   declare -r coordinator_name=$9 # deployment name of coordinator
 
-  instance_id=${coordinator_name##*-}
+  instance_id=${coordinator_name#*-}
 
   pod_ips=$(kubectl get pod -lapp.kubernetes.io/component=engine,app.kubernetes.io/instance=${instance_id} -o jsonpath='{.items[*].status.podIP}')
   pegasus_hosts=""


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
When starting the gremlin instance, you need to get the instance_id. If the release name of the current application contains' - ', for example, 'b-c', the coordinator_name is' coordinator-b-c ', and every char after the last '-' is captured in the case of existing code, and the instance_id is' c '. In fact, every char after the first '-' should be captured. instance_id is' b-c '.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#2524 

Fixes

