### PR TITLE
[BugFix] Make the error message truncated not so aggressive

### DIFF
--- a/coordinator/gscoordinator/op_executor.py
+++ b/coordinator/gscoordinator/op_executor.py
@@ -111,7 +111,7 @@ class OperationExecutor:
                 # TODO: make the stacktrace separated from normal error messages
                 # Too verbose.
                 if len(e.details()) > 3072:  # 3k bytes
-                    msg = f"{e.details()[:1014]} ... [truncated]"
+                    msg = f"{e.details()[:256]} ... [truncated]"
                 else:
                     msg = e.details()
                 raise AnalyticalEngineInternalError(msg)

--- a/coordinator/gscoordinator/op_executor.py
+++ b/coordinator/gscoordinator/op_executor.py
@@ -111,7 +111,7 @@ class OperationExecutor:
                 # TODO: make the stacktrace separated from normal error messages
                 # Too verbose.
                 if len(e.details()) > 3072:  # 3k bytes
-                    msg = f"{e.details()[:30]} ... [truncated]"
+                    msg = f"{e.details()[:1014]} ... [truncated]"
                 else:
                     msg = e.details()
                 raise AnalyticalEngineInternalError(msg)


### PR DESCRIPTION


## What do these changes do?
[code](https://github.com/alibaba/GraphScope/blob/086fa63622ee4fa67d8894fbcaee91e274ef550a/coordinator/gscoordinator/op_executor.py#L114) shows that when error message is too large, truncated to 30 chars. BUT A snippet of 30 chars is usually not enough to tell something useful. This change enlarge the 30 to 1024 to show more log.

## Related issue number
Fixes #2864

