### PR TITLE
Sort the server list before iterate to keep consistent between workers

### DIFF
--- a/interactive_engine/executor/assembly/v6d/src/bin/gaia_executor.rs
+++ b/interactive_engine/executor/assembly/v6d/src/bin/gaia_executor.rs
@@ -169,7 +169,9 @@ fn sync_global_process_partition_lists(
         if servers.len() > 1 {
             assert_eq!(partitions.len() % servers.len(), 0);
             let nchunk = partitions.len() / servers.len();
-            for (index, server) in servers.iter().enumerate() {
+            let mut sorted_servers = servers.clone();
+            sorted_servers.sort();
+            for (index, server) in sorted_servers.iter().enumerate() {
                 partition_lists.insert(*server, partitions[index * nchunk..(index + 1) * nchunk].to_vec());
             }
         }


### PR DESCRIPTION
## What do these changes do?

In some cases the server list is in different order inside different process, and yields unexpected partition dispatch plan, e.g.,

worker 1:

```
2023-06-30 04:55:27.508318003 INFO  (src/bin/gaia_executor.rs:167) [main] partition_lists before dedup = {1: [0, 1, 2, 3], 0: [0, 1, 2, 3]}
2023-06-30 04:55:27.508339604 INFO  (src/bin/gaia_executor.rs:177) [main] partition_lists = {1: [2, 3], 0: [0, 1]}
2023-06-30 04:55:27.508355604 INFO  (src/bin/gaia_executor.rs:190) [main] partition_server_index_map = {0: 0, 2: 1, 3: 1, 1: 0}
2023-06-30 04:55:27.508361404 INFO  (src/bin/gaia_executor.rs:105) [main] server_index: 0, partition_server_index_map: {0: 0, 2: 1, 3: 1, 1: 0}
2023-06-30 04:55:27.508449905 INFO  (/work/interactive_engine/executor/engine/pegasus/server/src/rpc.rs:314) [main] starting RPC job server on 0.0.0.0:8257 ...
2023-06-30 04:55:27.508457305 INFO  (src/bin/gaia_executor.rs:198) [main] RPC server of server[0] start on 0.0.0.0:8257
```

worker 2:

```
2023-06-30 04:55:27.508489205 INFO  (src/bin/gaia_executor.rs:167) [main] partition_lists before dedup = {0: [0, 1, 2, 3], 1: [0, 1, 2, 3]}
2023-06-30 04:55:27.508507605 INFO  (src/bin/gaia_executor.rs:177) [main] partition_lists = {0: [2, 3], 1: [0, 1]}
2023-06-30 04:55:27.508523506 INFO  (src/bin/gaia_executor.rs:190) [main] partition_server_index_map = {2: 0, 0: 1, 3: 0, 1: 1}
2023-06-30 04:55:27.508529206 INFO  (src/bin/gaia_executor.rs:105) [main] server_index: 1, partition_server_index_map: {2: 0, 0: 1, 3: 0, 1: 1}
2023-06-30 04:55:27.508591606 INFO  (/work/interactive_engine/executor/engine/pegasus/server/src/rpc.rs:314) [main] starting RPC job server on 0.0.0.0:8259 ...
2023-06-30 04:55:27.508598706 INFO  (src/bin/gaia_executor.rs:198) [main] RPC server of server[1] start on 0.0.0.0:8259
```

## Related issue number

Fixes #2675

