### PR TITLE
Add prepare-commit-msg

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,13 +22,15 @@
 			"settings": {},
 			"extensions": [
 				"streetsidesoftware.code-spell-checker",
-				"eamodio.gitlens"
+				"eamodio.gitlens",
+				"github.copilot",
+				"github.copilot-labs"
 			]
 		}
 	},
 
 	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "graphscope"
+	"remoteUser": "graphscope",
 
 	// Uncomment this to enable C++ and Rust debugging in containers
 	// "capAdd": ["SYS_PTRACE"],
@@ -61,7 +63,7 @@
 
 	// Uncomment these to use a named volume for your entire source tree
 	// https://code.visualstudio.com/remote/advancedcontainers/improve-performance#_use-a-named-volume-for-your-entire-source-tree
-	// "workspaceMount": "source=gs,target=/workspace,type=volume",
-	// "workspaceFolder": "/workspace"
-	// "postCreateCommand": "sudo chown -R graphscope:graphscope /workspace"
+	// "workspaceMount": "source=gs,target=/workspaces,type=volume",
+	// "workspaceFolder": "/workspaces"
+	"postCreateCommand": "sudo chown -R graphscope /workspaces && bash pre-commit/install-hook.sh && bash pre-commit/prepare-commit-msg"
 }

--- a/pre-commit/install-hook.sh
+++ b/pre-commit/install-hook.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 mkdir -p ~/.config/git/hooks/
 git config --global core.hooksPath ~/.config/git/hooks/
 touch ~/.config/git/hooks/pre-commit

--- a/pre-commit/prepare-commit-msg
+++ b/pre-commit/prepare-commit-msg
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+mkdir -p ~/.config/git/hooks/
+git config --global core.hooksPath ~/.config/git/hooks/
+touch ~/.config/git/hooks/prepare-commit-msg
+chmod +x ~/.config/git/hooks/prepare-commit-msg
+
+cat > ~/.config/git/hooks/prepare-commit-msg << EOF
+#!/bin/bash
+COMMIT_MSG_FILE=\$1
+echo "" >> "\$COMMIT_MSG_FILE"
+username=\$(git config --get user.name)
+echo "Commited by: \$username from Dev container" >> "\$COMMIT_MSG_FILE"
+EOF


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c34561b</samp>

This pull request adds scripts and configuration for setting up and using a pre-commit hook in the devcontainer. The hook automatically prepares commit messages with the user name and the devcontainer indicator.