### PR TITLE
chore: allow user pass variables for substitutions

### DIFF
--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
@@ -60,6 +60,16 @@ public class OfflineBuildOdps {
 
         String columnMappingConfigStr =
                 properties.getProperty(DataLoadConfig.COLUMN_MAPPING_CONFIG);
+        // User could specify a list of `key=value` pairs in command line,
+        // to substitute variables like `${key}` in columnMappingConfigStr
+        for (int i = 1; i < args.length; ++i) {
+            String[] kv = args[i].split("=");
+            if (kv.length == 2) {
+                String key = "${" + kv[0] + "}";
+                columnMappingConfigStr = columnMappingConfigStr.replace(key, kv[1]);
+            }
+        }
+
         String graphEndpoint = properties.getProperty(DataLoadConfig.GRAPH_ENDPOINT);
         String username = properties.getProperty(DataLoadConfig.USER_NAME, "");
         String password = properties.getProperty(DataLoadConfig.PASS_WORD, "");


### PR DESCRIPTION
Suppose the source file `config.init` contains a line
```json
{"xxx/${bizdate}": "${another-var}"
```

User could substitute the variables in `${}` by specify `key=value` in the command line:
```bash
java -jar data-load-tools.jar config.init bizdate=20180808 another-var=value
```

Then in runtime the content of `config.init` will be replaced to
```json
{"xxx/20180808": "value"}
```

