### PR TITLE
temporarily fix the urllib3 2.0.0 incompatible with openssl

### DIFF
--- a/coordinator/requirements.txt
+++ b/coordinator/requirements.txt
@@ -16,3 +16,4 @@ prometheus-client>=0.14.1
 setuptools==65.7.0
 packaging
 tqdm
+urllib3>=1.24.2,<2.0.0


### PR DESCRIPTION
The error is
```
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' 
module is compiled with OpenSSL 1.0.2k-fips  26 Jan 2017. See: 
https://github.com/urllib3/urllib3/issues/2168
```

urllib3 release 2.0.0 today and dropped support for openssl < 1.1.1, whereas out centos7 bundled openssl library is 1.0.2k.

This restraints could be dropped when our image base has been switch to ubuntu #2607