### PR TITLE
`sh` doesn't have `source`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,6 @@ all: learning client coordinator analytical interactive
 graphscope: all
 
 install: analytical-install interactive-install learning-install client coordinator
-    # client
-	pip3 install --user --editable $(CLIENT_DIR)
-	rm -rf $(CLIENT_DIR)/*.egg-info
-    # coordinator
-	pip3 install --user --editable $(COORDINATOR_DIR)
-	rm -rf $(COORDINATOR_DIR)/*.egg-info
-
 	echo "Run the following command to correctly set environment variable"
 	echo "export GRAPHSCOPE_HOME=$(INSTALL_PREFIX)"
 
@@ -74,11 +67,15 @@ client: learning
 	cd $(CLIENT_DIR) && \
 	pip3 install -r requirements.txt -r requirements-dev.txt --user && \
 	python3 setup.py build_ext --inplace --user
+	pip3 install --user --editable $(CLIENT_DIR)
+	rm -rf $(CLIENT_DIR)/*.egg-info
 
 coordinator: client
 	cd $(COORDINATOR_DIR) && \
 	pip3 install -r requirements.txt -r requirements-dev.txt --user && \
 	python3 setup.py build_builtin
+	pip3 install --user --editable $(COORDINATOR_DIR)
+	rm -rf $(COORDINATOR_DIR)/*.egg-info
 
 # We deliberately make $(ENGINE) depends on a file, and $(ENGINE)-install depends on $(ENGINE),
 # so that when we execute `make $(ENGINE)-install` after `make $(ENGINE)`, it will not

--- a/k8s/dockerfiles/analytical.Dockerfile
+++ b/k8s/dockerfiles/analytical.Dockerfile
@@ -11,12 +11,12 @@ ARG CI=false
 COPY --chown=graphscope:graphscope . /home/graphscope/GraphScope
 
 RUN cd /home/graphscope/GraphScope/ && \
-    if [ "${CI}" == "true" ]; then \
+    if [ "${CI}" = "true" ]; then \
         cp -r artifacts/analytical /home/graphscope/install; \
     else \
         export INSTALL_DIR=/home/graphscope/install; \
         mkdir ${INSTALL_DIR}; \
-        source /home/graphscope/.graphscope_env; \
+        . /home/graphscope/.graphscope_env; \
         make analytical-install INSTALL_PREFIX=${INSTALL_DIR}; \
         strip ${INSTALL_DIR}/bin/grape_engine; \
         strip ${INSTALL_DIR}/lib/*.so; \
@@ -47,12 +47,12 @@ FROM $REGISTRY/graphscope/graphscope-dev:$BUILDER_VERSION AS builder-java
 COPY --chown=graphscope:graphscope . /home/graphscope/GraphScope
 
 RUN cd /home/graphscope/GraphScope/ && \
-    if [ "${CI}" == "true" ]; then \
+    if [ "${CI}" = "true" ]; then \
         cp -r artifacts/analytical-java /home/graphscope/install; \
     else \
         export INSTALL_DIR=/home/graphscope/install; \
         mkdir ${INSTALL_DIR}; \
-        source /home/graphscope/.graphscope_env; \
+        . /home/graphscope/.graphscope_env; \
         make analytical-java-install INSTALL_PREFIX=${INSTALL_DIR}; \
         strip ${INSTALL_DIR}/bin/grape_engine; \
         strip ${INSTALL_DIR}/lib/*.so; \

--- a/k8s/dockerfiles/coordinator.Dockerfile
+++ b/k8s/dockerfiles/coordinator.Dockerfile
@@ -9,9 +9,10 @@ ARG CI=false
 COPY --chown=graphscope:graphscope . /home/graphscope/GraphScope
 
 RUN cd /home/graphscope/GraphScope/ && \
-    if [ "${CI}" == "true" ]; then \
+    if [ "${CI}" = "true" ]; then \
         cp -r artifacts/learning /home/graphscope/install; \
     else \
+        . /home/graphscope/.graphscope_env; \
         mkdir /home/graphscope/install; \
         make learning-install INSTALL_PREFIX=/home/graphscope/install; \
         source /home/graphscope/.graphscope_env; \

--- a/k8s/dockerfiles/graphscope-dev.Dockerfile
+++ b/k8s/dockerfiles/graphscope-dev.Dockerfile
@@ -37,11 +37,10 @@ RUN chmod +x /opt/graphscope/bin/* /opt/openmpi/bin/*
 RUN useradd -m graphscope -u 1001 \
     && echo 'graphscope ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-RUN chown -R graphscope:graphscope /opt/graphscope /opt/openmpi
 RUN yum install -y sudo vim && \
     yum clean all -y --enablerepo='*' && \
     rm -rf /var/cache/yum
-RUN mkdir /opt/vineyard && chown -R graphscope:graphscope /opt/vineyard
+RUN mkdir -p /opt/graphscope /opt/vineyard && chown -R graphscope:graphscope /opt/graphscope /opt/vineyard
 USER graphscope
 WORKDIR /home/graphscope
 
@@ -53,7 +52,7 @@ RUN ./gs install-deps dev --v6d-version=$VINEYARD_VERSION -j 2 && \
 
 SHELL [ "/usr/bin/scl", "enable", "rh-python38" ]
 
-RUN python3 -m pip --no-cache install pyyaml --user
+RUN python3 -m pip --no-cache install pyyaml ipython --user
 # Uncomment this line will results in a weird error when using the image together with commands, like
 # docker run --rm graphscope/graphscope-dev:latest bash -c 'echo xxx && ls -la'
 # The output of `ls -la` would not be shown.

--- a/k8s/dockerfiles/interactive-experimental.Dockerfile
+++ b/k8s/dockerfiles/interactive-experimental.Dockerfile
@@ -7,7 +7,7 @@ FROM $REGISTRY/graphscope/graphscope-dev:$BUILDER_VERSION AS builder
 COPY --chown=graphscope:graphscope . /home/graphscope/GraphScope
 
 RUN cd /home/graphscope/GraphScope/interactive_engine/compiler \
-    && source /home/graphscope/.graphscope_env \
+    && . /home/graphscope/.graphscope_env \
     && make build rpc.target=start_rpc_server_k8s
 
 ############### RUNTIME: frontend && executor #######################

--- a/k8s/dockerfiles/interactive.Dockerfile
+++ b/k8s/dockerfiles/interactive.Dockerfile
@@ -12,11 +12,11 @@ ENV profile=$profile
 COPY --chown=graphscope:graphscope . /home/graphscope/GraphScope
 
 RUN cd /home/graphscope/GraphScope/ && \
-    if [ "${CI}" == "true" ]; then \
+    if [ "${CI}" = "true" ]; then \
         cp -r artifacts/interactive /home/graphscope/install; \
     else \
         mkdir /home/graphscope/install; \
-        source /home/graphscope/.graphscope_env; \
+        . /home/graphscope/.graphscope_env; \
         make interactive-install BUILD_TYPE="$profile" INSTALL_PREFIX=/home/graphscope/install; \
     fi
 

--- a/k8s/dockerfiles/learning.Dockerfile
+++ b/k8s/dockerfiles/learning.Dockerfile
@@ -10,9 +10,10 @@ ARG CI=false
 COPY --chown=graphscope:graphscope . /home/graphscope/GraphScope
 
 RUN cd /home/graphscope/GraphScope/ && \
-    if [ "${CI}" == "true" ]; then \
+    if [ "${CI}" = "true" ]; then \
         cp -r artifacts/learning /home/graphscope/install; \
     else \
+        . /home/graphscope/.graphscope_env; \
         mkdir /home/graphscope/install; \
         make learning-install INSTALL_PREFIX=/home/graphscope/install; \
         source /home/graphscope/.graphscope_env; \
@@ -43,10 +44,9 @@ RUN sudo chmod a+wrx /tmp
 SHELL [ "/usr/bin/scl", "enable", "rh-python38" ]
 
 ENV GRAPHSCOPE_HOME=/opt/graphscope
-ENV PATH=$PATH:$GRAPHSCOPE_HOME/bin LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GRAPHSCOPE_HOME/lib
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GRAPHSCOPE_HOME/lib
 
-COPY --from=builder /home/graphscope/install /opt/graphscope
-RUN python3 -m pip install --no-cache-dir /opt/graphscope/*.whl && rm -rf /opt/graphscope/*.whl
+RUN sudo chmod a+wrx /tmp
 
 USER graphscope
 WORKDIR /home/graphscope

--- a/k8s/dockerfiles/manylinux2014-ext.Dockerfile
+++ b/k8s/dockerfiles/manylinux2014-ext.Dockerfile
@@ -22,7 +22,8 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
       tar xzf hadoop-3.3.0.tar.gz -C /opt/; \
     fi && \
     rm -rf hadoop-3.3.0* && \
-    rm -rf /opt/hadoop-3.3.0/share/doc
+    cd /opt/hadoop-3.3.0/share/ && \
+    rm -rf doc hadoop/client  hadoop/mapreduce  hadoop/tools  hadoop/yarn
 
 FROM centos:7
 

--- a/k8s/internal/graphscope.Dockerfile
+++ b/k8s/internal/graphscope.Dockerfile
@@ -62,7 +62,7 @@ COPY ./k8s/utils/kube_ssh /usr/local/bin/kube_ssh
 ARG CI=false
 
 RUN cd /home/graphscope/gs && \
-    if [ "${CI}" == "true" ]; then \
+    if [ "${CI}" = "true" ]; then \
         pushd artifacts/python/dist/wheelhouse; \
         for f in * ; do python3 -m pip install --no-cache-dir $f; done || true; \
         popd; \


### PR DESCRIPTION
- Move `pip install` to previous section, so that `make coordinator` will use local installed client, instead of download client wheel from remote.

- `sh` doesn't have `source` command, and docker use `sh` as default shell in dockerfiles.
- `sh` doesn't supports `==` operator
- Install ipython to `dev` docker
- Remove unnecessary hadoop contents to save space.