### PR TITLE
Support users to only input the kubeconfig path for connecting the k8s cluster

### DIFF
--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -1013,6 +1013,11 @@ class Session(object):
             # try to connect to exist coordinator
             self._coordinator_endpoint = self._config_params["addr"]
         elif self._cluster_type == types_pb2.K8S:
+            # if users only provide kube_config file path
+            if isinstance(self._config_params["k8s_client_config"], str):
+                self._config_params["k8s_client_config"] = {
+                    "config_file": self._config_params["k8s_client_config"]
+                }
             if isinstance(
                 self._config_params["k8s_client_config"],
                 kube_client.api_client.ApiClient,


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

- Support users to only input the kubeconfig path for connecting the k8s cluster
- Get the current kubeconfig for vineyardctl.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2796 

