### PR TITLE
Publish wheel packages on Linux arm64 platform nightly

### DIFF
--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -42,15 +42,22 @@ jobs:
       if: false
       uses: mxschmitt/action-tmate@v2
 
+    - name: Test Secret
+      env:
+        SUPER_SECRET: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        echo "${SUPER_SECRET}"
+
     - name: Build Wheel Package
+      if: false
       run: |
         # change the version for nightly release
         # 0.15.0 -> 0.15.0a20220808
         time=$(date "+%Y%m%d")
         version=$(cat ${GITHUB_WORKSPACE}/VERSION)
-        # if [[ "${{ GITHUB.REF }}" == "refs/heads/main" ]]; then
-        echo "${version}a${time}" > ${GITHUB_WORKSPACE}/VERSION;
-        # fi
+        if [[ "${{ GITHUB.REF }}" == "refs/heads/main" ]]; then
+          echo "${version}a${time}" > ${GITHUB_WORKSPACE}/VERSION;
+        fi
 
         cd ${GITHUB_WORKSPACE}/k8s/internal
         # build graphscope wheels

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -1,26 +1,16 @@
 name: Build GraphScope Wheels on Linux
 
 # on: [push, pull_request]
-# on:
-#   workflow_dispatch:
-#   schedule:
+on:
+  workflow_dispatch:
+  schedule:
     # The notifications for scheduled workflows are sent to the user who
     # last modified the cron syntax in the workflow file.
     # Trigger the workflow at 03:00(CST) every day.
-#     - cron:  '00 19 * * *'
-#   push:
-#     tags:
-#       - "v*"
-
-on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
+    - cron:  '00 19 * * *'
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+    tags:
+      - "v*"
 
 concurrency:
   group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
@@ -31,6 +21,7 @@ env:
 
 jobs:
   build-wheels-for-arm64:
+    if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: [self-hosted, Linux, ARM64]
 
     steps:
@@ -42,14 +33,7 @@ jobs:
       if: false
       uses: mxschmitt/action-tmate@v2
 
-    - name: Test Secret
-      env:
-        SUPER_SECRET: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        echo "${SUPER_SECRET}"
-
     - name: Build Wheel Package
-      if: false
       run: |
         # change the version for nightly release
         # 0.15.0 -> 0.15.0a20220808
@@ -76,7 +60,9 @@ jobs:
         mkdir ${GITHUB_WORKSPACE}/upload_pypi
         mv ${GITHUB_WORKSPACE}/python/dist/wheelhouse/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
         mv ${GITHUB_WORKSPACE}/coordinator/dist/wheelhouse/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
-        mv ${GITHUB_WORKSPACE}/coordinator/dist/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
+        # only wheel packages that platform aware need to be published.
+        # the wheel packages under the coordinator/dist directory are same to the amd64 platform
+        # mv ${GITHUB_WORKSPACE}/coordinator/dist/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build-graphscope-wheels-linux.yml
+++ b/.github/workflows/build-graphscope-wheels-linux.yml
@@ -1,16 +1,26 @@
 name: Build GraphScope Wheels on Linux
 
 # on: [push, pull_request]
-on:
-  workflow_dispatch:
-  schedule:
+# on:
+#   workflow_dispatch:
+#   schedule:
     # The notifications for scheduled workflows are sent to the user who
     # last modified the cron syntax in the workflow file.
     # Trigger the workflow at 03:00(CST) every day.
-    - cron:  '00 19 * * *'
+#     - cron:  '00 19 * * *'
+#   push:
+#     tags:
+#       - "v*"
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.repository }}-${{ github.event.number || github.head_ref || github.sha }}-${{ github.workflow }}
@@ -20,6 +30,74 @@ env:
   REGISTRY: registry.cn-hongkong.aliyuncs.com
 
 jobs:
+  build-wheels-for-arm64:
+    runs-on: [self-hosted, Linux, ARM64]
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Setup tmate session
+      if: false
+      uses: mxschmitt/action-tmate@v2
+
+    - name: Build Wheel Package
+      run: |
+        # change the version for nightly release
+        # 0.15.0 -> 0.15.0a20220808
+        time=$(date "+%Y%m%d")
+        version=$(cat ${GITHUB_WORKSPACE}/VERSION)
+        # if [[ "${{ GITHUB.REF }}" == "refs/heads/main" ]]; then
+        echo "${version}a${time}" > ${GITHUB_WORKSPACE}/VERSION;
+        # fi
+
+        cd ${GITHUB_WORKSPACE}/k8s/internal
+        # build graphscope wheels
+        sudo -E -u runner make graphscope-py3-package GRAPHSCOPE_HOME=/opt/graphscope INSTALL_PREFIX=/home/graphscope/graphscope-install
+
+        # build client wheels
+        sudo -E -u runner make graphscope-client-py3-package GRAPHSCOPE_HOME=/opt/graphscope
+
+        # package
+        cd ${GITHUB_WORKSPACE}
+        sudo chown $(id -u) -R .
+        tar -zcf client.tar.gz python/dist/wheelhouse/*.whl
+        tar -zcf graphscope.tar.gz coordinator/dist/
+
+        # move wheels into one floder to upload to PyPI
+        mkdir ${GITHUB_WORKSPACE}/upload_pypi
+        mv ${GITHUB_WORKSPACE}/python/dist/wheelhouse/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
+        mv ${GITHUB_WORKSPACE}/coordinator/dist/wheelhouse/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
+        mv ${GITHUB_WORKSPACE}/coordinator/dist/*.whl ${GITHUB_WORKSPACE}/upload_pypi/
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: wheel-${{ github.sha }}
+        path: |
+          client.tar.gz
+          graphscope.tar.gz
+        retention-days: 5
+
+    # We do this, since failures on test.pypi aren't that bad
+    - name: Publish to Test PyPI
+      # the limit of graphscope package in test.pypi is still 100MB, which is not enough.
+      if: false
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.TEST_PYPI_PASSWORD }}
+        repository_url: https://test.pypi.org/legacy/
+        packages_dir: upload_pypi/
+
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}
+        packages_dir: upload_pypi/
+
   build-wheels:
     if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope')
     runs-on: ubuntu-20.04


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c8dc471</samp>

This file updates the GitHub workflow for building GraphScope wheels for Linux. It adds support for ARM64 platforms and triggers the workflow on main branch events.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c8dc471</samp>

*  Add a new job to build wheels for Linux ARM64 platform ([link](https://github.com/alibaba/GraphScope/pull/2732/files?diff=unified&w=0#diff-16b5ddf4a0b5e7a6f19a52cc19488c933fb89d5535eba27060d7104ebce1fc6cR33-R100))

