### PR TITLE
bump up gremlinpython version to enable usage in python 3.11

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,11 +52,6 @@ jobs:
     - name: Build GraphScope
       run: |
         source ${HOME}/.graphscope_env
-        # Known bug of building wheels with python3.11,
-        # Caused by aiohttp <= 3.8.1, whereas gremlinpython 3.6.2 requires
-        # aiohttp <= 3.8.1. They have loosen the restrict in main, but still
-        # needs to wait for them releasing a newer version
-        # https://github.com/aio-libs/aiohttp/issues/6600
         make install INSTALL_PREFIX=/opt/graphscope
 
     - name: Run Python Test

--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -1,5 +1,5 @@
 etcd-distro>=3.5.1
-graphscope-client>=0.19.0
+graphscope-client>=0.20.0
 grpcio;python_version>="3.11"
 grpcio<=1.43.0,>=1.40.0;python_version<"3.11"
 grpcio-tools;python_version>="3.11"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-Cython==3.0a6
+Cython=3.0a6
 gremlinpython=3.6.3rc1
 grpcio;python_version>="3.11"
 grpcio<=1.43.0,>=1.40.0;python_version<"3.11"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 Cython==3.0a6
-gremlinpython>=3.4.9
+gremlinpython=3.6.3rc1
 grpcio;python_version>="3.11"
 grpcio<=1.43.0,>=1.40.0;python_version<"3.11"
 grpcio-tools;python_version>="3.11"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
-Cython=3.0a6
-gremlinpython=3.6.3rc1
+Cython==3.0a6
+gremlinpython==3.6.3rc1
 grpcio;python_version>="3.11"
 grpcio<=1.43.0,>=1.40.0;python_version<"3.11"
 grpcio-tools;python_version>="3.11"


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12c12ca</samp>

This pull request updates the dependencies of GraphScope to use the latest versions of graphscope-client and gremlinpython, which enable building wheels with python3.11 and fix a known bug. It also removes an outdated comment from `.github/workflows/nightly.yml`.
