### PR TITLE
ci: fixes the handling the pytorch dependency

### DIFF
--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -295,6 +295,8 @@ jobs:
 
           # install tensorflow
           python3 -m pip install pytest "tensorflow" "pandas" --user
+          # install pytorch
+          python3 -m pip install "torch"
           # install java
           sudo apt update -y && sudo apt install openjdk-11-jdk -y
 

--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -281,22 +281,22 @@ jobs:
           cd artifacts
           tar -zxf ./wheel-${{ github.sha }}/client.tar.gz
           pushd python/dist/wheelhouse
-          for f in * ; do python3 -m pip install $f || true; done
+          for f in * ; do python3 -m pip install --no-cache-dir $f || true; done
           popd
 
           # install graphscope
           tar -zxf ./wheel-${{ github.sha }}/graphscope.tar.gz
           pushd coordinator/dist
-          python3 -m pip install ./*.whl
+          python3 -m pip install --no-cache-dir ./*.whl
           popd
           pushd coordinator/dist/wheelhouse
-          python3 -m pip install ./*.whl
+          python3 -m pip install --no-cache-dir ./*.whl
           popd
 
           # install tensorflow
-          python3 -m pip install pytest "tensorflow" "pandas" --user
+          python3 -m pip install --no-cache-dir pytest "tensorflow" "pandas" --user
           # install pytorch
-          python3 -m pip install "torch"
+          python3 -m pip install --no-cache-dir "torch" --index-url https://download.pytorch.org/whl/cpu
           # install java
           sudo apt update -y && sudo apt install openjdk-11-jdk -y
 
@@ -345,20 +345,20 @@ jobs:
         cd artifacts
         tar -zxf ./wheel-${{ github.sha }}/client.tar.gz
         pushd python/dist/wheelhouse
-        for f in * ; do python3 -m pip install $f || true; done
+        for f in * ; do python3 -m pip install --no-cache-dir $f || true; done
         popd
 
         # install graphscope
         tar -zxf ./wheel-${{ github.sha }}/graphscope.tar.gz
         pushd coordinator/dist
-        python3 -m pip install ./*.whl
+        python3 -m pip install --no-cache-dir ./*.whl
         popd
         pushd coordinator/dist/wheelhouse
-        python3 -m pip install ./*.whl
+        python3 -m pip install --no-cache-dir ./*.whl
         popd
 
         # install pytest
-        python3 -m pip install pytest pytest-cov pytest-timeout
+        python3 -m pip install --no-cache-dir pytest pytest-cov pytest-timeout
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
@@ -431,20 +431,20 @@ jobs:
         cd artifacts
         tar -zxf ./wheel-${{ github.sha }}/client.tar.gz
         pushd python/dist/wheelhouse
-        for f in * ; do python3 -m pip install $f || true; done
+        for f in * ; do python3 -m pip install --no-cache-dir $f || true; done
         popd
 
         # install graphscope
         tar -zxf ./wheel-${{ github.sha }}/graphscope.tar.gz
         pushd coordinator/dist
-        python3 -m pip install ./*.whl
+        python3 -m pip install --no-cache-dir ./*.whl
         popd
         pushd coordinator/dist/wheelhouse
-        python3 -m pip install ./*.whl
+        python3 -m pip install --no-cache-dir ./*.whl
         popd
 
         # install pytest
-        python3 -m pip install pytest
+        python3 -m pip install --no-cache-dir pytest
 
         # download dataset
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
@@ -516,20 +516,20 @@ jobs:
         cd artifacts
         tar -zxf ./wheel-${{ github.sha }}/client.tar.gz
         pushd python/dist/wheelhouse
-        for f in * ; do python3 -m pip install $f || true; done
+        for f in * ; do python3 -m pip install --no-cache-dir $f || true; done
         popd
 
         # install graphscope
         tar -zxf ./wheel-${{ github.sha }}/graphscope.tar.gz
         pushd coordinator/dist
-        python3 -m pip install ./*.whl
+        python3 -m pip install --no-cache-dir ./*.whl
         popd
         pushd coordinator/dist/wheelhouse
-        python3 -m pip install ./*.whl
+        python3 -m pip install --no-cache-dir ./*.whl
         popd
 
         # install pytest
-        python3 -m pip install pytest
+        python3 -m pip install --no-cache-dir pytest
 
         # download dataset
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -153,7 +153,8 @@ graphscope-manylinux2014-py3:
 graphscope-client-manylinux2014-py3-nodocker:
 	set -euxo pipefail && \
 	cd $(WORKING_DIR)/../../python && \
-		python3 -m pip install -r requirements.txt -r requirements-dev.txt --user && \
+		python3 -m pip install --no-cache-dir "torch" --index-url https://download.pytorch.org/whl/cpu --user && \
+		python3 -m pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt --user && \
 	cd $(WORKING_DIR)/../../learning_engine/graph-learn && \
 	git submodule update --init third_party/pybind11 && \
 	cd graphlearn && \
@@ -211,7 +212,8 @@ graphscope-client-manylinux2014-py3-nodocker:
 
 graphscope-client-darwin-py3:
 	cd $(WORKING_DIR)/../../python && \
-		python3 -m pip install -r requirements.txt -r requirements-dev.txt --user && \
+		python3 -m pip install --no-cache-dir "torch" --index-url https://download.pytorch.org/whl/cpu --user && \
+		python3 -m pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt --user && \
 	cd $(WORKING_DIR)/../../learning_engine/graph-learn && \
 		(git submodule update --init third_party/pybind11 || true) && \
 		export GRAPHSCOPE_HOME=${GRAPHSCOPE_HOME} && \

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -152,6 +152,8 @@ graphscope-manylinux2014-py3:
 
 graphscope-client-manylinux2014-py3-nodocker:
 	set -euxo pipefail && \
+	cd $(WORKING_DIR)/../../python && \
+		python3 -m pip install -r requirements.txt -r requirements-dev.txt --user && \
 	cd $(WORKING_DIR)/../../learning_engine/graph-learn && \
 	git submodule update --init third_party/pybind11 && \
 	cd graphlearn && \
@@ -208,6 +210,8 @@ graphscope-client-manylinux2014-py3-nodocker:
 	done
 
 graphscope-client-darwin-py3:
+	cd $(WORKING_DIR)/../../python && \
+		python3 -m pip install -r requirements.txt -r requirements-dev.txt --user && \
 	cd $(WORKING_DIR)/../../learning_engine/graph-learn && \
 		(git submodule update --init third_party/pybind11 || true) && \
 		export GRAPHSCOPE_HOME=${GRAPHSCOPE_HOME} && \

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -20,3 +20,4 @@ sphinxext-opengraph
 tomli
 wheel
 setuptools==65.7.0
+torch

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -24,4 +24,3 @@ tqdm
 click
 vineyard>=0.16.3;sys_platform!="win32"
 simple-parsing
-torch==1.13.1

--- a/python/setup.py
+++ b/python/setup.py
@@ -264,8 +264,8 @@ def parsed_package_data():
 def build_learning_engine():
     ext_modules = [graphlearn_ext()]
     if torch and os.path.exists(os.path.join(glt_root_path, "graphlearn_torch")):
-        sys.path.append(
-            os.path.join(glt_root_path, "graphlearn_torch", "python", "utils")
+        sys.path.insert(
+            0, os.path.join(glt_root_path, "graphlearn_torch", "python", "utils")
         )
         from build import glt_ext_module
         from build import glt_v6d_ext_module
@@ -284,6 +284,7 @@ def build_learning_engine():
                 root_path=glt_root_path,
             )
         )
+        sys.path.pop(0)
     return ext_modules
 
 


### PR DESCRIPTION
## What do these changes do?

- Don't pin the pytorch version
- Move the pytorch dependency to `requirements-dev.txt` instead of `requirements.txt`, as it is so large and not everyone need it.
- Install pytorch where it is being required (the same logic with tensorflow)
- Make sure it has been installed before building the client wheels (otherwise the gltorch part would be skipped)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes https://github.com/alibaba/GraphScope/actions/runs/6525923593/job/17719122557

