### PR TITLE
ci: requires macos 12 as homebrew (and apple) do not provide support for this old version

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@
 # only_if: $CIRRUS_TAG != ''
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: "11"
+  MACOSX_DEPLOYMENT_TARGET: "12"
 
 macosx_arm64_wheel_task:
   macos_instance:

--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-wheels:
     if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope') || (github.event_name == 'workflow_dispatch')
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
       with:
@@ -128,7 +128,7 @@ jobs:
 
   build-client-wheels:
     if: (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'alibaba/GraphScope') || (github.event_name == 'workflow_dispatch')
-    runs-on: macos-11
+    runs-on: macos-12
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
@@ -259,7 +259,7 @@ jobs:
 
   python-test:
     if: ${{ (github.ref == 'refs/heads/main' && github.repository == 'alibaba/GraphScope') || (github.event_name == 'workflow_dispatch') }}
-    runs-on: macos-11
+    runs-on: macos-12
     needs: [build-wheels, build-client-wheels]
     strategy:
       fail-fast: false

--- a/README-zh.md
+++ b/README-zh.md
@@ -36,7 +36,7 @@ pip3 install graphscope
 
 注意 `graphscope` 的版本要求，需要 `Python` >= 3.7 及 `pip` >= 19.0.
 
-GraphScope 包在大多数流行的Linux发行版 (Ubuntu 20.04+ / Centos 7+) 与 macOS 11+ (Intel) / macOS 12+ (Apple silicon) 上测试通过，对于 Windows 用户，需要在 WSL2 上安装 Ubuntu 来使用 GraphScope。
+GraphScope 包在大多数流行的Linux发行版 (Ubuntu 20.04+ / Centos 7+) 与 macOS 12+ (Intel/Apple silicon) 上测试通过，对于 Windows 用户，需要在 WSL2 上安装 Ubuntu 来使用 GraphScope。
 
 接下来我们会用一个具体的例子，来演示 GraphScope 如何帮助数据科学家高效的分析、处理大规模图数据。
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ GraphScope pre-compiled package is distributed as a python package and can be ea
 pip3 install graphscope
 ```
 
-Note that `graphscope` requires `Python` >= `3.8` and `pip` >= `19.3`. The package is built for and tested on the most popular Linux (Ubuntu 20.04+ / CentOS 7+) and macOS 11+ (Intel) / macOS 12+ (Apple silicon) distributions. For Windows users, you may want to install Ubuntu on WSL2 to use this package.
+Note that `graphscope` requires `Python` >= `3.8` and `pip` >= `19.3`. The package is built for and tested on the most popular Linux (Ubuntu 20.04+ / CentOS 7+) and macOS 12+ (Intel/Apple silicon) distributions. For Windows users, you may want to install Ubuntu on WSL2 to use this package.
 
 Next, we will walk you through a concrete example to illustrate how GraphScope can be used by data scientists to effectively analyze large graphs.
 

--- a/docs/deployment/install_on_local.md
+++ b/docs/deployment/install_on_local.md
@@ -4,7 +4,7 @@ This guide will walk you through the process of installing GraphScope on your lo
 
 ## Prerequisites
 
-- Ubuntu 20.04 or later, CentOS 7 or later, or macOS 11 (Intel) / macOS 12 (Apple silicon) or later
+- Ubuntu 20.04 or later, CentOS 7 or later, or macOS 12 (Intel/Apple silicon) or later
 - Python 3.7 ~ 3.11, and pip >= 19.3
 - JDK 11 (If you want to use GIE, both JDK 8 and 20 have known compatibility issues)
 

--- a/docs/interactive_engine/getting_started.md
+++ b/docs/interactive_engine/getting_started.md
@@ -17,7 +17,7 @@ And it is tested on the following 64-bit operating systems:
 
 - Ubuntu 18.04 or later
 - CentOS 7 or later
-- macOS 11 (Intel) / macOS 12 (Apple silicon) or later, with both Intel chip and Apple M1 chip
+- macOS 12 (Intel/Apple silicon) or later, with both Intel chip and Apple M1 chip
 
 If your environment satisfies the above requirement, you can easily install GraphScope through pip:
 

--- a/docs/zh/deployment.rst
+++ b/docs/zh/deployment.rst
@@ -105,7 +105,7 @@ Coordinator 作为 GraphScope 后端服务的入口，通过 grpc 接收来自 P
 本地部署GraphScope
 -----------------
 
-我们提供了一个可在本地安装GraphScope相关依赖的脚本，该脚本可以运行在 Ubuntu 20.04+ 或 MacOS 11+ (Intel) / MacOS 12+ (Apple silicon) 平台上, 主要的用法如下：
+我们提供了一个可在本地安装GraphScope相关依赖的脚本，该脚本可以运行在 Ubuntu 20.04+ 或 MacOS 12+ (Intel/Apple silicon) 平台上, 主要的用法如下：
 你可以通过 `python3 gsctl.py -h` 获取更详细的帮助信息。
 
 * 安装 GraphScope 开发相关依赖

--- a/docs/zh/frequently_asked_questions.rst
+++ b/docs/zh/frequently_asked_questions.rst
@@ -11,7 +11,7 @@
 
     - CentOS 7+
     - Ubuntu 18.04+
-    - MacOS 10.15+
+    - MacOS 12 (Intel/Apple Silicon)
 
     对于分布式部署，需要用户拥有一个 Kubernetes 集群，GraphScope 在 **Kubernetes version >= v1.12.0+** 的环境上测试通过。
 

--- a/docs/zh/installation.rst
+++ b/docs/zh/installation.rst
@@ -7,7 +7,7 @@ GraphScope 目前支持的平台如下:
 - Python 3.7 - 3.9
 - Ubuntu 18.04 or later
 - CentOS 7 or later
-- macOS 11.2.1 (Big Sur) or later, with both Intel chip and Apple M1 chip
+- macOS 12 (Monterey) or later, with both Intel chip and Apple M1 chip
 
 
 单机环境下安装

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -19,11 +19,7 @@ endif
 
 # x86_64 or arm64
 ARCH := $(shell uname -m)
-ifeq ($(ARCH), arm64)
-	MACOS_WHEEL_VERSION := 12_0
-else
-	MACOS_WHEEL_VERSION := 11_0
-endif
+MACOS_WHEEL_VERSION := 12_0
 
 BUILD_PROGRESS    = auto
 


### PR DESCRIPTION
See also: https://github.com/alibaba/GraphScope/actions/runs/6460682621/job/17538859836

```
Warning: You are using macOS 11.
We (and Apple) do not provide support for this old version.
It is expected behaviour that some formulae will fail to build in this old version.
It is expected behaviour that Homebrew will be buggy and slow.
Do not create any issues about this on Homebrew's GitHub repositories.
Do not create any issues even if you think this message is unrelated.
Any opened issues will be immediately closed without response.
Do not ask for help from Homebrew or its maintainers on social media.
You may ask for help in Homebrew's discussions but are unlikely to receive a response.
Try to figure out the problem yourself and submit a fix as a pull request.
We will review it but may or may not accept it.
```