### PR TITLE
fix(interactive): Fix Bugs in Converting Match into Join

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphBuilder.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphBuilder.java
@@ -306,13 +306,12 @@ public class GraphBuilder extends RelBuilder {
         RelNode input = size() > 0 ? peek() : null;
         RelNode match =
                 GraphLogicalMultiMatch.create(
-                        (GraphOptCluster) cluster,
-                        null,
-                        input,
-                        first,
-                        ImmutableList.copyOf(others));
-        if (size() > 0) pop();
-        push(match);
+                        (GraphOptCluster) cluster, null, null, first, ImmutableList.copyOf(others));
+        if (input == null) {
+            push(match);
+        } else {
+            push(match).join(getJoinRelType(GraphOpt.Match.INNER), getJoinCondition(input, match));
+        }
         return this;
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/antlr4/visitor/GraphBuilderVisitor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/antlr4/visitor/GraphBuilderVisitor.java
@@ -23,6 +23,7 @@ import com.alibaba.graphscope.common.ir.tools.config.GraphOpt;
 import com.alibaba.graphscope.cypher.antlr4.visitor.type.ExprVisitorResult;
 import com.alibaba.graphscope.grammar.CypherGSBaseVisitor;
 import com.alibaba.graphscope.grammar.CypherGSParser;
+import com.google.common.base.Preconditions;
 
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rex.RexCall;
@@ -63,6 +64,8 @@ public class GraphBuilderVisitor extends CypherGSBaseVisitor<GraphBuilder> {
                     sentences.get(0),
                     (ctx.OPTIONAL() != null) ? GraphOpt.Match.OPTIONAL : GraphOpt.Match.INNER);
         } else if (sentences.size() > 1) {
+            Preconditions.checkArgument(
+                    ctx.OPTIONAL() == null, "multiple sentences in match should not be optional");
             builder.match(sentences.get(0), sentences.subList(1, sentences.size()));
         } else {
             throw new IllegalArgumentException("sentences in match should not be empty");

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/cypher/antlr4/MatchTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/cypher/antlr4/MatchTest.java
@@ -311,4 +311,39 @@ public class MatchTest {
                     + "], matchOpt=[INNER])",
                 node.explain().trim());
     }
+
+    @Test
+    public void match_17_test() {
+        RelNode node =
+                Utils.eval(
+                                "Match (a:person)-[]->(b:person) Match (a:person)-[]-(c:person),"
+                                        + " (c:person)-[]->(b:person) Return a, b")
+                        .build();
+        Assert.assertEquals(
+                "GraphLogicalProject(a=[a], b=[b], isAppend=[false])\n"
+                    + "  LogicalJoin(condition=[AND(=(a, a), =(b, b))], joinType=[inner])\n"
+                    + "    GraphLogicalSingleMatch(input=[null],"
+                    + " sentence=[GraphLogicalGetV(tableConfig=[{isAll=false, tables=[person]}],"
+                    + " alias=[b], opt=[END])\n"
+                    + "  GraphLogicalExpand(tableConfig=[{isAll=true, tables=[created, knows]}],"
+                    + " alias=[DEFAULT], opt=[OUT])\n"
+                    + "    GraphLogicalSource(tableConfig=[{isAll=false, tables=[person]}],"
+                    + " alias=[a], opt=[VERTEX])\n"
+                    + "], matchOpt=[INNER])\n"
+                    + "    GraphLogicalMultiMatch(input=[null],"
+                    + " sentences=[{s0=[GraphLogicalGetV(tableConfig=[{isAll=false,"
+                    + " tables=[person]}], alias=[c], opt=[OTHER])\n"
+                    + "  GraphLogicalExpand(tableConfig=[{isAll=true, tables=[created, knows]}],"
+                    + " alias=[DEFAULT], opt=[BOTH])\n"
+                    + "    GraphLogicalSource(tableConfig=[{isAll=false, tables=[person]}],"
+                    + " alias=[a], opt=[VERTEX])\n"
+                    + "], s1=[GraphLogicalGetV(tableConfig=[{isAll=false, tables=[person]}],"
+                    + " alias=[b], opt=[END])\n"
+                    + "  GraphLogicalExpand(tableConfig=[{isAll=true, tables=[created, knows]}],"
+                    + " alias=[DEFAULT], opt=[OUT])\n"
+                    + "    GraphLogicalSource(tableConfig=[{isAll=false, tables=[person]}],"
+                    + " alias=[c], opt=[VERTEX])\n"
+                    + "]}])",
+                node.explain().trim());
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
This PR fixes a bug related to queries like `Match (a) Match (a)-[]->(b), (b)-[]->(c) Return a, b`, where there are multiple sentences in the second Match clause, causing issues when converting such matches into join structures.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

