### PR TITLE
Bump up vineyard version to v0.14.2 to enable gar_fragment_loader

### DIFF
--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -160,7 +160,7 @@ jobs:
       run: |
         . ~/.graphscope_env
         python3 -m pip install libclang
-        git clone --single-branch -b v0.14.0 --depth=1 https://github.com/v6d-io/v6d.git /tmp/v6d
+        git clone --single-branch -b v0.14.2 --depth=1 https://github.com/v6d-io/v6d.git /tmp/v6d
         cd /tmp/v6d
         git submodule update --init
         cmake .  -DCMAKE_INSTALL_PREFIX=/usr/local \

--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.14.0
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.14.2
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/networkx-forward-algo-nightly.yml
+++ b/.github/workflows/networkx-forward-algo-nightly.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.14.0
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.14.2
       options:
         --shm-size 4096m
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,10 +43,10 @@ jobs:
         fi
         sudo mkdir /opt/graphscope
         sudo chown -R $(id -u):$(id -g) /opt/graphscope
-        ./gs install-deps dev --v6d-version v0.14.0
+        ./gs install-deps dev --v6d-version v0.14.2
 
     - name: Setup tmate session
-      if: false 
+      if: false
       uses: mxschmitt/action-tmate@v2
 
     - name: Build GraphScope

--- a/gs
+++ b/gs
@@ -1014,7 +1014,7 @@ install_vineyard() {
         -DCMAKE_INSTALL_PREFIX="${V6D_PREFIX}" \
         -DBUILD_VINEYARD_TESTS=OFF \
         -DBUILD_SHARED_LIBS=ON \
-        -DBUILD_VINEYARD_PYTHON_BINDINGS=ON  \
+        -DBUILD_VINEYARD_PYTHON_BINDINGS=ON \
         -DBUILD_VINEYARD_GRAPH_WITH_GAR=ON
   make -j"${jobs}"
   make install
@@ -1462,6 +1462,7 @@ gs_install_deps_command() {
     "librdkafka-dev"
     "protobuf-compiler-grpc"
     "rapidjson-dev"
+    "libcurl4-openssl-dev"
   )
 
   ANALYTICAL_CENTOS_7=("librdkafka-devel" "msgpack-devel" "rapidjson-devel")

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -7,7 +7,7 @@ ifeq ($(REGISTRY),)
 endif
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.14.0
+VINEYARD_VERSION ?= v0.14.2
 # This is the version of builder base image in most cases, except for graphscope-dev
 BUILDER_VERSION ?= $(VINEYARD_VERSION)
 # This is the version of runtime base image

--- a/k8s/actions-runner-controller/manylinux/Makefile
+++ b/k8s/actions-runner-controller/manylinux/Makefile
@@ -12,7 +12,7 @@ TARGETPLATFORM ?= $(shell arch)
 RUNNER_VERSION ?= 2.287.1
 DOCKER_VERSION ?= 20.10.12
 
-VINEYARD_VERSION ?= v0.14.0
+VINEYARD_VERSION ?= v0.14.2
 BUILDER_VERSION ?= $(VINEYARD_VERSION)
 
 # default list of platforms for which multiarch image is built

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -37,7 +37,7 @@ GRAPHSCOPE_HOME ?= /usr/local
 INSTALL_PREFIX ?= /opt/graphscope
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.14.0
+VINEYARD_VERSION ?= v0.14.2
 PROFILE ?= release
 CI ?= false
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.14.0"  # vineyard version
-readonly V6D_BRANCH="v0.14.0" # vineyard branch
+readonly V6D_VERSION="0.14.2"  # vineyard version
+readonly V6D_BRANCH="v0.14.2" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a96df68</samp>

This pull request updates the vineyard dependency from v0.13.4 to v0.14.1 in various files related to the GraphScope build, test, and deployment workflows. This ensures compatibility with the latest release of vineyard, which is a distributed in-memory data management framework used by GraphScope. It also fixes some minor formatting issues in the `gs` script and the `build-graphscope-wheels-macos.yml` workflow file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a96df68</samp>

*  Update vineyard version from v0.13.4 to v0.14.1 in various files to align with the latest release of vineyard, which is a distributed in-memory data management framework used by GraphScope ([link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-327dff1aed7f08f01ed019443c8057b4121eea585e8732824c0aa3070e7558ddL147-R147), [link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-1188b8d4622e6cf8f8a106f5cdeeff74bbd051769b1f7987d5b8dfae90553971L32-R32), [link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-40b7e4fb4c708833389572f2fb6a92943a654d9b0289a7b38d739d26ab039942L20-R20), [link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6L46-R49), [link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-7a5443b6636713baa6350c1cf3ec620b2771a8d411ea3180c5d46b502b9ab77dL964-R964), [link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-19a69f25bb584896a33a476b1ab61d5c34af33dcde90215500ed3fd2ebb0a1a2L10-R10), [link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-d0d5f62db7bcea7fb1a0b952787191876b46b4adde2dc11bbdd72f25a5dbb3f7L15-R15), [link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-ea4eb88f4011913fa5d7501e35c6e30610f83a5e712dde5fd002fa4345c45ce0L40-R40), [link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-c3ff4e129c54b291da6bdad23c8664c34a78325e7c02e8c13404041836bb82d6L18-R18))
*  Add `libcurl4-openssl-dev` and `libcurl-devel` to the list of packages that are installed for the analytical engine in the script `gs`, which is a tool for building and running GraphScope ([link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-7a5443b6636713baa6350c1cf3ec620b2771a8d411ea3180c5d46b502b9ab77dL1427-R1430))
*  Add `curl` to the list of packages that are installed for the interactive engine in the script `gs`, which is a tool for building and running GraphScope ([link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-7a5443b6636713baa6350c1cf3ec620b2771a8d411ea3180c5d46b502b9ab77dR1445))
*  Remove extra blank spaces in the comment block in the workflow file `build-graphscope-wheels-macos.yml`, which is a GitHub Actions workflow for building GraphScope wheels for macOS ([link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-327dff1aed7f08f01ed019443c8057b4121eea585e8732824c0aa3070e7558ddL37-R37))
*  Remove extra blank space in the command that builds vineyard from source in the script `gs`, which is a tool for building and running GraphScope ([link](https://github.com/alibaba/GraphScope/pull/2602/files?diff=unified&w=0#diff-7a5443b6636713baa6350c1cf3ec620b2771a8d411ea3180c5d46b502b9ab77dL964-R964))

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a96df68</samp>

> _We align with the latest release of vineyard_
> _The distributed framework of our data_
> _We update our dependencies and fix our format_
> _The graphscope of our metal fate_