### PR TITLE
Find python path correctly

### DIFF
--- a/coordinator/gscoordinator/template/CMakeLists.template
+++ b/coordinator/gscoordinator/template/CMakeLists.template
@@ -160,8 +160,8 @@ find_package(Threads REQUIRED)
 
 # find Python-------------------------------------------------------------------
 if (${CYTHON_PREGEL_APP} OR ${CYTHON_PIE_APP})
-  find_package (Python COMPONENTS Interpreter Development REQUIRED)
-  include_directories(SYSTEM ${Python_INCLUDE_DIRS})
+  find_package (Python3 COMPONENTS Interpreter Development REQUIRED)
+  include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
 endif ()
 
 # find MPI----------------------------------------------------------------------
@@ -301,7 +301,7 @@ if (CYTHON_PREGEL_APP)
                                                      _GRAPH_TYPE=${GRAPH_TYPE}
                                                      _GRAPH_HEADER=$_graph_header
                                                      _APP_HEADER=$_app_header)
-    target_link_libraries(${FRAME_NAME} ${Python_LIBRARIES})
+    target_link_libraries(${FRAME_NAME} ${Python3_LIBRARIES})
     set_target_properties(${FRAME_NAME} PROPERTIES COMPILE_FLAGS "-fPIC")
 elseif (CYTHON_PIE_APP)
     file(GLOB_RECURSE FILES_NEED_COMPILE "*.cc")
@@ -314,7 +314,7 @@ elseif (CYTHON_PIE_APP)
                                                      _GRAPH_TYPE=${GRAPH_TYPE}
                                                      _GRAPH_HEADER=$_graph_header
                                                      _APP_HEADER=$_app_header)
-    target_link_libraries(${FRAME_NAME} ${Python_LIBRARIES})
+    target_link_libraries(${FRAME_NAME} ${Python3_LIBRARIES})
     set_target_properties(${FRAME_NAME} PROPERTIES COMPILE_FLAGS "-fPIC")
 elseif (JAVA_PIE_APP)
     if (ENABLE_JAVA_SDK)

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -452,6 +452,7 @@ def compile_app(
         f"-DNETWORKX={engine_config['networkx']}",
         f"-DCMAKE_PREFIX_PATH='{GRAPHSCOPE_HOME};{OPAL_PREFIX}'",
     ]
+
     if types_pb2.CMAKE_EXTRA_OPTIONS in attr:
         extra_options = (
             attr[types_pb2.CMAKE_EXTRA_OPTIONS]
@@ -502,7 +503,7 @@ def compile_app(
             )
     elif app_type == "cpp_flash":
         cmake_commands += ["-DFLASH_APP=ON"]
-    elif app_type not in ("cpp_pie", "cpp_pregel"):
+    elif app_type not in ("cpp_pie", "cpp_pregel"):  # Cython
         if app_type == "cython_pregel":
             pxd_name = "pregel"
             cmake_commands += ["-DCYTHON_PREGEL_APP=ON"]
@@ -511,6 +512,13 @@ def compile_app(
         else:
             pxd_name = "pie"
             cmake_commands += ["-DCYTHON_PIE_APP=ON"]
+        if "Python_ROOT_DIR" in os.environ:
+            python3_path = os.path.join(os.environ["Python_ROOT_DIR"], "bin", "python3")
+        elif "CONDA_PREFIX" in os.environ:
+            python3_path = os.path.join(os.environ["CONDA_PREFIX"], "bin", "python3")
+        else:
+            python3_path = shutil.which("python3")
+        cmake_commands.append(f"-DPython3_EXECUTABLE={python3_path}")
 
         # Copy pxd file and generate cc file from pyx
         shutil.copyfile(


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6159a4</samp>

This pull request updates the `coordinator` module to use `Python3` for building and linking Cython apps. It also improves the code quality and readability of `utils.py`.

Fixed the failed CI of building udf applications on Mac.

The root cause is that the CMake find the path of python3.11, but python 3.11 droped the header `longintrepr.h`.