### PR TITLE
[Coordinator] Fix issue #2734: unifying timeout parameter in coordinators

### DIFF
--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -387,7 +387,9 @@ class CoordinatorServiceServicer(
     def FetchLogs(self, request, context):
         while self._streaming_logs:
             try:
-                info_message, error_message = self._pipe_merged.poll(timeout=self._poll_timeout_seconds)
+                info_message, error_message = self._pipe_merged.poll(
+                    timeout=self._poll_timeout_seconds
+                )
             except queue.Empty:
                 info_message, error_message = "", ""
             except Exception as e:
@@ -465,7 +467,9 @@ class CoordinatorServiceServicer(
             self._object_manager.put(object_id, gie_manager)
             # 60 seconds is enough, see also GH#1024; try 120
             # already add errs to outs
-            outs, _ = proc.communicate(timeout=self._comm_timeout_seconds)  # throws TimeoutError
+            outs, _ = proc.communicate(
+                timeout=self._comm_timeout_seconds
+            )  # throws TimeoutError
             return_code = proc.poll()
             if return_code != 0:
                 raise RuntimeError(f"Error code: {return_code}, message {outs}")

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -172,6 +172,8 @@ class CoordinatorServiceServicer(
 
         # dangling check
         self._dangling_timeout_seconds = dangling_timeout_seconds
+        self._comm_timeout_seconds = 120
+        self._poll_timeout_seconds = 2
         self._dangling_detecting_timer = None
         self._cleanup_instance = False
 
@@ -237,6 +239,9 @@ class CoordinatorServiceServicer(
         self._connected = True
         # Cleanup after timeout seconds
         self._dangling_timeout_seconds = request.dangling_timeout_seconds
+        # other timeout seconds
+        self._comm_timeout_seconds = getattr(request, 'comm_timeout_seconds', 120)
+        self._poll_timeout_seconds = getattr(request, 'poll_timeout_seconds', 2)
         # If true, also delete graphscope instance (such as pods) in closing process
         self._cleanup_instance = request.cleanup_instance
 
@@ -382,7 +387,7 @@ class CoordinatorServiceServicer(
     def FetchLogs(self, request, context):
         while self._streaming_logs:
             try:
-                info_message, error_message = self._pipe_merged.poll(timeout=2)
+                info_message, error_message = self._pipe_merged.poll(timeout=self._poll_timeout_seconds)
             except queue.Empty:
                 info_message, error_message = "", ""
             except Exception as e:
@@ -460,7 +465,7 @@ class CoordinatorServiceServicer(
             self._object_manager.put(object_id, gie_manager)
             # 60 seconds is enough, see also GH#1024; try 120
             # already add errs to outs
-            outs, _ = proc.communicate(timeout=120)  # throws TimeoutError
+            outs, _ = proc.communicate(timeout=self._comm_timeout_seconds)  # throws TimeoutError
             return_code = proc.poll()
             if return_code != 0:
                 raise RuntimeError(f"Error code: {return_code}, message {outs}")
@@ -852,6 +857,20 @@ def parse_sys_args():
         default=600,
         help="The length of time to wait starting from client disconnected before killing the graphscope instance",
     )
+    parser.add_argument(
+        "--comm_timeout_seconds",
+        type=int,
+        default=600,
+        help="The length of timeout to test communication when creating instance"
+    )
+
+    parser.add_argument(
+        "--poll_timeout_seconds",
+        type=int,
+        default=2,
+        help="The length of timeout to wait for pipe polling"
+    )
+
     parser.add_argument(
         "--waiting_for_delete",
         type=str2bool,

--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -240,8 +240,8 @@ class CoordinatorServiceServicer(
         # Cleanup after timeout seconds
         self._dangling_timeout_seconds = request.dangling_timeout_seconds
         # other timeout seconds
-        self._comm_timeout_seconds = getattr(request, 'comm_timeout_seconds', 120)
-        self._poll_timeout_seconds = getattr(request, 'poll_timeout_seconds', 2)
+        self._comm_timeout_seconds = getattr(request, "comm_timeout_seconds", 120)
+        self._poll_timeout_seconds = getattr(request, "poll_timeout_seconds", 2)
         # If true, also delete graphscope instance (such as pods) in closing process
         self._cleanup_instance = request.cleanup_instance
 
@@ -857,20 +857,6 @@ def parse_sys_args():
         default=600,
         help="The length of time to wait starting from client disconnected before killing the graphscope instance",
     )
-    parser.add_argument(
-        "--comm_timeout_seconds",
-        type=int,
-        default=600,
-        help="The length of timeout to test communication when creating instance"
-    )
-
-    parser.add_argument(
-        "--poll_timeout_seconds",
-        type=int,
-        default=2,
-        help="The length of timeout to wait for pipe polling"
-    )
-
     parser.add_argument(
         "--waiting_for_delete",
         type=str2bool,

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -1259,7 +1259,6 @@ class KubernetesClusterLauncher(AbstractLauncher):
                         )
                     time.sleep(self._del_retry_time_seconds)
 
-
     def _get_owner_reference_as_json(self):
         owner_reference = [
             {

--- a/coordinator/gscoordinator/kubernetes_launcher.py
+++ b/coordinator/gscoordinator/kubernetes_launcher.py
@@ -99,6 +99,9 @@ class KubernetesClusterLauncher(AbstractLauncher):
         preemptive=None,
         service_type=None,
         timeout_seconds=None,
+        kube_timeout_seconds=1,
+        retry_time_seconds=2,
+        del_retry_time_seconds=1,
         vineyard_cpu=None,
         vineyard_deployment=None,
         vineyard_image=None,
@@ -162,6 +165,12 @@ class KubernetesClusterLauncher(AbstractLauncher):
 
         assert timeout_seconds is not None
         self._timeout_seconds = timeout_seconds
+        # timeout seconds waiting for kube service ready
+        self._kube_timeout_seconds = kube_timeout_seconds
+        # retry time when waiting for kube service ready
+        self._retry_time_seconds = retry_time_seconds
+        # retry time when deleting dangling coordinators
+        self._del_retry_time_seconds = del_retry_time_seconds
 
         self._waiting_for_delete = waiting_for_delete
 
@@ -1017,7 +1026,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
                             self._core_api.list_namespaced_event,
                             namespace,
                             field_selector=field_selector,
-                            timeout_seconds=1,
+                            timeout_seconds=self._kube_timeout_seconds,
                         )
                         for event in stream:
                             msg = f"[{pod_name}]: {event['object'].message}"
@@ -1031,7 +1040,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
                 break
             if self._timeout_seconds + start_time < time.time():
                 raise TimeoutError("GraphScope Engines launching timeout.")
-            time.sleep(2)
+            time.sleep(self._retry_time_seconds)
 
         self._pod_name_list = []
         self._pod_ip_list = []
@@ -1243,12 +1252,13 @@ class KubernetesClusterLauncher(AbstractLauncher):
                         )
                     break
                 else:
-                    time.sleep(1)
                     if time.time() - start_time > self._timeout_seconds:
                         logger.error(
                             "Deleting dangling coordinator %s timeout",
                             self._coordinator_name,
                         )
+                    time.sleep(self._del_retry_time_seconds)
+
 
     def _get_owner_reference_as_json(self):
         owner_reference = [
@@ -1361,18 +1371,19 @@ class KubernetesClusterLauncher(AbstractLauncher):
                                     )
                                 break
                             else:
-                                time.sleep(1)
                                 if time.time() - start_time > self._timeout_seconds:
                                     logger.error(
                                         "Deleting namespace %s timeout", self._namespace
                                     )
+                                time.sleep(self._del_retry_time_seconds)
+
                 else:
                     # delete coordinator deployment and service
                     self._delete_dangling_coordinator()
             self._serving = False
             logger.info("Kubernetes launcher stopped")
 
-    def _allocate_learining_engine(self, object_id):
+    def _allocate_learning_engine(self, object_id):
         # check the learning engine flag
         if not self._with_learning:
             raise NotImplementedError("Learning engine not enabled")
@@ -1441,7 +1452,7 @@ class KubernetesClusterLauncher(AbstractLauncher):
         )
 
     def create_learning_instance(self, object_id, handle, config):
-        pod_name_list, _, pod_host_ip_list = self._allocate_learining_engine(object_id)
+        pod_name_list, _, pod_host_ip_list = self._allocate_learning_engine(object_id)
         if not pod_name_list or not pod_host_ip_list:
             raise RuntimeError("Failed to allocate learning engine")
         return self._distribute_learning_process(

--- a/coordinator/gscoordinator/local_launcher.py
+++ b/coordinator/gscoordinator/local_launcher.py
@@ -61,6 +61,8 @@ class LocalLauncher(AbstractLauncher):
         log_level: str,
         instance_id: str,
         timeout_seconds: int,
+        close_timeout_seconds:int=60,
+        retry_time_seconds: int=1,
     ):
         super().__init__()
         self._num_workers = num_workers
@@ -75,7 +77,8 @@ class LocalLauncher(AbstractLauncher):
         self._glog_level = parse_as_glog_level(log_level)
         self._instance_id = instance_id
         self._timeout_seconds = timeout_seconds
-
+        self._close_timeout_seconds = close_timeout_seconds
+        self._retry_time_seconds = retry_time_seconds
         self._vineyard_socket_prefix = os.path.join(get_tempdir(), "vineyard.sock.")
 
         # A graphscope instance may have multiple session by reconnecting to coordinator
@@ -184,10 +187,11 @@ class LocalLauncher(AbstractLauncher):
 
         start_time = time.time()
         while is_free_port(rpc_port):
-            time.sleep(1)
             if self._timeout_seconds + start_time < time.time():
                 self._analytical_engine_process.kill()
                 raise RuntimeError("Launch analytical engine failed due to timeout.")
+            time.sleep(self._retry_time_seconds)
+
         logger.info(
             "Analytical engine is listening on %s", self._analytical_engine_endpoint
         )
@@ -340,7 +344,7 @@ class LocalLauncher(AbstractLauncher):
             bufsize=1,
         )
         # 60 seconds is enough
-        process.wait(timeout=60)
+        process.wait(timeout=self._close_timeout_seconds)
         return process
 
     def close_learning_instance(self, object_id):
@@ -423,7 +427,6 @@ class LocalLauncher(AbstractLauncher):
 
         start_time = time.time()
         while is_free_port(self._etcd_client_port):
-            time.sleep(1)
             if self._timeout_seconds + start_time < time.time():
                 self._etcd_process.kill()
                 _, errs = self._etcd_process.communicate()
@@ -431,6 +434,8 @@ class LocalLauncher(AbstractLauncher):
                 msg = "Launch etcd service failed due to timeout: "
                 msg += "\n".join([line for line in stdout_watcher.poll_all()])
                 raise RuntimeError(msg)
+            time.sleep(self._retry_time_seconds)
+
         stdout_watcher.drop(True)
         stdout_watcher.suppress(not logger.isEnabledFor(logging.DEBUG))
         logger.info("Etcd is ready, endpoint is %s", self._etcd_endpoint)
@@ -493,10 +498,9 @@ class LocalLauncher(AbstractLauncher):
 
         start_time = time.time()
         if len(hosts) > 1:
-            time.sleep(5)  # should be OK
+            time.sleep(5*self._retry_time_seconds)  # should be OK
         else:
             while not os.path.exists(self._vineyard_socket):
-                time.sleep(1)
                 if self._vineyardd_process.poll() is not None:
                     msg = "Launch vineyardd failed: "
                     msg += "\n".join([line for line in stdout_watcher.poll_all()])
@@ -508,6 +512,8 @@ class LocalLauncher(AbstractLauncher):
                     # outs, _ = self._vineyardd_process.communicate()
                     # logger.error("Start vineyardd timeout, %s", outs)
                     raise RuntimeError("Launch vineyardd failed due to timeout.")
+                time.sleep(self._retry_time_seconds)
+
         stdout_watcher.drop(True)
         stdout_watcher.suppress(not logger.isEnabledFor(logging.DEBUG))
         logger.info(

--- a/coordinator/gscoordinator/local_launcher.py
+++ b/coordinator/gscoordinator/local_launcher.py
@@ -61,8 +61,8 @@ class LocalLauncher(AbstractLauncher):
         log_level: str,
         instance_id: str,
         timeout_seconds: int,
-        close_timeout_seconds:int=60,
-        retry_time_seconds: int=1,
+        close_timeout_seconds:int = 60,
+        retry_time_seconds: int = 1,
     ):
         super().__init__()
         self._num_workers = num_workers
@@ -498,7 +498,7 @@ class LocalLauncher(AbstractLauncher):
 
         start_time = time.time()
         if len(hosts) > 1:
-            time.sleep(5*self._retry_time_seconds)  # should be OK
+            time.sleep(5 * self._retry_time_seconds)  # should be OK
         else:
             while not os.path.exists(self._vineyard_socket):
                 if self._vineyardd_process.poll() is not None:

--- a/coordinator/gscoordinator/local_launcher.py
+++ b/coordinator/gscoordinator/local_launcher.py
@@ -61,7 +61,7 @@ class LocalLauncher(AbstractLauncher):
         log_level: str,
         instance_id: str,
         timeout_seconds: int,
-        close_timeout_seconds:int = 60,
+        close_timeout_seconds: int = 60,
         retry_time_seconds: int = 1,
     ):
         super().__init__()


### PR DESCRIPTION
## What do these changes do?

1. Add timeout parameters for coordinations such that they can be adjusted via arguments;
2. Add retry time parameters for coordinations such that they can be adjusted via arguments;
3. Refine the logic of testing timeout to avoid the unwanted error if timeout is less than retry time;
4. Correct a typo in a function name.

## Related issue number

Fixes #2734

