### PR TITLE
fix(flex): Support set edge strategy on each `vertex_type_pair_relation`

### DIFF
--- a/flex/interactive/examples/modern_graph/modern_graph.yaml
+++ b/flex/interactive/examples/modern_graph/modern_graph.yaml
@@ -44,13 +44,13 @@ schema:
   edge_types:
     - type_id: 0
       type_name: knows
-      x_csr_params:
-        incoming_edge_strategy: Multiple
-        outgoing_edge_strategy: Multiple
       vertex_type_pair_relations:
         - source_vertex: person
           destination_vertex: person
           relation: MANY_TO_MANY
+          x_csr_params:
+            incoming_edge_strategy: Multiple
+            outgoing_edge_strategy: Multiple
       properties:
         - property_id: 0
           property_name: weight
@@ -58,13 +58,13 @@ schema:
             primitive_type: DT_DOUBLE
     - type_id: 1
       type_name: created
-      x_csr_params:
-        incoming_edge_strategy: Multiple
-        outgoing_edge_strategy: Single
       vertex_type_pair_relations:
         - source_vertex: person
           destination_vertex: software
           relation: ONE_TO_MANY
+          x_csr_params:
+            incoming_edge_strategy: Multiple
+            outgoing_edge_strategy: Single
       properties:
         - property_id: 0
           property_name: weight

--- a/flex/storages/rt_mutable_graph/README.md
+++ b/flex/storages/rt_mutable_graph/README.md
@@ -72,26 +72,26 @@ schema:
         - id
   edge_types:
     - type_name: knows
-      x_csr_params:
-        incoming_edge_strategy: None
-        outgoing_edge_strategy: Multiple
       vertex_type_pair_relations:
         source_vertex: person
         destination_vertex: person
         relation: MANY_TO_MANY
+        x_csr_params:
+          incoming_edge_strategy: Multiple
+          outgoing_edge_strategy: Multiple
       properties:
         - property_id: 0
           property_name: weight
           property_type:
             primitive_type: DT_DOUBLE
     - type_name: created
-      x_csr_params: 
-        incoming_edge_strategy: None
-        outgoing_edge_strategy: Single
       vertex_type_pair_relations:
         source_vertex: person
         destination_vertex: software
         relation: ONE_TO_MANY
+        x_csr_params: 
+          incoming_edge_strategy: Multiple
+          outgoing_edge_strategy: Single
       properties:
         - property_id: 0
           property_name: weight

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -617,18 +617,8 @@ static bool parse_edge_schema(YAML::Node node, Schema& schema) {
                              property_types, prop_names)) {
     return false;
   }
-  EdgeStrategy ie = EdgeStrategy::kMultiple;
-  EdgeStrategy oe = EdgeStrategy::kMultiple;
-  {
-    auto csr_node = node["x_csr_params"];
-    std::string ie_str, oe_str;
-    if (get_scalar(node, "outgoing_edge_strategy", oe_str)) {
-      oe = StringToEdgeStrategy(oe_str);
-    }
-    if (get_scalar(node, "incoming_edge_strategy", ie_str)) {
-      ie = StringToEdgeStrategy(ie_str);
-    }
-  }
+  EdgeStrategy default_ie = EdgeStrategy::kMultiple;
+  EdgeStrategy default_oe = EdgeStrategy::kMultiple;
 
   // get vertex type pair relation
   auto vertex_type_pair_node = node["vertex_type_pair_relations"];
@@ -644,8 +634,8 @@ static bool parse_edge_schema(YAML::Node node, Schema& schema) {
   for (auto i = 0; i < vertex_type_pair_node.size(); ++i) {
     std::string src_label_name, dst_label_name;
     auto cur_node = vertex_type_pair_node[i];
-    EdgeStrategy cur_ie = ie;
-    EdgeStrategy cur_oe = oe;
+    EdgeStrategy cur_ie = default_ie;
+    EdgeStrategy cur_oe = default_oe;
     if (!get_scalar(cur_node, "source_vertex", src_label_name)) {
       LOG(ERROR) << "Expect field source_vertex for edge [" << edge_label_name
                  << "] in vertex_type_pair_relations";


### PR DESCRIPTION
User now can put `x_csr_params` to provide csr-related configuration for each edge triplet.