### PR TITLE
Fix the coordinator dockerfile to only install the pip packages that match the current python version.

### DIFF
--- a/k8s/dockerfiles/coordinator.Dockerfile
+++ b/k8s/dockerfiles/coordinator.Dockerfile
@@ -55,4 +55,6 @@ USER graphscope
 WORKDIR /home/graphscope
 
 COPY --from=builder /home/graphscope/install /opt/graphscope/
-RUN python3 -m pip install --user --no-cache-dir /opt/graphscope/*.whl && sudo rm -rf /opt/graphscope/*.whl
+RUN python3 -m pip install --user --no-cache-dir \
+    /opt/graphscope/*cp$(python3 -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}'.replace('.',''))")*.whl \
+    && sudo rm -rf /opt/graphscope/*.whl


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

As titled

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2689 

