### PR TITLE
Use CONFIG mode to find protobuf to address the absl dependency issue.

### DIFF
--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -223,7 +223,10 @@ endif ()
 find_package(libgrapelite REQUIRED)
 include_directories(${LIBGRAPELITE_INCLUDE_DIRS})
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG QUIET)
+if (NOT Protobuf_FOUND)
+    find_package(Protobuf REQUIRED)
+endif()
 include_directories(${Protobuf_INCLUDE_DIRS})
 
 if (ENABLE_JAVA_SDK)


### PR DESCRIPTION
See also:
- https://github.com/protocolbuffers/protobuf/issues/12292
- the macos CI failure: https://github.com/alibaba/GraphScope/actions/runs/5271097039/jobs/9531496683

