### PR TITLE
fix chart download path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         ossutil64 -i "${oss_accesskey_id}" \
                   -k "${oss_accesskey_secret}" \
                   -e ${{ env.OSS_ENDPOINT }} \
-                  cp -r oss://graphscope/charts ./
+                  cp -r oss://graphscope/charts ./charts
 
     - name: Package Charts
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,6 @@ jobs:
         sudo chmod +x /usr/bin/ossutil64
 
         # download released charts
-        cd ${GITHUB_WORKSPACE}/charts
         ossutil64 -i "${oss_accesskey_id}" \
                   -k "${oss_accesskey_secret}" \
                   -e ${{ env.OSS_ENDPOINT }} \


### PR DESCRIPTION
Previously `cd $GITHUB_WORKSPACE/charts && cp -r oss://graphscope/charts ./` will output all contents to `$GITHUB_WORKSPACE/charts/charts/xxx`.

Change to `cd $GITHUB_WORKSPACE && cp -r oss://graphscope/charts ./charts` will output all contents to `$GITHUB_WORKSPACE/charts/xxx`.

The latter case would make older .tgz files in the same level of the newest tgz file that `helm package` generated.