### PR TITLE
Make sure grape-engine exit when CTRL-C without crash

### DIFF
--- a/analytical_engine/core/grape_engine.cc
+++ b/analytical_engine/core/grape_engine.cc
@@ -98,16 +98,19 @@ class GrapeEngine {
       LOG(INFO) << "grape-engine (master) RPC server is stopping...";
       rpc_server_->StopServer();
       service_thread_.join();
+      rpc_server_.reset();
     }
 
     if (dispatcher_) {
       LOG(INFO) << "grape-engine dispatcher is stopping...";
       dispatcher_->Stop();
+      dispatcher_.reset();
     }
 
     if (vineyard_server_) {
       LOG(INFO) << "vineyardd instance is stopping...";
       vineyard_server_->Stop();
+      vineyard_server_.reset();
     }
   }
 

--- a/analytical_engine/core/launcher.cc
+++ b/analytical_engine/core/launcher.cc
@@ -113,6 +113,7 @@ void VineyardServer::Stop() {
   if (proc_ && proc_->valid()) {
     kill(proc_->id(), SIGTERM);
     proc_->wait();
+    proc_.reset();
   }
 }
 

--- a/analytical_engine/core/server/dispatcher.h
+++ b/analytical_engine/core/server/dispatcher.h
@@ -176,8 +176,8 @@ class Dispatcher {
   bool running_;
   grape::CommSpec comm_spec_;
   std::shared_ptr<Subscriber> subscriber_;
-  vineyard::BlockingQueue<std::shared_ptr<CommandDetail>> cmd_queue_;
-  vineyard::BlockingQueue<std::vector<DispatchResult>> result_queue_;
+  vineyard::PCBlockingQueue<std::shared_ptr<CommandDetail>> cmd_queue_;
+  vineyard::PCBlockingQueue<std::vector<DispatchResult>> result_queue_;
 };
 
 }  // namespace gs


### PR DESCRIPTION
## What do these changes do?

- Reset the pointer to prevent double-shutdown which causes crash inside grpc
- Terminate dispatcher (and its queues) correctly when closing

## Related issue number

Fixes #2749

