### PR TITLE
Bump up the version of kubernetes-log-export-action to v5

### DIFF
--- a/.github/workflows/gss.yml
+++ b/.github/workflows/gss.yml
@@ -167,7 +167,7 @@ jobs:
 
         minikube image load ${{ env.GSS_IMAGE }}:${SHORT_SHA}
 
-    - uses: dashanji/kubernetes-log-export-action@v4
+    - uses: dashanji/kubernetes-log-export-action@v5
       env:
         SHOW_TIMESTAMPS: 'true'
         OUTPUT_DIR: ${{ github.workspace }}/helm-installation-logs
@@ -241,8 +241,9 @@ jobs:
         cd ${GITHUB_WORKSPACE}/python
         python3 -m pytest -s -vvv graphscope/tests/kubernetes/test_store_service.py -k test_demo_after_restart
 
-    - uses: dashanji/kubernetes-log-export-action@v4
+    - uses: dashanji/kubernetes-log-export-action@v5
       env:
+        OUTPUT_DIR: ${{ github.workspace }}/helm-installation-logs
         MODE: stop
 
     - name: upload the k8s logs to artifact

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -431,7 +431,7 @@ jobs:
           minikube image load graphscope/learning:${SHORT_SHA}
           echo "loaded learning"
 
-      - uses: dashanji/kubernetes-log-export-action@v4
+      - uses: dashanji/kubernetes-log-export-action@v5
         env:
           SHOW_TIMESTAMPS: 'true'
           OUTPUT_DIR: ${{ github.workspace }}/k8s-ci-helm-installation-logs
@@ -459,14 +459,15 @@ jobs:
 
           python3 -m pytest -s -vvv ./graphscope/tests/kubernetes/test_demo_script.py -k test_helm_installation
 
-      - uses: dashanji/kubernetes-log-export-action@v4
+      - uses: dashanji/kubernetes-log-export-action@v5
         env:
+          OUTPUT_DIR: ${{ github.workspace }}/k8s-ci-helm-installation-logs
           MODE: stop
 
       - name: Delete Helm Cluster
         run: helm delete graphscope
 
-      - uses: dashanji/kubernetes-log-export-action@v4
+      - uses: dashanji/kubernetes-log-export-action@v5
         env:
           SHOW_TIMESTAMPS: 'true'
           OUTPUT_DIR: ${{ github.workspace }}/k8s-ci-demo-script-test-logs
@@ -525,8 +526,9 @@ jobs:
           # Check the result file have successfully written to the given location
           # hdfs dfs -test -e /ldbc_sample/res.csv_0 && hdfs dfs -test -e /ldbc_sample/res.csv_1
 
-      - uses: dashanji/kubernetes-log-export-action@v4
+      - uses: dashanji/kubernetes-log-export-action@v5
         env:
+          OUTPUT_DIR: ${{ github.workspace }}/k8s-ci-demo-script-test-logs
           MODE: stop
 
       - name: Upload the k8s logs to artifact
@@ -688,7 +690,7 @@ jobs:
           # install python gremlin client
           pip install gremlinpython
 
-      - uses: dashanji/kubernetes-log-export-action@v4
+      - uses: dashanji/kubernetes-log-export-action@v5
         env:
           SHOW_TIMESTAMPS: 'true'
           OUTPUT_DIR: ${{ github.workspace }}/k8s-failover-logs
@@ -713,8 +715,9 @@ jobs:
           # run failover test
           cd ${GITHUB_WORKSPACE}/interactive_engine/compiler && ./ir_k8s_failover_ci.sh default test-gie-standalone 2 1
 
-      - uses: dashanji/kubernetes-log-export-action@v4
+      - uses: dashanji/kubernetes-log-export-action@v5
         env:
+          OUTPUT_DIR: ${{ github.workspace }}/k8s-failover-logs
           MODE: stop
 
       - name: upload the k8s logs to artifact


### PR DESCRIPTION
## What do these changes do?

* Add the previous logs of restarted pods.
* Add the description info of not running pods.
* Add the pod yaml of the specific pods.

Actually, the current kubernetes-log-export-action will export all needed debugging info:

- Pod logs.
- Previous logs for restarted pods.
- Pod yamls.
- Pod description info.
- Events in the specific namespaces.

Signed-off-by: Ye Cao <caoye.cao@alibaba-inc.com>

Committed-by: Ye Cao from Dev container


