### PR TITLE
fix(interactive): Fix several bugs in data-load-tools 

### DIFF
--- a/charts/graphscope-store/templates/configmap.yaml
+++ b/charts/graphscope-store/templates/configmap.yaml
@@ -25,7 +25,7 @@ data:
     ingestor.node.count={{ .Values.ingestor.replicaCount }}
     coordinator.node.count={{ .Values.coordinator.replicaCount }}
     ingestor.queue.count={{ .Values.ingestor.replicaCount }}
-    partition.count={{ .Values.store.replicaCount | mul 128 }}
+    partition.count={{ .Values.store.replicaCount | mul 16 }}
     engine.type={{ .Values.engineType }}
     discovery.mode={{ .Values.discoveryMode }}
 

--- a/interactive_engine/assembly/src/bin/groot/store_ctl.sh
+++ b/interactive_engine/assembly/src/bin/groot/store_ctl.sh
@@ -98,7 +98,7 @@ start_server() {
             -XX:+PrintGCApplicationStoppedTime
             -Xloggc:${LOG_DIR}/${LOG_NAME}.gc.log
             -XX:+UseGCLogFileRotation
-            -XX:NumberOfGCLogFiles=32
+            -XX:NumberOfGCLogFiles=4
             -XX:GCLogFileSize=64m"
 
 	java ${java_opt} \
@@ -107,7 +107,7 @@ start_server() {
 		-Dlog.dir="${LOG_DIR}" \
 		-Dlog.name="${LOG_NAME}" \
 		-cp "${libpath}" com.alibaba.graphscope.groot.servers.GrootGraph \
-		"$@" > >(tee -a "${LOG_DIR}/${LOG_NAME}.out") 2> >(tee -a "${LOG_DIR}/${LOG_NAME}.err" >&2)
+		"$@" # > >(tee -a "${LOG_DIR}/${LOG_NAME}.out") 2> >(tee -a "${LOG_DIR}/${LOG_NAME}.err" >&2)
 }
 
 # parse argv

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/util/PkHashUtils.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/util/PkHashUtils.java
@@ -43,12 +43,12 @@ public final class PkHashUtils {
     }
 
     /**
-     * Generates 64 bit hash from byte array of the given length and seed.
+     * Generates 64-bit hash from byte array of the given length and seed.
      *
      * @param data byte array to hash
      * @param length length of the array to hash
      * @param seed initial seed value
-     * @return 64 bit hash of the given array
+     * @return 64-bit hash of the given array
      */
     private static long hash64(final byte[] data, int length, int seed) {
         final long m = 0xc6a4a7935bd1e995L;
@@ -103,11 +103,11 @@ public final class PkHashUtils {
     }
 
     /**
-     * Generates 64 bit hash from byte array with default seed value.
+     * Generates 64-bit hash from byte array with default seed value.
      *
      * @param data byte array to hash
      * @param length length of the array to hash
-     * @return 64 bit hash of the given string
+     * @return 64-bit hash of the given string
      */
     private static long hash64(final byte[] data, int length) {
         return hash64(data, length, 0xc70f6907);

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildMapperOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildMapperOdps.java
@@ -82,7 +82,7 @@ public class DataBuildMapperOdps extends MapperBase {
         String[] items = new String[columnCount];
         for (int i = 0; i < columnCount; i++) {
             if (record.get(i) == null) {
-                //                items[i] = "";
+                // items[i] = "";
                 items[i] = null;
             } else {
                 items[i] = record.get(i).toString();

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildMapperOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildMapperOdps.java
@@ -66,10 +66,10 @@ public class DataBuildMapperOdps extends MapperBase {
     @Override
     public void map(long recordNum, Record record, TaskContext context) throws IOException {
         TableInfo tableInfo = context.getInputTableInfo();
-        String tableName = tableInfo.getTableName();
-        ColumnMappingInfo info = this.fileToColumnMappingInfo.get(tableName);
+        String identifier = tableInfo.getTableName() + "|" + tableInfo.getPartPath();
+        ColumnMappingInfo info = this.fileToColumnMappingInfo.get(identifier);
         if (info == null) {
-            logger.warn("Mapper: ignore [{}], table info: [{}]", tableName, tableInfo);
+            logger.warn("Mapper: ignore [{}], table info: [{}]", identifier, tableInfo);
             return;
         }
         String[] items = Utils.parseRecords(record);

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildMapperOdpsDebug.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildMapperOdpsDebug.java
@@ -19,6 +19,7 @@ import com.alibaba.graphscope.groot.common.config.DataLoadConfig;
 import com.alibaba.graphscope.groot.common.schema.api.*;
 import com.alibaba.graphscope.groot.common.schema.mapper.GraphSchemaMapper;
 import com.alibaba.graphscope.groot.common.schema.wrapper.PropertyValue;
+import com.alibaba.graphscope.groot.common.util.SchemaUtils;
 import com.aliyun.odps.data.Record;
 import com.aliyun.odps.data.TableInfo;
 import com.aliyun.odps.mapred.MapperBase;
@@ -29,25 +30,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.text.SimpleDateFormat;
+import java.nio.ByteBuffer;
 import java.util.*;
 
-public class DataBuildMapperOdps extends MapperBase {
-    private static final Logger logger = LoggerFactory.getLogger(DataBuildMapperOdps.class);
-    public static final SimpleDateFormat DST_FMT = new SimpleDateFormat("yyyyMMddHHmmssSSS");
-    public static String charSet = "ISO8859-1";
-
+public class DataBuildMapperOdpsDebug extends MapperBase {
+    private static final Logger logger = LoggerFactory.getLogger(DataBuildMapperOdpsDebug.class);
     private GraphSchema graphSchema;
     private DataEncoder dataEncoder;
     private Map<String, ColumnMappingInfo> fileToColumnMappingInfo;
 
     private Record outKey;
-    private Record outVal;
 
     @Override
     public void setup(TaskContext context) throws IOException {
-        outKey = context.createMapOutputKeyRecord();
-        outVal = context.createMapOutputValueRecord();
+        outKey = context.createOutputRecord();
 
         String metaData = context.getJobConf().get(DataLoadConfig.META_INFO);
         ObjectMapper objectMapper = new ObjectMapper();
@@ -60,7 +56,6 @@ public class DataBuildMapperOdps extends MapperBase {
         fileToColumnMappingInfo =
                 objectMapper.readValue(
                         columnMappingsJson, new TypeReference<Map<String, ColumnMappingInfo>>() {});
-        DST_FMT.setTimeZone(TimeZone.getTimeZone("GMT+00:00"));
     }
 
     @Override
@@ -72,6 +67,7 @@ public class DataBuildMapperOdps extends MapperBase {
             logger.warn("Mapper: ignore [{}], table info: [{}]", tableName, tableInfo);
             return;
         }
+
         String[] items = Utils.parseRecords(record);
 
         int labelId = info.getLabelId();
@@ -80,26 +76,69 @@ public class DataBuildMapperOdps extends MapperBase {
         Map<Integer, Integer> colMap = info.getPropertiesColMap();
         Map<Integer, PropertyValue> properties = Utils.buildProperties(type, items, colMap);
 
-        BytesRef valRef = this.dataEncoder.encodeProperties(labelId, properties);
-        outVal.set(new Object[] {new String(valRef.getBytes(), charSet)});
         if (type instanceof GraphVertex) {
+            outKey.set(1, getVertexRawKeys((GraphVertex) type, items));
             BytesRef keyRef =
                     Utils.getVertexKeyRef(dataEncoder, (GraphVertex) type, properties, tableId);
-            outKey.set(new Object[] {new String(keyRef.getBytes(), charSet)});
-            context.write(outKey, outVal);
+            outKey.set(0, getVertexKeyEncoded(keyRef));
+            context.write(outKey);
         } else if (type instanceof GraphEdge) {
+            outKey.set(1, getEdgeRawKeys(info, items));
             BytesRef out =
                     Utils.getEdgeKeyRef(
                             dataEncoder, graphSchema, info, items, properties, tableId, true);
-            outKey.set(new Object[] {new String(out.getBytes(), charSet)});
-            context.write(outKey, outVal);
+            outKey.set(0, getEdgeKeyEncoded(out));
+            context.write(outKey);
             BytesRef in =
                     Utils.getEdgeKeyRef(
                             dataEncoder, graphSchema, info, items, properties, tableId, false);
-            outKey.set(new Object[] {new String(in.getBytes(), charSet)});
-            context.write(outKey, outVal);
+            outKey.set(0, getEdgeKeyEncoded(in));
+            context.write(outKey);
         } else {
             throw new IllegalArgumentException("Invalid label " + labelId);
         }
+    }
+
+    private String getVertexRawKeys(GraphVertex type, String[] items) throws IOException {
+        List<Integer> pkIds = SchemaUtils.getVertexPrimaryKeyList(type);
+        return concatenateItemsByIndices(items, pkIds);
+    }
+
+    private String getEdgeRawKeys(ColumnMappingInfo info, String[] items) throws IOException {
+        Map<Integer, Integer> srcPkColMap = info.getSrcPkColMap();
+        Map<Integer, Integer> dstPkColMap = info.getDstPkColMap();
+
+        List<Integer> pkIds = new ArrayList<>(srcPkColMap.keySet());
+        pkIds.addAll(dstPkColMap.keySet());
+        return concatenateItemsByIndices(items, pkIds);
+    }
+
+    private static String concatenateItemsByIndices(String[] array, List<Integer> indices)
+            throws IOException {
+        StringBuilder builder = new StringBuilder();
+        if (indices.isEmpty()) {
+            throw new IOException("indices are empty!");
+        }
+        for (int index : indices) {
+            builder.append(array[index]).append(",");
+        }
+        builder.deleteCharAt(builder.length() - 1);
+        return builder.toString();
+    }
+
+    private String getVertexKeyEncoded(BytesRef keyRef) {
+        ByteBuffer buffer = ByteBuffer.wrap(keyRef.getBytes());
+        long tableId = buffer.getLong(0);
+        long hashId = buffer.getLong(8);
+        return tableId + "|" + hashId;
+    }
+
+    private String getEdgeKeyEncoded(BytesRef keyRef) {
+        ByteBuffer buffer = ByteBuffer.wrap(keyRef.getBytes());
+        long tableId = buffer.getLong(0);
+        long srcHashId = buffer.getLong(8);
+        long dstHashId = buffer.getLong(16);
+        long eid = buffer.getLong(24);
+        return tableId + "|" + srcHashId + "|" + dstHashId + "|" + eid;
     }
 }

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildMapperOdpsDebug.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildMapperOdpsDebug.java
@@ -137,7 +137,7 @@ public class DataBuildMapperOdpsDebug extends MapperBase {
         ByteBuffer buffer = ByteBuffer.wrap(keyRef.getBytes());
         long tableId = buffer.getLong(0);
         long hashId = buffer.getLong(8);
-        return tableId + "|" + hashId;
+        return tableId + "/" + hashId;
     }
 
     private String getEdgeKeyEncoded(BytesRef keyRef) {
@@ -146,6 +146,6 @@ public class DataBuildMapperOdpsDebug extends MapperBase {
         long srcHashId = buffer.getLong(8);
         long dstHashId = buffer.getLong(16);
         long eid = buffer.getLong(24);
-        return tableId + "|" + srcHashId + "|" + dstHashId + "|" + eid;
+        return tableId + "/" + srcHashId + "/" + dstHashId + "/" + eid;
     }
 }

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildReducerOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataBuildReducerOdps.java
@@ -97,6 +97,7 @@ public class DataBuildReducerOdps extends ReducerBase {
         }
 
         String chkData = sstFileEmpty ? "0" : "1," + getFileMD5(sstFileName);
+        System.out.println("Checksum: " + chkData);
         writeFile(chkFileName, chkData);
 
         fs.copy(chkFileName, Paths.get(uniquePath, chkFileName).toString());

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataEncoder.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/DataEncoder.java
@@ -50,6 +50,9 @@ public class DataEncoder {
         scratch.putLong(tableId << 1);
         scratch.putLong(hashId);
         scratch.putLong(SNAPSHOT_ID);
+        // System.out.println("EncodeVertexKey: labelId:" + type.getLabelId() + "; tableId:" +
+        // tableId);
+        // System.out.println("scratch: [" + (tableId << 1) + "],[" + hashId + "]");
         flip(scratch);
         return new BytesRef(scratch.array(), 0, scratch.limit());
     }

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
@@ -25,6 +25,7 @@ import com.alibaba.graphscope.groot.dataload.util.OSSFS;
 import com.alibaba.graphscope.groot.dataload.util.VolumeFS;
 import com.alibaba.graphscope.groot.sdk.GrootClient;
 import com.alibaba.graphscope.proto.groot.DataLoadTargetPb;
+import com.alibaba.graphscope.proto.groot.GraphDefPb;
 import com.aliyun.odps.Odps;
 import com.aliyun.odps.data.TableInfo;
 import com.aliyun.odps.mapred.JobClient;
@@ -103,7 +104,10 @@ public class OfflineBuildOdps {
                         .setPassword(password)
                         .build();
 
-        GraphSchema schema = GraphDef.parseProto(client.prepareDataLoad(targets));
+        GraphDefPb graphDefPb = client.prepareDataLoad(targets);
+        System.out.println("GraphDef: " + graphDefPb);
+        GraphSchema schema = GraphDef.parseProto(graphDefPb);
+
         String schemaJson = GraphSchemaMapper.parseFromSchema(schema).toJsonString();
         // number of reduce task
         int partitionNum = client.getPartitionNum();
@@ -133,7 +137,7 @@ public class OfflineBuildOdps {
         job.set("odps.mr.run.mode", "sql");
         job.set("odps.mr.sql.group.enable", "true");
         job.setFunctionTimeout(2400);
-        job.setMemoryForReducerJVM(2048);
+        job.setMemoryForReducerJVM(4096);
 
         for (Map.Entry<String, GraphElement> entry : tableType.entrySet()) {
             if (entry.getValue() instanceof GraphVertex || entry.getValue() instanceof GraphEdge) {

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
@@ -54,7 +54,7 @@ public class OfflineBuildOdps {
         odps = SessionState.get().getOdps();
 
         String configStr = properties.getProperty(DataLoadConfig.COLUMN_MAPPING_CONFIG);
-        configStr = Utils.replaceVars(configStr, Arrays.copyOfRange(args,1, args.length));
+        configStr = Utils.replaceVars(configStr, Arrays.copyOfRange(args, 1, args.length));
 
         String graphEndpoint = properties.getProperty(DataLoadConfig.GRAPH_ENDPOINT);
         String username = properties.getProperty(DataLoadConfig.USER_NAME, "");
@@ -95,7 +95,8 @@ public class OfflineBuildOdps {
         job.setMapOutputKeySchema(SchemaUtils.fromString("key:string"));
         job.setMapOutputValueSchema(SchemaUtils.fromString("value:string"));
 
-        mappingConfig.forEach((name, x) -> InputUtils.addTable(Utils.parseTableURL(odps, name), job));
+        mappingConfig.forEach(
+                (name, x) -> InputUtils.addTable(Utils.parseTableURL(odps, name), job));
 
         String dataSinkType = properties.getProperty(DataLoadConfig.DATA_SINK_TYPE, "VOLUME");
         Map<String, String> config;

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdpsDebug.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdpsDebug.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alibaba.graphscope.groot.dataload.databuild;
+
+import com.alibaba.graphscope.groot.common.config.DataLoadConfig;
+import com.alibaba.graphscope.groot.common.schema.api.GraphSchema;
+import com.alibaba.graphscope.groot.common.schema.mapper.GraphSchemaMapper;
+import com.alibaba.graphscope.groot.common.schema.wrapper.GraphDef;
+import com.alibaba.graphscope.groot.sdk.GrootClient;
+import com.alibaba.graphscope.proto.groot.DataLoadTargetPb;
+import com.alibaba.graphscope.proto.groot.GraphDefPb;
+import com.aliyun.odps.Odps;
+import com.aliyun.odps.OdpsException;
+import com.aliyun.odps.mapred.JobClient;
+import com.aliyun.odps.mapred.conf.JobConf;
+import com.aliyun.odps.mapred.conf.SessionState;
+import com.aliyun.odps.mapred.utils.InputUtils;
+import com.aliyun.odps.mapred.utils.OutputUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+public class OfflineBuildOdpsDebug {
+    private static final Logger logger = LoggerFactory.getLogger(OfflineBuildOdpsDebug.class);
+
+    private static Odps odps;
+
+    public static void main(String[] args) throws IOException, OdpsException {
+        String propertiesFile = args[0];
+
+        Properties properties = new Properties();
+        try (InputStream is = new FileInputStream(propertiesFile)) {
+            properties.load(is);
+        }
+        odps = SessionState.get().getOdps();
+
+        String configStr = properties.getProperty(DataLoadConfig.COLUMN_MAPPING_CONFIG);
+        configStr = Utils.replaceVars(configStr, Arrays.copyOfRange(args,1, args.length));
+
+        String graphEndpoint = properties.getProperty(DataLoadConfig.GRAPH_ENDPOINT);
+        String username = properties.getProperty(DataLoadConfig.USER_NAME, "");
+        String password = properties.getProperty(DataLoadConfig.PASS_WORD, "");
+
+        Map<String, FileColumnMapping> mappingConfig = Utils.parseColumnMapping(configStr);
+
+        List<DataLoadTargetPb> targets = Utils.getDataLoadTargets(mappingConfig);
+
+        GrootClient client = Utils.getClient(graphEndpoint, username, password);
+
+        GraphDefPb graphDefPb = client.prepareDataLoad(targets);
+        System.out.println("GraphDef: " + graphDefPb);
+
+        JobConf job = new JobConf();
+
+        job.set("odps.isolation.session.enable", "true"); // Avoid java sandbox protection
+        job.set("odps.sql.udf.java.retain.legacy", "false"); // exclude legacy jar files
+        job.setInstancePriority(0); // Default priority is 9
+        job.set("odps.mr.run.mode", "sql");
+        job.set("odps.mr.sql.group.enable", "true");
+
+        job.setMapperClass(DataBuildMapperOdpsDebug.class);
+        job.setNumReduceTasks(0);
+
+        mappingConfig.forEach((name, x) -> InputUtils.addTable(Utils.parseTableURL(odps, name), job));
+        String outputTable = properties.getProperty(DataLoadConfig.OUTPUT_TABLE);
+        OutputUtils.addTable(Utils.parseTableURL(odps, outputTable), job);
+        GraphSchema schema = GraphDef.parseProto(graphDefPb);
+
+        String schemaJson = GraphSchemaMapper.parseFromSchema(schema).toJsonString();
+        Map<String, ColumnMappingInfo> info = Utils.getMappingInfo(odps, schema, mappingConfig);
+
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, String> outputMeta = new HashMap<>();
+        outputMeta.put(DataLoadConfig.SCHEMA_JSON, schemaJson);
+        outputMeta.put(DataLoadConfig.COLUMN_MAPPINGS, mapper.writeValueAsString(info));
+        job.set(DataLoadConfig.META_INFO, mapper.writeValueAsString(outputMeta));
+
+        JobClient.runJob(job);
+    }
+}

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdpsDebug.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdpsDebug.java
@@ -52,7 +52,7 @@ public class OfflineBuildOdpsDebug {
         odps = SessionState.get().getOdps();
 
         String configStr = properties.getProperty(DataLoadConfig.COLUMN_MAPPING_CONFIG);
-        configStr = Utils.replaceVars(configStr, Arrays.copyOfRange(args,1, args.length));
+        configStr = Utils.replaceVars(configStr, Arrays.copyOfRange(args, 1, args.length));
 
         String graphEndpoint = properties.getProperty(DataLoadConfig.GRAPH_ENDPOINT);
         String username = properties.getProperty(DataLoadConfig.USER_NAME, "");
@@ -78,7 +78,8 @@ public class OfflineBuildOdpsDebug {
         job.setMapperClass(DataBuildMapperOdpsDebug.class);
         job.setNumReduceTasks(0);
 
-        mappingConfig.forEach((name, x) -> InputUtils.addTable(Utils.parseTableURL(odps, name), job));
+        mappingConfig.forEach(
+                (name, x) -> InputUtils.addTable(Utils.parseTableURL(odps, name), job));
         String outputTable = properties.getProperty(DataLoadConfig.OUTPUT_TABLE);
         OutputUtils.addTable(Utils.parseTableURL(odps, outputTable), job);
         GraphSchema schema = GraphDef.parseProto(graphDefPb);
@@ -91,7 +92,7 @@ public class OfflineBuildOdpsDebug {
         outputMeta.put(DataLoadConfig.SCHEMA_JSON, schemaJson);
         outputMeta.put(DataLoadConfig.COLUMN_MAPPINGS, mapper.writeValueAsString(info));
         job.set(DataLoadConfig.META_INFO, mapper.writeValueAsString(outputMeta));
-
+        System.out.println(mapper.writeValueAsString(outputMeta));
         JobClient.runJob(job);
     }
 }

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/SstOutputFormat.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/SstOutputFormat.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 public class SstOutputFormat extends FileOutputFormat<BytesWritable, BytesWritable> {
 
@@ -60,7 +61,11 @@ public class SstOutputFormat extends FileOutputFormat<BytesWritable, BytesWritab
             try {
                 sstFileWriter.put(key.copyBytes(), value.copyBytes());
             } catch (RocksDBException e) {
-                throw new IOException(e);
+                ByteBuffer buffer = ByteBuffer.wrap(key.copyBytes());
+                long tableId = buffer.getLong(0) >> 1;
+                long hashId = buffer.getLong(8);
+                throw new IOException(
+                        "Write SST Error! TableId: [" + tableId + "], hashId: [" + hashId + "]", e);
             }
         }
 

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/Utils.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/Utils.java
@@ -1,0 +1,218 @@
+package com.alibaba.graphscope.groot.dataload.databuild;
+
+import com.alibaba.graphscope.groot.common.exception.PropertyDefNotFoundException;
+import com.alibaba.graphscope.groot.common.schema.api.*;
+import com.alibaba.graphscope.groot.common.schema.wrapper.PropertyValue;
+import com.alibaba.graphscope.groot.sdk.GrootClient;
+import com.alibaba.graphscope.proto.groot.DataLoadTargetPb;
+import com.aliyun.odps.Odps;
+import com.aliyun.odps.data.Record;
+import com.aliyun.odps.data.TableInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+public class Utils {
+    // For Main Job
+    static List<DataLoadTargetPb> getDataLoadTargets(
+            Map<String, FileColumnMapping> columnMappingConfig) {
+        List<DataLoadTargetPb> targets = new ArrayList<>();
+        for (FileColumnMapping fileColumnMapping : columnMappingConfig.values()) {
+            DataLoadTargetPb.Builder builder = DataLoadTargetPb.newBuilder();
+            builder.setLabel(fileColumnMapping.getLabel());
+            if (fileColumnMapping.getSrcLabel() != null) {
+                builder.setSrcLabel(fileColumnMapping.getSrcLabel());
+            }
+            if (fileColumnMapping.getDstLabel() != null) {
+                builder.setDstLabel(fileColumnMapping.getDstLabel());
+            }
+            targets.add(builder.build());
+        }
+        return targets;
+    }
+
+    public static Map<String, FileColumnMapping> parseColumnMapping(String str)
+            throws JsonProcessingException {
+        ObjectMapper m = new ObjectMapper();
+        return m.readValue(str, new TypeReference<Map<String, FileColumnMapping>>() {});
+    }
+
+    public static Map<String, ColumnMappingInfo> getMappingInfo(
+            Odps odps, GraphSchema schema, Map<String, FileColumnMapping> config) {
+        Map<String, ColumnMappingInfo> columnMappingInfo = new HashMap<>();
+        config.forEach(
+                (fileName, fileColumnMapping) -> {
+                    ColumnMappingInfo subInfo = fileColumnMapping.toColumnMappingInfo(schema);
+                    // Note the project and partition is stripped (if exists)
+                    columnMappingInfo.put(Utils.getTableName(odps, fileName), subInfo);
+                });
+        return columnMappingInfo;
+    }
+
+    public static String getTableName(Odps odps, String tableFullName) {
+        TableInfo info = parseTableURL(odps, tableFullName);
+        return info.getTableName();
+    }
+
+    /**
+     * Parse table URL to @TableInfo
+     * @param url the pattern of [projectName.]tableName[|partitionSpec]
+     * @return TableInfo
+     */
+    public static TableInfo parseTableURL(Odps odps, String url) {
+        String projectName = odps.getDefaultProject();
+        String tableName;
+        String partitionSpec = null;
+        if (url.contains(".")) {
+            String[] items = url.split("\\.");
+            projectName = items[0];
+            tableName = items[1];
+        } else {
+            tableName = url;
+        }
+        if (tableName.contains("|")) {
+            String[] items = tableName.split("\\|");
+            tableName = items[0];
+            partitionSpec = items[1];
+        }
+
+        TableInfo.TableInfoBuilder builder = TableInfo.builder();
+        builder.projectName(projectName);
+
+        builder.tableName(tableName);
+        if (partitionSpec != null) {
+            builder.partSpec(partitionSpec);
+        }
+        return builder.build();
+    }
+
+    public static Map<Long, DataLoadTargetPb> getTableToTargets(
+            GraphSchema schema, Map<String, ColumnMappingInfo> info) {
+        Map<Long, DataLoadTargetPb> tableToTarget = new HashMap<>();
+        for (ColumnMappingInfo columnMappingInfo : info.values()) {
+            long tableId = columnMappingInfo.getTableId();
+            int labelId = columnMappingInfo.getLabelId();
+            GraphElement graphElement = schema.getElement(labelId);
+            String label = graphElement.getLabel();
+            DataLoadTargetPb.Builder builder = DataLoadTargetPb.newBuilder();
+            builder.setLabel(label);
+            if (graphElement instanceof GraphEdge) {
+                builder.setSrcLabel(
+                        schema.getElement(columnMappingInfo.getSrcLabelId()).getLabel());
+                builder.setDstLabel(
+                        schema.getElement(columnMappingInfo.getDstLabelId()).getLabel());
+            }
+            tableToTarget.put(tableId, builder.build());
+        }
+        return tableToTarget;
+    }
+
+    public static GrootClient getClient(String endpoint, String username, String password) {
+        return GrootClient.newBuilder()
+                .setHosts(endpoint)
+                .setUsername(username)
+                .setPassword(password)
+                .build();
+    }
+
+    public static boolean parseBoolean(String str) {
+        return str.equalsIgnoreCase("true");
+    }
+
+    public static String replaceVars(String str, String[] args) {
+        // User could specify a list of `key=value` pairs in command line,
+        // to substitute variables like `${key}` in configStr
+        for (String arg : args) {
+            String[] kv = arg.split("=");
+            if (kv.length == 2) {
+                String key = "${" + kv[0] + "}";
+                str = str.replace(key, kv[1]);
+            }
+        }
+        return str;
+    }
+
+    /// For Mapper
+    public static Map<Integer, PropertyValue> buildProperties(
+            GraphElement typeDef, String[] items, Map<Integer, Integer> mapping) {
+        Map<Integer, PropertyValue> operationProperties = new HashMap<>(mapping.size());
+        mapping.forEach(
+                (colIdx, propertyId) -> {
+                    GraphProperty prop = typeDef.getProperty(propertyId);
+                    String label = typeDef.getLabel();
+                    String msg = "Label [" + label + "]: ";
+                    if (prop == null) {
+                        msg += "propertyId [" + propertyId + "] not found";
+                        throw new PropertyDefNotFoundException(msg);
+                    }
+                    if (colIdx >= items.length) {
+                        msg += "Invalid mapping [" + colIdx + "]->[" + propertyId + "]";
+                        msg += "Data: " + Arrays.toString(items);
+                        throw new IllegalArgumentException(msg);
+                    }
+                    PropertyValue propertyValue = null;
+                    if (items[colIdx] != null) {
+                        propertyValue = new PropertyValue(prop.getDataType(), items[colIdx]);
+                    }
+                    operationProperties.put(propertyId, propertyValue);
+                });
+        return operationProperties;
+    }
+
+    public static BytesRef getVertexKeyRef(
+            DataEncoder encoder,
+            GraphVertex type,
+            Map<Integer, PropertyValue> properties,
+            long tableId) {
+        return encoder.encodeVertexKey(type, properties, tableId);
+    }
+
+    public static BytesRef getEdgeKeyRef(
+            DataEncoder encoder,
+            GraphSchema schema,
+            ColumnMappingInfo info,
+            String[] items,
+            Map<Integer, PropertyValue> properties,
+            long tableId,
+            boolean forward) {
+        int labelId = info.getLabelId();
+        GraphEdge type = (GraphEdge) schema.getElement(labelId);
+
+        int srcLabelId = info.getSrcLabelId();
+        Map<Integer, Integer> srcPkColMap = info.getSrcPkColMap();
+        GraphVertex srcType = (GraphVertex) schema.getElement(srcLabelId);
+        Map<Integer, PropertyValue> srcPkMap = Utils.buildProperties(srcType, items, srcPkColMap);
+
+        int dstLabelId = info.getDstLabelId();
+        Map<Integer, Integer> dstPkColMap = info.getDstPkColMap();
+        GraphVertex dstType = (GraphVertex) schema.getElement(dstLabelId);
+        Map<Integer, PropertyValue> dstPkMap = Utils.buildProperties(dstType, items, dstPkColMap);
+
+        return encoder.encodeEdgeKey(
+                srcType, srcPkMap, dstType, dstPkMap, type, properties, tableId, forward);
+    }
+
+    public static String[] parseRecords(Record record) {
+        String[] items = new String[record.getColumnCount()];
+        for (int i = 0; i < items.length; i++) {
+            Object curRecord = record.get(i);
+            items[i] = curRecord == null ? null : curRecord.toString();
+        }
+        return items;
+    }
+
+    public static String convertDateForLDBC(String input) {
+        SimpleDateFormat SRC_FMT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        SimpleDateFormat DST_FMT = new SimpleDateFormat("yyyyMMddHHmmssSSS");
+        DST_FMT.setTimeZone(TimeZone.getTimeZone("GMT+00:00"));
+        try {
+            return DST_FMT.format(SRC_FMT.parse(input));
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/Utils.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/Utils.java
@@ -48,14 +48,14 @@ public class Utils {
                 (fileName, fileColumnMapping) -> {
                     ColumnMappingInfo subInfo = fileColumnMapping.toColumnMappingInfo(schema);
                     // Note the project and partition is stripped (if exists)
-                    columnMappingInfo.put(Utils.getTableName(odps, fileName), subInfo);
+                    columnMappingInfo.put(Utils.getTableIdentifier(odps, fileName), subInfo);
                 });
         return columnMappingInfo;
     }
 
-    public static String getTableName(Odps odps, String tableFullName) {
+    public static String getTableIdentifier(Odps odps, String tableFullName) {
         TableInfo info = parseTableURL(odps, tableFullName);
-        return info.getTableName();
+        return info.getTableName() + "|" + info.getPartPath();
     }
 
     /**

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/external/ExternalStorage.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/external/ExternalStorage.java
@@ -71,6 +71,10 @@ public abstract class ExternalStorage {
             chkFile.delete();
             return;
         }
+        if (chkArray.length != 2) {
+            throw new IOException(
+                    "Checksum format error: content: [" + chkArray + "]; path: " + chkPath);
+        }
         String chkMD5Value = chkArray[1];
         downloadDataSimple(srcPath, dstPath);
         String sstMD5Value = getFileMD5(dstPath);


### PR DESCRIPTION
1. Fix that partspec is not included in the table identifier that caused label id could not be correctly retrieved.
2. Disable the backup instance of reducer, which could truncated the file that uploaded to volume.
3. Limit the total size of log files.