### PR TITLE
Use vineyardctl API to inject the vineyard sidecar

### DIFF
--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -481,7 +481,7 @@ class EngineCluster:
     def get_vineyard_service_endpoint(self, api_client):
         # return f"{self.vineyard_service_name}:{self._vineyard_service_port}"
         service_name = self.vineyard_service_name
-        service_type = "ClusterIP"
+        service_type = self._service_type
         if self.vineyard_deployment_exists():
             service_name = self._vineyard_deployment + "-rpc"
         endpoints = get_service_endpoints(

--- a/coordinator/gscoordinator/cluster_builder.py
+++ b/coordinator/gscoordinator/cluster_builder.py
@@ -446,18 +446,6 @@ class EngineCluster:
         )
         return service
 
-    def get_vineyard_service(self):
-        service_type = self._service_type
-        name = f"{self._vineyard_prefix}{self._instance_id}"
-        ports = [kube_client.V1ServicePort(name=name, port=self._vineyard_service_port)]
-        service_spec = ResourceBuilder.get_service_spec(
-            service_type, ports, self._engine_labels, None
-        )
-        service = ResourceBuilder.get_service(
-            self._namespace, name, service_spec, self._engine_labels
-        )
-        return service
-
     def get_learning_service(self, object_id, start_port):
         service_type = self._service_type
         num_workers = self._num_workers
@@ -488,15 +476,14 @@ class EngineCluster:
 
     @property
     def vineyard_service_name(self):
-        return self.engine_stateful_set_name + "-vineyard-sidecar-rpc"
+        return f"{self.engine_stateful_set_name}-{self._instance_id}-vineyard-rpc"
 
     def get_vineyard_service_endpoint(self, api_client):
         # return f"{self.vineyard_service_name}:{self._vineyard_service_port}"
         service_name = self.vineyard_service_name
-        service_type = self._service_type
+        service_type = "ClusterIP"
         if self.vineyard_deployment_exists():
             service_name = self._vineyard_deployment + "-rpc"
-            service_type = "ClusterIP"
         endpoints = get_service_endpoints(
             api_client=api_client,
             namespace=self._namespace,

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -618,6 +618,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
             sidecar_size=self._vineyard_shared_mem,
             sidecar_cpu=self._vineyard_cpu,
             sidecar_memory=self._vineyard_mem,
+            sidecar_service_type=self._service_type,
             output="json",
             capture=True,
         )

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -152,6 +152,10 @@ class KubernetesClusterLauncher(AbstractLauncher):
         self._engine_mem = engine_mem
         self._vineyard_shared_mem = vineyard_shared_mem
 
+        self._vineyard_cpu = vineyard_cpu
+        self._vineyard_mem = vineyard_mem
+        self._vineyard_image = vineyard_image
+
         self._with_dataset = with_dataset
         self._preemptive = preemptive
         self._service_type = service_type
@@ -432,6 +436,198 @@ class KubernetesClusterLauncher(AbstractLauncher):
         )
         self._resource_object.append(response)
 
+    # The function is used to inject vineyard as a sidecar container into the workload
+    # and return the json string of new workload which is injected with vineyard sidecar
+    #
+    # Assume we have a workload json as below:
+    #
+    # {
+    #  "apiVersion": "apps/v1",
+    #  "kind": "Deployment",
+    #  "metadata": {
+    #    "name": "nginx-deployment",
+    #    "namespace": "vineyard-job"
+    #  },
+    #  "spec": {
+    #    "selector": {
+    #      "matchLabels": {
+    #        "app": "nginx"
+    #      }
+    #    },
+    #    "template": {
+    #      "metadata": {
+    #        "labels": {
+    #          "app": "nginx"
+    #        }
+    #      },
+    #      "spec": {
+    #        "containers": [
+    #          {
+    #            "name": "nginx",
+    #            "image": "nginx:1.14.2",
+    #            "ports": [
+    #              {
+    #                "containerPort": 80
+    #              }
+    #            ]
+    #          }
+    #        ]
+    #      }
+    #    }
+    #  }
+    # }
+    #
+    # The function will return a new workload json as below:
+    #
+    # {
+    #  "apiVersion": "apps/v1",
+    #  "kind": "Deployment",
+    #  "metadata": {
+    #    "creationTimestamp": null,
+    #    "name": "nginx-deployment",
+    #    "namespace": "vineyard-job"
+    #  },
+    #  "spec": {
+    #    "selector": {
+    #      "matchLabels": {
+    #        "app": "nginx"
+    #      }
+    #    }
+    #  },
+    #  "template": {
+    #    "metadata": null,
+    #    "labels": {
+    #      "app": "nginx",
+    #      "app.vineyard.io/name": "vineyard-sidecar"
+    #    },
+    #    "spec": {
+    #      "containers": [
+    #        {
+    #          "command": null,
+    #          "image": "nginx:1.14.2",
+    #          "name": "nginx",
+    #          "ports": [
+    #            {
+    #              "containerPort": 80
+    #            }
+    #          ],
+    #          "volumeMounts": [
+    #            {
+    #              "mountPath": "/var/run",
+    #              "name": "vineyard-socket"
+    #            }
+    #          ]
+    #        },
+    #        {
+    #          "command": [
+    #            "/bin/bash",
+    #            "-c",
+    #            "/usr/bin/wait-for-it.sh -t 60 vineyard-sidecar-etcd-service.vineyard-job.svc.cluster.local:2379; \\\n
+    #             sleep 1; /usr/local/bin/vineyardd --sync_crds true --socket /var/run/vineyard.sock --size 256Mi \\\n
+    #             --stream_threshold 80 --etcd_cmd etcd --etcd_prefix /vineyard \\\n
+    #             --etcd_endpoint http://vineyard-sidecar-etcd-service:2379\n"
+    #          ],
+    #          "env": [
+    #            {
+    #              "name": "VINEYARDD_UID",
+    #              "value": null
+    #            },
+    #            {
+    #              "name": "VINEYARDD_NAME",
+    #              "value": "vineyard-sidecar"
+    #            },
+    #            {
+    #              "name": "VINEYARDD_NAMESPACE",
+    #              "value": "vineyard-job"
+    #            }
+    #          ],
+    #          "image": "vineyardcloudnative/vineyardd:latest",
+    #          "imagePullPolicy": "IfNotPresent",
+    #          "name": "vineyard-sidecar",
+    #          "ports": [
+    #            {
+    #              "containerPort": 9600,
+    #              "name": "vineyard-rpc",
+    #              "protocol": "TCP"
+    #            }
+    #          ],
+    #          "volumeMounts": [
+    #            {
+    #              "mountPath": "/var/run",
+    #              "name": "vineyard-socket"
+    #            }
+    #          ]
+    #        }
+    #      ],
+    #      "volumes": [
+    #        {
+    #          "emptyDir": {},
+    #          "name": "vineyard-socket"
+    #        }
+    #      ]
+    #    }
+    #  }
+    # }
+
+    def _inject_vineyard_as_sidecar(self, workload):
+        import vineyard
+
+        # create the annotations for the workload's template if not exists
+        if workload.spec.template.metadata.annotations is None:
+            workload.spec.template.metadata.annotations = {}
+
+        # create the labels for the workload's template if not exists
+        if workload.spec.template.metadata.labels is None:
+            workload.spec.template.metadata.labels = {}
+
+        workload_json = json.dumps(
+            self._api_client.sanitize_for_serialization(workload)
+        )
+
+        sts_name = self._engine_cluster.engine_stateful_set_name
+        owner_reference = [
+            {
+                "apiVersion": self._owner_references[0].api_version,
+                "kind": self._owner_references[0].kind,
+                "name": self._owner_references[0].name,
+                "uid": self._owner_references[0].uid,
+            }
+        ]
+
+        owner_reference_json = json.dumps(owner_reference)
+        # inject vineyard sidecar into the workload
+        #
+        # the name is used to specify the name of the sidecar container, which is also the
+        # labelSelector of the rpc service and the etcd service.
+        #
+        # the apply_resources is used to apply resources to the kubernetes cluster during
+        # the injection.
+        #
+        # for more details about vineyardctl inject, please refer to the link below:
+        # https://github.com/v6d-io/v6d/tree/main/k8s/cmd#vineyardctl-inject
+
+        new_workload_json = vineyard.deploy.vineyardctl.inject(
+            resource=workload_json,
+            sidecar_volume_mountpath="/tmp/vineyard_workspace",
+            name=sts_name + "-vineyard-sidecar",
+            apply_resources=True,
+            owner_references=owner_reference_json,
+            sidecar_image=self._vineyard_image,
+            sidecar_size=self._vineyard_shared_mem,
+            sidecar_cpu=self._vineyard_cpu,
+            sidecar_memory=self._vineyard_mem,
+            output="json",
+            capture=True,
+        )
+
+        normalized_workload_json = json.loads(new_workload_json)
+        final_workload_json = json.loads(normalized_workload_json["workload"])
+
+        fake_kube_response = FakeKubeResponse(final_workload_json)
+
+        new_workload = self._api_client.deserialize(fake_kube_response, type(workload))
+        return new_workload
+
     def _create_engine_stateful_set(self):
         logger.info("Create engine headless services...")
         service = self._engine_cluster.get_engine_headless_service()
@@ -446,8 +642,8 @@ class KubernetesClusterLauncher(AbstractLauncher):
             stateful_set = self._add_pod_affinity_for_vineyard_deployment(
                 workload=stateful_set
             )
-
-        stateful_set.metadata.owner_references = self._owner_references
+        else:
+            stateful_set = self._inject_vineyard_as_sidecar(stateful_set)
         response = self._apps_api.create_namespaced_stateful_set(
             self._namespace, stateful_set
         )
@@ -503,8 +699,6 @@ class KubernetesClusterLauncher(AbstractLauncher):
         if self._with_mars:
             # scheduler used by Mars
             self._create_mars_scheduler()
-        if self._vineyard_deployment is None:
-            self._create_vineyard_service()
 
     def _waiting_for_services_ready(self):
         logger.info("Waiting for services ready...")

--- a/docs/frequently_asked_questions.rst
+++ b/docs/frequently_asked_questions.rst
@@ -55,13 +55,13 @@ If you don't find an answer to your question here, feel free to file an `Issues`
 
     If GraphScope seems to get stuck, the possible cause might be:
 
-    - In the session launching stage, the most cases are waiting for Pods ready. The time consuming may be caused by a poor network connection during pulling image, or by failing to acquire the requested resources to launch a session.
+    - In the session launching stage, the most cases are waiting for Pods ready. The time consumption may be caused by a poor network connection during pulling image, or by failing to acquire the requested resources to launch a session.
     - In the graph loading stage, it is time consuming to load and build a large graph.
-    - When running a user-defined or built-in analytical algorithm, it may takes time to compile the algorithm over the loaded graph.
+    - When running a user-defined or built-in analytical algorithm, it may take time to compile the algorithm over the loaded graph.
 
 8. Why `No such file or directory` error when loading graph?
 
-    This mostly occur when you are deploying GraphScope in a Kubernetes cluster, the file must be visible to the ``engnine`` Pod of GraphScope. You may need to mount a volume to the Pods or use cloud storage providers.
+    This mostly occurs when you are deploying GraphScope in a Kubernetes cluster, the file must be visible to the ``engnine`` Pod of GraphScope. You may need to mount a volume to the Pods or use cloud storage providers.
 
     Specifically, if your cluster is deployed with `kind <https://kind.sigs.k8s.io>`_, you may need to setup `extra-mounts <https://kind.sigs.k8s.io/docs/user/configuration/#extra-mounts>`_ to mount your local directory to kind nodes.
 
@@ -95,9 +95,9 @@ If you don't find an answer to your question here, feel free to file an `Issues`
 
     - Check: First use ``kubectl logs graphscope-store-zookeeper-0`` to check log. If the log shows ``mkdir: cannot create directory '/bitnami/zookeeper/data': Permission denied``.
 
-    - Reason: Normaly, the permission of NFS directories we created is ``root 755`` (depends on your sepcify environment), but the default user of graphscope-store is ``graphscope(1001)``, so these pods have no permission to write on NFS.
+    - Reason: Normally, the permission of NFS directories we created is ``root 755`` (depends on your specific environment), but the default user of graphscope-store is ``graphscope(1001)``, so these pods have no permission to write on NFS.
 
-    - Solution: There are two slutions to solve this.
+    - Solution: There are two solutions to solve this.
 
         The brutal one is using ``chmod 777`` on all related PV directories, this is efficient but not recommended in production environment.
 
@@ -105,7 +105,7 @@ If you don't find an answer to your question here, feel free to file an `Issues`
 
 12. why ``Timeout Exception`` raised during launching GraphScope instance on kubernetes cluster?
 
-    It will take a few minutes for pulling image during the first time for launching GraphScope instance. Thus, the ``Timeout Exception`` may caused by a poor network connection.
+    It will take a few minutes for pulling image during the first time for launching GraphScope instance. Thus, the ``Timeout Exception`` may be caused by a poor network connection.
     You can increase the value of ``timeout_seconds`` parameter as your expectation by ``graphscope.set_option(timeout_seconds=600))``.
 
 13. Failed to run GraphScope (either in single machine or in docker container) due to failed connection to building blocks like etcd?
@@ -114,7 +114,7 @@ If you don't find an answer to your question here, feel free to file an `Issues`
 
 14. How to print debug info in GAE Cython SDK Algorithms?
 
-    python3 print function is a convinent way to show useful debug info, use print with param flush=True then the stream is forcibly flushed.
+    python3 print function is a convenient way to show useful debug info, use print with param flush=True then the stream is forcibly flushed.
 
     More details please refer to `Python Documentation <https://docs.python.org/3.3/library/functions.html#print>`_.
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -20,6 +20,6 @@ ujson;python_version>="3.11"
 PyYAML
 rich
 tqdm
-vineyard>=0.14;sys_platform!="win32"
-vineyard-io>=0.14;sys_platform!="win32"
+vineyard>=0.14.8;sys_platform!="win32"
+vineyard-io>=0.14.8;sys_platform!="win32"
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1581da2</samp>

This pull request refactors the vineyard deployment in GraphScope to use a sidecar container instead of a separate container in the engine pod. This improves the performance and stability of the system and simplifies the management of vineyard. It also fixes some typos and errors in the documentation. The main changes are in `coordinator/gscoordinator/cluster_builder.py` and `coordinator/gscoordinator/kubernetes_launcher.py`.