### PR TITLE
Improve GetInnerVertex() by querying local fragment only

### DIFF
--- a/analytical_engine/core/fragment/arrow_projected_fragment.h
+++ b/analytical_engine/core/fragment/arrow_projected_fragment.h
@@ -822,11 +822,9 @@ class ArrowProjectedFragment
 
   inline bool GetInnerVertex(const oid_t& oid, vertex_t& v) const {
     vid_t gid;
-    if (vm_ptr_->GetGid(internal_oid_t(oid), gid)) {
-      if (vid_parser_.GetFid(gid) == fid_) {
-        v.SetValue(vid_parser_.GetLid(gid));
-        return true;
-      }
+    if (vm_ptr_->GetGid(fid_, internal_oid_t(oid), gid)) {
+      v.SetValue(vid_parser_.GetLid(gid));
+      return true;
     }
     return false;
   }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

The current implementation of GetInnerVertex() is to query all the fragment, it's not needed as we only need the inner vertex

