### PR TITLE
ci: Add check for conventional commit and docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           # Types allowed (newline-delimited).
           # Default: https://github.com/commitizen/conventional-commit-types
           types: |
-            build 
+            build
             ci
             docs
             feat
@@ -82,7 +82,7 @@ jobs:
             release
             [A-Z]+
           # If the PR contains one of these newline-delimited labels, the
-          # validation is skipped. 
+          # validation is skipped.
           ignoreLabels: |
             bot
             ignore-semantic-pull-request
@@ -93,17 +93,17 @@ jobs:
         header: pr-title-lint-error
         message: |
           Thank you for opening this pull request! 👋🏼
-          
-          We require PR titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/),    
-          which in the format of `<type>(<scope>): <description>`. Don't know how to choose a type? Refer to [here](https://gist.github.com/brianclements/841ea7bffdb01346392c#type).    
-          e.g., 
+
+          We require PR titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/),
+          which in the format of `<type>(<scope>): <description>`. Don't know how to choose a type? Refer to [here](https://gist.github.com/brianclements/841ea7bffdb01346392c#type).
+          e.g.,
             - fix: Correct typo
             - feat(interactive): Add support for `g.V().outE().inV()`
             - refactor!: Drop support for Python 3.8
             - feat(analytical): Add delta-version for PageRank
           > Note that since pull request titles only have a single line, you have to use ! to indicate breaking changes.
 
-          Details:  
+          Details:
           ```
           ${{ steps.pr-convention.outputs.error_message }}
           ```
@@ -111,7 +111,7 @@ jobs:
     # Delete a previous comment when the issue has been resolved
     - if: ${{ steps.pr-convention.outputs.error_message == null }}
       uses: marocchino/sticky-pull-request-comment@v2
-      with:   
+      with:
         header: pr-title-lint-error
         delete: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,13 +30,100 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
         submodules: true
         fetch-depth: 0
-
+    
     - uses: dorny/paths-filter@v2
-      id: changes
+      id: doc-changes
       with:
         filters: |
           src:
             - 'docs/**'
+    
+    - uses: actions-ecosystem/action-regex-match@v2
+      id: pr-regex-match
+      with:
+        text: ${{ github.event.pull_request.title }}
+        regex: 'feat.*'
+
+    - uses: amannn/action-semantic-pull-request@v5
+      id: pr-convention
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          # Types allowed (newline-delimited).
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            build 
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            test
+            chore
+          # Scopes allowed (newline-delimited).
+          scopes: |
+            core
+            python
+            k8s
+            coordinator
+            one
+            interactive
+            insight
+            analytical
+            learning
+          # A scope can be not provided.
+          requireScope: false
+          # Configure which scopes are disallowed in PR titles (newline-delimited).
+          # For instance by setting the value below, `chore(release): ...` (lowercase)
+          # and `ci(e2e,release): ...` (unknown scope) will be rejected.
+          # These are regex patterns auto-wrapped in `^ $`.
+          disallowScopes: |
+            release
+            [A-Z]+
+          # If the PR contains one of these newline-delimited labels, the
+          # validation is skipped. 
+          ignoreLabels: |
+            bot
+            ignore-semantic-pull-request
+
+    - uses: marocchino/sticky-pull-request-comment@v2
+      if: always() && (steps.pr-convention.outputs.error_message != null)
+      with:
+        header: pr-title-lint-error
+        message: |
+          Thank you for opening this pull request! 👋🏼
+          
+          We require PR titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/),    
+          which in the format of `<type>(<scope>): <description>`. Don't know how to choose a type? Refer to [here](https://gist.github.com/brianclements/841ea7bffdb01346392c#type).    
+          e.g., 
+            - fix: Correct typo
+            - feat(interactive): Add support for `g.V().outE().inV()`
+            - refactor!: Drop support for Python 3.8
+            - feat(analytical): Add delta-version for PageRank
+          > Note that since pull request titles only have a single line, you have to use ! to indicate breaking changes.
+
+          Details:  
+          ```
+          ${{ steps.pr-convention.outputs.error_message }}
+          ```
+
+    # Delete a previous comment when the issue has been resolved
+    - if: ${{ steps.pr-convention.outputs.error_message == null }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:   
+        header: pr-title-lint-error
+        delete: true
+
+    - if: ${{ steps.pr-regex-match.outputs.match != '' && steps.doc-changes.outputs.src == 'false' }}
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: lack-documentation
+        message: |
+          ❌ **Uh oh!**
+          We suggest that a PR with type `feat` should has corresponding documentations.
+          If you believe this PR could be merged without documentation, please add `yecol` as an extra reviewer for confirmation.
+          Thank you!
 
     - name: Setup Java11
       uses: actions/setup-java@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,14 +30,14 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
         submodules: true
         fetch-depth: 0
-    
+
     - uses: dorny/paths-filter@v2
       id: doc-changes
       with:
         filters: |
           src:
             - 'docs/**'
-    
+
     - uses: actions-ecosystem/action-regex-match@v2
       id: pr-regex-match
       with:


### PR DESCRIPTION
With this PR merged, new checks are introduced:
- the PR titles should follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/),  
    which in the format of `<type>(<scope>): <description>`. e.g., 
   - fix: Correct typo
   - feat(interactive): Add support for `g.V().outE().inV()`
   - refactor!: Drop support for Python 3.8
   - feat(analytical): Add delta-version for PageRank
- if the PR is in type of `feat(<scope>):`, then documentation must be updated.