### PR TITLE
fix(interactive): Fix bugs in Label Name to Id Conversion

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
@@ -71,22 +71,27 @@ public class GremlinResultAnalyzer {
                 parserType = UnionResultParser.create(step);
             } else if (Utils.equalClass(step, SubgraphStep.class)) {
                 parserType = GremlinResultParserFactory.SUBGRAPH;
-            } else if (Utils.equalClass(step, HasStep.class)
-                    || Utils.equalClass(step, DedupGlobalStep.class)
-                    || Utils.equalClass(step, RangeGlobalStep.class)
-                    || Utils.equalClass(step, OrderGlobalStep.class)
-                    || Utils.equalClass(step, IsStep.class)
-                    || Utils.equalClass(step, WherePredicateStep.class)
-                    || Utils.equalClass(step, TraversalFilterStep.class)
-                    || Utils.equalClass(step, WhereTraversalStep.class)
-                    || Utils.equalClass(step, NotStep.class)
-                    || Utils.equalClass(step, CoinStep.class)
-                    || Utils.equalClass(step, SampleGlobalStep.class)) {
+            } else if (isSameInAndOutputType(step)) {
                 // do nothing;
             } else {
                 throw new UnsupportedStepException(step.getClass(), "unimplemented yet");
             }
         }
         return parserType;
+    }
+
+    // the step has the same input and output data type
+    public static boolean isSameInAndOutputType(Step step) {
+        return Utils.equalClass(step, HasStep.class)
+                || Utils.equalClass(step, DedupGlobalStep.class)
+                || Utils.equalClass(step, RangeGlobalStep.class)
+                || Utils.equalClass(step, OrderGlobalStep.class)
+                || Utils.equalClass(step, IsStep.class)
+                || Utils.equalClass(step, WherePredicateStep.class)
+                || Utils.equalClass(step, TraversalFilterStep.class)
+                || Utils.equalClass(step, WhereTraversalStep.class)
+                || Utils.equalClass(step, NotStep.class)
+                || Utils.equalClass(step, CoinStep.class)
+                || Utils.equalClass(step, SampleGlobalStep.class);
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
When converting a label name into an ID, it is necessary to first infer whether it is a vertex label or an edge label based on the operator preceding the elementMap. There will be issues when the preceding operator falls into one of the following categories: 
1. When the preceding operator is an `ExpandFusionStep` after optimization (fusion of outE + filter + inV); 
2. When the preceding operator is an operator like `limit` or `where` that does not change the input type.

This PR addresses the two issues mentioned above.

<!-- Please give a short brief about these changes. -->

## Related issue number
fix #3219 

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

