### PR TITLE
chore: Refine the logic to probe GRAPHSCOPE_HOME

### DIFF
--- a/coordinator/gscoordinator/local_launcher.py
+++ b/coordinator/gscoordinator/local_launcher.py
@@ -206,10 +206,6 @@ class LocalLauncher(AbstractLauncher):
 
         env = os.environ.copy()
         env["GRAPHSCOPE_HOME"] = GRAPHSCOPE_HOME
-        if ".install_prefix" in INTERACTIVE_ENGINE_SCRIPT:
-            env["GRAPHSCOPE_HOME"] = os.path.dirname(
-                os.path.dirname(INTERACTIVE_ENGINE_SCRIPT)
-            )
 
         if os.environ.get("PARALLEL_INTERACTIVE_EXECUTOR_ON_VINEYARD", "OFF") != "ON":
             # only one GIE/GAIA executor will be launched locally, even there are
@@ -323,10 +319,6 @@ class LocalLauncher(AbstractLauncher):
     def close_interactive_instance(self, object_id):
         env = os.environ.copy()
         env["GRAPHSCOPE_HOME"] = GRAPHSCOPE_HOME
-        if ".install_prefix" in INTERACTIVE_ENGINE_SCRIPT:
-            env["GRAPHSCOPE_HOME"] = os.path.dirname(
-                os.path.dirname(INTERACTIVE_ENGINE_SCRIPT)
-            )
         cmd = [
             INTERACTIVE_ENGINE_SCRIPT,
             "close_gremlin_instance_on_local",

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -84,9 +84,6 @@ except ModuleNotFoundError:
 #   1) get from environment variable `GRAPHSCOPE_HOME`, if not exist,
 #   2) infer from COORDINATOR_HOME
 GRAPHSCOPE_HOME = os.environ.get("GRAPHSCOPE_HOME", None)
-ANALYTICAL_ENGINE_HOME = GRAPHSCOPE_HOME
-ANALYTICAL_ENGINE_PATH = os.path.join(GRAPHSCOPE_HOME, "bin", "grape_engine")
-INTERACTIVE_ENGINE_SCRIPT = os.path.join(GRAPHSCOPE_HOME, "bin", "giectl")
 
 if GRAPHSCOPE_HOME is None:
     # Note: The order of locations matters
@@ -100,12 +97,13 @@ if GRAPHSCOPE_HOME is None:
         ANALYTICAL_ENGINE_PATH = os.path.join(location, "bin", "grape_engine")
         if os.path.isfile(ANALYTICAL_ENGINE_PATH):
             GRAPHSCOPE_HOME = location
-            ANALYTICAL_ENGINE_HOME = GRAPHSCOPE_HOME
-
-            INTERACTIVE_ENGINE_SCRIPT = os.path.join(GRAPHSCOPE_HOME, "bin", "giectl")
             break
 
-if GRAPHSCOPE_HOME is None:
+if GRAPHSCOPE_HOME is not None:
+    ANALYTICAL_ENGINE_HOME = GRAPHSCOPE_HOME
+    ANALYTICAL_ENGINE_PATH = os.path.join(GRAPHSCOPE_HOME, "bin", "grape_engine")
+    INTERACTIVE_ENGINE_SCRIPT = os.path.join(GRAPHSCOPE_HOME, "bin", "giectl")
+else:
     # resolve from develop source tree
     # Here the GRAPHSCOPE_HOME has been set to the root of the source tree,
     # So the engine location doesn't need to check again,

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -84,6 +84,10 @@ except ModuleNotFoundError:
 #   1) get from environment variable `GRAPHSCOPE_HOME`, if not exist,
 #   2) infer from COORDINATOR_HOME
 GRAPHSCOPE_HOME = os.environ.get("GRAPHSCOPE_HOME", None)
+ANALYTICAL_ENGINE_HOME = GRAPHSCOPE_HOME
+ANALYTICAL_ENGINE_PATH = os.path.join(GRAPHSCOPE_HOME, "bin", "grape_engine")
+INTERACTIVE_ENGINE_SCRIPT = os.path.join(GRAPHSCOPE_HOME, "bin", "giectl")
+
 if GRAPHSCOPE_HOME is None:
     # Note: The order of locations matters
     possible_locations = [


### PR DESCRIPTION
Committed-by: siyuanzhang.zsy from Dev container

Previously it could not auto detect grape_engine from `/opt/graphscope`, need to rely on `GRAPHSCOPE_HOME` be set.

Also try to simplify the logic to probe GRAPHSCOPE_HOME, and others. But its still messy.

And delete the unused `.install_prefix` usage.

