### PR TITLE
fix: Fixes error in docs generation by removing the submodule

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -255,6 +255,7 @@ jobs:
         fi
 
         rm -rf _build/
+        rm -rf ../flex/ || true
         rm -rf ../learning_engine/ || true
         rm -rf ../python || true
         rm -rf ../analytical_engine/java || true

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,6 +2,11 @@ name: PR-Check
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
     branches:
       - main
 


### PR DESCRIPTION
The submodule was first introduced in #3010 and it should be removed before `git add -A` to gh-pages.

Fixes https://github.com/alibaba/GraphScope/actions/runs/5665819421/job/15351324239

