### PR TITLE
Fixes the building failure of client wheel on Linux arm64 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,14 +74,8 @@ client: learning
 	python3 -m pip install -r requirements.txt -r requirements-dev.txt --user && \
 	export PATH=$(PATH):$(HOME)/.local/bin && \
 	python3 setup.py build_ext --inplace --user
-	if [[ "${ARCH}" == "aarch64" ]]; then \
-		python3 setup.py bdist_wheel; \
-		python3 -m pip install --user dist/*.whl; \
-		rm -fr  $(CLIENT_DIR)/build; \
-	else \
-		python3 -m pip install --user --editable $(CLIENT_DIR); \
-		rm -rf $(CLIENT_DIR)/*.egg-info; \
-	fi
+	python3 -m pip install --user --no-build-isolation --editable $(CLIENT_DIRNT_DIR)
+	rm -rf $(CLIENT_DIR)/*.egg-info
 
 coordinator: client
 	cd $(COORDINATOR_DIR) && \

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,7 +1,6 @@
 # Python
 __pycache__/
 *.pyc
-*.pyi
 .ipynb_checkpoints
 *.egg-info/
 *.egg/
@@ -14,6 +13,7 @@ lib/
 
 # Protobuf GRPC
 *.pb.*
+*.pyi*
 *_pb2.py
 *_pb2_grpc.py
 

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,6 +1,7 @@
 # Python
 __pycache__/
 *.pyc
+*.pyi
 .ipynb_checkpoints
 *.egg-info/
 *.egg/


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b62fa8</samp>

Simplify client package installation and ignore type annotation files. The changes make the `Makefile` more robust and avoid cluttering the `python` directory with `.pyi` files.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9b62fa8</samp>

*  Simplify client package installation by removing architecture-specific logic and using `--no-build-isolation` option ([link](https://github.com/alibaba/GraphScope/pull/2780/files?diff=unified&w=0#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L77-R78) in `Makefile`)

