### PR TITLE
refactor(analytical): Remove `nativeLibLoader` in GRAPE-jdk

### DIFF
--- a/analytical_engine/CMakeLists.txt
+++ b/analytical_engine/CMakeLists.txt
@@ -494,6 +494,12 @@ if(ENABLE_JAVA_SDK)
     set(GAE_JAVA_RUNTIME_JAR "${GAE_JAVA_RUNTIME_DIR}/target/grape-runtime-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
     set(GAE_JAVA_GRAPHX_JAR "${GAE_JAVA_DIR}/grape-graphx/target/grape-graphx-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
     set(GAE_JAVA_GIRAPH_JAR "${GAE_JAVA_DIR}/grape-giraph/target/grape-giraph-${GRAPHSCOPE_ANALYTICAL_JAR_VERSION}-shaded.jar")
+    # condiationally set grape-jni's name according to platform
+    if (APPLE)
+        set(GAE_JAVA_JNI_LIB "${GAE_JAVA_DIR}/grape-runtime/target/native/libgrape-jni.dylib")
+    else ()
+        set(GAE_JAVA_JNI_LIB "${GAE_JAVA_DIR}/grape-runtime/target/native/libgrape-jni.so")
+    endif()
 
     add_custom_command(
         OUTPUT "${GAE_JAVA_RUNTIME_JAR}"
@@ -510,6 +516,7 @@ if(ENABLE_JAVA_SDK)
     install(FILES "${GAE_JAVA_RUNTIME_JAR}" DESTINATION lib)
     install(FILES "${GAE_JAVA_GRAPHX_JAR}" DESTINATION lib)
     install(FILES "${GAE_JAVA_GIRAPH_JAR}" DESTINATION lib)
+    install(FILES "${GAE_JAVA_JNI_LIB}" DESTINATION lib)
     install(FILES "${GAE_JAVA_DIR}/grape_jvm_opts" DESTINATION conf)
     install(FILES "${GAE_JAVA_DIR}/run_graphx.sh" DESTINATION bin)
  endif()

--- a/analytical_engine/java/grape-giraph/pom.xml
+++ b/analytical_engine/java/grape-giraph/pom.xml
@@ -78,10 +78,6 @@
       <artifactId>giraph-core</artifactId>
       <version>1.3.0-hadoop2</version>
     </dependency>
-    <!-- <dependency>
-      <groupId>org.scijava</groupId>
-      <artifactId>native-lib-loader</artifactId>
-    </dependency> -->
   </dependencies>
   <build>
     <plugins>

--- a/analytical_engine/java/grape-giraph/pom.xml
+++ b/analytical_engine/java/grape-giraph/pom.xml
@@ -78,10 +78,10 @@
       <artifactId>giraph-core</artifactId>
       <version>1.3.0-hadoop2</version>
     </dependency>
-    <dependency>
+    <!-- <dependency>
       <groupId>org.scijava</groupId>
       <artifactId>native-lib-loader</artifactId>
-    </dependency>
+    </dependency> -->
   </dependencies>
   <build>
     <plugins>

--- a/analytical_engine/java/grape-giraph/src/test/java/com/alibaba/graphscope/serialization/FFIByteVectorStreamTest.java
+++ b/analytical_engine/java/grape-giraph/src/test/java/com/alibaba/graphscope/serialization/FFIByteVectorStreamTest.java
@@ -21,18 +21,13 @@ import com.alibaba.graphscope.stdcxx.FFIByteVectorFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.scijava.nativelib.NativeLoader;
 
 import java.io.IOException;
 
 public class FFIByteVectorStreamTest {
 
     static {
-        try {
-            NativeLoader.loadLibrary("grape-jni");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        System.loadLibrary("grape-jni");
     }
 
     private FFIByteVectorOutputStream outputStream;

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -77,10 +77,10 @@
       <artifactId>scala-library</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
+    <!-- <dependency>
       <groupId>org.scijava</groupId>
       <artifactId>native-lib-loader</artifactId>
-    </dependency>
+    </dependency> -->
   </dependencies>
 
   <build>

--- a/analytical_engine/java/grape-jdk/pom.xml
+++ b/analytical_engine/java/grape-jdk/pom.xml
@@ -77,10 +77,6 @@
       <artifactId>scala-library</artifactId>
       <scope>provided</scope>
     </dependency>
-    <!-- <dependency>
-      <groupId>org.scijava</groupId>
-      <artifactId>native-lib-loader</artifactId>
-    </dependency> -->
   </dependencies>
 
   <build>

--- a/analytical_engine/java/grape-runtime/build.xml
+++ b/analytical_engine/java/grape-runtime/build.xml
@@ -52,22 +52,5 @@
     <exec dir="${project.build.directory}/native" executable="strip" failonerror="true">
       <arg line="libgrape-jni.so"/>
     </exec>
-
-    <mkdir dir="${project.build.directory}/classes/natives"/>
-    <exec dir="${project.build.directory}/classes/natives" executable="mkdir" failonerror="false" os="Linux">
-        <arg line="linux_64"/>
-    </exec>
-
-    <exec dir="${project.build.directory}/native" executable="cp" failonerror="true" os="Linux">
-      <arg line="libgrape-jni.so ${project.build.directory}/classes/natives/linux_64"/>
-    </exec>
-
-    <exec dir="${project.build.directory}/classes/natives" executable="mkdir" failonerror="false" os="Mac OS X">
-        <arg line="osx_64"/>
-    </exec>
-
-    <exec dir="${project.build.directory}/native" executable="cp" failonerror="true" os="Mac OS X">
-      <arg line="libgrape-jni.so ${project.build.directory}/classes/natives/osx_64"/>
-    </exec>
   </target>
 </project>

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -72,10 +72,10 @@
     <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
-    <dependency>
+    <!-- <dependency>
       <groupId>org.scijava</groupId>
       <artifactId>native-lib-loader</artifactId>
-    </dependency>
+    </dependency> -->
   </dependencies>
   <build>
     <plugins>

--- a/analytical_engine/java/grape-runtime/pom.xml
+++ b/analytical_engine/java/grape-runtime/pom.xml
@@ -72,10 +72,6 @@
     <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
-    <!-- <dependency>
-      <groupId>org.scijava</groupId>
-      <artifactId>native-lib-loader</artifactId>
-    </dependency> -->
   </dependencies>
   <build>
     <plugins>

--- a/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/GraphScopeClassLoader.java
+++ b/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/GraphScopeClassLoader.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.graphscope.runtime;
 
-import org.scijava.nativelib.NativeLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +48,7 @@ public class GraphScopeClassLoader {
 
     static {
         try {
-            NativeLoader.loadLibrary("grape-jni");
+            System.loadLibrary("grape-jni");
             logger.info("loaded jni lib");
         } catch (Exception e) {
             e.printStackTrace();

--- a/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/LoadLibrary.java
+++ b/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/LoadLibrary.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.graphscope.runtime;
 
-import org.scijava.nativelib.NativeLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,11 +31,7 @@ public class LoadLibrary {
     private static Logger logger = LoggerFactory.getLogger(LoadLibrary.class);
 
     static {
-        try {
-            NativeLoader.loadLibrary("grape-jni");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        System.loadLibrary("grape-jni");
     }
 
     /**
@@ -46,11 +41,7 @@ public class LoadLibrary {
      */
     public static void invoke(String userLibrary) {
         logger.info("loading " + userLibrary);
-        try {
-            NativeLoader.loadLibrary(userLibrary);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        System.loadLibrary(userLibrary);
         logger.info("Load libary cl: " + LoadLibrary.class.getClassLoader());
         try {
             LIBRARIES = ClassLoader.class.getDeclaredField("loadedLibraryNames");

--- a/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/LoadLibrary.java
+++ b/analytical_engine/java/grape-runtime/src/main/java/com/alibaba/graphscope/runtime/LoadLibrary.java
@@ -19,7 +19,6 @@ package com.alibaba.graphscope.runtime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Vector;
 
 /**

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -224,11 +224,6 @@
         <artifactId>spark-yarn_2.12</artifactId>
         <version>${spark.version}</version>
       </dependency>
-      <!-- <dependency>
-        <groupId>org.scijava</groupId>
-        <artifactId>native-lib-loader</artifactId>
-        <version>${native-lib-loader.version}</version>
-      </dependency> -->
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>

--- a/analytical_engine/java/pom.xml
+++ b/analytical_engine/java/pom.xml
@@ -224,11 +224,11 @@
         <artifactId>spark-yarn_2.12</artifactId>
         <version>${spark.version}</version>
       </dependency>
-      <dependency>
+      <!-- <dependency>
         <groupId>org.scijava</groupId>
         <artifactId>native-lib-loader</artifactId>
         <version>${native-lib-loader.version}</version>
-      </dependency>
+      </dependency> -->
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-all</artifactId>


### PR DESCRIPTION
Committed-by: zhanglei1949 from Dev container

Currently we pack the `libgrape-jni.so/dylib` into `grape-runtime-shaded-{}.jar` and  use `NativeLibLoader` to load the jni lib at runtime. But If we want to package `GRAPE-jdk` into GraphScope wheel package, we need to user `auditwheel` to reorg the dynamic linking and RPATH staffs.

So maybe we should abandon current approach, just copy `libgrape-jni` to /opt/graphscope/lib, such that is can be found by auditwheel.

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Related Issue: #3064 

