### PR TITLE
Support to backup and recover the specific graphs via vineyardctl

### DIFF
--- a/docs/deployment/persistent_storage_of_graphs_on_k8s.md
+++ b/docs/deployment/persistent_storage_of_graphs_on_k8s.md
@@ -1,0 +1,240 @@
+# Persistent storage of graphs on the Kubernetes cluster
+
+If you want to persistently store specific graphs that have been calculated over a long period of time on the Kubernetes cluster and restore them later, this document provides step-by-step instructions on how to do this with the Kubernetes PersistentVolumes.
+
+## Prerequisites
+- You have a Kubernetes cluster on hand. If you don't have a Kubernetes cluster, please refer to [Prepare a Kubernetes cluster](./deploy_graphscope_on_self_managed_k8s.md#prepare-a-kubernetes-cluster) for details.
+
+- You have the `graphscope` Python library installed. If you don't have installed it, please refer to [Install GraphScope Client](./deploy_graphscope_on_self_managed_k8s.md#install-graphscope-client) for details.
+
+## Create a pv and pvc
+
+```bash
+$ kubectl create namespace graphscope-system
+```
+
+Then create the pv as follows, the pv will be mounted to `/var/vineyard/dump` in the Kubernetes node. You can change the path to any other path you want.
+
+```bash
+$ cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: graphscope-pv
+  labels:
+    app.kubernetes.io/name: test-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /var/vineyard/dump
+  storageClassName: manual
+EOF
+```
+
+Create pvc as follows. Most importantly, the pvc can't be deleted, otherwise the data will be lost.
+
+```bash
+$ cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: graphscope-pvc
+  namespace: graphscope-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-pv
+  resources:
+    requests:
+      storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: manual
+EOF
+```
+
+## Store graphs to the pvc
+
+After the above preparations are completed, you can deploy the graphscope cluster as follows:
+
+```python
+import graphscope
+import os
+import vineyard
+from graphscope.dataset import load_modern_graph
+
+# export the gs_test_dir to the environment variable
+k8s_volumes = {
+    "data": {
+        "type": "hostPath",
+        "field": {"path": os.environ["GS_TEST_DIR"], "type": "Directory"},
+        "mounts": {"mountPath": "/testingdata"},
+    }
+}
+
+# create a graphscope session with the external 
+# vineyard deployment.
+#  
+# Notice, the num_workers should not be greater than the
+# number of nodes in the kubernetes cluster.  
+sess = graphscope.session(
+    num_workers=1,
+    k8s_image_registry="docker.io",
+    k8s_image_tag="ccc",
+    k8s_namespace="graphscope-system",
+    k8s_vineyard_deployment="vineyardd-sample",
+    k8s_volumes=k8s_volumes,
+)
+
+# load modern graph 
+graph = load_modern_graph(sess, "/testingdata/modern_graph")
+
+# create the gie instance
+interactive = sess.gremlin(graph)
+
+# get the subgraph
+sub_graph = interactive.subgraph(
+    'g.V().hasLabel("person").outE("knows")'
+)
+
+# project the projected graph to simple graph.
+simple_g = sub_graph.project(vertices={"person": []}, edges={"knows": []})
+
+pr_result = graphscope.pagerank(simple_g, delta=0.8)
+tc_result = graphscope.triangles(simple_g)
+
+# add the PageRank and triangle-counting results as new columns to the property graph
+sub_graph.add_column(pr_result, {"Ranking": "r"})
+sub_graph.add_column(tc_result, {"TC": "r"})
+
+# print the simple graph and subgraph's vineyard_id
+# REMEMBER the several vineyard ids, you need to use them to restore the graphs next time.
+print(simple_g.vineyard_id)
+# REMEMBER THIS: 997255889378630
+print(sub_graph.vineyard_id)
+# REMEMBER THIS: 997163552113975
+
+# store the simple graph and subgraph to the pvc
+# use the previous path of the pv and the pvc name here
+sess.store_graphs_to_pvc(
+    graphIDs=[vineyard.ObjectID(simple_g.vineyard_id), vineyard.ObjectID(sub_graph.vineyard_id)],
+    path="/var/vineyard/dump",
+    pvc_name="graphscope-pvc",
+)
+
+# check the simple graph's schema
+print(simple_g.schema)
+# oid_type: LONG
+# vid_type: ULONG
+# type: VERTEX
+# Label: person
+# Properties: 
+#
+# type: EDGE
+# Label: knows
+# Properties: 
+# Relations: [Relation(source='person', destination='person')]
+
+# check the subgraph's schema
+print(sub_graph.schema)
+
+# oid_type: LONG
+# vid_type: ULONG
+# type: VERTEX
+# Label: person
+# Properties: Property(0, name, STRING), Property(1, age, INT), Property(2, id, LONG)
+#
+# type: VERTEX
+# Label: software
+# Properties: Property(0, name, STRING), Property(1, lang, STRING), Property(2, id, LONG)
+#
+# type: EDGE
+# Label: created
+# Properties: Property(0, eid, LONG), Property(1, weight, DOUBLE)
+# Relations: [Relation(source='person', destination='software')]
+# type: EDGE
+# Label: knows
+# Properties: Property(0, eid, LONG), Property(1, weight, DOUBLE)
+# Relations: [Relation(source='person', destination='person')]
+
+# close the session
+sess.close()
+```
+
+## Retore graphs from the pvc
+
+Remember the vineyard ids printed above and the pvc name and then you can restore the graphs from the pvc as follows.
+
+```python
+import graphscope
+import os
+import vineyard
+
+# create a graphscope session with the external 
+# vineyard deployment.
+#  
+# Notice, the num_workers should not be greater than the
+# number of nodes in the kubernetes cluster.  
+sess = graphscope.session(
+    num_workers=1,
+    k8s_image_registry="docker.io",
+    k8s_image_tag="ccc",
+    k8s_namespace="graphscope-system",
+    k8s_vineyard_deployment="vineyardd-sample",
+)
+
+# load graphs from the pvc
+sess.restore_graphs_from_pvc(
+    path="/var/vineyard/dump",
+    pvc_name="graphscope-pvc"
+)
+
+# get the simple graph and subgraph
+simple_g = sess.g(vineyard.ObjectID(997255889378630))
+sub_graph = sess.g(vineyard.ObjectID(997163552113975))
+
+# check the graphs' schema
+print(simple_g.schema)
+# oid_type: LONG
+# vid_type: ULONG
+# type: VERTEX
+# Label: person
+# Properties: 
+#
+# type: EDGE
+# Label: knows
+# Properties: 
+# Relations: [Relation(source='person', destination='person')]
+
+print(sub_graph.schema)
+# oid_type: LONG
+# vid_type: ULONG
+# type: VERTEX
+# Label: person
+# Properties: Property(0, name, STRING), Property(1, age, INT), Property(2, id, LONG)
+#
+# type: VERTEX
+# Label: software
+# Properties: Property(0, name, STRING), Property(1, lang, STRING), Property(2, id, LONG)
+#
+# type: EDGE
+# Label: created
+# Properties: Property(0, eid, LONG), Property(1, weight, DOUBLE)
+# Relations: [Relation(source='person', destination='software')]
+# type: EDGE
+# Label: knows
+# Properties: Property(0, eid, LONG), Property(1, weight, DOUBLE)
+# Relations: [Relation(source='person', destination='person')]
+```
+
+## Clean up
+
+If you don't need the graphs anymore, you can delete the pvc and pv as follows.
+
+```bash
+$ kubectl delete pvc graphscope-pvc -n graphscope-system
+$ kubectl delete pv graphscope-pv
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ and the vineyard store that offers efficient in-memory data transfers.
    deployment/install_on_local
    deployment/deploy_graphscope_on_self_managed_k8s
    deployment/deploy_with_existing_vineyard_cluster
+   deployment/persistent_storage_of_graphs_on_k8s
    .. deployment/deploy_graphscope_on_clouds
    deployment/deploy_graphscope_with_helm
    deployment/install_in_offline_env

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -1148,8 +1148,9 @@ class Session(object):
         Also, if you want to store graphs of different sessions to the same pv,
         you'd better to create different pvc for different sessions at first.
 
-        Notice, before calling this function, you should make sure that the
-        pvc is bound to the pv and the pv's capacity is enough to store the
+        Notice, before calling this function, the KUBECONFIG environment variable
+        should be set to the path of your kubeconfig file. And you should make sure
+        that the pvc is bound to the pv and the pv's capacity is enough to store the
         graphs.
 
         The method uses the vineyardctl to create a kubernetes job to serialize
@@ -1174,8 +1175,8 @@ class Session(object):
             if isinstance(object, Graph):
                 object_ids.append(object.vineyard_id)
             else:
-                object_ids.append(object)
-        object_ids = ",".join(object_ids)
+                object_ids.append(vineyard.ObjectID(object))
+        object_ids = ",".join(repr(id) for id in object_ids)
         vineyard_deployment_name = self._config_params["k8s_vineyard_deployment"]
         namespace = self._config_params["k8s_namespace"]
         self._check_vineyard_deployment_exists(vineyard_deployment_name, namespace)
@@ -1188,13 +1189,15 @@ class Session(object):
             vineyard_deployment_namespace=namespace,
             namespace=namespace,
             path=path,
-            objectids=",".join(object_ids),
+            objectids=object_ids,
             pvc_name=pvc_name,
         )
 
     def restore_from_pvc(self, path: str, pvc_name: str):
         """
         Restores the graphs from the given path in the given PVC.
+        Notice, before calling this function, the KUBECONFIG environment variable
+        should be set to the path of your kubeconfig file.
 
         Args:
             path: The path in the pv to which the pvc is bound.

--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -34,9 +34,9 @@ import uuid
 import warnings
 
 try:
+    import vineyard
     from kubernetes import client as kube_client
     from kubernetes import config as kube_config
-    import vineyard
 except ImportError:
     kube_client = None
     kube_config = None
@@ -62,6 +62,7 @@ from graphscope.framework.graph import GraphDAGNode
 from graphscope.framework.operation import Operation
 from graphscope.framework.utils import decode_dataframe
 from graphscope.framework.utils import decode_numpy
+from graphscope.framework.utils import random_string
 from graphscope.interactive.query import InteractiveQuery
 from graphscope.proto import graph_def_pb2
 from graphscope.proto import message_pb2
@@ -586,10 +587,10 @@ class Session(object):
             "show_log",
             "log_level",
         )
-        
+
         # the mapping table from old vineyard object id to new vineyard object id
         self._vineyard_object_mapping_table = {}
-        
+
         saved_locals = locals()
         for param in self._accessable_params:
             self._config_params[param] = saved_locals[param]
@@ -1029,15 +1030,7 @@ class Session(object):
             ):
                 api_client = self._config_params["k8s_client_config"]
             else:
-                try:
-                    api_client = resolve_api_client(
-                        self._config_params["k8s_client_config"]
-                    )
-                except kube_config.ConfigException as e:
-                    raise RuntimeError(
-                        "Kubernetes environment not found, you may want to"
-                        ' launch session locally with param cluster_type="hosts"'
-                    ) from e
+                api_client = self._get_api_client()
             self._launcher = KubernetesClusterLauncher(
                 api_client=api_client,
                 **self._config_params,
@@ -1108,64 +1101,145 @@ class Session(object):
         """Get configuration of the session."""
         return self._config_params
 
-    def backup_vineyard_depployment(self, graphIDs: str, path: str, pvc_name: str):
-        if self._cluster_type != types_pb2.K8S:
-            return
-        # check if session exist
-        if self.session_id is None:
-            return
-        vineyard_deployment_name = self._config_params["k8s_vineyard_deployment"]
-        vineyard_deployment_namespace = self._config_params["k8s_namespace"]
-        # The next function will create a kubernetes job for backuping
-        # the specific graphIDs to the specific path of the specific pvc
-        # if the graphIDs is None, it will backup all the graphs stored
-        # in the vineyard deployment
-        vineyard.deploy.vineyardctl.deploy.backup_job(
-            kubeconfig = self._config_params["k8s_client_config"],
-            backup_name = "vineyard-backup",
-            vineyard_deployment_name = vineyard_deployment_name,
-            vineyard_deployment_namespace = vineyard_deployment_namespace,
-            path = path,
-            objectIDs = graphIDs,
-            pvc_name = pvc_name,
-        )
-    
-    def recover_vineyard_deployment(self, path: str, pvc_name: str):
-        if self._cluster_type != types_pb2.K8S:
-            return
-        # check if session exist
-        if self.session_id is None:
-            return
-        vineyard_deployment_name = self._config_params["k8s_vineyard_deployment"]
-        vineyard_deployment_namespace = self._config_params["k8s_namespace"]
-        vineyard.deploy.vineyardctl.deploy.recover_job(
-            kubeconfig = self._config_params["k8s_client_config"],
-            backup_name = "vineyard-recover",
-            vineyard_deployment_name = vineyard_deployment_name,
-            vineyard_deployment_namespace = vineyard_deployment_namespace,
-            recover_path = path,
-            pvc_name = pvc_name,
-        )
+    def _get_api_client(self):
         try:
-            api_client = resolve_api_client(
-                self._config_params["k8s_client_config"]
-            )
+            api_client = resolve_api_client(self._config_params["k8s_client_config"])
         except kube_config.ConfigException as e:
             raise RuntimeError(
                 "Kubernetes environment not found, you may want to"
                 ' launch session locally with param cluster_type="hosts"'
             ) from e
+        return api_client
+
+    def _check_pvc_exist(self, pvc_name, pvc_namespace):
+        api_client = self._get_api_client()
         _core_api = kube_client.CoreV1Api(api_client)
-        config_map = _core_api.read_namespaced_config_map(
-            name="vineyard-recover" + "-mapping-table",
-            namespace=vineyard_deployment_namespace,
+        try:
+            _core_api.read_namespaced_persistent_volume_claim(
+                name=pvc_name,
+                namespace=pvc_namespace,
+            )
+        except kube_client.rest.ApiException as e:
+            raise RuntimeError(
+                f"PVC {pvc_name} not found in namespace {pvc_namespace}"
+            ) from e
+
+    def _check_vineyard_deployment_for_ready(
+        self, vineyard_deployment_name, vineyard_deployment_namespace
+    ):
+        api_client = self._get_api_client()
+        _app_api = kube_client.AppsV1Api(api_client)
+        try:
+            _app_api.read_namespaced_deployment(
+                name=vineyard_deployment_name,
+                namespace=vineyard_deployment_namespace,
+            )
+        except kube_client.rest.ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(
+                    f"Vineyard deployment {vineyard_deployment_name} not found in namespace {vineyard_deployment_namespace}"
+                ) from e
+            else:
+                raise e
+
+    def store_graphs_to_pvc(self, graphIDs, path: str, pvc_name: str):
+        """
+        Stores the given graph IDs to the given path with the given PVC.
+        Also, if you want to store graphs of different sessions to the same pv,
+        you'd better to create different pvc for different sessions at first.
+
+        Notice, before calling this function, you should make sure that the
+        pvc is bound to the pv and the pv's capacity is enough to store the
+        graphs.
+
+        The method uses the vineyardctl to create a kubernetes job to serialize
+        the selected graphs. For more information, see the vineyardctl documentation.
+
+        https://github.com/v6d-io/v6d/tree/main/k8s/cmd#vineyardctl-deploy-backup-job
+
+        Args:
+            graph_ids: The list of graph IDs to store.
+                       Supported types:
+                       - list: list of vineyard.ObjectID
+            path: The path in the pv to which the pvc is bound.
+            pvc_name: The name of the PVC.
+
+        Raises:
+            RuntimeError: If the cluster type is not Kubernetes.
+        """
+        if self._cluster_type != types_pb2.K8S:
+            raise RuntimeError("Only support kubernetes cluster")
+        if not isinstance(graphIDs, list):
+            raise RuntimeError("graphIDs should be a list of vineyard.ObjectID")
+        objectids = ",".join(repr(id) for id in graphIDs)
+        vineyard_deployment_name = self._config_params["k8s_vineyard_deployment"]
+        namespace = self._config_params["k8s_namespace"]
+        self._check_vineyard_deployment_for_ready(vineyard_deployment_name, namespace)
+        self._check_pvc_exist(pvc_name, namespace)
+        # The next function will create a kubernetes job for backuping
+        # the specific graphIDs to the specific path of the specific pvc
+        vineyard.deploy.vineyardctl.deploy.backup_job(
+            backup_name="vineyard-backup-" + random_string(6),
+            vineyard_deployment_name=vineyard_deployment_name,
+            vineyard_deployment_namespace=namespace,
+            namespace=namespace,
+            path=path,
+            objectids=objectids,
+            pvc_name=pvc_name,
         )
 
+    def restore_graphs_from_pvc(self, path: str, pvc_name: str):
+        """
+        Restores the graphs from the given path in the given PVC.
+
+        Args:
+            path: The path in the pv to which the pvc is bound.
+            pvc_name: The name of the PVC.
+
+        Raises:
+            RuntimeError: If the cluster type is not Kubernetes.
+        """
+        if self._cluster_type != types_pb2.K8S:
+            raise RuntimeError("Only support kubernetes cluster")
+        vineyard_deployment_name = self._config_params["k8s_vineyard_deployment"]
+        namespace = self._config_params["k8s_namespace"]
+        self._check_vineyard_deployment_for_ready(vineyard_deployment_name, namespace)
+        self._check_pvc_exist(pvc_name, namespace)
+        random_suffix = random_string(6)
+        vineyard.deploy.vineyardctl.deploy.recover_job(
+            recover_name="vineyard-recover-" + random_suffix,
+            vineyard_deployment_name=vineyard_deployment_name,
+            vineyard_deployment_namespace=namespace,
+            namespace=namespace,
+            recover_path=path,
+            pvc_name=pvc_name,
+        )
+
+        api_client = self._get_api_client()
+        _core_api = kube_client.CoreV1Api(api_client)
+        try:
+            config_map = _core_api.read_namespaced_config_map(
+                name="vineyard-recover-" + random_suffix + "-mapping-table",
+                namespace=namespace,
+            )
+        except kube_client.rest.ApiException as e:
+            if e.status == 404:
+                raise RuntimeError(
+                    f"ConfigMap vineyard-recover-{random_suffix}-mapping-table not found in namespace {namespace}"
+                ) from e
+            else:
+                raise e
+
         # parse configmap data to the self._vineyard_object_mapping_table
-        for key in config_map.data:
-            self._vineyard_object_mapping_table[key] = config_map.data[key]
+        self._vineyard_object_mapping_table = config_map.data
 
     def get_vineyard_object_mapping_table(self):
+        """
+        Get the vineyard object mapping table
+        from the old object id to new object id
+        during storing and restoring graph to pvc
+        on the kubernetes cluster.
+        """
         return self._vineyard_object_mapping_table
 
     def g(
@@ -1178,8 +1252,16 @@ class Session(object):
         vertex_map="global",
         compact_edges=False,
     ):
-        if isinstance(incoming_data, vineyard.ObjectID) and self._vineyard_object_mapping_table[str(incoming_data)] is not None:
-            incoming_data = vineyard.ObjectID(self._vineyard_object_mapping_table[str(incoming_data)])
+        if (
+            isinstance(incoming_data, vineyard.ObjectID)
+            and repr(vineyard.ObjectID(incoming_data))
+            in self._vineyard_object_mapping_table
+        ):
+            graph_vineyard_id = self._vineyard_object_mapping_table[
+                repr(vineyard.ObjectID(incoming_data))
+            ]
+            logger.info("Restore graph from original graph {graph_vineyard_id}")
+            incoming_data = vineyard.ObjectID(graph_vineyard_id)
         return self._wrapper(
             GraphDAGNode(
                 self,

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -1123,7 +1123,7 @@ class Graph(GraphInterface):
                 identical with the one that called serialized method.
         """
         try:
-            
+            import vineyard
             import vineyard.io
         except ImportError:
             raise RuntimeError(

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -1123,7 +1123,7 @@ class Graph(GraphInterface):
                 identical with the one that called serialized method.
         """
         try:
-            import vineyard
+            
             import vineyard.io
         except ImportError:
             raise RuntimeError(

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -25,6 +25,10 @@ import time
 
 import numpy as np
 import pytest
+import vineyard
+from kubernetes import client
+from kubernetes import config
+from kubernetes.client.rest import ApiException
 
 import graphscope
 from graphscope import Graph
@@ -175,6 +179,9 @@ def gs_session_with_lazy_mode():
 def create_vineyard_deployment_on_single_node():
     import vineyard
 
+
+@pytest.fixture
+def create_vineyard_deployment_on_single_node():
     # create vineyard deployment on single node
     # set the replicas of vineyard and etcd to 1 as there is only one node in the cluster
     vineyard.deploy.vineyardctl.deploy.vineyard_deployment(
@@ -503,6 +510,179 @@ def test_query_modern_graph(
     # traversal on moder graph
     g = interactive.traversal_source()
     modern_bytecode(g)
+
+
+def create_pv(name, path):
+    config.load_kube_config()
+    v1 = client.CoreV1Api()
+    try:
+        pv = {
+            "apiVersion": "v1",
+            "kind": "PersistentVolume",
+            "metadata": {
+                "name": name,
+                "labels": {
+                    "app.kubernetes.io/name": name,
+                },
+            },
+            "spec": {
+                "capacity": {"storage": "1Gi"},
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": "manual",
+                "hostPath": {
+                    "path": path,
+                    "type": "DirectoryOrCreate",
+                },
+            },
+        }
+
+        v1.create_persistent_volume(body=pv)
+    except ApiException as e:
+        logger.error(
+            "Exception when calling CoreV1Api->create_persistent_volume: %s\n" % e
+        )
+
+
+def create_pvc(name, namespace, pv_name):
+    config.load_kube_config()
+    v1 = client.CoreV1Api()
+    try:
+        pvc = {
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": name,
+                "namespace": namespace,
+            },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "resources": {"requests": {"storage": "1Gi"}},
+                "storageClassName": "manual",
+                "selector": {
+                    "matchLabels": {
+                        "app.kubernetes.io/name": pv_name,
+                    }
+                },
+            },
+        }
+
+        v1.create_namespaced_persistent_volume_claim(namespace=namespace, body=pvc)
+    except ApiException as e:
+        logger.error(
+            "Exception when calling CoreV1Api->create_persistent_volume_claim: %s\n" % e
+        )
+
+
+def create_namespace(name):
+    config.load_kube_config()
+    v1 = client.CoreV1Api()
+    try:
+        # Create a new namespace object
+        ns = client.V1Namespace()
+        ns.metadata = client.V1ObjectMeta(name=name)
+        v1.create_namespace(ns)
+    except ApiException as e:
+        logger.error("Exception when calling CoreV1Api->create_namespace: %s\n" % e)
+
+
+def test_store_and_restore_graphs(
+    modern_graph_data_dir,
+):
+    namespace = "graphscope-system"
+    create_namespace(namespace)
+    old_sess = graphscope.session(
+        num_workers=1,
+        k8s_namespace="graphscope-system",
+        k8s_image_registry=get_gs_registry_on_ci_env(),
+        k8s_image_tag=get_gs_tag_on_ci_env(),
+        k8s_coordinator_cpu=2,
+        k8s_coordinator_mem="4Gi",
+        k8s_vineyard_cpu=2,
+        k8s_vineyard_mem="1Gi",
+        k8s_engine_cpu=2,
+        k8s_engine_mem="4Gi",
+        vineyard_shared_mem="4Gi",
+        k8s_vineyard_deployment="vineyardd-sample",
+        k8s_volumes=get_k8s_volumes(),
+    )
+    graph = load_modern_graph(old_sess, "/testingdata/modern_graph")
+    interactive = old_sess.gremlin(graph)
+    graph_vineyard_id = vineyard.ObjectID(graph.vineyard_id)
+    graph_person_count = interactive.execute(
+        'g.V().hasLabel("person").outE("knows").bothV().dedup().count()'
+    ).all()[0]
+    graph_knows_count = interactive.execute(
+        'g.V().hasLabel("person").outE("knows").count()'
+    ).all()[0]
+
+    sub_graph = interactive.subgraph(  # noqa: F841
+        'g.V().hasLabel("person").outE("knows")'
+    )
+    sub_graph_person_count = interactive.execute(
+        'g.V().hasLabel("person").outE("knows").bothV().dedup().count()'
+    ).all()[0]
+    sub_graph_knows_count = interactive.execute(
+        'g.V().hasLabel("person").outE("knows").count()'
+    ).all()[0]
+
+    sub_graph_vineyard_id = vineyard.ObjectID(sub_graph.vineyard_id)
+    # create the pv and pvc for backup
+    pv_name = "test-pv"
+    path = "/var/vineyard/dump"
+    pvc_name = "test-pvc"
+    create_pv(pv_name, path)
+    create_pvc(pvc_name, namespace, pv_name)
+    # store the specific graphs to pvc
+    old_sess.store_graphs_to_pvc(
+        graphIDs=[graph_vineyard_id, sub_graph_vineyard_id],
+        path=path,
+        pvc_name=pvc_name,
+    )
+
+    old_sess.close()
+    # wait the session to be closed
+    wait_for_pod_deletion("coordinator", namespace)
+    wait_for_pod_deletion("gs-engine", namespace)
+
+    # create a new session to recover the graph
+    new_sess = graphscope.session(
+        num_workers=1,
+        k8s_namespace="graphscope-system",
+        k8s_image_registry=get_gs_registry_on_ci_env(),
+        k8s_image_tag=get_gs_tag_on_ci_env(),
+        k8s_coordinator_cpu=2,
+        k8s_coordinator_mem="4Gi",
+        k8s_vineyard_cpu=2,
+        k8s_vineyard_mem="1Gi",
+        k8s_engine_cpu=2,
+        k8s_engine_mem="4Gi",
+        vineyard_shared_mem="4Gi",
+        k8s_vineyard_deployment="vineyardd-sample",
+        k8s_volumes=get_k8s_volumes(),
+    )
+    new_sess.restore_graphs_from_pvc(
+        path=path,
+        pvc_name=pvc_name,
+    )
+
+    new_graph = new_sess.g(vineyard.ObjectID(graph_vineyard_id))
+    interactive = new_sess.gremlin(new_graph)
+    new_graph_person_count = interactive.execute(
+        'g.V().hasLabel("person").outE("knows").bothV().dedup().count()'
+    ).all()[0]
+    new_graph_knows_count = interactive.execute(
+        'g.V().hasLabel("person").outE("knows").count()'
+    ).all()[0]
+
+    new_sub_graph = new_sess.g(vineyard.ObjectID(sub_graph_vineyard_id))
+    interactive2 = new_sess.gremlin(new_sub_graph)
+    new_sub_graph_person_count = interactive2.execute("g.V().count()").all()[0]
+    new_sub_graph_knows_count = interactive2.execute("g.E().count()").all()[0]
+
+    assert graph_person_count == new_graph_person_count
+    assert graph_knows_count == new_graph_knows_count
+    assert sub_graph_person_count == new_sub_graph_person_count
+    assert sub_graph_knows_count == new_sub_graph_knows_count
 
 
 def test_serialize_roundtrip(gs_session_distributed, p2p_property_dir):

--- a/python/graphscope/tests/kubernetes/test_demo_script.py
+++ b/python/graphscope/tests/kubernetes/test_demo_script.py
@@ -628,12 +628,12 @@ def test_store_and_restore_graphs(
     sub_graph_vineyard_id = vineyard.ObjectID(sub_graph.vineyard_id)
     # create the pv and pvc for backup
     pv_name = "test-pv"
-    path = "/var/vineyard/dump"
+    path = "/var/vineyard1/test"
     pvc_name = "test-pvc"
     create_pv(pv_name, path)
     create_pvc(pvc_name, namespace, pv_name)
     # store the specific graphs to pvc
-    old_sess.store_graphs_to_pvc(
+    old_sess.store_to_pvc(
         graphIDs=[graph_vineyard_id, sub_graph_vineyard_id],
         path=path,
         pvc_name=pvc_name,
@@ -660,7 +660,7 @@ def test_store_and_restore_graphs(
         k8s_vineyard_deployment="vineyardd-sample",
         k8s_volumes=get_k8s_volumes(),
     )
-    new_sess.restore_graphs_from_pvc(
+    new_sess.restore_from_pvc(
         path=path,
         pvc_name=pvc_name,
     )

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -20,6 +20,6 @@ ujson;python_version>="3.11"
 PyYAML
 rich
 tqdm
-vineyard>=0.14.8;sys_platform!="win32"
-vineyard-io>=0.14.8;sys_platform!="win32"
+vineyard>=0.15.0;sys_platform!="win32"
+vineyard-io>=0.15.0;sys_platform!="win32"
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b435676</samp>

This pull request enhances the vineyard integration for GraphScope on Kubernetes. It enables backup and recovery of vineyard deployments using the `Session` class, and simplifies the code in the `Graph` class by removing a redundant import.

## Related issue number

Fixes parts of #2539 

Wait vineyard to release a new version.
