### PR TITLE
Retry download when checksum failed in groot data-loading process

### DIFF
--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/external/ExternalStorage.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/external/ExternalStorage.java
@@ -35,6 +35,21 @@ public abstract class ExternalStorage {
 
     public abstract void downloadDataSimple(String srcPath, String dstPath) throws IOException;
 
+    public void downloadDataWithRetry(String srcPath, String dstPath) throws IOException {
+        int maxRetry = 5;
+        for (int i = 0; i < maxRetry; ++i) {
+            try {
+                downloadData(srcPath, dstPath);
+                break;
+            } catch (IOException e) {
+                if (i == maxRetry - 1) {
+                    throw e;
+                } else {
+                    logger.error("Failed to download data, retrying...", e);
+                }
+            }
+        }
+    }
     public void downloadData(String srcPath, String dstPath) throws IOException {
         // Check chk
         String chkPath = srcPath.substring(0, srcPath.length() - ".sst".length()) + ".chk";
@@ -52,6 +67,7 @@ public abstract class ExternalStorage {
         }
         String[] chkArray = new String(chkData).split(",");
         if ("0".equals(chkArray[0])) {
+            chkFile.delete();
             return;
         }
         String chkMD5Value = chkArray[1];

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/jna/JnaGraphStore.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/jna/JnaGraphStore.java
@@ -107,7 +107,7 @@ public class JnaGraphStore implements GraphPartition {
         String unique_path = items[items.length - 2];
         String sstName = sstPath.substring(sstPath.lastIndexOf('/') + 1);
         String sstLocalPath = downloadPath.toString() + "/" + unique_path + "/" + sstName;
-        storage.downloadData(sstPath, sstLocalPath);
+        storage.downloadDataWithRetry(sstPath, sstLocalPath);
     }
 
     @Override


### PR DESCRIPTION
This PR modify the ingest process of groot to enable retry download data from remote when checksum failed, in order to make data-loading process more robust

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #3005

