### PR TITLE
ci: run test cases in subprocess with pytest-sdist

### DIFF
--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -385,7 +385,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/python
           pip3 install -r requirements.txt -r requirements-dev.txt
-          pip3 install pytest pytest-cov pytest-timeout
+          pip3 install pytest pytest-cov pytest-timeout pytest-xdist
 
           # build python client proto
           cd ${GITHUB_WORKSPACE}/python
@@ -461,7 +461,10 @@ jobs:
           export GS_ADDR=${NODE_IP}:${NODE_PORT}
           cd ${GITHUB_WORKSPACE}/python
 
-          python3 -m pytest -s -vvv ./graphscope/tests/kubernetes/test_demo_script.py -k test_helm_installation
+          python3 -m pytest -d --tx popen//python=python3 \
+                            -s -vvv \
+                            ./graphscope/tests/kubernetes/test_demo_script.py \
+                            -k test_helm_installation
 
       - uses: dashanji/kubernetes-log-export-action@v5
         env:
@@ -488,10 +491,11 @@ jobs:
           cd ${GITHUB_WORKSPACE}/python
           export PATH=${HOME}/.local/bin:${PATH}
 
-          python3 -m pytest --ignore=./graphscope/tests/kubernetes/test_store_service.py \
-                          --cov=graphscope --cov-config=.coveragerc --cov-report=xml \
-                          --cov-report=term -s -vvv --log-cli-level=INFO \
-                          ./graphscope/tests/kubernetes
+          python3 -m pytest -d --tx popen//python=python3 \
+                            --ignore=./graphscope/tests/kubernetes/test_store_service.py \
+                            --cov=graphscope --cov-config=.coveragerc --cov-report=xml --cov-report=term \
+                            -s -vvv --log-cli-level=INFO \
+                            ./graphscope/tests/kubernetes
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v3
@@ -526,7 +530,10 @@ jobs:
 
           # run test
           cd ${GITHUB_WORKSPACE}/python
-          python3 -m pytest -s -vvv ./graphscope/tests/kubernetes/test_demo_script.py -k test_demo_on_hdfs
+          python3 -m pytest -d --tx popen//python=python3 \
+                            -s -vvv \
+                            ./graphscope/tests/kubernetes/test_demo_script.py \
+                            -k test_demo_on_hdfs
           # Check the result file have successfully written to the given location
           # hdfs dfs -test -e /ldbc_sample/res.csv_0 && hdfs dfs -test -e /ldbc_sample/res.csv_1
 
@@ -580,7 +587,7 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/python
           pip3 install -r requirements.txt -r requirements-dev.txt
-          pip3 install pytest pytest-cov pytest-timeout
+          pip3 install pytest pytest-cov pytest-timeout pytest-xdist
 
           # build python client proto
           python3 setup.py build_proto

--- a/.github/workflows/local-ci.yml
+++ b/.github/workflows/local-ci.yml
@@ -294,7 +294,7 @@ jobs:
           popd
 
           # install tensorflow
-          python3 -m pip install --no-cache-dir pytest "tensorflow" "pandas" --user
+          python3 -m pip install --no-cache-dir pytest pytest-xdist "tensorflow" "pandas" --user
           # install pytorch
           python3 -m pip install --no-cache-dir "torch" --index-url https://download.pytorch.org/whl/cpu
           # install java
@@ -308,7 +308,9 @@ jobs:
         env:
           GS_TEST_DIR: ${{ github.workspace }}/gstest
         run: |
-          python3 -m pytest -s -v $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
+          python3 -m pytest -d --tx popen//python=python3 \
+                            -s -v \
+                            $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/minitest
 
       - name: Upload GIE log
         if: failure()
@@ -358,7 +360,7 @@ jobs:
         popd
 
         # install pytest
-        python3 -m pip install --no-cache-dir pytest pytest-cov pytest-timeout
+        python3 -m pip install --no-cache-dir pytest pytest-cov pytest-timeout pytest-xdist
 
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
@@ -373,9 +375,11 @@ jobs:
         # download dataset
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
 
-        python3 -m pytest -s -v --cov=graphscope --cov-config=python/.coveragerc \
-                                --cov-report=xml --cov-report=term --exitfirst \
-                                $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/unittest
+        python3 -m pytest -d --tx popen//python=python3 \
+                          -s -v \
+                          --cov=graphscope --cov-config=python/.coveragerc --cov-report=xml --cov-report=term \
+                          --exitfirst \
+                          $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/tests/unittest
 
     - name: Upload Coverage
       if: ${{ needs.changes.outputs.gae-python == 'true' || github.ref == 'refs/heads/main' }}
@@ -444,7 +448,7 @@ jobs:
         popd
 
         # install pytest
-        python3 -m pip install --no-cache-dir pytest
+        python3 -m pip install --no-cache-dir pytest pytest-xdist
 
         # download dataset
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
@@ -460,9 +464,10 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
       run: |
         pip3 show networkx
-        python3 -m pytest --exitfirst -s -vvv \
-            $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/tests \
-            --ignore=$(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/tests/convert
+        python3 -m pytest -d --tx popen//python=python3 \
+                          --exitfirst -s -vvv \
+                          $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/tests \
+                          --ignore=$(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/tests/convert
 
     - name: Convert Test
       if: ${{ needs.changes.outputs.networkx == 'true' && steps.nx-filter.outputs.convert == 'true' }}
@@ -471,8 +476,9 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
       run: |
         pip3 show networkx
-        python3 -m pytest --exitfirst -s -vvv \
-            $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/tests/convert
+        python3 -m pytest -d --tx popen//python=python3 \
+                          --exitfirst -s -vvv \
+                          $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/tests/convert
 
   networkx-algo-and-generator-test:
     runs-on: ubuntu-20.04
@@ -529,7 +535,7 @@ jobs:
         popd
 
         # install pytest
-        python3 -m pip install --no-cache-dir pytest
+        python3 -m pip install --no-cache-dir pytest pytest-xdist
 
         # download dataset
         git clone -b master --single-branch --depth=1 https://github.com/7br/gstest.git ${GS_TEST_DIR}
@@ -541,8 +547,9 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
       run: |
         pip3 show networkx
-        python3 -m pytest --exitfirst -s -v \
-            $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/algorithms/tests/builtin
+        python3 -m pytest -d --tx popen//python=python3 \
+                          --exitfirst -s -v \
+                          $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/algorithms/tests/builtin
 
     - name: Generator test
       if: ${{ needs.changes.outputs.networkx == 'true' && steps.nx-filter.outputs.generator == 'true' }}
@@ -551,13 +558,15 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
       run: |
         pip3 show networkx
-        python3 -m pytest --exitfirst -s -v \
-            $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/generators/tests
+        python3 -m pytest -d --tx popen//python=python3 \
+                          --exitfirst -s -v \
+                          $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/generators/tests
 
     - name: Readwrite test
       if: ${{ needs.changes.outputs.networkx == 'true' && steps.nx-filter.outputs.io == 'true' }}
       env:
         DEPLOYMENT: ${{ matrix.deployment }}
       run: |
-        python3 -m pytest --exitfirst -s -v -m "not slow" \
-            $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/readwrite/tests
+        python3 -m pytest -d --tx popen//python=python3 \
+                          --exitfirst -s -v -m "not slow" \
+                          $(dirname $(python3 -c "import graphscope; print(graphscope.__file__)"))/nx/readwrite/tests

--- a/python/graphscope/tests/conftest.py
+++ b/python/graphscope/tests/conftest.py
@@ -17,6 +17,8 @@
 #
 
 import os
+import sys
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -914,3 +916,22 @@ def pytest_collection_modifyitems(items):
             timeout_marker = item.get_marker("timeout")
         if timeout_marker is None:
             item.add_marker(pytest.mark.timeout(600))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def patch_print_pytest_xdist():
+    """
+    pytest-xdist disables stdout capturing by default, which means that print()
+    statements are not captured and displayed in the terminal.
+
+    That's because xdist cannot support -s for technical reasons wrt the process
+    execution mechanism.
+
+    See also: https://github.com/pytest-dev/pytest-xdist/issues/354
+    """
+    original_print = print
+    with patch("builtins.print") as mock_print:
+        mock_print.side_effect = lambda *args, **kwargs: original_print(
+            *args, **{"file": sys.stderr, **kwargs}
+        )
+        yield mock_print

--- a/python/requirements-dev.txt
+++ b/python/requirements-dev.txt
@@ -10,6 +10,7 @@ myst-parser>=0.13.0
 pylint
 pytest
 pytest-cov
+pytest-xdist
 pytest-timeout
 Pygments>=2.4.1
 sphinx>=7.1.2


### PR DESCRIPTION
To fixes cases like python tests are all passed but the pytest process failed with segfault, causing a "RED" mark.

Fixes failures like: https://github.com/alibaba/GraphScope/actions/runs/6542043095/job/17765519436