### PR TITLE
issue2606 change decode error strategy compatible with cpp std::string

### DIFF
--- a/python/graphscope/client/archive.py
+++ b/python/graphscope/client/archive.py
@@ -72,12 +72,14 @@ class OutArchive(object):
         Get string's length first (stored as a size_t), then get number of bytes
         equivalents to the length.
         Default using utf-8 to decode, if there is any bytes cannot be converted,
-        'errors="backslashreplace' inserts a \xNN escape sequence.So these
-        special bytes can be reserved.
+        'errors="backslashreplace' inserts a escape sequence.So these special
+        bytes can be reserved.
         Ref:https://docs.python.org/3/howto/unicode.html?highlight=bytes%20decode
         """
         size = self.get_size()
-        string = self.get_block(size).tobytes().decode("utf-8", errors="backslashreplace")
+        string = (
+            self.get_block(size).tobytes().decode("utf-8", errors="backslashreplace")
+        )
         return string
 
     def get_int(self):

--- a/python/graphscope/client/archive.py
+++ b/python/graphscope/client/archive.py
@@ -71,9 +71,13 @@ class OutArchive(object):
         """Peek a string.
         Get string's length first (stored as a size_t), then get number of bytes
         equivalents to the length.
+        Default using utf-8 to decode, if there is any bytes cannot be converted,
+        'errors="backslashreplace' inserts a \xNN escape sequence.So these
+        special bytes can be reserved.
+        Ref:https://docs.python.org/3/howto/unicode.html?highlight=bytes%20decode
         """
         size = self.get_size()
-        string = self.get_block(size).tobytes().decode("utf-8", errors="ignore")
+        string = self.get_block(size).tobytes().decode("utf-8", errors="backslashreplace")
         return string
 
     def get_int(self):


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 17fa1ae</samp>

Improved error handling for string serialization and deserialization in `OutArchive`. Replaced `ignore` with `backslashreplace` strategy to preserve non-UTF-8 bytes in `get_string` function.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2606

