### PR TITLE
[GIE] Refine FFI interface `build_physical_plan`

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/RpcExecutionClient.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/RpcExecutionClient.java
@@ -26,6 +26,7 @@ import com.alibaba.pegasus.RpcChannel;
 import com.alibaba.pegasus.RpcClient;
 import com.alibaba.pegasus.intf.ResultProcessor;
 import com.alibaba.pegasus.service.protocol.PegasusClient;
+import com.google.protobuf.ByteString;
 
 import io.grpc.Status;
 
@@ -49,7 +50,9 @@ public class RpcExecutionClient extends ExecutionClient<RpcChannel> {
     public void submit(ExecutionRequest request, ExecutionResponseListener listener)
             throws Exception {
         PegasusClient.JobRequest jobRequest =
-                PegasusClient.JobRequest.parseFrom((byte[]) request.getRequestPhysical().build());
+                PegasusClient.JobRequest.newBuilder()
+                        .setPlan(ByteString.copyFrom((byte[]) request.getRequestPhysical().build()))
+                        .build();
         PegasusClient.JobConfig jobConfig =
                 PegasusClient.JobConfig.newBuilder()
                         .setJobId(request.getRequestId())

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -48,6 +48,7 @@ import com.alibaba.pegasus.RpcClient;
 import com.alibaba.pegasus.intf.ResultProcessor;
 import com.alibaba.pegasus.service.protocol.PegasusClient;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -377,7 +378,10 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
         byte[] physicalPlanBytes = irPlan.toPhysicalBytes(configs);
         irPlan.close();
 
-        PegasusClient.JobRequest request = PegasusClient.JobRequest.parseFrom(physicalPlanBytes);
+        PegasusClient.JobRequest request =
+                PegasusClient.JobRequest.newBuilder()
+                        .setPlan(ByteString.copyFrom(physicalPlanBytes))
+                        .build();
         PegasusClient.JobConfig jobConfig =
                 PegasusClient.JobConfig.newBuilder()
                         .setJobId(jobId)
@@ -423,7 +427,9 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
                         jobName,
                         physicalBuilder.explain());
                 PegasusClient.JobRequest request =
-                        PegasusClient.JobRequest.parseFrom(physicalPlanBytes);
+                        PegasusClient.JobRequest.newBuilder()
+                                .setPlan(ByteString.copyFrom(physicalPlanBytes))
+                                .build();
                 PegasusClient.JobConfig jobConfig =
                         PegasusClient.JobConfig.newBuilder()
                                 .setJobId(jobId)

--- a/interactive_engine/executor/ir/common/src/utils.rs
+++ b/interactive_engine/executor/ir/common/src/utils.rs
@@ -650,6 +650,21 @@ impl From<physical_pb::physical_opr::operator::OpKind> for physical_pb::Physical
     }
 }
 
+impl From<(physical_pb::physical_opr::operator::OpKind, Vec<physical_pb::physical_opr::MetaData>)>
+    for physical_pb::PhysicalOpr
+{
+    fn from(
+        op_kind_with_meta: (
+            physical_pb::physical_opr::operator::OpKind,
+            Vec<physical_pb::physical_opr::MetaData>,
+        ),
+    ) -> Self {
+        let (op_kind, meta_data) = op_kind_with_meta;
+        let opr = physical_pb::physical_opr::Operator { op_kind: Some(op_kind) };
+        physical_pb::PhysicalOpr { opr: Some(opr), meta_data }
+    }
+}
+
 impl From<pb::MetaData> for physical_pb::physical_opr::MetaData {
     fn from(meta_data: pb::MetaData) -> Self {
         physical_pb::physical_opr::MetaData { r#type: meta_data.r#type, alias: meta_data.alias }

--- a/interactive_engine/executor/ir/core/src/plan/ffi.rs
+++ b/interactive_engine/executor/ir/core/src/plan/ffi.rs
@@ -58,7 +58,7 @@ use std::os::raw::c_char;
 use ir_common::expr_parse::str_to_expr_pb;
 use ir_common::generated::algebra as pb;
 use ir_common::generated::common as common_pb;
-use ir_physical_client::physical_builder::JobBuilder;
+use ir_physical_client::physical_builder::PlanBuilder;
 use pegasus::BuildJobError;
 use prost::Message;
 
@@ -623,25 +623,20 @@ pub extern "C" fn build_physical_plan(
         plan.meta = plan.meta.with_partition();
     }
     let mut plan_meta = plan.meta.clone();
-    let mut builder = JobBuilder::default();
+    let mut builder = PlanBuilder::default();
     let build_result = plan.add_job_builder(&mut builder, &mut plan_meta);
     let result = match build_result {
         Ok(_) => {
-            let req_result = builder.build();
-            match req_result {
-                Ok(req) => {
-                    let mut req_bytes = req.encode_to_vec().into_boxed_slice();
-                    let data = FfiData {
-                        ptr: req_bytes.as_mut_ptr() as *mut c_void,
-                        len: req_bytes.len(),
-                        error: FfiResult::success(),
-                    };
-                    std::mem::forget(req_bytes);
+            let physical_plan = builder.build();
+            let mut plan_bytes = physical_plan.encode_to_vec().into_boxed_slice();
+            let data = FfiData {
+                ptr: plan_bytes.as_mut_ptr() as *mut c_void,
+                len: plan_bytes.len(),
+                error: FfiResult::success(),
+            };
+            std::mem::forget(plan_bytes);
 
-                    data
-                }
-                Err(e) => e.into(),
-            }
+            data
         }
         Err(e) => e.into(),
     };

--- a/interactive_engine/executor/ir/integrated/tests/catalog_test.rs
+++ b/interactive_engine/executor/ir/integrated/tests/catalog_test.rs
@@ -36,7 +36,7 @@ mod test {
     use ir_core::plan::meta::{PlanMeta, STORE_META};
     use ir_core::plan::physical::AsPhysical;
     use ir_core::{plan::meta::Schema, JsonIO};
-    use ir_physical_client::physical_builder::JobBuilder;
+    use ir_physical_client::physical_builder::{JobBuilder, PlanBuilder};
     use pegasus::result::ResultStream;
 
     use crate::common::test::*;
@@ -1655,10 +1655,11 @@ mod test {
                 .unwrap(),
         );
         println!("{:?}", plan);
-        let mut job_builder = JobBuilder::default();
+        let mut plan_builder = PlanBuilder::default();
         let mut plan_meta = plan.get_meta().clone();
-        plan.add_job_builder(&mut job_builder, &mut plan_meta)
+        plan.add_job_builder(&mut plan_builder, &mut plan_meta)
             .unwrap();
+        let job_builder = JobBuilder::with_plan(plan_builder);
         let request = job_builder.build().unwrap();
         submit_query(request, 2)
     }
@@ -1941,10 +1942,11 @@ mod test {
                 .generate_simple_extend_match_plan()
                 .unwrap(),
         );
-        let mut job_builder = JobBuilder::default();
+        let mut plan_builder = PlanBuilder::default();
         let mut plan_meta = plan.get_meta().clone();
-        plan.add_job_builder(&mut job_builder, &mut plan_meta)
+        plan.add_job_builder(&mut plan_builder, &mut plan_meta)
             .unwrap();
+        let job_builder = JobBuilder::with_plan(plan_builder);
         let request = job_builder.build().unwrap();
         let mut results = submit_query(request, 2);
         let mut count = 0;

--- a/interactive_engine/executor/ir/integrated/tests/join_test.rs
+++ b/interactive_engine/executor/ir/integrated/tests/join_test.rs
@@ -24,7 +24,6 @@ mod test {
     use graph_store::ldbc::LDBCVertexParser;
     use ir_common::generated::algebra as algebra_pb;
     use ir_common::generated::common as common_pb;
-    use ir_common::generated::physical as pb;
     use ir_physical_client::physical_builder::*;
     use pegasus_server::JobRequest;
     use runtime::process::entry::Entry;
@@ -35,19 +34,21 @@ mod test {
     // g.V().match( __.as("a").hasLabel("person").has("name","marko").out("knows").as("b"), __.as("b").out("created").as("c"))
     fn init_join_request(join_kind: i32) -> JobRequest {
         // all vertices
-        let source_opr_1 = pb::Scan {
+        let source_opr_1 = algebra_pb::Scan {
             scan_opt: 0,
-            alias: Some(TAG_A),
+            alias: Some(TAG_A.into()),
             params: Some(query_params(vec![], vec![], None)),
             idx_predicate: None,
+            meta_data: None,
         };
 
         // person vertices
-        let source_opr_2 = pb::Scan {
+        let source_opr_2 = algebra_pb::Scan {
             scan_opt: 0,
-            alias: Some(TAG_A),
+            alias: Some(TAG_A.into()),
             params: Some(query_params(vec![PERSON_LABEL.into()], vec![], None)),
             idx_predicate: None,
+            meta_data: None,
         };
 
         let mut job_builder = JobBuilder::default();

--- a/interactive_engine/executor/ir/integrated/tests/match_test.rs
+++ b/interactive_engine/executor/ir/integrated/tests/match_test.rs
@@ -28,7 +28,7 @@ mod test {
     use ir_core::plan::logical::LogicalPlan;
     use ir_core::plan::meta::set_schema_from_json;
     use ir_core::plan::physical::AsPhysical;
-    use ir_physical_client::physical_builder::JobBuilder;
+    use ir_physical_client::physical_builder::{JobBuilder, PlanBuilder};
     use pegasus_server::JobRequest;
     use runtime::process::entry::Entry;
 
@@ -128,11 +128,11 @@ mod test {
         plan.append_operator_as_node(sink.into(), vec![id])
             .unwrap();
 
-        let mut job_builder = JobBuilder::default();
+        let mut plan_builder = PlanBuilder::default();
         let mut plan_meta = plan.get_meta().clone();
-        plan.add_job_builder(&mut job_builder, &mut plan_meta)
+        plan.add_job_builder(&mut plan_builder, &mut plan_meta)
             .unwrap();
-
+        let job_builder = JobBuilder::with_plan(plan_builder);
         job_builder.build().unwrap()
     }
 
@@ -220,11 +220,11 @@ mod test {
         plan.append_operator_as_node(sink.into(), vec![id])
             .unwrap();
 
-        let mut job_builder = JobBuilder::default();
+        let mut plan_builder = PlanBuilder::default();
         let mut plan_meta = plan.get_meta().clone();
-        plan.add_job_builder(&mut job_builder, &mut plan_meta)
+        plan.add_job_builder(&mut plan_builder, &mut plan_meta)
             .unwrap();
-
+        let job_builder = JobBuilder::with_plan(plan_builder);
         job_builder.build().unwrap()
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Return physical plan bytes from ffi interface `build_physical_plan` directly,  instead of wrapping the physical plan in the JobRequest, which was previously bound to the pegasus engine API.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

