### PR TITLE
Correct the python sssp result by setting generate_eid to false in load_p2p_network dataset

### DIFF
--- a/docs/analytical_engine/tutorial_dev_algo_python.rst
+++ b/docs/analytical_engine/tutorial_dev_algo_python.rst
@@ -201,7 +201,7 @@ To run your own algorithms, you may trigger it in place where you defined it.
     import graphscope
     from graphscope.dataset import load_p2p_network
 
-    g = load_p2p_network()
+    g = load_p2p_network(generate_eid=False)
 
     # load my algorithm
     my_app = SSSP_Pregel()

--- a/docs/zh/analytics_engine.rst
+++ b/docs/zh/analytics_engine.rst
@@ -319,7 +319,7 @@ GraphScope 支持用户在自定义算法中通过 :code:`context.math` 上的�
     import graphscope
     from graphscope.dataset import load_p2p_network
 
-    g = load_p2p_network()
+    g = load_p2p_network(generate_eid=False)
 
     # 加载自己的算法
     my_app = SSSP_Pregel()

--- a/python/graphscope/dataset/p2p_network.py
+++ b/python/graphscope/dataset/p2p_network.py
@@ -23,7 +23,7 @@ from graphscope.dataset.io_utils import DATA_SITE
 from graphscope.dataset.io_utils import download_file
 
 
-def load_p2p_network(sess=None, prefix=None, directed=False):
+def load_p2p_network(sess=None, prefix=None, directed=False, generate_eid=True):
     """Load p2p graph.
     A peer-to-peer dataset derived from Gnutella peer-to-peer network, August 31 2002,
     with generated data on vertices and edges. See more details here:
@@ -37,6 +37,8 @@ def load_p2p_network(sess=None, prefix=None, directed=False):
             With standalone mode, set prefix None will try to download from
             source URL. Defaults to None.
         directed (bool, optional): Determine to load a directed or undirected graph.
+            Defaults to True.
+        generate_eid (bool, optional): True will generate id for each edge as the first property.
             Defaults to True.
 
     Returns:
@@ -76,7 +78,7 @@ def load_p2p_network(sess=None, prefix=None, directed=False):
     if sess is None:
         sess = get_default_session()
 
-    graph = sess.g(directed=directed)
+    graph = sess.g(directed=directed, generate_eid=generate_eid)
     graph = graph.add_vertices(
         os.path.join(prefix, "p2p-31_property_v_0"), "host"
     ).add_edges(

--- a/tutorials/06_writing_your_own_algorithms.ipynb
+++ b/tutorials/06_writing_your_own_algorithms.ipynb
@@ -302,7 +302,7 @@
     "\n",
     "from graphscope.dataset import load_p2p_network\n",
     "\n",
-    "graph = load_p2p_network(directed=False)"
+    "graph = load_p2p_network(directed=False, generate_eid=False)"
    ]
   },
   {

--- a/tutorials/zh/06_writing_your_own_algorithms.ipynb
+++ b/tutorials/zh/06_writing_your_own_algorithms.ipynb
@@ -298,7 +298,7 @@
     "\n",
     "from graphscope.dataset import load_p2p_network\n",
     "\n",
-    "graph = load_p2p_network(directed=False)"
+    "graph = load_p2p_network(directed=False, generate_eid=False)"
    ]
   },
   {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!--
copilot: summary
-->
### <samp>🤖 Generated by Copilot at 39ff275</samp>

This pull request improves the tutorial for developing algorithms in Python with GraphScope by adding a `generate_eid` parameter to the `load_p2p_network` function, which can enhance performance. It also fixes a typo and updates the documentation in both English and Chinese versions.
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

<!--
copilot: walkthrough
-->
### <samp>🤖 Generated by Copilot at 39ff275</samp>

*  Add a new parameter `generate_eid` to the `load_p2p_network` function in the `graphscope.dataset` module to allow users to control whether to generate edge IDs for the p2p network graph or not ([link](https://github.com/alibaba/GraphScope/pull/2762/files?diff=unified&w=0#diff-ea55337135903216feb5bd71745e6e417810343dcfa62efd70f7956f87ac4f3dL26-R26), [link](https://github.com/alibaba/GraphScope/pull/2762/files?diff=unified&w=0#diff-ea55337135903216feb5bd71745e6e417810343dcfa62efd70f7956f87ac4f3dR41-R42), [link](https://github.com/alibaba/GraphScope/pull/2762/files?diff=unified&w=0#diff-ea55337135903216feb5bd71745e6e417810343dcfa62efd70f7956f87ac4f3dL79-R81)).

