### PR TITLE
Disable JAVA SDK (with a warning) when JNI not found

### DIFF
--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -19,6 +19,18 @@ option(LET_IT_CRASH_ON_EXCEPTION "Disable boost leaf's error handling and let it
 execute_process(COMMAND uname -m OUTPUT_VARIABLE SYSTEM_PROCESSOR)
 string(REGEX REPLACE "\n$" "" SYSTEM_PROCESSOR "${SYSTEM_PROCESSOR}")
 
+# find jni ---------------------------------------------------------------------
+if (ENABLE_JAVA_SDK)
+    find_package(JNI QUIET)
+    if (JNI_FOUND)
+        include_directories(SYSTEM ${JAVA_INCLUDE_PATH})
+        include_directories(SYSTEM ${JAVA_INCLUDE_PATH2})
+    else()
+        message(WARNING "Disable Java SDK because JNI libraries not found")
+        set(ENABLE_JAVA_SDK OFF)
+    endif()
+endif()
+
 if (ENABLE_JAVA_SDK)
     #check whether we are using clang.
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -229,13 +241,6 @@ if (NOT Protobuf_FOUND)
 endif()
 include_directories(${Protobuf_INCLUDE_DIRS})
 
-if (ENABLE_JAVA_SDK)
-# find jni---------------------------------------------------------------------
-    find_package(JNI REQUIRED)
-    include_directories(SYSTEM ${JAVA_INCLUDE_PATH})
-    include_directories(SYSTEM ${JAVA_INCLUDE_PATH2})
-endif()
-
 find_package(gRPC QUIET)
 if(gRPC_FOUND)
     set(GRPC_LIBRARIES gRPC::gpr gRPC::grpc gRPC::grpc++)
@@ -290,19 +295,19 @@ target_link_libraries(gs_proto PUBLIC
 
 add_library(gs_util SHARED "core/flags.cc" "core/launcher.cc")
 target_link_libraries(gs_util PRIVATE
-        ${LIBGRAPELITE_LIBRARIES}
-        ${GFLAGS_LIBRARIES}
-        ${VINEYARD_LIBRARIES}
-        ${Boost_LIBRARIES}
-    )
+    ${LIBGRAPELITE_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${VINEYARD_LIBRARIES}
+    ${Boost_LIBRARIES}
+)
 
 if (ENABLE_JAVA_SDK)
     target_sources(gs_util PRIVATE "core/java/javasdk.cc")
     target_compile_definitions(gs_util PUBLIC ENABLE_JAVA_SDK)
     target_link_libraries(gs_util PRIVATE
-            ${JAVA_JVM_LIBRARY}
-            ${JNI_LIBRARIES}
-        )
+        ${JAVA_JVM_LIBRARY}
+        ${JNI_LIBRARIES}
+    )
 endif()
 
 add_executable(grape_engine
@@ -313,14 +318,14 @@ add_executable(grape_engine
     )
 target_include_directories(grape_engine PRIVATE proto utils)
 target_link_libraries(grape_engine PRIVATE
-        gs_proto
-        gs_util
-        ${LIBGRAPELITE_LIBRARIES}
-        ${GFLAGS_LIBRARIES}
-        ${CMAKE_DL_LIBS}
-        ${Boost_LIBRARIES}
-        ${VINEYARD_LIBRARIES}
-    )
+    gs_proto
+    gs_util
+    ${LIBGRAPELITE_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${CMAKE_DL_LIBS}
+    ${Boost_LIBRARIES}
+    ${VINEYARD_LIBRARIES}
+)
 
 if (ENABLE_JAVA_SDK)
     target_compile_definitions(grape_engine PUBLIC ENABLE_JAVA_SDK)
@@ -571,15 +576,15 @@ install_gsa_dependency_modules("${PROJECT_SOURCE_DIR}/cmake")
 
 configure_file(graphscope-analytical-config.in.cmake
         "${PROJECT_BINARY_DIR}/graphscope-analytical-config.cmake" @ONLY
-        )
+)
 configure_file(graphscope-analytical-config-version.in.cmake
         "${PROJECT_BINARY_DIR}/graphscope-analytical-config-version.cmake" @ONLY
-        )
+)
 install(FILES "${PROJECT_BINARY_DIR}/graphscope-analytical-config.cmake"
         "${PROJECT_BINARY_DIR}/graphscope-analytical-config-version.cmake"
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/graphscope-analytical
-        )
+)
 install(EXPORT graphscope-analytical-targets
         FILE graphscope-analytical-targets.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/graphscope-analytical
-        )
+)


### PR DESCRIPTION
## What do these changes do?

Opt-out the Java SDK when JNI is not found for more flexibility as the cmake option `ENABLE_JAVA_SDK` defaults to `ON`.

## Related issue number

See also: #2809

