### PR TITLE
Fixes the 'sudo' in dockerfile for gss image

### DIFF
--- a/k8s/dockerfiles/graphscope-store.Dockerfile
+++ b/k8s/dockerfiles/graphscope-store.Dockerfile
@@ -21,10 +21,10 @@ RUN cd /home/graphscope/graphscope \
 
 FROM ubuntu:22.04
 
-RUN sudo apt-get update -y && \
-    sudo apt-get install -y default-jdk && \
-    sudo apt-get clean -y && \
-    sudo rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && \
+    apt-get install -y sudo default-jdk && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV GRAPHSCOPE_HOME=/usr/local
 ENV JAVA_HOME=/usr/lib/jvm/default-java


### PR DESCRIPTION
## Related issue number

See failure in nightly CI: https://github.com/alibaba/GraphScope/actions/runs/4984139366/jobs/8922080662

