### PR TITLE
[GAE/WCC] Fix WCC' implementation on undirected graph

### DIFF
--- a/analytical_engine/apps/property/auto_wcc_property.h
+++ b/analytical_engine/apps/property/auto_wcc_property.h
@@ -124,12 +124,14 @@ class AutoWCCProperty
             }
           }
 
-          es = frag.GetIncomingAdjList(v, j);
-          for (auto& e : es) {
-            auto u = e.neighbor();
-            label_id_t u_label = frag.vertex_label(u);
-            if (ctx.partial_result[u_label][u] > cid) {
-              ctx.partial_result[u_label].SetValue(u, cid);
+          if (frag.directed()) {
+            es = frag.GetIncomingAdjList(v, j);
+            for (auto& e : es) {
+              auto u = e.neighbor();
+              label_id_t u_label = frag.vertex_label(u);
+              if (ctx.partial_result[u_label][u] > cid) {
+                ctx.partial_result[u_label].SetValue(u, cid);
+              }
             }
           }
         }
@@ -156,12 +158,14 @@ class AutoWCCProperty
             }
           }
 
-          es = frag.GetIncomingAdjList(v, j);
-          for (auto& e : es) {
-            auto u = e.neighbor();
-            label_id_t u_label = frag.vertex_label(u);
-            if (ctx.partial_result[u_label][u] > cid) {
-              ctx.partial_result[u_label].SetValue(u, cid);
+          if (frag.directed()) {
+            es = frag.GetIncomingAdjList(v, j);
+            for (auto& e : es) {
+              auto u = e.neighbor();
+              label_id_t u_label = frag.vertex_label(u);
+              if (ctx.partial_result[u_label][u] > cid) {
+                ctx.partial_result[u_label].SetValue(u, cid);
+              }
             }
           }
         }

--- a/analytical_engine/apps/property/wcc_property.h
+++ b/analytical_engine/apps/property/wcc_property.h
@@ -114,13 +114,15 @@ class WCCProperty : public PropertyAppBase<FRAG_T, WCCPropertyContext<FRAG_T>> {
             }
           }
 
-          es = frag.GetIncomingAdjList(v, j);
-          for (auto& e : es) {
-            auto u = e.neighbor();
-            label_id_t u_label = frag.vertex_label(u);
-            if (ctx.comp_id[u_label][u] > cid) {
-              ctx.comp_id[u_label][u] = cid;
-              ctx.next_modified[u_label][u] = true;
+          if (frag.directed()) {
+            es = frag.GetIncomingAdjList(v, j);
+            for (auto& e : es) {
+              auto u = e.neighbor();
+              label_id_t u_label = frag.vertex_label(u);
+              if (ctx.comp_id[u_label][u] > cid) {
+                ctx.comp_id[u_label][u] = cid;
+                ctx.next_modified[u_label][u] = true;
+              }
             }
           }
         }
@@ -178,13 +180,15 @@ class WCCProperty : public PropertyAppBase<FRAG_T, WCCPropertyContext<FRAG_T>> {
             }
           }
 
-          es = frag.GetIncomingAdjList(v, j);
-          for (auto& e : es) {
-            auto u = e.neighbor();
-            label_id_t u_label = frag.vertex_label(u);
-            if (ctx.comp_id[u_label][u] > cid) {
-              ctx.comp_id[u_label][u] = cid;
-              ctx.next_modified[u_label][u] = true;
+          if (frag.directed()) {
+            es = frag.GetIncomingAdjList(v, j);
+            for (auto& e : es) {
+              auto u = e.neighbor();
+              label_id_t u_label = frag.vertex_label(u);
+              if (ctx.comp_id[u_label][u] > cid) {
+                ctx.comp_id[u_label][u] = cid;
+                ctx.next_modified[u_label][u] = true;
+              }
             }
           }
         }

--- a/analytical_engine/benchmarks/apps/wcc/property_wcc.h
+++ b/analytical_engine/benchmarks/apps/wcc/property_wcc.h
@@ -88,12 +88,15 @@ class PropertyWCC
                   ctx.next_modified.Insert(u);
                 }
               }
-              es = frag.GetIncomingAdjList(v, 0);
-              for (auto& e : es) {
-                auto u = e.get_neighbor();
-                if (ctx.comp_id[u] > cid) {
-                  grape::atomic_min(ctx.comp_id[u], cid);
-                  ctx.next_modified.Insert(u);
+
+              if (frag.directed()) {
+                es = frag.GetIncomingAdjList(v, 0);
+                for (auto& e : es) {
+                  auto u = e.get_neighbor();
+                  if (ctx.comp_id[u] > cid) {
+                    grape::atomic_min(ctx.comp_id[u], cid);
+                    ctx.next_modified.Insert(u);
+                  }
                 }
               }
             });
@@ -130,12 +133,15 @@ class PropertyWCC
           ctx.next_modified.Insert(u);
         }
       }
-      es = frag.GetIncomingAdjList(v, 0);
-      for (auto& e : es) {
-        auto u = e.get_neighbor();
-        if (ctx.comp_id[u] > cid) {
-          grape::atomic_min(ctx.comp_id[u], cid);
-          ctx.next_modified.Insert(u);
+
+      if (frag.directed()) {
+        es = frag.GetIncomingAdjList(v, 0);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          if (ctx.comp_id[u] > cid) {
+            grape::atomic_min(ctx.comp_id[u], cid);
+            ctx.next_modified.Insert(u);
+          }
         }
       }
     });

--- a/analytical_engine/benchmarks/apps/wcc/wcc.h
+++ b/analytical_engine/benchmarks/apps/wcc/wcc.h
@@ -81,12 +81,15 @@ class WCC : public grape::ParallelAppBase<FRAG_T, WCCContext<FRAG_T>>,
                   ctx.next_modified.Insert(u);
                 }
               }
-              es = frag.GetIncomingAdjList(v);
-              for (auto& e : es) {
-                auto u = e.get_neighbor();
-                if (ctx.comp_id[u] > cid) {
-                  grape::atomic_min(ctx.comp_id[u], cid);
-                  ctx.next_modified.Insert(u);
+
+              if (frag.directed()) {
+                es = frag.GetIncomingAdjList(v);
+                for (auto& e : es) {
+                  auto u = e.get_neighbor();
+                  if (ctx.comp_id[u] > cid) {
+                    grape::atomic_min(ctx.comp_id[u], cid);
+                    ctx.next_modified.Insert(u);
+                  }
                 }
               }
             });
@@ -123,12 +126,15 @@ class WCC : public grape::ParallelAppBase<FRAG_T, WCCContext<FRAG_T>>,
           ctx.next_modified.Insert(u);
         }
       }
-      es = frag.GetIncomingAdjList(v);
-      for (auto& e : es) {
-        auto u = e.get_neighbor();
-        if (ctx.comp_id[u] > cid) {
-          grape::atomic_min(ctx.comp_id[u], cid);
-          ctx.next_modified.Insert(u);
+
+      if (frag.directed()) {
+        es = frag.GetIncomingAdjList(v);
+        for (auto& e : es) {
+          auto u = e.get_neighbor();
+          if (ctx.comp_id[u] > cid) {
+            grape::atomic_min(ctx.comp_id[u], cid);
+            ctx.next_modified.Insert(u);
+          }
         }
       }
     });


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
There are multiple implementations of WCC, however, some implementations seem only work on directed graph, these implementations will not cause an error on undirected graph, but have some small bad performance.

I see networkX only support WCC on directed graph, but, it seems our platform can use WCC both on directed and undirected graph with a small change and have no performance impact, and that's the PR does.
![f1](https://user-images.githubusercontent.com/9260628/229488369-2c0cdaaa-e549-4ef6-bc8c-d4a8c8a44f99.png)
![f2](https://user-images.githubusercontent.com/9260628/229488416-fb15343b-2c7c-482c-a420-9b38ab5acc85.png)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

