### PR TITLE
fix typo of install_deps to install-deps

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -294,10 +294,10 @@ sess.close()
 为了构建 graphscope Python 包以及引擎，你需要安装一些依赖和构建工具。
 
 ```bash
-./gs install_deps dev
+./gs install-deps dev
 
 # 如果在中国，加入参数 `--cn` 来加速下载
-./gs install_deps dev --cn
+./gs install-deps dev --cn
 ```
 
 现在你可以使用 `make` 来构建 GraphScope

--- a/README.md
+++ b/README.md
@@ -327,10 +327,10 @@ Please note that we have not hardened this release for production use and it lac
 To build graphscope Python package and the engine binaries, you need to install some dependencies and build tools.
 
 ```bash
-./gs install_deps dev
+./gs install-deps dev
 
 # With argument --cn to speed up the download if you are in China.
-./gs install_deps dev --cn
+./gs install-deps dev --cn
 ```
 
 Then you can build GraphScope with pre-configured `make` commands.

--- a/docs/zh/deployment.rst
+++ b/docs/zh/deployment.rst
@@ -111,7 +111,7 @@ Coordinator 作为 GraphScope 后端服务的入口，通过 grpc 接收来自 P
 * 安装 GraphScope 开发相关依赖
 .. code:: shell
 
-    ./gs install_deps dev
+    ./gs install-deps dev
 
 * 本地部署 GraphScope
 .. code:: shell

--- a/docs/zh/developer_guide.rst
+++ b/docs/zh/developer_guide.rst
@@ -106,7 +106,7 @@ macOS
 .. code:: bash
 
     cd GraphScope/k8s/internal
-    ./gs install_deps dev
+    ./gs install-deps dev
     source ~/.graphscope_env
 
 - 构建 GraphScope Server Wheels


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6555cc6</samp>

This pull request fixes a typo in the command `./gs install_deps dev` and updates it to `./gs install-deps dev` in several documentation files. The typo causes an error when running the command.

