### PR TITLE
Improve the error message when passing unexpected arguments to `g.project()`

### DIFF
--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -687,6 +687,19 @@ class GraphDAGNode(DAGNode, GraphInterface):
                 A new graph projected from the property graph, evaluated in eager mode.
         """
         check_argument(self.graph_type == graph_def_pb2.ARROW_PROPERTY)
+        if isinstance(vertices, (list, set)) or isinstance(edges, (list, set)):
+            raise ValueError(
+                "\nThe project vertices or edges cannot be a set or a list, rather, a dict is expected, \n"
+                "where the key is the label name and the value is a list of property name. E.g.,\n"
+                "\n"
+                "    g.project(vertices={'person': ['name', 'age']},\n"
+                "              edges={'knows': ['weight']})\n"
+                "\n"
+                "The property list for vertices and edges can be empty if not needed, e.g.,\n"
+                "\n"
+                "    g.project(vertices={'person': []}, edges={'knows': []})\n"
+            )
+
         op = dag_utils.project_arrow_property_graph(
             self, json.dumps(vertices), json.dumps(edges)
         )


### PR DESCRIPTION
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes https://github.com/alibaba/GraphScope/discussions/2619#discussioncomment-5698332
Fixes https://github.com/alibaba/GraphScope/discussions/2626#discussioncomment-5698356

After this pull request, the error message looks like

```python
In [4]: g = g.project(vertices={"paper"}, edges={"cites"})
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ in <module>:1                                                                                    │
│                                                                                                  │
│ /usr/local/lib/python3.11/site-packages/graphscope/framework/graph.py:1136 in project            │
│                                                                                                  │
│   1133 │   ):                                                                                    │
│   1134 │   │   if not self.loaded():                                                             │
│   1135 │   │   │   raise RuntimeError("The graph is not loaded")                                 │
│ ❱ 1136 │   │   return self._session._wrapper(self._graph_node.project(vertices, edges))          │
│   1137 │                                                                                         │
│   1138 │   def _attach_interactive_instance(self, instance):                                     │
│   1139 │   │   """Store the instance when a new interactive instance is started.                 │
│                                                                                                  │
│ /usr/local/lib/python3.11/site-packages/graphscope/framework/graph.py:691 in project             │
│                                                                                                  │
│    688 │   │   """                                                                               │
│    689 │   │   check_argument(self.graph_type == graph_def_pb2.ARROW_PROPERTY)                   │
│    690 │   │   if isinstance(vertices, set) or isinstance(edges, set):                           │
│ ❱  691 │   │   │   raise ValueError("The project vertices or edges cannot be a set, rather, a d  │
│    692 │   │   │   │   │   │   │    "\n"                                                         │
│    693 │   │   │   │   │   │   │    "    g.project(vertices={'person': ['name', 'age']},\n"      │
│    694 │   │   │   │   │   │   │    "              edges={'knows': ['weight']})\n"               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError:
The project vertices or edges cannot be a set, rather, a dict is expected, e.g.,

    g.project(vertices={'person': ['name', 'age']},
              edges={'knows': ['weight']})

The property list for vertices and edges can be empty if not needed, e.g.,

    g.project(vertices={'person': []}, edges={'knows': []})
```

