### PR TITLE
Allow finetune parameters for each statefulsets

### DIFF
--- a/charts/graphscope-store/templates/NOTES.txt
+++ b/charts/graphscope-store/templates/NOTES.txt
@@ -2,7 +2,7 @@
 
 {{- if contains "NodePort" .Values.frontend.service.type }}
 
-  export IP=$(kubectl -n {{ .Release.Namespace }} get pod {{ include "graphscope-store.frontend.fullname" . }}-0  -o jsonpath="{.status.hostIP}")
+  export NODE_IP=$(kubectl -n {{ .Release.Namespace }} get pod {{ include "graphscope-store.frontend.fullname" . }}-0  -o jsonpath="{.status.hostIP}")
 
 {{- else if contains "LoadBalancer" .Values.frontend.service.type }}
 
@@ -13,10 +13,10 @@
 
   After the EXTERNAL_IP is available, executing these commands:
 
-  export IP=$(kubectl -n {{ .Release.Namespace }} get svc {{ include "graphscope-store.frontend.fullname" . }} -ojsonpath="{.status.loadBalancer.ingress[0].ip}")
+  export NODE_IP=$(kubectl -n {{ .Release.Namespace }} get svc {{ include "graphscope-store.frontend.fullname" . }} -ojsonpath="{.status.loadBalancer.ingress[0].ip}")
 
 {{- end }}
   export GRPC_PORT=$(kubectl -n {{ .Release.Namespace }} get services {{ include "graphscope-store.frontend.fullname" . }} -o jsonpath="{.spec.ports[0].nodePort}")
   export GREMLIN_PORT=$(kubectl -n {{ .Release.Namespace }} get services {{ include "graphscope-store.frontend.fullname" . }} -o jsonpath="{.spec.ports[1].nodePort}")
-  echo "GRPC endpoint is: ${IP}:${GRPC_PORT}"
-  echo "GREMLIN endpoint is: ${IP}:${GREMLIN_PORT}"
+  echo "GRPC endpoint is: ${NODE_IP}:${GRPC_PORT}"
+  echo "GREMLIN endpoint is: ${NODE_IP}:${GREMLIN_PORT}"

--- a/charts/graphscope-store/templates/coordinator/statefulset.yaml
+++ b/charts/graphscope-store/templates/coordinator/statefulset.yaml
@@ -31,25 +31,25 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: coordinator
-        {{- if .Values.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- if .Values.coordinator.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.coordinator.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
         {{- if (include "graphscope-store.createConfigmap" .) }}
         checksum/configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.podAnnotations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- if .Values.coordinator.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.coordinator.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "graphscope-store.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.hostAliases }}
-      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- if .Values.coordinator.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.coordinator.hostAliases "context" $) | nindent 8 }}
       {{- end }}
-      hostNetwork: {{ .Values.hostNetwork }}
-      hostIPC: {{ .Values.hostIPC }}
-      {{- if .Values.schedulerName }}
-      schedulerName: {{ .Values.schedulerName | quote }}
+      hostNetwork: {{ .Values.coordinator.hostNetwork }}
+      hostIPC: {{ .Values.coordinator.hostIPC }}
+      {{- if .Values.coordinator.schedulerName }}
+      schedulerName: {{ .Values.coordinator.schedulerName | quote }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}

--- a/charts/graphscope-store/templates/frontend/statefulset.yaml
+++ b/charts/graphscope-store/templates/frontend/statefulset.yaml
@@ -31,25 +31,25 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: frontend
-        {{- if .Values.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- if .Values.frontend.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.frontend.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
         {{- if (include "graphscope-store.createConfigmap" .) }}
         checksum/configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.podAnnotations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- if .Values.frontend.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.frontend.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "graphscope-store.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.hostAliases }}
-      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- if .Values.frontend.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.frontend.hostAliases "context" $) | nindent 8 }}
       {{- end }}
-      hostNetwork: {{ .Values.hostNetwork }}
-      hostIPC: {{ .Values.hostIPC }}
-      {{- if .Values.schedulerName }}
-      schedulerName: {{ .Values.schedulerName | quote }}
+      hostNetwork: {{ .Values.frontend.hostNetwork }}
+      hostIPC: {{ .Values.frontend.hostIPC }}
+      {{- if .Values.frontend.schedulerName }}
+      schedulerName: {{ .Values.frontend.schedulerName | quote }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}

--- a/charts/graphscope-store/templates/ingestor/statefulset.yaml
+++ b/charts/graphscope-store/templates/ingestor/statefulset.yaml
@@ -31,25 +31,25 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: ingestor
-        {{- if .Values.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- if .Values.ingestor.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.ingestor.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
         {{- if (include "graphscope-store.createConfigmap" .) }}
         checksum/configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.podAnnotations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- if .Values.ingestor.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.ingestor.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "graphscope-store.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.hostAliases }}
-      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- if .Values.ingestor.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.ingestor.hostAliases "context" $) | nindent 8 }}
       {{- end }}
-      hostNetwork: {{ .Values.hostNetwork }}
-      hostIPC: {{ .Values.hostIPC }}
-      {{- if .Values.schedulerName }}
-      schedulerName: {{ .Values.schedulerName | quote }}
+      hostNetwork: {{ .Values.ingestor.hostNetwork }}
+      hostIPC: {{ .Values.ingestor.hostIPC }}
+      {{- if .Values.ingestor.schedulerName }}
+      schedulerName: {{ .Values.ingestor.schedulerName | quote }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}

--- a/charts/graphscope-store/templates/store/statefulset.yaml
+++ b/charts/graphscope-store/templates/store/statefulset.yaml
@@ -31,25 +31,25 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
         app.kubernetes.io/component: store
-        {{- if .Values.podLabels }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- if .Values.store.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.store.podLabels "context" $) | nindent 8 }}
         {{- end }}
       annotations:
         {{- if (include "graphscope-store.createConfigmap" .) }}
         checksum/configuration: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.podAnnotations }}
-        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- if .Values.store.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.store.podAnnotations "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- include "graphscope-store.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.hostAliases }}
-      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- if .Values.store.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.store.hostAliases "context" $) | nindent 8 }}
       {{- end }}
-      hostNetwork: {{ .Values.hostNetwork }}
-      hostIPC: {{ .Values.hostIPC }}
-      {{- if .Values.schedulerName }}
-      schedulerName: {{ .Values.schedulerName | quote }}
+      hostNetwork: {{ .Values.store.hostNetwork }}
+      hostIPC: {{ .Values.store.hostIPC }}
+      {{- if .Values.store.schedulerName }}
+      schedulerName: {{ .Values.store.schedulerName | quote }}
       {{- end }}
       {{- if .Values.affinity }}
       affinity: {{- include "common.tplvalues.render" (dict "value" .Values.affinity "context" $) | nindent 8 }}

--- a/charts/graphscope-store/values.yaml
+++ b/charts/graphscope-store/values.yaml
@@ -91,6 +91,32 @@ store:
 
     annotations: {}
 
+  ## @param hostAliases pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param hostNetwork Specify if host network should be enabled for pods
+  ##
+  hostNetwork: false
+  ## @param hostIPC Specify if host IPC should be enabled for pods
+  ##
+  hostIPC: false
+  ## @param podLabels Extra labels for pods
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param podAnnotations Extra annotations for pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+
 ## GraphScope Frontend parameters
 ##
 frontend:
@@ -150,6 +176,32 @@ frontend:
     annotations: {}
 
 
+  ## @param hostAliases pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param hostNetwork Specify if host network should be enabled for pods
+  ##
+  hostNetwork: false
+  ## @param hostIPC Specify if host IPC should be enabled for pods
+  ##
+  hostIPC: false
+  ## @param podLabels Extra labels for pods
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param podAnnotations Extra annotations for pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
+
 ## GraphScope Ingestor parameters
 ##
 ingestor:
@@ -167,6 +219,32 @@ ingestor:
     gaiaRpc: 60000
     gaiaEngine: 60001
     annotations: {}
+
+  ## @param hostAliases pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param hostNetwork Specify if host network should be enabled for pods
+  ##
+  hostNetwork: false
+  ## @param hostIPC Specify if host IPC should be enabled for pods
+  ##
+  hostIPC: false
+  ## @param podLabels Extra labels for pods
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param podAnnotations Extra annotations for pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
 
 ## GraphScope Coordinator parameters
 ##
@@ -205,6 +283,32 @@ coordinator:
     gaiaRpc: 60000
     gaiaEngine: 60001
     annotations: {}
+
+  ## @param hostAliases pods host aliases
+  ## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  ##
+  hostAliases: []
+  ## @param hostNetwork Specify if host network should be enabled for pods
+  ##
+  hostNetwork: false
+  ## @param hostIPC Specify if host IPC should be enabled for pods
+  ##
+  hostIPC: false
+  ## @param podLabels Extra labels for pods
+  ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  ##
+  podLabels: {}
+  ## @param podAnnotations Extra annotations for pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+  ##
+
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  schedulerName: ""
 
 ## @section Common parameters
 ##
@@ -288,27 +392,7 @@ containerSecurityContext:
   runAsUser: 1001
   runAsNonRoot: true
   # allowPrivilegeEscalation: false
-## @param hostAliases Kafka pods host aliases
-## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
-##
-hostAliases: []
-## @param hostNetwork Specify if host network should be enabled for Kafka pods
-##
-hostNetwork: false
-## @param hostIPC Specify if host IPC should be enabled for Kafka pods
-##
-hostIPC: false
-## @param podLabels Extra labels for Kafka pods
-## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
-##
-podLabels: {}
-## @param podAnnotations Extra annotations for Kafka pods
-## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
-##
-podAnnotations: {}
-## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
-## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
-##
+
 podAffinityPreset: ""
 ## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
@@ -358,13 +442,11 @@ terminationGracePeriodSeconds: ""
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
 ##
 podManagementPolicy: Parallel
-## @param priorityClassName Name of the existing priority class to be used by kafka pods
+## @param priorityClassName Name of the existing priority class to be used by pods
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##
 priorityClassName: ""
-## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
-##
-schedulerName: ""
+
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 ##
 updateStrategy:
@@ -387,7 +469,7 @@ serviceAccount:
   ##
   create: true
   ## @param serviceAccount.name The name of the service account to use. If not set and `create` is `true`, a name is generated
-  ## If not set and create is true, a name is generated using the kafka.serviceAccountName template
+  ## If not set and create is true, a name is generated
   ##
   name: ""
   ## @param serviceAccount.automountServiceAccountToken Allows auto mount of ServiceAccountToken on the serviceAccount created

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/ingestor/BatchSender.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/ingestor/BatchSender.java
@@ -149,7 +149,11 @@ public class BatchSender implements MetricsAgent {
                 (storeId, batchBuilder) -> {
                     while (!shouldStop) {
                         try {
-                            storeSendBuffer.get(storeId).put(batchBuilder.build());
+                            BlockingQueue<StoreDataBatch> curBuffer = storeSendBuffer.get(storeId);
+                            if (curBuffer.remainingCapacity() == 0) {
+                                logger.warn("Buffer of store [" + storeId + "] is full");
+                            }
+                            curBuffer.put(batchBuilder.build());
                             break;
                         } catch (InterruptedException e) {
                             logger.warn("send buffer interrupted", e);

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/ingestor/IngestProcessor.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/ingestor/IngestProcessor.java
@@ -259,10 +259,10 @@ public class IngestProcessor implements MetricsAgent {
 
     private void updateMetrics() {
         long currentTime = System.nanoTime();
-        long propcessed = this.totalProcessed;
+        long processed = this.totalProcessed;
         long interval = currentTime - this.lastUpdateTime;
         this.writeRecordsPerSecond =
-                1000000000 * (propcessed - this.lastUpdateProcessed) / interval;
+                1000000000 * (processed - this.lastUpdateProcessed) / interval;
         long walBlockTime = this.walBlockTimeNano;
         this.walBlockPerSecondMs =
                 1000 * (walBlockTime - this.lastUpdateWalBlockTimeNano) / interval;
@@ -272,7 +272,7 @@ public class IngestProcessor implements MetricsAgent {
 
         this.lastUpdateStoreBlockTimeNano = storeBlockTime;
         this.lastUpdateWalBlockTimeNano = walBlockTime;
-        this.lastUpdateProcessed = propcessed;
+        this.lastUpdateProcessed = processed;
         this.lastUpdateTime = currentTime;
     }
 

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/ingestor/IngestProcessor.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/ingestor/IngestProcessor.java
@@ -261,8 +261,7 @@ public class IngestProcessor implements MetricsAgent {
         long currentTime = System.nanoTime();
         long processed = this.totalProcessed;
         long interval = currentTime - this.lastUpdateTime;
-        this.writeRecordsPerSecond =
-                1000000000 * (processed - this.lastUpdateProcessed) / interval;
+        this.writeRecordsPerSecond = 1000000000 * (processed - this.lastUpdateProcessed) / interval;
         long walBlockTime = this.walBlockTimeNano;
         this.walBlockPerSecondMs =
                 1000 * (walBlockTime - this.lastUpdateWalBlockTimeNano) / interval;


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48a5556</samp>

This pull request improves the customizability and usability of the GraphScope Store Helm chart by using more specific values for different pod settings in the `statefulset.yaml` files of each component. It also fixes some minor typos in the `values.yaml` file, the `NOTES.txt` file, and the `IngestProcessor` and `BatchSender` classes.
