### PR TITLE
fix(interactive): Not requiring eid in update/delete edges in groot

### DIFF
--- a/interactive_engine/assembly/src/conf/groot/logback.xml
+++ b/interactive_engine/assembly/src/conf/groot/logback.xml
@@ -1,4 +1,5 @@
 <configuration scan="true" scanPeriod="30 seconds">
+    <define name="hostname" class="ch.qos.logback.core.property.CanonicalHostNamePropertyDefiner"/>
     <property name="log_dir" value="${log.dir:-/var/log/graphscope}"/>
     <property name="log_name" value="${log.name:-groot}"/>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -6,16 +7,16 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${log_dir}/${log_name}.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>60</maxHistory>
-            <totalSizeCap>10GB</totalSizeCap>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>[%d{ISO8601}][%p][%t][%c:%L] %m%n</pattern>
+            <pattern>[%d{ISO8601}][%p][%t][${hostname}][%c:%L] %m%n</pattern>
         </encoder>
     </appender>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%d{ISO8601}][%p][%t][%c:%L] %m%n</pattern>
+            <pattern>[%d{ISO8601}][%p][%t][${hostname}][%c:%L] %m%n</pattern>
         </encoder>
     </appender>
     <appender name="Metric" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -23,8 +24,8 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${log_dir}/metric.log.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>100MB</maxFileSize>
-            <maxHistory>60</maxHistory>
-            <totalSizeCap>10GB</totalSizeCap>
+            <maxHistory>10</maxHistory>
+            <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
             <pattern>%m%n</pattern>

--- a/interactive_engine/executor/assembly/groot/src/store/graph.rs
+++ b/interactive_engine/executor/assembly/groot/src/store/graph.rs
@@ -368,7 +368,7 @@ fn delete_vertex<G: MultiVersionGraph>(graph: &G, snapshot_id: i64, op: &Operati
 }
 
 fn overwrite_edge<G: MultiVersionGraph>(graph: &G, snapshot_id: i64, op: &OperationPb) -> GraphResult<()> {
-    trace!("overwrite_edge");
+    debug!("overwrite_edge");
     let data_operation_pb = parse_pb::<DataOperationPb>(op.get_dataBytes())?;
 
     let edge_id_pb = parse_pb::<EdgeIdPb>(data_operation_pb.get_keyBlob())?;
@@ -388,7 +388,7 @@ fn overwrite_edge<G: MultiVersionGraph>(graph: &G, snapshot_id: i64, op: &Operat
 }
 
 fn update_edge<G: MultiVersionGraph>(graph: &G, snapshot_id: i64, op: &OperationPb) -> GraphResult<()> {
-    trace!("update_edge");
+    debug!("update_edge");
     let data_operation_pb = parse_pb::<DataOperationPb>(op.get_dataBytes())?;
 
     let edge_id_pb = parse_pb::<EdgeIdPb>(data_operation_pb.get_keyBlob())?;
@@ -405,7 +405,7 @@ fn update_edge<G: MultiVersionGraph>(graph: &G, snapshot_id: i64, op: &Operation
 fn clear_edge_properties<G: MultiVersionGraph>(
     graph: &G, snapshot_id: i64, op: &OperationPb,
 ) -> GraphResult<()> {
-    trace!("update_edge");
+    debug!("clear_edge_properties");
     let data_operation_pb = parse_pb::<DataOperationPb>(op.get_dataBytes())?;
 
     let edge_id_pb = parse_pb::<EdgeIdPb>(data_operation_pb.get_keyBlob())?;
@@ -420,7 +420,7 @@ fn clear_edge_properties<G: MultiVersionGraph>(
 }
 
 fn delete_edge<G: MultiVersionGraph>(graph: &G, snapshot_id: i64, op: &OperationPb) -> GraphResult<()> {
-    trace!("delete_edge");
+    debug!("delete_edge");
     let data_operation_pb = parse_pb::<DataOperationPb>(op.get_dataBytes())?;
 
     let edge_id_pb = parse_pb::<EdgeIdPb>(data_operation_pb.get_keyBlob())?;

--- a/interactive_engine/executor/common/dyn_type/src/serde.rs
+++ b/interactive_engine/executor/common/dyn_type/src/serde.rs
@@ -17,10 +17,10 @@ use std::any::TypeId;
 use std::collections::BTreeMap;
 use std::io;
 
+use chrono::{Datelike, Timelike};
 use pegasus_common::codec::{Decode, Encode, ReadExt, WriteExt};
 
 use crate::{de_dyn_obj, DateTimeFormats, Object, Primitives};
-use chrono::{Datelike, Timelike};
 
 impl Encode for Primitives {
     fn write_to<W: WriteExt>(&self, writer: &mut W) -> io::Result<()> {

--- a/interactive_engine/executor/ir/core/src/plan/logical.rs
+++ b/interactive_engine/executor/ir/core/src/plan/logical.rs
@@ -20,13 +20,12 @@ use std::fmt;
 use std::iter::FromIterator;
 use std::rc::Rc;
 
+use fraction::Fraction;
 use ir_common::error::ParsePbError;
 use ir_common::generated::algebra as pb;
 use ir_common::generated::algebra::pattern::binder::Item;
 use ir_common::generated::common as common_pb;
 use ir_common::{KeyId, LabelId, NameOrId};
-
-use fraction::Fraction;
 use vec_map::VecMap;
 
 use crate::error::{IrError, IrResult};
@@ -1580,7 +1579,7 @@ impl AsLogical for pb::Unfold {
             let curr_node = plan_meta.get_curr_node();
             let tag_id = get_or_set_tag_id(tag, plan_meta)?;
             // plan_meta.set_tag_nodes(tag_id, plan_meta.get_curr_referred_nodes().to_vec());
-            
+
             let tag_nodes = plan_meta.get_tag_nodes(tag_id).to_vec();
             plan_meta.refer_to_nodes(curr_node, tag_nodes.clone());
         }

--- a/interactive_engine/executor/store/groot/src/api/mod.rs
+++ b/interactive_engine/executor/store/groot/src/api/mod.rs
@@ -14,7 +14,7 @@
 //! limitations under the License.
 
 pub mod condition;
-mod elem;
+pub mod elem;
 mod filter;
 mod multi_version;
 pub mod prelude;

--- a/interactive_engine/executor/store/groot/src/db/graph/iter.rs
+++ b/interactive_engine/executor/store/groot/src/db/graph/iter.rs
@@ -182,12 +182,13 @@ impl IntoIterator for EdgeKindScan {
                     {
                         Ok(decoder) => {
                             let edge_kind = self.edge_kind_info.get_type();
-                            Some(Ok(RocksEdgeImpl::new(
+                            let edge = RocksEdgeImpl::new(
                                 edge_id.into(),
                                 edge_kind.into(),
                                 Some(decoder),
                                 raw_val,
-                            )))
+                            );
+                            Some(Ok(edge))
                         }
                         Err(e) => Some(Err(e.into())),
                     }

--- a/interactive_engine/executor/store/groot/src/db/graph/types/edge.rs
+++ b/interactive_engine/executor/store/groot/src/db/graph/types/edge.rs
@@ -152,6 +152,7 @@ pub struct EdgeInfoIter {
 
 impl EdgeInfoIter {
     pub fn next(&mut self) -> Option<EdgeInfoRef> {
+        debug!("EdgeInfoIter::next");
         loop {
             let info = self.inner.next()?.as_ref();
             if info.is_alive_at(self.si) {
@@ -161,6 +162,7 @@ impl EdgeInfoIter {
     }
 
     pub fn next_info(&mut self) -> Option<Arc<EdgeInfo>> {
+        debug!("EdgeInfoIter::next_info");
         loop {
             let info = self.inner.next()?;
             if info.is_alive_at(self.si) {
@@ -204,6 +206,7 @@ impl EdgeTypeManager {
     }
 
     pub fn get_edge(&self, si: SnapshotId, label: LabelId) -> GraphResult<EdgeInfoRef> {
+        debug!("EdgeTypeManager::get_edge");
         let guard = epoch::pin();
         let inner = self.get_inner(&guard);
         let info = res_unwrap!(inner.get_edge(si, label), get_edge, si, label)?;
@@ -212,6 +215,7 @@ impl EdgeTypeManager {
     }
 
     pub fn get_edge_info(&self, si: SnapshotId, label: LabelId) -> GraphResult<Arc<EdgeInfo>> {
+        debug!("EdgeTypeManager::get_edge_info");
         let guard = &epoch::pin();
         let inner = self.get_inner(guard);
         let ret = res_unwrap!(inner.get_edge_info(si, label), get_edge, si, label)?;
@@ -219,6 +223,7 @@ impl EdgeTypeManager {
     }
 
     pub fn get_all_edges(&self, si: SnapshotId) -> EdgeInfoIter {
+        debug!("EdgeTypeManager::get_all_edges");
         let guard = epoch::pin();
         let inner = self.get_inner(&guard);
         let iter = inner.get_all_edges();
@@ -348,6 +353,7 @@ impl EdgeManagerInner {
     }
 
     fn get_edge(&self, si: SnapshotId, label: LabelId) -> GraphResult<&EdgeInfo> {
+        debug!("EdgeManagerInner::get_edge {:?}", label);
         if let Some(info) = self.info_map.get(&label) {
             if info.lifetime.is_alive_at(si) {
                 return Ok(info.as_ref());
@@ -362,16 +368,17 @@ impl EdgeManagerInner {
     }
 
     fn get_edge_info(&self, si: SnapshotId, label: LabelId) -> GraphResult<Arc<EdgeInfo>> {
+        debug!("EdgeManagerInner::get_edge_info {:?}", label);
         if let Some(info) = self.info_map.get(&label) {
             if info.lifetime.is_alive_at(si) {
                 return Ok(info.clone());
             }
             let msg = format!("edge#{} is not alive at {}", label, si);
-            let err = gen_graph_err!(GraphErrorCode::TypeNotFound, msg, get_edge, si, label);
+            let err = gen_graph_err!(GraphErrorCode::TypeNotFound, msg, get_edge_info, si, label);
             return Err(err);
         }
         let msg = format!("edge#{} not found", label);
-        let err = gen_graph_err!(GraphErrorCode::TypeNotFound, msg, get_edge, si, label);
+        let err = gen_graph_err!(GraphErrorCode::TypeNotFound, msg, get_edge_info, si, label);
         Err(err)
     }
 
@@ -391,6 +398,7 @@ impl EdgeManagerInner {
     }
 
     fn get_all_edges(&self) -> Values<LabelId, Arc<EdgeInfo>> {
+        debug!("EdgeManagerInner::get_all_edges");
         self.info_map.values()
     }
 

--- a/interactive_engine/groot-client/src/main/java/com/alibaba/graphscope/groot/sdk/GrootClient.java
+++ b/interactive_engine/groot-client/src/main/java/com/alibaba/graphscope/groot/sdk/GrootClient.java
@@ -129,13 +129,18 @@ public class GrootClient {
         submit(requests, callback);
     }
 
-    private long modifyVerticesAndEdge(List<Vertex> vertices, List<Edge> edges, WriteTypePb writeType) {
+    private long modifyVerticesAndEdge(
+            List<Vertex> vertices, List<Edge> edges, WriteTypePb writeType) {
         List<WriteRequestPb> requests = getVertexWriteRequestPbs(vertices, writeType);
         requests.addAll(getEdgeWriteRequestPbs(edges, writeType));
         return submit(requests);
     }
 
-    private void modifyVerticesAndEdge(List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback, WriteTypePb writeType) {
+    private void modifyVerticesAndEdge(
+            List<Vertex> vertices,
+            List<Edge> edges,
+            StreamObserver<BatchWriteResponse> callback,
+            WriteTypePb writeType) {
         List<WriteRequestPb> requests = getVertexWriteRequestPbs(vertices, writeType);
         requests.addAll(getEdgeWriteRequestPbs(edges, writeType));
         submit(requests, callback);
@@ -153,15 +158,18 @@ public class GrootClient {
         return modifyVerticesAndEdge(vertices, edges, WriteTypePb.DELETE);
     }
 
-    public void addVerticesAndEdges(List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
+    public void addVerticesAndEdges(
+            List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
         modifyVerticesAndEdge(vertices, edges, callback, WriteTypePb.INSERT);
     }
 
-    public void updateVerticesAndEdges(List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
+    public void updateVerticesAndEdges(
+            List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
         modifyVerticesAndEdge(vertices, edges, callback, WriteTypePb.UPDATE);
     }
 
-    public void deleteVerticesAndEdges(List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
+    public void deleteVerticesAndEdges(
+            List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
         modifyVerticesAndEdge(vertices, edges, callback, WriteTypePb.DELETE);
     }
 

--- a/interactive_engine/groot-client/src/main/java/com/alibaba/graphscope/groot/sdk/GrootClient.java
+++ b/interactive_engine/groot-client/src/main/java/com/alibaba/graphscope/groot/sdk/GrootClient.java
@@ -129,6 +129,42 @@ public class GrootClient {
         submit(requests, callback);
     }
 
+    private long modifyVerticesAndEdge(List<Vertex> vertices, List<Edge> edges, WriteTypePb writeType) {
+        List<WriteRequestPb> requests = getVertexWriteRequestPbs(vertices, writeType);
+        requests.addAll(getEdgeWriteRequestPbs(edges, writeType));
+        return submit(requests);
+    }
+
+    private void modifyVerticesAndEdge(List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback, WriteTypePb writeType) {
+        List<WriteRequestPb> requests = getVertexWriteRequestPbs(vertices, writeType);
+        requests.addAll(getEdgeWriteRequestPbs(edges, writeType));
+        submit(requests, callback);
+    }
+
+    public long addVerticesAndEdges(List<Vertex> vertices, List<Edge> edges) {
+        return modifyVerticesAndEdge(vertices, edges, WriteTypePb.INSERT);
+    }
+
+    public long updateVerticesAndEdges(List<Vertex> vertices, List<Edge> edges) {
+        return modifyVerticesAndEdge(vertices, edges, WriteTypePb.UPDATE);
+    }
+
+    public long deleteVerticesAndEdges(List<Vertex> vertices, List<Edge> edges) {
+        return modifyVerticesAndEdge(vertices, edges, WriteTypePb.DELETE);
+    }
+
+    public void addVerticesAndEdges(List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
+        modifyVerticesAndEdge(vertices, edges, callback, WriteTypePb.INSERT);
+    }
+
+    public void updateVerticesAndEdges(List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
+        modifyVerticesAndEdge(vertices, edges, callback, WriteTypePb.UPDATE);
+    }
+
+    public void deleteVerticesAndEdges(List<Vertex> vertices, List<Edge> edges, StreamObserver<BatchWriteResponse> callback) {
+        modifyVerticesAndEdge(vertices, edges, callback, WriteTypePb.DELETE);
+    }
+
     /**
      * Add vertex by realtime write
      * @param vertex vertex that contains label and pk properties and other properties

--- a/interactive_engine/groot-client/src/main/java/com/alibaba/graphscope/groot/sdk/schema/Edge.java
+++ b/interactive_engine/groot-client/src/main/java/com/alibaba/graphscope/groot/sdk/schema/Edge.java
@@ -12,6 +12,8 @@ public class Edge {
     public Map<String, String> dstPk;
     public Map<String, String> properties;
 
+    public long eid;
+
     /**
      * Construct an edge
      * @param label edge label
@@ -59,6 +61,10 @@ public class Edge {
         this(label, src, dst, null);
     }
 
+    public void setEid(long eid) {
+        this.eid = eid;
+    }
+
     public String getLabel() {
         return label;
     }
@@ -88,6 +94,7 @@ public class Edge {
                 .setLabel(label)
                 .setSrcVertexKey(toVertexRecordKey(srcLabel, srcPk))
                 .setDstVertexKey(toVertexRecordKey(dstLabel, dstPk))
+                .setInnerId(eid)
                 .build();
     }
 

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/ClientWriteService.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/ClientWriteService.java
@@ -42,7 +42,7 @@ public class ClientWriteService extends ClientWriteGrpc.ClientWriteImplBase {
         String writeSession = request.getClientId();
         int writeRequestsCount = request.getWriteRequestsCount();
         List<WriteRequest> writeRequests = new ArrayList<>(writeRequestsCount);
-        logger.info(
+        logger.debug(
                 "received batchWrite request. requestId ["
                         + requestId
                         + "] writeSession ["

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/GraphWriter.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/GraphWriter.java
@@ -205,6 +205,10 @@ public class GraphWriter implements MetricsAgent {
     private void addUpdateEdgeOperation(
             OperationBatch.Builder batchBuilder, GraphSchema schema, DataRecord dataRecord) {
         EdgeId edgeId = getEdgeId(schema, dataRecord, false);
+        if (edgeId.id == 0) {
+                // This is for update edge, if edgeInnerId is 0, generate new id, incase there isn't such a edge
+                edgeId.id = edgeIdGenerator.getNextId();
+        }
         EdgeKind edgeKind = getEdgeKind(schema, dataRecord);
         GraphElement edgeDef = schema.getElement(edgeKind.getEdgeLabelId().getId());
 
@@ -356,7 +360,6 @@ public class GraphWriter implements MetricsAgent {
                     getPrimaryKeysHashId(dstVertexDef.getLabelId(), dstVertexPkVals, dstVertexDef);
             long edgeInnerId =
                     overwrite ? edgeIdGenerator.getNextId() : edgeRecordKey.getEdgeInnerId();
-
             return new EdgeId(
                     new VertexId(srcVertexHashId), new VertexId(dstVertexHashId), edgeInnerId);
         }

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/GraphWriter.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/GraphWriter.java
@@ -206,8 +206,9 @@ public class GraphWriter implements MetricsAgent {
             OperationBatch.Builder batchBuilder, GraphSchema schema, DataRecord dataRecord) {
         EdgeId edgeId = getEdgeId(schema, dataRecord, false);
         if (edgeId.id == 0) {
-                // This is for update edge, if edgeInnerId is 0, generate new id, incase there isn't such a edge
-                edgeId.id = edgeIdGenerator.getNextId();
+            // This is for update edge, if edgeInnerId is 0, generate new id, incase there isn't
+            // such a edge
+            edgeId.id = edgeIdGenerator.getNextId();
         }
         EdgeKind edgeKind = getEdgeKind(schema, dataRecord);
         GraphElement edgeDef = schema.getElement(edgeKind.getEdgeLabelId().getId());

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/operation/EdgeId.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/operation/EdgeId.java
@@ -17,9 +17,9 @@ import com.alibaba.graphscope.proto.groot.EdgeIdPb;
 
 public class EdgeId {
 
-    private VertexId srcId;
-    private VertexId dstId;
-    private long id;
+    public VertexId srcId;
+    public VertexId dstId;
+    public long id;
 
     public EdgeId(VertexId srcId, VertexId dstId, long id) {
         this.srcId = srcId;


### PR DESCRIPTION
- Add API for writing vertices and edges in one batch
- Add eid to the Edge class in client
- Update an not existing edge will create a new edge.
- Update and Delete when eid is not given will try to search for it by src and dst vertex first.

