### PR TITLE
Prepare to release 0.21.0

### DIFF
--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -1,30 +1,23 @@
 name: Build GraphScope Wheels on Linux
 
 # on: [push, pull_request]
-#on:
-  #workflow_dispatch:
-  #schedule:
-    ## The notifications for scheduled workflows are sent to the user who
-    ## last modified the cron syntax in the workflow file.
-    ## Trigger the workflow at 03:00(CST) every day.
-    #- cron:  '00 19 * * *'
-  #push:
-    #tags:
-      #- "v*"
-
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    # The notifications for scheduled workflows are sent to the user who
+    # last modified the cron syntax in the workflow file.
+    # Trigger the workflow at 03:00(CST) every day.
+    - cron:  '00 19 * * *'
+  push:
+    tags:
+      - "v*"
 
 env:
   REGISTRY: registry.cn-hongkong.aliyuncs.com
 
 jobs:
   build-wheels:
-    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
 
     steps:
@@ -96,7 +89,7 @@ jobs:
         packages_dir: upload_pypi/
 
   build-image:
-    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
     needs: [build-wheels]
 
@@ -163,7 +156,7 @@ jobs:
         sudo docker push ${{ env.REGISTRY }}/graphscope/jupyter:${tag}
 
   ubuntu-python-test:
-    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     needs: [build-wheels]
     strategy:
@@ -219,7 +212,7 @@ jobs:
         python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
 
   centos-test:
-    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     needs: [build-wheels]
     container:

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -1,23 +1,30 @@
 name: Build GraphScope Wheels on Linux
 
 # on: [push, pull_request]
+#on:
+  #workflow_dispatch:
+  #schedule:
+    ## The notifications for scheduled workflows are sent to the user who
+    ## last modified the cron syntax in the workflow file.
+    ## Trigger the workflow at 03:00(CST) every day.
+    #- cron:  '00 19 * * *'
+  #push:
+    #tags:
+      #- "v*"
+
 on:
-  workflow_dispatch:
-  schedule:
-    # The notifications for scheduled workflows are sent to the user who
-    # last modified the cron syntax in the workflow file.
-    # Trigger the workflow at 03:00(CST) every day.
-    - cron:  '00 19 * * *'
-  push:
-    tags:
-      - "v*"
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  pull_request:
+    branches:
+      - main
 
 env:
   REGISTRY: registry.cn-hongkong.aliyuncs.com
 
 jobs:
   build-wheels:
-    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
 
     steps:
@@ -82,7 +89,6 @@ jobs:
         packages_dir: upload_pypi/
 
     - name: Publish distribution to PyPI
-      if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
       uses: pypa/gh-action-pypi-publish@v1.4.2
       with:
         user: __token__
@@ -90,7 +96,7 @@ jobs:
         packages_dir: upload_pypi/
 
   build-image:
-    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
     needs: [build-wheels]
 
@@ -157,13 +163,13 @@ jobs:
         sudo docker push ${{ env.REGISTRY }}/graphscope/jupyter:${tag}
 
   ubuntu-python-test:
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     needs: [build-wheels]
     strategy:
       matrix:
         # The protobuf version of tenorflow and grpcio is conflicts in python 3.11
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/download-artifact@v3
@@ -213,7 +219,7 @@ jobs:
         python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
 
   centos-test:
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: ubuntu-20.04
     needs: [build-wheels]
     container:

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -1,27 +1,20 @@
 name: Build GraphScope Wheels on MacOS
 
 # on: [push, pull_request]
-#on:
-  #workflow_dispatch:
-  #schedule:
-    ## The notifications for scheduled workflows are sent to the user who
-    ## last modified the cron syntax in the workflow file.
-    ## Trigger the workflow at 03:00(CST) every day.
-    #- cron:  '00 19 * * *'
-  #push:
-    #tags:
-      #- "v*"
-
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    # The notifications for scheduled workflows are sent to the user who
+    # last modified the cron syntax in the workflow file.
+    # Trigger the workflow at 03:00(CST) every day.
+    - cron:  '00 19 * * *'
+  push:
+    tags:
+      - "v*"
 
 jobs:
   build-wheels:
-    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v3
@@ -104,7 +97,7 @@ jobs:
         retention-days: 5
 
   build-client-wheels:
-    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: macos-10.15
     strategy:
       matrix:
@@ -190,7 +183,7 @@ jobs:
 
   # Action gh-action-pypi-publish not support non-linux os.
   publish-wheels:
-    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
     needs: [build-wheels, build-client-wheels]
     strategy:
@@ -237,7 +230,7 @@ jobs:
         packages_dir: upload_pypi/
 
   python-test:
-    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: macos-latest
     needs: [build-wheels, build-client-wheels]
     strategy:
@@ -287,5 +280,5 @@ jobs:
         python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
 
     - name: Setup tmate session
-      if: always()
+      if: false
       uses: mxschmitt/action-tmate@v2

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -1,20 +1,27 @@
 name: Build GraphScope Wheels on MacOS
 
 # on: [push, pull_request]
+#on:
+  #workflow_dispatch:
+  #schedule:
+    ## The notifications for scheduled workflows are sent to the user who
+    ## last modified the cron syntax in the workflow file.
+    ## Trigger the workflow at 03:00(CST) every day.
+    #- cron:  '00 19 * * *'
+  #push:
+    #tags:
+      #- "v*"
+
 on:
-  workflow_dispatch:
-  schedule:
-    # The notifications for scheduled workflows are sent to the user who
-    # last modified the cron syntax in the workflow file.
-    # Trigger the workflow at 03:00(CST) every day.
-    - cron:  '00 19 * * *'
-  push:
-    tags:
-      - "v*"
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-wheels:
-    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v3
@@ -97,7 +104,7 @@ jobs:
         retention-days: 5
 
   build-client-wheels:
-    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: macos-10.15
     strategy:
       matrix:
@@ -183,7 +190,7 @@ jobs:
 
   # Action gh-action-pypi-publish not support non-linux os.
   publish-wheels:
-    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
+    # if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04
     needs: [build-wheels, build-client-wheels]
     strategy:
@@ -230,7 +237,7 @@ jobs:
         packages_dir: upload_pypi/
 
   python-test:
-    if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
+    # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope' }}
     runs-on: macos-latest
     needs: [build-wheels, build-client-wheels]
     strategy:
@@ -280,5 +287,5 @@ jobs:
         python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
 
     - name: Setup tmate session
-      if: false
+      if: always()
       uses: mxschmitt/action-tmate@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,6 @@ jobs:
       id: tag
       run: echo "TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
       
-
     - name: Upload Charts to OSS
       uses: tvrcgo/upload-to-oss@master
       with:

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -51,7 +51,7 @@ graphscope:
 
 graphscope-jupyter-manylinux2014-py3:
 	docker run --rm -it -v $(WORKING_DIR)/../..:/work \
-		   ${REGISTRY}/graphscope/graphscope-dev:${VINEYARD_VERSION} \
+		   ${REGISTRY}/graphscope/graphscope-dev:wheel \
 		   bash -c 'pip3 install graphscope-client -U && \
 					cd /work/python/jupyter/graphscope && \
 					python3 setup.py bdist_wheel'
@@ -132,13 +132,12 @@ graphscope-manylinux2014-py3-nodocker:
 	done
 
 graphscope-manylinux2014-py3:
-	docker pull ${REGISTRY}/graphscope/graphscope-dev:${VINEYARD_VERSION}
+	docker pull ${REGISTRY}/graphscope/graphscope-dev:wheel
 	docker run --rm -v $(WORKING_DIR)/../..:/work \
-		${REGISTRY}/graphscope/graphscope-dev:${VINEYARD_VERSION} \
+		${REGISTRY}/graphscope/graphscope-dev:wheel \
 		bash -c 'source ~/.graphscope_env && \
 			cd /work/k8s/internal && \
 			make graphscope-manylinux2014-py3-nodocker GRAPHSCOPE_HOME=${GRAPHSCOPE_HOME} INSTALL_PREFIX=${INSTALL_PREFIX}'
-
 
 graphscope-client-manylinux2014-py3-nodocker:
 	set -euxo pipefail && \
@@ -152,7 +151,7 @@ graphscope-client-manylinux2014-py3-nodocker:
 	cmake -DKNN=OFF -DWITH_VINEYARD=ON -DTESTING=OFF .. && \
 	make graphlearn_shared -j`nproc` && \
 	export LD_LIBRARY_PATH=$(WORKING_DIR)/../../learning_engine/graph-learn/graphlearn/built/lib:$$LD_LIBRARY_PATH && \
-	for py in cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311; do \
+	for py in cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311; do \
 		cd $(WORKING_DIR)/../../python; \
 		export PATH=/opt/python/$$py/bin:$$PATH; \
 		python3 -m pip install -U pip; \
@@ -200,7 +199,7 @@ graphscope-client-darwin-py3:
 		done
 
 graphscope-client-manylinux2014-py3:
-	docker pull ${REGISTRY}/graphscope/graphscope-dev:${VINEYARD_VERSION}
+	docker pull ${REGISTRY}/graphscope/graphscope-dev:wheel
 	docker run --rm -v $(WORKING_DIR)/../..:/work \
-		${REGISTRY}/graphscope/graphscope-dev:${VINEYARD_VERSION} \
+		${REGISTRY}/graphscope/graphscope-dev:wheel \
 		bash -c 'source ~/.graphscope_env && cd /work/k8s/internal && make graphscope-client-manylinux2014-py3-nodocker GRAPHSCOPE_HOME=${GRAPHSCOPE_HOME}'


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a840013</samp>

Use updated graphscope-dev image and build wheels for Python 3.7 in `k8s/internal/Makefile`. This simplifies the installation process and supports a newer Python version.

## What do these changes do?

<!-- Please give a short brief about these changes. -->
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a840013</samp>

* Change the docker image tag for graphscope-dev from vineyard version to wheel to use the latest image with pre-built wheels for graphscope and graphscope-client ([link](https://github.com/alibaba/GraphScope/pull/2637/files?diff=unified&w=0#diff-ea4eb88f4011913fa5d7501e35c6e30610f83a5e712dde5fd002fa4345c45ce0L54-R54), [link](https://github.com/alibaba/GraphScope/pull/2637/files?diff=unified&w=0#diff-ea4eb88f4011913fa5d7501e35c6e30610f83a5e712dde5fd002fa4345c45ce0L135-R141), [link](https://github.com/alibaba/GraphScope/pull/2637/files?diff=unified&w=0#diff-ea4eb88f4011913fa5d7501e35c6e30610f83a5e712dde5fd002fa4345c45ce0L203-R204))
* Add Python 3.7 support for graphscope-client by building the wheel for cp37-cp37m in the `Makefile` ([link](https://github.com/alibaba/GraphScope/pull/2637/files?diff=unified&w=0#diff-ea4eb88f4011913fa5d7501e35c6e30610f83a5e712dde5fd002fa4345c45ce0L155-R154))

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

