### PR TITLE
feat(interactive): support project properties of a `path`

### DIFF
--- a/docs/interactive_engine/tinkerpop/supported_gremlin_steps.md
+++ b/docs/interactive_engine/tinkerpop/supported_gremlin_steps.md
@@ -578,7 +578,7 @@ The following steps are extended to denote more complex situations.
 In Graph querying, expanding a multiple-hops path from a starting point is called `PathExpand`, which is commonly used in graph scenarios. In addition, there are different requirements for expanding strategies in different scenarios, i.e. it is required to output a simple path or all vertices explored along the expanding path. We introduce the with()-step to configure the corresponding behaviors of the `PathExpand`-step.
 
 #### out()
-Expand a multiple-hops path along the outgoing edges, which length is within the given range.
+Expand a multiple-hops path along the outgoing edges, which length is within the given range. 
 
 Parameters: </br>
 lengthRange - the lower and the upper bounds of the path length, </br> edgeLabels - the edge labels to traverse.
@@ -603,6 +603,9 @@ g.V().out("1..10", "knows")
 # expand hops within the range of [1, 10) along the outgoing edges which label is `knows` or `created`,
 # vertices can be duplicated and only the end vertex should be kept
 g.V().out("1..10", "knows", "created")
+# expand hops within the range of [1, 10) along the outgoing edges,
+# and project the properties "id" and "name" of every vertex along the path
+g.V().out("1..10").with('RESULT_OPT', 'ALL_V').values("name")
 ```
 Running Example:
 ```bash
@@ -615,6 +618,12 @@ gremlin> g.V().out("1..3", "knows").with('RESULT_OPT', 'ALL_V_E')
 gremlin> g.V().out("1..3", "knows").with('RESULT_OPT', 'END_V').endV()
 ==>v[2]
 ==>v[4]
+gremlin> g.V().out("1..3", "knows").with('RESULT_OPT', 'ALL_V').values("name")
+==>[marko, vadas]
+==>[marko, josh]
+gremlin> g.V().out("1..3", "knows").with('RESULT_OPT', 'ALL_V').valueMap("id","name")
+==>{id=[[1, 2]], name=[[marko, vadas]]}
+==>{id=[[1, 4]], name=[[marko, josh]]}
 ```
 #### in()
 Expand a multiple-hops path along the incoming edges, which length is within the given range.

--- a/interactive_engine/executor/ir/core/src/plan/logical.rs
+++ b/interactive_engine/executor/ir/core/src/plan/logical.rs
@@ -1295,10 +1295,6 @@ impl AsLogical for pb::PathExpand {
             let tag_id = get_or_set_tag_id(alias, plan_meta)?;
             plan_meta.set_tag_nodes(tag_id, vec![plan_meta.get_curr_node()]);
         }
-        // PathExpand would never require adding columns
-        plan_meta
-            .curr_node_meta_mut()
-            .set_columns_opt(ColumnsOpt::None);
 
         Ok(())
     }

--- a/interactive_engine/executor/ir/core/src/plan/physical.rs
+++ b/interactive_engine/executor/ir/core/src/plan/physical.rs
@@ -316,10 +316,21 @@ impl AsPhysical for pb::PathExpand {
                         sample_ratio: 1.0,
                         extra: Default::default(),
                     };
-
                     // Notice that, when properties of a `Path` is needed, we need to cache the properties of the vertices/edges in the path.
                     // For example, `g.V().out("1..3").with("RESULT_OPT, "ALL_V").values("name")`, we need to cache the property of "name" in all the vertices in the path.
                     // If "RESULT_OPT" is "ALL_V_E", we assume the property of the edges in the path is also needed.
+
+                    // first, cache properties on the path start vertex.
+                    let start_auxilia = pb::GetV {
+                        tag: self.start_tag.clone(),
+                        opt: 4, //ItSelf
+                        params: Some(new_params.clone()),
+                        alias: self.start_tag.clone(),
+                        meta_data: None,
+                    };
+                    builder.get_v(start_auxilia);
+
+                    // then, cache properties during the path expanding.
                     let result_opt: pb::path_expand::ResultOpt =
                         unsafe { std::mem::transmute(self.result_opt) };
                     let expand_base = self

--- a/interactive_engine/executor/ir/graph_proxy/src/apis/graph/element/path.rs
+++ b/interactive_engine/executor/ir/graph_proxy/src/apis/graph/element/path.rs
@@ -256,11 +256,34 @@ impl GraphElement for GraphPath {
     }
 
     fn get_property(&self, key: &NameOrId) -> Option<PropertyValue> {
-        self.get_path_end().get_property(key)
+        match self {
+            GraphPath::AllPath(path) | GraphPath::SimpleAllPath(path) => {
+                let mut properties = vec![];
+                for v_or_e in path {
+                    if let Some(p) = v_or_e.get_property(key) {
+                        properties.push(p.try_to_owned().unwrap());
+                    }
+                }
+                Some(PropertyValue::Owned(Object::Vector(properties)))
+            }
+
+            GraphPath::EndV((v_or_e, _)) | GraphPath::SimpleEndV((v_or_e, _, _)) => {
+                v_or_e.get_property(key)
+            }
+        }
     }
 
     fn get_all_properties(&self) -> Option<HashMap<NameOrId, Object>> {
-        self.get_path_end().get_all_properties()
+        match self {
+            GraphPath::AllPath(_) | GraphPath::SimpleAllPath(_) => {
+                // not supported yet.
+                None
+            }
+
+            GraphPath::EndV((v_or_e, _)) | GraphPath::SimpleEndV((v_or_e, _, _)) => {
+                v_or_e.get_all_properties()
+            }
+        }
     }
 }
 

--- a/interactive_engine/executor/ir/graph_proxy/src/apis/graph/element/path.rs
+++ b/interactive_engine/executor/ir/graph_proxy/src/apis/graph/element/path.rs
@@ -29,6 +29,7 @@ use pegasus_common::downcast::AsAny;
 use pegasus_common::impl_as_any;
 
 use crate::apis::{Edge, Element, GraphElement, PropertyValue, Vertex, ID};
+use crate::utils::expr::eval::Context;
 
 #[derive(Clone, Debug, Hash, PartialEq, PartialOrd)]
 pub enum VertexOrEdge {
@@ -216,6 +217,12 @@ impl GraphElement for VertexOrEdge {
             VertexOrEdge::V(v) => v.get_all_properties(),
             VertexOrEdge::E(e) => e.get_all_properties(),
         }
+    }
+}
+
+impl Context<VertexOrEdge> for VertexOrEdge {
+    fn get(&self, _tag: Option<&NameOrId>) -> Option<&VertexOrEdge> {
+        Some(&self)
     }
 }
 

--- a/interactive_engine/executor/ir/runtime/src/assembly.rs
+++ b/interactive_engine/executor/ir/runtime/src/assembly.rs
@@ -159,6 +159,10 @@ impl<P: PartitionInfo, C: ClusterInfo> FnGenerator<P, C> {
         Ok(opr.gen_map()?)
     }
 
+    fn gen_path_condition(&self, opr: pb::PathExpand) -> FnGenResult<RecordFilter> {
+        Ok(opr.gen_filter()?)
+    }
+
     fn gen_coin(&self, opr: algebra_pb::Sample) -> FnGenResult<RecordFilter> {
         Ok(opr.gen_filter()?)
     }
@@ -604,11 +608,9 @@ impl<P: PartitionInfo, C: ClusterInfo> IRJobAssembly<P, C> {
                     }
                     let times = range.upper - range.lower - 1;
                     if times > 0 {
-                        if let Some(condition) = path.condition.as_ref() {
+                        if path.condition.is_some() {
                             let mut until = IterCondition::max_iters(times as u32);
-                            let func = self
-                                .udf_gen
-                                .gen_filter(algebra_pb::Select { predicate: Some(condition.clone()) })?;
+                            let func = self.udf_gen.gen_path_condition(path.clone())?;
                             until.set_until(func);
                             // Notice that if UNTIL condition set, we expand path without `Emit`
                             stream = stream

--- a/interactive_engine/executor/ir/runtime/src/process/operator/filter/mod.rs
+++ b/interactive_engine/executor/ir/runtime/src/process/operator/filter/mod.rs
@@ -13,6 +13,7 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 mod coin;
+mod path_condition;
 mod select;
 
 use pegasus::api::function::FilterFunction;

--- a/interactive_engine/executor/ir/runtime/src/process/operator/filter/path_condition.rs
+++ b/interactive_engine/executor/ir/runtime/src/process/operator/filter/path_condition.rs
@@ -1,0 +1,66 @@
+//
+//! Copyright 2023 Alibaba Group Holding Limited.
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//! http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+
+use std::convert::TryInto;
+
+use graph_proxy::utils::expr::eval_pred::{EvalPred, PEvaluator};
+use ir_common::error::ParsePbError;
+use ir_common::generated::physical as pb;
+use pegasus::api::function::{FilterFunction, FnResult};
+
+use crate::error::{FnExecError, FnGenResult};
+use crate::process::entry::Entry;
+use crate::process::operator::filter::FilterFuncGen;
+use crate::process::record::Record;
+
+/// a filter for path until condition
+#[derive(Debug)]
+struct PathConditionOperator {
+    pub filter: PEvaluator,
+}
+
+impl FilterFunction<Record> for PathConditionOperator {
+    fn test(&self, input: &Record) -> FnResult<bool> {
+        if let Some(entry) = input.get(None) {
+            if let Some(path) = entry.as_graph_path() {
+                // we assume the until condition must be tested on the path end
+                let path_end = path.get_path_end();
+                let res = self
+                    .filter
+                    .eval_bool(Some(path_end))
+                    .map_err(|e| FnExecError::from(e))?;
+                return Ok(res);
+            }
+        }
+        Err(FnExecError::unexpected_data_error(&format!(
+            "unexpected input for path until condition {:?}",
+            input.get(None),
+        )))?
+    }
+}
+
+impl FilterFuncGen for pb::PathExpand {
+    fn gen_filter(self) -> FnGenResult<Box<dyn FilterFunction<Record>>> {
+        if let Some(predicate) = self.condition {
+            let path_condition_operator = PathConditionOperator { filter: predicate.try_into()? };
+            if log_enabled!(log::Level::Debug) && pegasus::get_current_worker().index == 0 {
+                debug!("Runtime path condition operator: {:?}", path_condition_operator);
+            }
+            Ok(Box::new(path_condition_operator))
+        } else {
+            Err(ParsePbError::EmptyFieldError("empty path condition pb".to_string()).into())
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As titled. We support to project property of a `path`, i.e., we project the property of each element in `path`. 

e.g., on modern graph:
```
gremlin> g.V().out("1..3", "knows").with('RESULT_OPT', 'ALL_V').values("name")
==>[marko, vadas]
==>[marko, josh]
```


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #3199

