### PR TITLE
Update the pre-genereated unload_op when the op itself been deepcopied

### DIFF
--- a/python/graphscope/client/session.py
+++ b/python/graphscope/client/session.py
@@ -672,7 +672,7 @@ class Session(object):
         #       "vineyard_socket": "...",
         #       "vineyard_rpc_endpoint": "..."
         #   }
-        self._engine_config: {} = None
+        self._engine_config: dict = None
 
         # interactive instance related graph map
         self._interactive_instance_dict = {}
@@ -713,7 +713,7 @@ class Session(object):
         return self._session_id
 
     @property
-    def dag(self):
+    def dag(self) -> Dag:
         return self._dag
 
     def _log_session_info(self):

--- a/python/graphscope/framework/app.py
+++ b/python/graphscope/framework/app.py
@@ -442,6 +442,7 @@ class App(object):
         # copy and set op evaluated
         self._app_node.op = deepcopy(self._app_node.op)
         self._app_node.evaluated = True
+        self._app_node._unload_op = unload_app(self._app_node)
         self._session.dag.add_op(self._app_node.op)
         self._saved_signature = self.signature
 

--- a/python/graphscope/framework/context.py
+++ b/python/graphscope/framework/context.py
@@ -610,6 +610,7 @@ class Context(object):
         # copy and set op evaluated
         self._context_node.op = deepcopy(self._context_node.op)
         self._context_node.evaluated = True
+        self._context_node._unload_op = dag_utils.unload_context(self._context_node)
         self._saved_signature = self.signature
 
     @property

--- a/python/graphscope/nx/classes/graph.py
+++ b/python/graphscope/nx/classes/graph.py
@@ -369,6 +369,9 @@ class Graph(_GraphBase):
         self._is_client_view = False
 
         # statically create the unload op
+        #
+        # networkx operations update the op, but keep the key as same, thus
+        # the unload op don't need to be refreshed.
         if self.op is None:
             self._unload_op = None
         else:


### PR DESCRIPTION
## What do these changes do?

The issue was first introduced in #2843. See also error messages in CI like https://github.com/alibaba/GraphScope/actions/runs/5222275661/jobs/9428251359
