### PR TITLE
fix(interactive): fixes some unsafe rust code that cannot be compiled with recent stable rust compilers

### DIFF
--- a/interactive_engine/executor/assembly/groot/src/executor/gaia/gaia_library.rs
+++ b/interactive_engine/executor/assembly/groot/src/executor/gaia/gaia_library.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 
 use groot_store::db::api::GraphConfigBuilder;
 use groot_store::db::common::bytes::util::parse_pb;
-use groot_store::db::common::unsafe_util::to_mut;
 use groot_store::db::graph::store::GraphStore;
 use groot_store::db::proto::model::ConfigPb;
 use pegasus_network::config::ServerAddr;
@@ -46,7 +45,7 @@ pub extern "C" fn initialize(config_bytes: *const u8, len: usize) -> EngineHandl
 #[no_mangle]
 pub extern "C" fn addPartition(engine_handle: EngineHandle, partition_id: i32, graph_handle: GraphHandle) {
     trace!("add partition {} to engine", partition_id);
-    let engine_ptr = unsafe { to_mut(&*(engine_handle as *const GaiaServer)) };
+    let engine_ptr = unsafe { &mut *(engine_handle as *mut GaiaServer) };
     let graph_ptr = unsafe { Arc::from_raw(&*(graph_handle as *const GraphStore)) };
     engine_ptr.add_partition(partition_id as u32, graph_ptr);
 }
@@ -54,14 +53,14 @@ pub extern "C" fn addPartition(engine_handle: EngineHandle, partition_id: i32, g
 #[no_mangle]
 pub extern "C" fn updatePartitionRouting(engine_handle: EngineHandle, partition_id: i32, server_id: i32) {
     trace!("update partition {} routing to server {}", partition_id, server_id);
-    let engine_ptr = unsafe { to_mut(&*(engine_handle as *const GaiaServer)) };
+    let engine_ptr = unsafe { &mut *(engine_handle as *mut GaiaServer) };
     engine_ptr.update_partition_routing(partition_id as u32, server_id as u32);
 }
 
 #[no_mangle]
 pub extern "C" fn startEngine(engine_handle: EngineHandle) -> Box<EnginePortsResponse> {
     trace!("start gaia engine");
-    let engine_ptr = unsafe { to_mut(&*(engine_handle as *const GaiaServer)) };
+    let engine_ptr = unsafe { &mut *(engine_handle as *mut GaiaServer) };
     match engine_ptr.start() {
         Ok((engine_port, server_port)) => EnginePortsResponse::new(engine_port as i32, server_port as i32),
         Err(e) => {
@@ -74,7 +73,7 @@ pub extern "C" fn startEngine(engine_handle: EngineHandle) -> Box<EnginePortsRes
 #[no_mangle]
 pub extern "C" fn stopEngine(engine_handle: EngineHandle) {
     trace!("stop gaia engine");
-    let engine_ptr = unsafe { to_mut(&*(engine_handle as *const GaiaServer)) };
+    let engine_ptr = unsafe { &mut *(engine_handle as *mut GaiaServer) };
     engine_ptr.stop();
 }
 
@@ -95,6 +94,6 @@ pub extern "C" fn updatePeerView(engine_handle: EngineHandle, peer_view_string_r
             (id, ServerAddr::new(String::from(hostname), port))
         })
         .collect::<Vec<(u64, ServerAddr)>>();
-    let engine_ptr = unsafe { to_mut(&*(engine_handle as *const GaiaServer)) };
+    let engine_ptr = unsafe { &mut *(engine_handle as *mut GaiaServer) };
     engine_ptr.update_peer_view(peer_view);
 }

--- a/interactive_engine/executor/common/dyn_type/Cargo.toml
+++ b/interactive_engine/executor/common/dyn_type/Cargo.toml
@@ -8,3 +8,4 @@ dyn-clonable = "0.9.0"
 itertools = "0.10"
 lazy_static = "1.3.0"
 pegasus_common = { path = "../../engine/pegasus/common" }
+rustversion = "1.0"

--- a/interactive_engine/executor/store/groot/src/db/common/mod.rs
+++ b/interactive_engine/executor/store/groot/src/db/common/mod.rs
@@ -3,4 +3,3 @@ pub mod concurrency;
 pub mod iterator;
 pub mod numeric;
 pub mod str;
-pub mod unsafe_util;

--- a/interactive_engine/executor/store/groot/src/db/common/unsafe_util.rs
+++ b/interactive_engine/executor/store/groot/src/db/common/unsafe_util.rs
@@ -1,3 +1,0 @@
-pub unsafe fn to_mut<T>(t: &T) -> &mut T {
-    &mut *(t as *const T as *mut T)
-}

--- a/interactive_engine/executor/store/groot/src/db/graph/store.rs
+++ b/interactive_engine/executor/store/groot/src/db/graph/store.rs
@@ -101,7 +101,8 @@ impl MultiVersionGraph for GraphStore {
                 .edge_manager
                 .get_all_edges(snapshot_id as i64);
             while let Some(info) = iter.next() {
-                let mut edge_kind_iter = info.into_iter();
+                let edge_kinds = info.lock();
+                let mut edge_kind_iter = edge_kinds.iter_kinds();
                 while let Some(edge_kind_info) = edge_kind_iter.next() {
                     if let Some(edge) = self.get_edge_from_relation(
                         snapshot_id,


### PR DESCRIPTION
## What do these changes do?

This pull request fixes some incompatible issues with recently stable Rust compilers (>=1.72.0).

- TypeId casting:
  
  The `TypeId` in rust becomes `i128` since https://github.com/rust-lang/rust/commit/9e5573a0d275c71dce59b715d981c6880d30703a, makes the original `std::mem::transmute` stop working.

- The ref to mut-ref `&mut *(t as *const T as *mut T)` has become undefined behaviour since Rust 1.70, and was rejected by recent nightly compilers.

- The `EdgeInfo::kinds` yields a anti-pattern design for Rust (a constant Vec is modified without any protection). This pull request adds a lock to the `kinds` vector, and refactors its iter implementation to make it safer (and, can be compiled).