### PR TITLE
Flex: Fix a bug in idindexer and Immediately serialize after reading each file

### DIFF
--- a/flex/engines/graph_db/database/graph_db.cc
+++ b/flex/engines/graph_db/database/graph_db.cc
@@ -66,14 +66,14 @@ void GraphDB::Init(
       LOG(INFO) << "Initializing graph db through bulk loading";
       {
         MutablePropertyFragment graph;
-        graph.Init(schema, vertex_files, edge_files, thread_num);
-        graph.Serialize(data_dir_path.string());
+        graph.Init(schema, vertex_files, edge_files, data_dir_path, thread_num);
+        // graph.Serialize(data_dir_path.string());
       }
       graph_.Deserialize(data_dir_path.string());
     } else {
       LOG(INFO) << "Initializing empty graph db";
-      graph_.Init(schema, vertex_files, edge_files, thread_num);
-      graph_.Serialize(data_dir_path.string());
+      graph_.Init(schema, vertex_files, edge_files, data_dir_path, thread_num);
+      // graph_.Serialize(data_dir_path.string());
     }
   } else {
     LOG(INFO) << "Initializing graph db from data files of work directory";

--- a/flex/engines/graph_db/database/graph_db.cc
+++ b/flex/engines/graph_db/database/graph_db.cc
@@ -67,13 +67,11 @@ void GraphDB::Init(
       {
         MutablePropertyFragment graph;
         graph.Init(schema, vertex_files, edge_files, data_dir_path, thread_num);
-        // graph.Serialize(data_dir_path.string());
       }
       graph_.Deserialize(data_dir_path.string());
     } else {
       LOG(INFO) << "Initializing empty graph db";
       graph_.Init(schema, vertex_files, edge_files, data_dir_path, thread_num);
-      // graph_.Serialize(data_dir_path.string());
     }
   } else {
     LOG(INFO) << "Initializing graph db from data files of work directory";

--- a/flex/storages/rt_mutable_graph/mutable_csr.cc
+++ b/flex/storages/rt_mutable_graph/mutable_csr.cc
@@ -52,6 +52,7 @@ void MutableCsr<EDATA_T>::Serialize(const std::string& path) {
   }
 
   init_nbr_list_.dump_to_file(path + ".nbr_list", init_nbr_list_.size());
+  init_nbr_list_.release();
 }
 
 template <typename EDATA_T>
@@ -107,6 +108,7 @@ void MutableCsr<std::string>::Serialize(const std::string& path) {
     fflush(fout);
     fclose(fout);
   }
+  nbr_list_.clear();
 }
 
 void MutableCsr<std::string>::Deserialize(const std::string& path) {

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -313,7 +313,6 @@ void MutablePropertyFragment::Init(
       SerializeVertex(data_dir_path, v_label_i);
     }
     if (!vertex_files.empty()) {
-      // SerializeVertices(data_dir_path);
       LOG(INFO) << "finished loading vertices";
     }
 
@@ -337,7 +336,6 @@ void MutablePropertyFragment::Init(
       }
     }
     if (!edge_files.empty()) {
-      // SerializeEdges(data_dir_path);
       LOG(INFO) << "finished loading edges";
     }
   } else {
@@ -360,7 +358,6 @@ void MutablePropertyFragment::Init(
         thrd.join();
       }
       if (!vertex_files.empty()) {
-        // SerializeVertices(data_dir_path);
         LOG(INFO) << "finished loading vertices";
       }
     }
@@ -400,7 +397,6 @@ void MutablePropertyFragment::Init(
         thrd.join();
       }
       if (!edge_files.empty()) {
-        // SerializeEdges(data_dir_path);
         LOG(INFO) << "finished loading edges";
       }
     }
@@ -439,27 +435,6 @@ void MutablePropertyFragment::SerializeVertex(const std::string& prefix,
                                 vertex_num(index));
 }
 
-void MutablePropertyFragment::SerializeVertices(const std::string& prefix) {
-  std::string data_dir = prefix + "/data";
-  if (!std::filesystem::exists(data_dir)) {
-    std::filesystem::create_directory(data_dir);
-  }
-  auto io_adaptor = std::unique_ptr<grape::LocalIOAdaptor>(
-      new grape::LocalIOAdaptor(prefix + "/init_snapshot.bin"));
-  io_adaptor->Open("ab");
-  for (size_t i = 0; i < vertex_label_num_; ++i) {
-    lf_indexers_[i].Serialize(data_dir + "/indexer_" + std::to_string(i));
-  }
-  label_t cur_index = 0;
-  for (auto& table : vertex_data_) {
-    table.Serialize(io_adaptor,
-                    data_dir + "/vtable_" + std::to_string(cur_index),
-                    vertex_num(cur_index));
-    ++cur_index;
-  }
-  io_adaptor->Close();
-}
-
 void MutablePropertyFragment::SerializeEdge(const std::string& prefix,
                                             const std::string& src_label,
                                             const std::string& dst_label,
@@ -470,35 +445,6 @@ void MutablePropertyFragment::SerializeEdge(const std::string& prefix,
                         edge_label);
   oe_[index]->Serialize(data_dir + "/oe_" + src_label + "_" + dst_label + "_" +
                         edge_label);
-}
-void MutablePropertyFragment::SerializeEdges(const std::string& prefix) {
-  std::string data_dir = prefix + "/data";
-  if (!std::filesystem::exists(data_dir)) {
-    std::filesystem::create_directory(data_dir);
-  }
-  for (size_t src_label_i = 0; src_label_i != vertex_label_num_;
-       ++src_label_i) {
-    std::string src_label =
-        schema_.get_vertex_label_name(static_cast<label_t>(src_label_i));
-    for (size_t dst_label_i = 0; dst_label_i != vertex_label_num_;
-         ++dst_label_i) {
-      std::string dst_label =
-          schema_.get_vertex_label_name(static_cast<label_t>(dst_label_i));
-      for (size_t e_label_i = 0; e_label_i != edge_label_num_; ++e_label_i) {
-        std::string edge_label =
-            schema_.get_edge_label_name(static_cast<label_t>(e_label_i));
-        if (!schema_.exist(src_label, dst_label, edge_label)) {
-          continue;
-        }
-        size_t index = src_label_i * vertex_label_num_ * edge_label_num_ +
-                       dst_label_i * edge_label_num_ + e_label_i;
-        ie_[index]->Serialize(data_dir + "/ie_" + src_label + "_" + dst_label +
-                              "_" + edge_label);
-        oe_[index]->Serialize(data_dir + "/oe_" + src_label + "_" + dst_label +
-                              "_" + edge_label);
-      }
-    }
-  }
 }
 
 void MutablePropertyFragment::Serialize(const std::string& prefix) {

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.h
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.h
@@ -42,7 +42,7 @@ class MutablePropertyFragment {
       const std::vector<std::pair<std::string, std::string>>& vertex_files,
       const std::vector<std::tuple<std::string, std::string, std::string,
                                    std::string>>& edge_files,
-      int thread_num = 1);
+      const std::string& data_dir_path, int thread_num = 1);
 
   void IngestEdge(label_t src_label, vid_t src_lid, label_t dst_label,
                   vid_t dst_lid, label_t edge_label, timestamp_t ts,
@@ -51,6 +51,18 @@ class MutablePropertyFragment {
   const Schema& schema() const;
 
   void Serialize(const std::string& prefix);
+
+  void SerializeSchema(const std::string& prefix);
+
+  void SerializeVertex(const std::string& prefix, size_t index);
+
+  void SerializeVertices(const std::string& prefix);
+
+  void SerializeEdges(const std::string& prefix);
+
+  void SerializeEdge(const std::string& prefix, const std::string& src_label,
+                     const std::string& dst_label,
+                     const std::string& edge_label, size_t index);
 
   void Deserialize(const std::string& prefix);
 

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -692,16 +692,15 @@ void build_lf_indexer(const IdIndexer<int64_t, INDEX_T>& input,
   lf.hash_policy_.set_mod_function_by_index(
       input.hash_policy_.get_mod_function_index());
   lf.num_slots_minus_one_ = input.num_slots_minus_one_;
-  std::vector<std::pair<int64_t,INDEX_T>> res;
+  std::vector<std::pair<int64_t, INDEX_T>> res;
   for (auto oid : input.keys_) {
     size_t index = input.hash_policy_.index_for_hash(
         input.hasher_(oid), input.num_slots_minus_one_);
     for (int8_t distance = 0; input.distances_[index] >= distance;
          ++distance, ++index) {
-      
       INDEX_T ret = input.indices_[index];
       if (input.keys_[ret] == oid) {
-        if(index >= input.num_slots_minus_one_){
+        if (index >= input.num_slots_minus_one_) {
           res.emplace_back(oid, ret);
         } else {
           lf.indices_[index] = ret;
@@ -712,11 +711,11 @@ void build_lf_indexer(const IdIndexer<int64_t, INDEX_T>& input,
   }
   static constexpr INDEX_T sentinel = std::numeric_limits<INDEX_T>::max();
 
-  for(const auto& [oid, lid]: res){
+  for (const auto& [oid, lid] : res) {
     size_t index = input.hash_policy_.index_for_hash(
         input.hasher_(oid), input.num_slots_minus_one_);
     while (true) {
-      if(lf.indices_[index] == sentinel){
+      if (lf.indices_[index] == sentinel) {
         lf.indices_[index] = lid;
         break;
       }

--- a/flex/utils/property/column.h
+++ b/flex/utils/property/column.h
@@ -70,6 +70,7 @@ class TypedColumn : public ColumnBase {
 
   void Serialize(const std::string& path, size_t size) override {
     buffer_.dump_to_file(path, size);
+    buffer_.release();
   }
 
   void Deserialize(const std::string& path) override {

--- a/flex/utils/property/table.cc
+++ b/flex/utils/property/table.cc
@@ -167,6 +167,14 @@ void Table::Serialize(std::unique_ptr<grape::LocalIOAdaptor>& writer,
   }
 }
 
+void Table::Serialize(const std::string& prefix, size_t row_num) {
+  std::unique_ptr<grape::LocalIOAdaptor> writer(
+      new grape::LocalIOAdaptor(prefix + ".meta"));
+  writer->Open("wb");
+  Serialize(writer, prefix, row_num);
+  writer->Close();
+}
+
 void Table::Deserialize(std::unique_ptr<grape::LocalIOAdaptor>& reader,
                         const std::string& prefix) {
   col_id_indexer_.Deserialize(reader);
@@ -188,6 +196,14 @@ void Table::Deserialize(std::unique_ptr<grape::LocalIOAdaptor>& reader,
   }
 
   buildColumnPtrs();
+}
+
+void Table::Deserialize(const std::string& prefix) {
+  std::unique_ptr<grape::LocalIOAdaptor> reader(
+      new grape::LocalIOAdaptor(prefix + ".meta"));
+  reader->Open();
+  Deserialize(reader, prefix);
+  reader->Close();
 }
 
 Any Table::at(size_t row_id, size_t col_id) {

--- a/flex/utils/property/table.h
+++ b/flex/utils/property/table.h
@@ -65,8 +65,11 @@ class Table {
   void Serialize(std::unique_ptr<grape::LocalIOAdaptor>& writer,
                  const std::string& prefix, size_t row_num);
 
+  void Serialize(const std::string& prefix, size_t row_num);
+
   void Deserialize(std::unique_ptr<grape::LocalIOAdaptor>& reader,
                    const std::string& prefix);
+  void Deserialize(const std::string& prefix);
 
   Any at(size_t row_id, size_t col_id);
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Fix a bug in idindexer, Immediately serialize after reading each file.

## Related issue number



