### PR TITLE
Add a tip to the GAE document to remind users of potential errors.

### DIFF
--- a/docs/analytical_engine/deployment.md
+++ b/docs/analytical_engine/deployment.md
@@ -63,6 +63,8 @@ wcc_result = graphscope.wcc(g)
 print(wcc_result.to_dataframe({'id': 'v.id', 'group': 'r'}))
 ```
 
+> **Tip:** If you encounter the error **Failed to project to simple graph as no vertex exists in this graph.**, it means that the graph is empty. You can import the loading method as `from graphscope.dataset import load_modern_graph` , then load the modern graph with current session, e.g. `g = load_modern_graph(sess, "path/to/your/graph")`, the "path/to/your/graph" is the path where the graph data is stored in the pod.
+
 The only difference is the elimination of extraneous resources, resulting in less complexity, fewer inconveniences, fewer resources required, and equivalent functionality.
 
 ## Uninstall deployment


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 37fba3e</samp>

Update the documentation of GraphScope deployment to include a tip for handling empty graphs. Suggest using `graphscope.dataset` to load a sample graph for testing graph analytical algorithms.