### PR TITLE
fix(analytical): reduce louvain memory usage

### DIFF
--- a/analytical_engine/apps/pregel/louvain/auxiliary.h
+++ b/analytical_engine/apps/pregel/louvain/auxiliary.h
@@ -46,7 +46,7 @@ constexpr int phase_one_minor_step_2 = 2;
 template <typename VID_T>
 struct LouvainNodeState {
   using vid_t = VID_T;
-  using edata_t = double;
+  using edata_t = float;
 
   vid_t community = 0;
   edata_t community_sigma_total;
@@ -65,7 +65,7 @@ struct LouvainNodeState {
   bool use_fake_edges = false;
   bool is_alived_community = true;
 
-  std::map<vid_t, edata_t> fake_edges;
+  std::vector<std::pair<vid_t, edata_t>> fake_edges;
   std::vector<vid_t> nodes_in_community;
   edata_t total_edge_weight;
 
@@ -89,7 +89,7 @@ struct LouvainNodeState {
 template <typename VID_T>
 struct LouvainMessage {
   using vid_t = VID_T;
-  using edata_t = double;
+  using edata_t = float;
 
   vid_t community_id;
   edata_t community_sigma_total;
@@ -102,7 +102,7 @@ struct LouvainMessage {
   // the community compress its member's data and make self a new vertex for
   // next phase.
   edata_t internal_weight = 0;
-  std::map<vid_t, edata_t> edges;
+  std::vector<std::pair<vid_t, edata_t>> edges;
   std::vector<vid_t> nodes_in_self_community;
 
   LouvainMessage()
@@ -123,7 +123,7 @@ struct LouvainMessage {
 
   ~LouvainMessage() = default;
 
-  // for message manager to serialize and diserialize LouvainMessage
+  // for message manager to serialize and deserialize LouvainMessage
   friend grape::InArchive& operator<<(grape::InArchive& in_archive,
                                       const LouvainMessage& u) {
     in_archive << u.community_id;
@@ -151,7 +151,7 @@ struct LouvainMessage {
 };
 
 /**
- * Determine if progress is still being made or if the computaion should halt.
+ * Determine if progress is still being made or if the computation should halt.
  *
  * @param history change history of the pass.
  * @param min_progress The minimum delta X required to be considered progress.

--- a/analytical_engine/apps/pregel/louvain/auxiliary.h
+++ b/analytical_engine/apps/pregel/louvain/auxiliary.h
@@ -17,6 +17,7 @@
 #define ANALYTICAL_ENGINE_APPS_PREGEL_LOUVAIN_AUXILIARY_H_
 
 #include <map>
+#include <utility>
 #include <vector>
 
 #include "grape/grape.h"

--- a/analytical_engine/apps/pregel/louvain/louvain_context.h
+++ b/analytical_engine/apps/pregel/louvain/louvain_context.h
@@ -37,13 +37,13 @@ class LouvainContext
   using fragment_t = FRAG_T;
   using oid_t = typename FRAG_T::oid_t;
   using vid_t = typename FRAG_T::vid_t;
-  using edata_t = double;
   using vertex_t = typename FRAG_T::vertex_t;
   using state_t = LouvainNodeState<vid_t>;
   using vertex_state_array_t =
       typename fragment_t::template vertex_array_t<state_t>;
 
  public:
+  using edata_t = typename state_t::edata_t;
   explicit LouvainContext(const FRAG_T& fragment)
       : grape::VertexDataContext<FRAG_T, typename COMPUTE_CONTEXT_T::vd_t>(
             fragment),
@@ -94,8 +94,8 @@ class LouvainContext
     return sum;
   }
 
-  edata_t GetLocalEdgeWeightSum() {
-    edata_t sum = 0;
+  double GetLocalEdgeWeightSum() {
+    double sum = 0;
     for (const auto& val : local_total_edge_weight_) {
       sum += val;
     }
@@ -118,7 +118,7 @@ class LouvainContext
 
   std::vector<int64_t>& local_change_num() { return local_change_num_; }
 
-  std::vector<edata_t>& local_total_edge_weight() {
+  std::vector<double>& local_total_edge_weight() {
     return local_total_edge_weight_;
   }
   std::vector<double>& local_actual_quality() { return local_actual_quality_; }
@@ -137,9 +137,9 @@ class LouvainContext
   COMPUTE_CONTEXT_T compute_context_;
   vertex_state_array_t vertex_state_;
 
-  // members to store local aggrated value
+  // members to store local aggregated value
   std::vector<int64_t> local_change_num_;
-  std::vector<edata_t> local_total_edge_weight_;
+  std::vector<double> local_total_edge_weight_;
   std::vector<double> local_actual_quality_;
 
   bool halt_;  // phase-1 halt


### PR DESCRIPTION
Committed-by: siyuanzhang.zsy from Dev container

baseline 初始engine内存50M， p2p 图 50M，运行louvain 额外内存 300 M
  - 存临时的边结构 map -> vector  额外内存 300 M -> 250 M
  - 及时清除无用的临时 edge 和 nodes  250 M -> 232 M
  - vid_type uint64 -> uint32, edata double -> float  232 M -> 151 M

注意：
  - 如要使用 uint32 作为 vid 类型, 载图时指定 vid_type `sess.g(vid_type='uint32')`
  - map 换成 vector 之后，算法效率会有所下降，具体为通过终点找边时，必须遍历 vector，时间复杂度为 O(E)，E 为构建出来的社区新边的大小。一般来说，会比原图小很多。

Fixes #3244

