### PR TITLE
[GIE Compiler] Unify Gremlin Timeout Configurations

### DIFF
--- a/interactive_engine/compiler/conf/ir.compiler.properties
+++ b/interactive_engine/compiler/conf/ir.compiler.properties
@@ -32,3 +32,6 @@ graph.planner: {"isOn":true,"opt":"RBO","rules":["FilterMatchRule"]}
 # neo4j.bolt.server.disabled: true
 # set neo4j server port if neo4j server is enabled
 # neo4j.bolt.server.port: 7687
+
+# set timeout in system config, can be overridden by session config per query
+# query.execution.timeout.ms: 3000000

--- a/interactive_engine/compiler/src/main/antlr4/GremlinGS.g4
+++ b/interactive_engine/compiler/src/main/antlr4/GremlinGS.g4
@@ -27,6 +27,7 @@ query
 // g
 // g.with(ARGS_EVAL_TIMEOUT, 2000L)
 // g.with(Tokens.ARGS_EVAL_TIMEOUT, 2000L)
+// g.with('evaluationTimeout', 2000L)
 traversalSource
     : TRAVERSAL_ROOT (DOT traversalMethod_with) ?
     ;
@@ -169,13 +170,18 @@ traversalMethod_bothE
 // with('UNTIL', expression)
 // with('ARGS_EVAL_TIMEOUT', 2000L) // set evaluation timeout to 2 seconds
 // with('Tokens.ARGS_EVAL_TIMEOUT', 2000L) // set evaluation timeout to 2 seconds
+// with('evaluationTimeout', 2000L) // set evaluation timeout to 2 seconds
 traversalMethod_with
-    : 'with' LPAREN stringLiteral COMMA stringLiteral RPAREN
-    | 'with' LPAREN evaluationTimeoutKey COMMA integerLiteral RPAREN
+    : 'with' LPAREN stringLiteral COMMA genericLiteral RPAREN
+    | 'with' LPAREN evaluationTimeoutKey COMMA evaluationTimeoutValue RPAREN
     ;
 
 evaluationTimeoutKey
     : 'ARGS_EVAL_TIMEOUT' | 'Tokens.ARGS_EVAL_TIMEOUT'
+    ;
+
+evaluationTimeoutValue
+    : integerLiteral
     ;
 
 // outV()

--- a/interactive_engine/compiler/src/main/antlr4/GremlinGS.g4
+++ b/interactive_engine/compiler/src/main/antlr4/GremlinGS.g4
@@ -25,8 +25,10 @@ query
     ;
 
 // g
+// g.with(ARGS_EVAL_TIMEOUT, 2000L)
+// g.with(Tokens.ARGS_EVAL_TIMEOUT, 2000L)
 traversalSource
-    : TRAVERSAL_ROOT
+    : TRAVERSAL_ROOT (DOT traversalMethod_with) ?
     ;
 
 // g.rootTraversal()
@@ -165,8 +167,15 @@ traversalMethod_bothE
 // with('PATH_OPT', 'SIMPLE' | 'ARBITRARY')
 // with('RESULT_OPT', 'ALL_V' | 'END_V')
 // with('UNTIL', expression)
+// with('ARGS_EVAL_TIMEOUT', 2000L) // set evaluation timeout to 2 seconds
+// with('Tokens.ARGS_EVAL_TIMEOUT', 2000L) // set evaluation timeout to 2 seconds
 traversalMethod_with
     : 'with' LPAREN stringLiteral COMMA stringLiteral RPAREN
+    | 'with' LPAREN evaluationTimeoutKey COMMA integerLiteral RPAREN
+    ;
+
+evaluationTimeoutKey
+    : 'ARGS_EVAL_TIMEOUT' | 'Tokens.ARGS_EVAL_TIMEOUT'
     ;
 
 // outV()

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/ExecutionClient.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/ExecutionClient.java
@@ -20,6 +20,7 @@ import com.alibaba.graphscope.common.client.channel.ChannelFetcher;
 import com.alibaba.graphscope.common.client.type.ExecutionRequest;
 import com.alibaba.graphscope.common.client.type.ExecutionResponseListener;
 import com.alibaba.graphscope.common.config.Configs;
+import com.alibaba.graphscope.common.config.QueryTimeoutConfig;
 
 /**
  * client to submit request to remote engine service
@@ -33,7 +34,10 @@ public abstract class ExecutionClient<C> {
         this.channelFetcher = channelFetcher;
     }
 
-    public abstract void submit(ExecutionRequest request, ExecutionResponseListener listener)
+    public abstract void submit(
+            ExecutionRequest request,
+            ExecutionResponseListener listener,
+            QueryTimeoutConfig timeoutConfig)
             throws Exception;
 
     public abstract void close() throws Exception;

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/FrontendConfig.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/FrontendConfig.java
@@ -29,5 +29,8 @@ public class FrontendConfig {
     public static final Config<Integer> NEO4J_BOLT_SERVER_PORT =
             Config.intConfig("neo4j.bolt.server.port", 7687);
 
+    public static final Config<Integer> QUERY_EXECUTION_TIMEOUT_MS =
+            Config.intConfig("query.execution.timeout.ms", 3000000);
+
     public static final Config<String> ENGINE_TYPE = Config.stringConfig("engine.type", "pegasus");
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/QueryTimeoutConfig.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/QueryTimeoutConfig.java
@@ -23,7 +23,7 @@ public class QueryTimeoutConfig {
     private final long channelTimeoutMS;
     // timeout in milliseconds for total query execution
     private final long executionTimeoutMS;
-    private static final double GRADUAL_FACTOR = 0.0d;
+    private static final double GRADUAL_FACTOR = 0.1d;
 
     public QueryTimeoutConfig(long engineTimeoutMS) {
         this.engineTimeoutMS = engineTimeoutMS;

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/QueryTimeoutConfig.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/QueryTimeoutConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.graphscope.common.config;
+
+public class QueryTimeoutConfig {
+    private final long executionTimeoutMS;
+    private final long channelTimeoutMS;
+    private final long engineTimeoutMS;
+    private static final double GRADUAL_FACTOR = 0.1d;
+
+    public QueryTimeoutConfig(long executionTimeoutMS) {
+        this.executionTimeoutMS = executionTimeoutMS;
+        this.channelTimeoutMS = (long) (executionTimeoutMS * (1 - GRADUAL_FACTOR));
+        this.engineTimeoutMS = (long) (executionTimeoutMS * (1 - 2 * GRADUAL_FACTOR));
+    }
+
+    public long getExecutionTimeoutMS() {
+        return executionTimeoutMS;
+    }
+
+    public long getChannelTimeoutMS() {
+        return channelTimeoutMS;
+    }
+
+    public long getEngineTimeoutMS() {
+        return engineTimeoutMS;
+    }
+
+    @Override
+    public String toString() {
+        return "QueryTimeoutConfig{"
+                + "executionTimeoutMS="
+                + executionTimeoutMS
+                + ", channelTimeoutMS="
+                + channelTimeoutMS
+                + ", engineTimeoutMS="
+                + engineTimeoutMS
+                + '}';
+    }
+}

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/QueryTimeoutConfig.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/QueryTimeoutConfig.java
@@ -17,15 +17,18 @@
 package com.alibaba.graphscope.common.config;
 
 public class QueryTimeoutConfig {
-    private final long executionTimeoutMS;
-    private final long channelTimeoutMS;
+    // timeout in milliseconds for engine execution
     private final long engineTimeoutMS;
-    private static final double GRADUAL_FACTOR = 0.1d;
+    // timeout in milliseconds for channel communication
+    private final long channelTimeoutMS;
+    // timeout in milliseconds for total query execution
+    private final long executionTimeoutMS;
+    private static final double GRADUAL_FACTOR = 0.0d;
 
-    public QueryTimeoutConfig(long executionTimeoutMS) {
-        this.executionTimeoutMS = executionTimeoutMS;
-        this.channelTimeoutMS = (long) (executionTimeoutMS * (1 - GRADUAL_FACTOR));
-        this.engineTimeoutMS = (long) (executionTimeoutMS * (1 - 2 * GRADUAL_FACTOR));
+    public QueryTimeoutConfig(long engineTimeoutMS) {
+        this.engineTimeoutMS = engineTimeoutMS;
+        this.channelTimeoutMS = (long) (engineTimeoutMS * (1 + GRADUAL_FACTOR));
+        this.executionTimeoutMS = (long) (engineTimeoutMS * (1 + 2 * GRADUAL_FACTOR));
     }
 
     public long getExecutionTimeoutMS() {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/executor/GraphPlanExecution.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/executor/GraphPlanExecution.java
@@ -18,6 +18,7 @@ package com.alibaba.graphscope.cypher.executor;
 
 import com.alibaba.graphscope.common.client.ExecutionClient;
 import com.alibaba.graphscope.common.client.type.ExecutionRequest;
+import com.alibaba.graphscope.common.config.QueryTimeoutConfig;
 import com.alibaba.graphscope.common.ir.tools.AliasInference;
 import com.alibaba.graphscope.common.ir.tools.GraphPlanner;
 import com.alibaba.graphscope.common.ir.tools.LogicalPlan;
@@ -41,10 +42,15 @@ import java.util.stream.Collectors;
 public class GraphPlanExecution<C> implements StatementResults.SubscribableExecution {
     private final ExecutionClient<C> client;
     private final GraphPlanner.Summary planSummary;
+    private final QueryTimeoutConfig timeoutConfig;
 
-    public GraphPlanExecution(ExecutionClient<C> client, GraphPlanner.Summary planSummary) {
+    public GraphPlanExecution(
+            ExecutionClient<C> client,
+            GraphPlanner.Summary planSummary,
+            QueryTimeoutConfig timeoutConfig) {
         this.client = client;
         this.planSummary = planSummary;
+        this.timeoutConfig = timeoutConfig;
     }
 
     @Override
@@ -60,7 +66,7 @@ public class GraphPlanExecution<C> implements StatementResults.SubscribableExecu
                     new CypherRecordProcessor(
                             new CypherRecordParser(getOutputType(planSummary.getLogicalPlan())),
                             querySubscriber);
-            this.client.submit(request, recordProcessor);
+            this.client.submit(request, recordProcessor, timeoutConfig);
             return recordProcessor;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/executor/GraphQueryExecutor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/executor/GraphQueryExecutor.java
@@ -19,6 +19,7 @@ package com.alibaba.graphscope.cypher.executor;
 import com.alibaba.graphscope.common.antlr4.Antlr4Parser;
 import com.alibaba.graphscope.common.client.ExecutionClient;
 import com.alibaba.graphscope.common.config.Configs;
+import com.alibaba.graphscope.common.config.QueryTimeoutConfig;
 import com.alibaba.graphscope.common.ir.runtime.PhysicalBuilder;
 import com.alibaba.graphscope.common.ir.tools.GraphPlanner;
 import com.alibaba.graphscope.common.manager.IrMetaQueryCallback;
@@ -53,6 +54,7 @@ public class GraphQueryExecutor extends FabricExecutor {
     private final ExecutionClient client;
 
     private final GraphPlanner graphPlanner;
+    private final FabricConfig fabricConfig;
 
     public GraphQueryExecutor(
             FabricConfig config,
@@ -75,6 +77,7 @@ public class GraphQueryExecutor extends FabricExecutor {
                 internalLog,
                 statementLifecycles,
                 fabricWorkerExecutor);
+        this.fabricConfig = config;
         this.graphConfig = graphConfig;
         this.antlr4Parser = antlr4Parser;
         this.graphPlanner = graphPlanner;
@@ -118,7 +121,7 @@ public class GraphQueryExecutor extends FabricExecutor {
                 }
                 QuerySubject querySubject = new QuerySubject.BasicQuerySubject();
                 StatementResults.SubscribableExecution execution =
-                        new GraphPlanExecution(this.client, planSummary);
+                        new GraphPlanExecution(this.client, planSummary, getQueryTimeoutConfig());
                 metaQueryCallback.afterExec(irMeta);
                 StatementResult result = StatementResults.connectVia(execution, querySubject);
                 return result;
@@ -130,5 +133,9 @@ public class GraphQueryExecutor extends FabricExecutor {
                 metaQueryCallback.afterExec(irMeta);
             }
         }
+    }
+
+    private QueryTimeoutConfig getQueryTimeoutConfig() {
+        return new QueryTimeoutConfig(fabricConfig.getTransactionTimeout().toMillis());
     }
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/result/CypherRecordProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/result/CypherRecordProcessor.java
@@ -102,8 +102,7 @@ public class CypherRecordProcessor implements QueryExecution, ExecutionResponseL
 
     @Override
     public boolean await() throws Exception {
-        boolean hasNext = this.recordIterator.hasNext();
-        return hasNext;
+        return this.recordIterator.hasNext();
     }
 
     @Override

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/result/CypherRecordProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/result/CypherRecordProcessor.java
@@ -96,11 +96,14 @@ public class CypherRecordProcessor implements QueryExecution, ExecutionResponseL
     }
 
     @Override
-    public void cancel() {}
+    public void cancel() {
+        this.recordIterator.close();
+    }
 
     @Override
     public boolean await() throws Exception {
-        return this.recordIterator.hasNext();
+        boolean hasNext = this.recordIterator.hasNext();
+        return hasNext;
     }
 
     @Override

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/GraphTraversalSourceVisitor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/GraphTraversalSourceVisitor.java
@@ -31,9 +31,9 @@ public class GraphTraversalSourceVisitor extends GremlinGSBaseVisitor<GraphTrave
 
     @Override
     public GraphTraversalSource visitTraversalSource(GremlinGSParser.TraversalSourceContext ctx) {
-        if (ctx.getChildCount() != 1) {
+        if (ctx.getChildCount() > 3) {
             throw new UnsupportedEvalException(
-                    ctx.getClass(), "supported pattern of source is [g]");
+                    ctx.getClass(), "supported pattern of source is [g] or [g.with(..)]");
         }
         return g;
     }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
@@ -756,7 +756,9 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
         Step endStep = graphTraversal.asAdmin().getEndStep();
         if (!(endStep instanceof PathExpandStep)) {
             throw new UnsupportedEvalException(
-                    ctx.getClass(), "with should follow path expand, i.e. out('1..2').with(..)");
+                    ctx.getClass(),
+                    "with should follow source or path expand, i.e. g.with(..) or"
+                            + " out('1..2').with(..)");
         }
         String optKey = GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral(0));
         String optValue = GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral(1));

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
@@ -760,8 +760,9 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
                     "with should follow source or path expand, i.e. g.with(..) or"
                             + " out('1..2').with(..)");
         }
-        String optKey = GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral(0));
-        String optValue = GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral(1));
+        String optKey = GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral());
+        Object optValue =
+                GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral());
         return graphTraversal.with(optKey, optValue);
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/processor/IrTestOpProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/processor/IrTestOpProcessor.java
@@ -18,6 +18,7 @@ package com.alibaba.graphscope.gremlin.integration.processor;
 
 import com.alibaba.graphscope.common.client.channel.ChannelFetcher;
 import com.alibaba.graphscope.common.config.Configs;
+import com.alibaba.graphscope.common.config.QueryTimeoutConfig;
 import com.alibaba.graphscope.common.ir.tools.GraphPlanner;
 import com.alibaba.graphscope.common.manager.IrMetaQueryCallback;
 import com.alibaba.graphscope.common.store.IrMeta;
@@ -101,7 +102,8 @@ public class IrTestOpProcessor extends IrStandardOpProcessor {
                                             ctx, traversal, testGraph, this.configs),
                                     jobId,
                                     script,
-                                    irMeta);
+                                    irMeta,
+                                    new QueryTimeoutConfig(ctx.getRequestTimeout()));
                             metaQueryCallback.afterExec(irMeta);
                         });
                 return op;

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -40,6 +40,7 @@ import com.alibaba.graphscope.gremlin.plugin.script.AntlrGremlinScriptEngineFact
 import com.alibaba.graphscope.gremlin.plugin.strategy.ExpandFusionStepStrategy;
 import com.alibaba.graphscope.gremlin.plugin.strategy.RemoveUselessStepStrategy;
 import com.alibaba.graphscope.gremlin.plugin.strategy.ScanFusionStepStrategy;
+import com.alibaba.graphscope.gremlin.result.processor.AbstractResultProcessor;
 import com.alibaba.graphscope.gremlin.result.processor.GremlinResultProcessor;
 import com.alibaba.pegasus.RpcClient;
 import com.alibaba.pegasus.intf.ResultProcessor;
@@ -149,6 +150,9 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
                                 elapsed / 1000000.0f,
                                 startTime);
                         if (t != null) {
+                            if (v instanceof AbstractResultProcessor) {
+                                ((AbstractResultProcessor) v).cancel();
+                            }
                             Optional<Throwable> possibleTemporaryException =
                                     determineIfTemporaryException(t);
                             if (possibleTemporaryException.isPresent()) {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -260,7 +260,6 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
             String script,
             IrMeta irMeta) {
         QueryTimeoutConfig timeoutConfig = new QueryTimeoutConfig(ctx.getRequestTimeout());
-        logger.info("query execution timeout is {}", timeoutConfig);
         return GremlinExecutor.LifeCycle.build()
                 .evaluationTimeoutOverride(timeoutConfig.getExecutionTimeoutMS())
                 .beforeEval(

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/processor/AbstractResultProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/processor/AbstractResultProcessor.java
@@ -118,6 +118,10 @@ public abstract class AbstractResultProcessor extends StandardOpProcessor
         }
     }
 
+    public synchronized void cancel() {
+        this.locked = true;
+    }
+
     protected abstract void aggregateResults();
 
     protected void writeResultList(

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/service/IrGremlinServer.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/service/IrGremlinServer.java
@@ -72,6 +72,7 @@ public class IrGremlinServer implements AutoCloseable {
         if (port >= 0) {
             this.settings.port = port;
         }
+        this.settings.evaluationTimeout = FrontendConfig.QUERY_EXECUTION_TIMEOUT_MS.get(configs);
         this.graph = TinkerFactory.createModern();
         this.g = this.graph.traversal(IrCustomizedTraversalSource.class);
     }

--- a/interactive_engine/executor/engine/pegasus/clients/java/client/src/main/java/com/alibaba/pegasus/ClientExample.java
+++ b/interactive_engine/executor/engine/pegasus/clients/java/client/src/main/java/com/alibaba/pegasus/ClientExample.java
@@ -99,7 +99,7 @@ public class ClientExample {
         List<RpcChannel> channels = new ArrayList<>();
         channels.add(rpcChannel0);
         channels.add(rpcChannel1);
-        RpcClient rpcClient = new RpcClient(600000, channels);
+        RpcClient rpcClient = new RpcClient(channels);
 
         logger.info("Will try to send request");
         JobConfig confPb =
@@ -148,7 +148,8 @@ public class ClientExample {
                     public void error(Status status) {
                         resultIterator.fail(status.getCause());
                     }
-                });
+                },
+                600000);
         rpcClient.shutdown();
     }
 }

--- a/interactive_engine/executor/engine/pegasus/clients/java/client/src/main/java/com/alibaba/pegasus/RpcClient.java
+++ b/interactive_engine/executor/engine/pegasus/clients/java/client/src/main/java/com/alibaba/pegasus/RpcClient.java
@@ -39,10 +39,8 @@ public class RpcClient {
     private static final Logger logger = LoggerFactory.getLogger(RpcClient.class);
     private final List<RpcChannel> channels;
     private final List<JobServiceStub> serviceStubs;
-    private final long rpcTimeout;
 
-    public RpcClient(long grpcTimeout, List<RpcChannel> channels) {
-        this.rpcTimeout = grpcTimeout;
+    public RpcClient(List<RpcChannel> channels) {
         this.channels = Objects.requireNonNull(channels);
         this.serviceStubs =
                 channels.stream()
@@ -50,13 +48,13 @@ public class RpcClient {
                         .collect(Collectors.toList());
     }
 
-    public void submit(JobRequest jobRequest, ResultProcessor processor) {
+    public void submit(JobRequest jobRequest, ResultProcessor processor, long rpcTimeoutMS) {
         AtomicInteger counter = new AtomicInteger(this.channels.size());
         AtomicBoolean finished = new AtomicBoolean(false);
         serviceStubs.forEach(
                 asyncStub -> {
                     asyncStub
-                            .withDeadlineAfter(rpcTimeout, TimeUnit.MILLISECONDS)
+                            .withDeadlineAfter(rpcTimeoutMS, TimeUnit.MILLISECONDS)
                             .submit(
                                     jobRequest,
                                     new JobResponseObserver(processor, finished, counter));


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Unify gremlin timeout configurations. By this pr, the console will output like this if gremlin query execution timeout is set to 2000ms.

<img width="1627" alt="image" src="https://github.com/alibaba/GraphScope/assets/22363306/922d0702-1a7f-4904-814c-0e9ebd6e7102">


Timeout can be set by two ways: 
1. system configuration, set `query.execution.timeout.ms: 2000` in `conf/ir.compiler.properties`
2. set per query in gremlin query `g.with(ARGS_EVAL_TIMEOUT, 2000).V()` or `g.with(Tokens.ARGS_EVAL_TIMEOUT, 2000).V()`. if timeout value is of long type, suffix with 'L'

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #2854 

