### PR TITLE
fix(analytical): fixes wrong result when flatten from projected arrow fragment

### DIFF
--- a/analytical_engine/core/fragment/arrow_flattened_fragment.h
+++ b/analytical_engine/core/fragment/arrow_flattened_fragment.h
@@ -681,9 +681,8 @@ class ArrowFlattenedFragment {
     auto& schema = fragment_->schema();
     label_id_t vertex_label_num =
         static_cast<label_id_t>(schema.AllVertexEntries().size());
-    for (label_id_t v_label = 0; v_label < vertex_label_num;
-         v_label++) {
-      if (schema_.IsVertexValid(v_label)){
+    for (label_id_t v_label = 0; v_label < vertex_label_num; v_label++) {
+      if (schema_.IsVertexValid(v_label)) {
         if (fragment_->GetVertex(v_label, oid, v)) {
           // generate continuous lid
           v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
@@ -753,9 +752,8 @@ class ArrowFlattenedFragment {
     auto& schema = fragment_->schema();
     label_id_t vertex_label_num =
         static_cast<label_id_t>(schema.AllVertexEntries().size());
-    for (label_id_t v_label = 0; v_label < vertex_label_num;
-         v_label++) {
-      if (schema_.IsVertexValid(v_label)){
+    for (label_id_t v_label = 0; v_label < vertex_label_num; v_label++) {
+      if (schema_.IsVertexValid(v_label)) {
         if (fragment_->GetInnerVertex(v_label, oid, v)) {
           // generate continuous lid
           v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
@@ -770,9 +768,8 @@ class ArrowFlattenedFragment {
     auto& schema = fragment_->schema();
     label_id_t vertex_label_num =
         static_cast<label_id_t>(schema.AllVertexEntries().size());
-    for (label_id_t v_label = 0; v_label < vertex_label_num;
-         v_label++) {
-      if (schema_.IsVertexValid(v_label)){
+    for (label_id_t v_label = 0; v_label < vertex_label_num; v_label++) {
+      if (schema_.IsVertexValid(v_label)) {
         if (fragment_->GetOuterVertex(v_label, oid, v)) {
           // generate continuous lid
           v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
@@ -801,9 +798,8 @@ class ArrowFlattenedFragment {
     auto& schema = fragment_->schema();
     label_id_t vertex_label_num =
         static_cast<label_id_t>(schema.AllVertexEntries().size());
-    for (label_id_t v_label = 0; v_label < vertex_label_num;
-         v_label++) {
-      if (schema_.IsVertexValid(v_label)){
+    for (label_id_t v_label = 0; v_label < vertex_label_num; v_label++) {
+      if (schema_.IsVertexValid(v_label)) {
         if (fragment_->Oid2Gid(v_label, oid, gid)) {
           return true;
         }

--- a/analytical_engine/core/fragment/arrow_flattened_fragment.h
+++ b/analytical_engine/core/fragment/arrow_flattened_fragment.h
@@ -678,12 +678,17 @@ class ArrowFlattenedFragment {
   }
 
   inline bool GetVertex(const oid_t& oid, vertex_t& v) const {
-    for (label_id_t v_label = 0; v_label < fragment_->vertex_label_num();
+    auto& schema = fragment_->schema();
+    label_id_t vertex_label_num =
+        static_cast<label_id_t>(schema.AllVertexEntries().size());
+    for (label_id_t v_label = 0; v_label < vertex_label_num;
          v_label++) {
-      if (fragment_->GetVertex(v_label, oid, v)) {
-        // generate continuous lid
-        v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
-        return true;
+      if (schema_.IsVertexValid(v_label)){
+        if (fragment_->GetVertex(v_label, oid, v)) {
+          // generate continuous lid
+          v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
+          return true;
+        }
       }
     }
     return false;
@@ -745,24 +750,34 @@ class ArrowFlattenedFragment {
   }
 
   inline bool GetInnerVertex(const oid_t& oid, vertex_t& v) const {
-    for (label_id_t v_label = 0; v_label < fragment_->vertex_label_num();
+    auto& schema = fragment_->schema();
+    label_id_t vertex_label_num =
+        static_cast<label_id_t>(schema.AllVertexEntries().size());
+    for (label_id_t v_label = 0; v_label < vertex_label_num;
          v_label++) {
-      if (fragment_->GetInnerVertex(v_label, oid, v)) {
-        // generate continuous lid
-        v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
-        return true;
+      if (schema_.IsVertexValid(v_label)){
+        if (fragment_->GetInnerVertex(v_label, oid, v)) {
+          // generate continuous lid
+          v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
+          return true;
+        }
       }
     }
     return false;
   }
 
   inline bool GetOuterVertex(const oid_t& oid, vertex_t& v) const {
-    for (label_id_t v_label = 0; v_label < fragment_->vertex_label_num();
+    auto& schema = fragment_->schema();
+    label_id_t vertex_label_num =
+        static_cast<label_id_t>(schema.AllVertexEntries().size());
+    for (label_id_t v_label = 0; v_label < vertex_label_num;
          v_label++) {
-      if (fragment_->GetOuterVertex(v_label, oid, v)) {
-        // generate continuous lid
-        v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
-        return true;
+      if (schema_.IsVertexValid(v_label)){
+        if (fragment_->GetOuterVertex(v_label, oid, v)) {
+          // generate continuous lid
+          v.SetValue(union_id_parser_.GenerateContinuousLid(v.GetValue()));
+          return true;
+        }
       }
     }
     return false;
@@ -783,9 +798,15 @@ class ArrowFlattenedFragment {
   }
 
   inline bool Oid2Gid(const oid_t& oid, vid_t& gid) const {
-    for (label_id_t label = 0; label < fragment_->vertex_label_num(); label++) {
-      if (fragment_->Oid2Gid(label, oid, gid)) {
-        return true;
+    auto& schema = fragment_->schema();
+    label_id_t vertex_label_num =
+        static_cast<label_id_t>(schema.AllVertexEntries().size());
+    for (label_id_t v_label = 0; v_label < vertex_label_num;
+         v_label++) {
+      if (schema_.IsVertexValid(v_label)){
+        if (fragment_->Oid2Gid(v_label, oid, gid)) {
+          return true;
+        }
       }
     }
     return false;


### PR DESCRIPTION
fix error: wrong result when flatten from projected data

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

