### PR TITLE
Fixes two compliation warnings

### DIFF
--- a/interactive_engine/executor/engine/pegasus/pegasus/src/communication/buffer.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/src/communication/buffer.rs
@@ -118,7 +118,7 @@ impl<D: Data> BufSlotPtr<D> {
     fn destroy(&mut self) {
         unsafe {
             let ptr = self.ptr;
-            Box::from_raw(ptr.as_ptr());
+            drop(Box::from_raw(ptr.as_ptr()));
         }
     }
 }

--- a/interactive_engine/executor/store/exp_store/src/graph_db/csr_topo.rs
+++ b/interactive_engine/executor/store/exp_store/src/graph_db/csr_topo.rs
@@ -44,7 +44,7 @@ impl<I: IndexType> MutEdgeVec<I> {
         let mut num_edges = 0;
         // will be sorted via label
         for label in adj.keys().cloned().sorted() {
-            for vec in adj.get_mut(&label) {
+            if let Some(vec) = adj.get_mut(&label) {
                 vec.sort();
                 self.offsets[node]
                     .inner


### PR DESCRIPTION
## What do these changes do?

```
warning: unused return value of `std::boxed::Box::<T>::from_raw` that must be used
   --> /Users/runner/work/GraphScope/GraphScope/interactive_engine/executor/engine/pegasus/pegasus/src/communication/buffer.rs:121:13
    |
121 |             Box::from_raw(ptr.as_ptr());
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: call `drop(Box::from_raw(ptr))` if you intend to drop the `Box`
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
121 |             let _ = Box::from_raw(ptr.as_ptr());
    |             +++++++
   Compiling pegasus_server v0.1.0 (/Users/runner/work/GraphScope/GraphScope/interactive_engine/executor/engine/pegasus/server)
warning: `pegasus` (lib) generated 1 warning
   Compiling timely v0.10.0
   Compiling env_logger v0.7.1
   Compiling itertools v0.9.0
   Compiling titlecase v1.1.0
   Compiling serde_bytes v0.11.10
   Compiling futures-io v0.3.28
   Compiling futures v0.3.28
   Compiling graph_store v0.2.0 (/Users/runner/work/GraphScope/GraphScope/interactive_engine/executor/store/exp_store)
warning: for loop over an `Option`. This is more readably written as an `if let` statement
  --> /Users/runner/work/GraphScope/GraphScope/interactive_engine/executor/store/exp_store/src/graph_db/csr_topo.rs:47:24
   |
47 |             for vec in adj.get_mut(&label) {
   |                        ^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(for_loops_over_fallibles)]` on by default
help: to check pattern in a loop use `while let`
   |
47 |             while let Some(vec) = adj.get_mut(&label) {
   |             ~~~~~~~~~~~~~~~   ~~~
help: consider using `if let` to clear intent
   |
47 |             if let Some(vec) = adj.get_mut(&label) {
   |             ~~~~~~~~~~~~   ~~~
warning: `graph_store` (lib) generated 1 warning
```
