### PR TITLE
[GAE-Java] Relax version enforce for some mvn dependencies

### DIFF
--- a/analytical_engine/java/grape-rdd-reader/pom.xml
+++ b/analytical_engine/java/grape-rdd-reader/pom.xml
@@ -83,7 +83,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-android</version>
         </dependency>
         <dependency>
 <!--            include this package to resolve error javax.annotation.generated not found java 11-->
@@ -168,7 +167,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>enforce</id>
@@ -177,7 +176,12 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <requireUpperBoundDeps/>
+                                <requireUpperBoundDeps>
+                                    <excludes>
+                                        <exclude>com.google.j2objc:j2objc-annotations</exclude>
+                                        <exclude>com.google.errorprone:error_prone_annotations</exclude>
+                                    </excludes>
+                                </requireUpperBoundDeps>
                             </rules>
                         </configuration>
                     </execution>

--- a/analytical_engine/java/grape-rdd-reader/pom.xml
+++ b/analytical_engine/java/grape-rdd-reader/pom.xml
@@ -39,45 +39,30 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-bom</artifactId>
-            <version>${grpc.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
-            <version>${protobuf.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.0</version> <!-- prevent downgrade via protobuf-java-util -->
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-testing</artifactId>
-            <version>${grpc.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -88,7 +73,6 @@
 <!--            include this package to resolve error javax.annotation.generated not found java 11-->
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>${javax.annotation.version}</version>
         </dependency>
     </dependencies>
 

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -100,6 +100,7 @@
     <protoc.version>3.19.2</protoc.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <native-lib-loader.version>2.3.5</native-lib-loader.version>
+    <gson.version>2.9.0</gson.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -233,6 +234,49 @@
         <artifactId>mockito-all</artifactId>
         <version>1.10.19</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>${javax.annotation.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-bom</artifactId>
+          <version>${grpc.version}</version>
+          <type>pom</type>
+          <scope>import</scope>
+      </dependency>
+      <dependency>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty-shaded</artifactId>
+          <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-protobuf</artifactId>
+          <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-stub</artifactId>
+          <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java-util</artifactId>
+          <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+          <version>${gson.version}</version> <!-- prevent downgrade via protobuf-java-util -->
+      </dependency>
+      <dependency>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-testing</artifactId>
+          <version>${grpc.version}</version>
+          <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -90,6 +90,7 @@
     <dep.netty.version>4.1.44.Final</dep.netty.version>
     <dep.fastutil.version>6.5.4</dep.fastutil.version>
     <dep.kryo.version>4.0.0</dep.kryo.version>
+    <guava.version>32.0.0-jre</guava.version>
     <spark.version>3.1.3</spark.version>
     <maven.javadoc.version>3.4.0</maven.javadoc.version>
     <javadoc.output.directory>grape-jdk-javadoc</javadoc.output.directory>
@@ -188,7 +189,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>30.1.1-jre</version>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
When upgrading `guava` for `GAE Java SDK`, there seems to be some problem with `maven-enforcer-plugin`. Relax this version control.