### PR TITLE
ci: fixes the check of libarrow-dev existence on Ubuntu

### DIFF
--- a/python/graphscope/gsctl/scripts/install_deps_command.sh
+++ b/python/graphscope/gsctl/scripts/install_deps_command.sh
@@ -133,7 +133,7 @@ ANALYTICAL_MACOS=(
 )
 
 _install_apache_arrow_ubuntu() {
-  if ! command -v dpkg -s libarrow-dev &>/dev/null; then
+  if ! dpkg -s libarrow-dev &>/dev/null; then
     log "Installing apache-arrow."
     ${SUDO} apt-get install -y lsb-release
     # shellcheck disable=SC2046,SC2019,SC2018

--- a/python/graphscope/gsctl/scripts/lib/install_vineyard.sh
+++ b/python/graphscope/gsctl/scripts/lib/install_vineyard.sh
@@ -35,6 +35,8 @@ install_vineyard() {
   fi
   pushd ${directory} || exit
 
+  # make sure it complain loudly if installing vineyard fails
+  set -e
   cmake . -DCMAKE_PREFIX_PATH="${install_prefix}" \
         -DCMAKE_INSTALL_PREFIX="${V6D_PREFIX}" \
         -DBUILD_VINEYARD_TESTS=OFF \
@@ -46,6 +48,7 @@ install_vineyard() {
   strip "${V6D_PREFIX}"/bin/vineyard* "${V6D_PREFIX}"/lib/libvineyard*
   pip3 install --no-cache -i https://pypi.org/simple -U "vineyard" "vineyard-io"
   cp -rs "${V6D_PREFIX}"/* "${install_prefix}"/
+  set +e
   popd || exit
   popd || exit
   cleanup_files "${workdir}/${directory}" "${workdir}/${file}"


### PR DESCRIPTION
## What do these changes do?

The `command -v` is not what we want actually, removing.

## Related issue number

Fixes https://github.com/alibaba/GraphScope/actions/runs/6525924157/job/17719124120

