### PR TITLE
fix(interactive): Make Pegasus Related Settings Configurable Per Query

### DIFF
--- a/interactive_engine/compiler/src/main/antlr4/GremlinGS.g4
+++ b/interactive_engine/compiler/src/main/antlr4/GremlinGS.g4
@@ -29,7 +29,7 @@ query
 // g.with(Tokens.ARGS_EVAL_TIMEOUT, 2000L)
 // g.with('evaluationTimeout', 2000L)
 traversalSource
-    : TRAVERSAL_ROOT (DOT traversalMethod_with) ?
+    : TRAVERSAL_ROOT (DOT traversalMethod_with) *
     ;
 
 // g.rootTraversal()

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/Configs.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/Configs.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
@@ -74,6 +75,10 @@ public class Configs {
         } else {
             return this.properties.getProperty(name, defaultValue);
         }
+    }
+
+    public Iterator<Object> getKeys() {
+        return this.properties.keys().asIterator();
     }
 
     @Override

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/GraphTraversalSourceVisitor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/GraphTraversalSourceVisitor.java
@@ -18,9 +18,12 @@ package com.alibaba.graphscope.gremlin.antlr4;
 
 import com.alibaba.graphscope.grammar.GremlinGSBaseVisitor;
 import com.alibaba.graphscope.grammar.GremlinGSParser;
-import com.alibaba.graphscope.gremlin.exception.UnsupportedEvalException;
+import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversalSource;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+
+import java.util.List;
 
 public class GraphTraversalSourceVisitor extends GremlinGSBaseVisitor<GraphTraversalSource> {
     private GraphTraversalSource g;
@@ -31,9 +34,24 @@ public class GraphTraversalSourceVisitor extends GremlinGSBaseVisitor<GraphTrave
 
     @Override
     public GraphTraversalSource visitTraversalSource(GremlinGSParser.TraversalSourceContext ctx) {
-        if (ctx.getChildCount() > 3) {
-            throw new UnsupportedEvalException(
-                    ctx.getClass(), "supported pattern of source is [g] or [g.with(..)]");
+        List<GremlinGSParser.TraversalMethod_withContext> withCtxList = ctx.traversalMethod_with();
+        if (ObjectUtils.isNotEmpty(withCtxList)) {
+            withCtxList.forEach(k -> visitTraversalMethod_with(k));
+        }
+        return g;
+    }
+
+    @Override
+    public GraphTraversalSource visitTraversalMethod_with(
+            GremlinGSParser.TraversalMethod_withContext ctx) {
+        if (ctx.stringLiteral() != null
+                && ctx.genericLiteral() != null
+                && g instanceof IrCustomizedTraversalSource) {
+            IrCustomizedTraversalSource customSource = (IrCustomizedTraversalSource) g;
+            String key = GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral());
+            Object value =
+                    GenericLiteralVisitor.getInstance().visitGenericLiteral(ctx.genericLiteral());
+            customSource.addConfig(key, value);
         }
         return g;
     }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/GremlinAntlrToJava.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/GremlinAntlrToJava.java
@@ -33,24 +33,16 @@ public class GremlinAntlrToJava extends GremlinGSBaseVisitor<Object> {
     final GremlinGSBaseVisitor<GraphTraversalSource> gvisitor;
     final GremlinGSBaseVisitor<GraphTraversal> tvisitor;
 
-    private static GremlinAntlrToJava instance;
     // return nested traversal as IrCustomizedTraversal type
     private static Supplier<GraphTraversal<?, ?>> traversalSupplier =
             () -> new IrCustomizedTraversal<>();
-
-    public static GremlinAntlrToJava getInstance(GraphTraversalSource g) {
-        if (instance == null) {
-            instance = new GremlinAntlrToJava(g);
-        }
-        return instance;
-    }
 
     public static Supplier<GraphTraversal<?, ?>> getTraversalSupplier() {
         return traversalSupplier;
     }
 
-    private GremlinAntlrToJava(GraphTraversalSource g) {
-        this.g = g;
+    public GremlinAntlrToJava(GraphTraversalSource g) {
+        this.g = g.clone();
         this.gvisitor = new GraphTraversalSourceVisitor(this.g);
         this.tvisitor = new TraversalRootVisitor(this.gvisitor);
     }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -43,20 +43,23 @@ import com.alibaba.graphscope.gremlin.plugin.script.AntlrGremlinScriptEngineFact
 import com.alibaba.graphscope.gremlin.plugin.strategy.ExpandFusionStepStrategy;
 import com.alibaba.graphscope.gremlin.plugin.strategy.RemoveUselessStepStrategy;
 import com.alibaba.graphscope.gremlin.plugin.strategy.ScanFusionStepStrategy;
+import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversal;
+import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversalSource;
 import com.alibaba.graphscope.gremlin.result.processor.AbstractResultProcessor;
 import com.alibaba.graphscope.gremlin.result.processor.GremlinResultProcessor;
 import com.alibaba.pegasus.RpcClient;
 import com.alibaba.pegasus.intf.ResultProcessor;
 import com.alibaba.pegasus.service.protocol.PegasusClient;
+import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.groovy.jsr223.TimedInterruptTimeoutException;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -69,7 +72,9 @@ import org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 
+import javax.script.SimpleBindings;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -77,8 +82,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
-
-import javax.script.SimpleBindings;
 
 public class IrStandardOpProcessor extends StandardOpProcessor {
     protected Graph graph;
@@ -307,6 +310,9 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
             QueryTimeoutConfig timeoutConfig,
             QueryLogger queryLogger)
             throws InvalidProtocolBufferException, IOException, RuntimeException {
+        // get configs per query from traversal
+        Configs queryConfigs = getQueryConfigs(traversal);
+
         InterOpCollection opCollection = (new InterOpCollectionBuilder(traversal)).build();
         // fuse order with limit to topK
         InterOpCollection.applyStrategies(opCollection);
@@ -318,7 +324,7 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
         IrPlan irPlan = new IrPlan(irMeta, opCollection);
         // print script and jobName with ir plan
         queryLogger.info("ir plan {}", irPlan.getPlanAsJson());
-        byte[] physicalPlanBytes = irPlan.toPhysicalBytes(configs);
+        byte[] physicalPlanBytes = irPlan.toPhysicalBytes(queryConfigs);
         irPlan.close();
 
         PegasusClient.JobRequest request =
@@ -329,15 +335,34 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
                 PegasusClient.JobConfig.newBuilder()
                         .setJobId(jobId)
                         .setJobName(jobName)
-                        .setWorkers(PegasusConfig.PEGASUS_WORKER_NUM.get(configs))
-                        .setBatchSize(PegasusConfig.PEGASUS_BATCH_SIZE.get(configs))
-                        .setMemoryLimit(PegasusConfig.PEGASUS_MEMORY_LIMIT.get(configs))
-                        .setBatchCapacity(PegasusConfig.PEGASUS_OUTPUT_CAPACITY.get(configs))
+                        .setWorkers(PegasusConfig.PEGASUS_WORKER_NUM.get(queryConfigs))
+                        .setBatchSize(PegasusConfig.PEGASUS_BATCH_SIZE.get(queryConfigs))
+                        .setMemoryLimit(PegasusConfig.PEGASUS_MEMORY_LIMIT.get(queryConfigs))
+                        .setBatchCapacity(PegasusConfig.PEGASUS_OUTPUT_CAPACITY.get(queryConfigs))
                         .setTimeLimit(timeoutConfig.getEngineTimeoutMS())
                         .setAll(PegasusClient.Empty.newBuilder().build())
                         .build();
         request = request.toBuilder().setConf(jobConfig).build();
         this.rpcClient.submit(request, resultProcessor, timeoutConfig.getChannelTimeoutMS());
+    }
+
+    private Configs getQueryConfigs(Traversal traversal) {
+        // the config priority is query > system env > system property > config file
+        Iterator<Object> keyIterator = this.configs.getKeys();
+        Map configMap = Maps.newHashMap();
+        while (keyIterator.hasNext()) {
+            String key = keyIterator.next().toString();
+            configMap.put(key, this.configs.get(key));
+        }
+        if (traversal instanceof IrCustomizedTraversal) {
+            Optional<TraversalSource> sourceOpt =
+                    ((IrCustomizedTraversal) traversal).getTraversalSource();
+            if (sourceOpt.isPresent()) {
+                // will override the config set before
+                configMap.putAll(((IrCustomizedTraversalSource) sourceOpt.get()).getConfigs());
+            }
+        }
+        return new Configs(configMap);
     }
 
     public static void applyStrategies(Traversal traversal) {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -53,6 +53,7 @@ import com.alibaba.pegasus.service.protocol.PegasusClient;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+
 import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
 import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
@@ -72,7 +73,6 @@ import org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 
-import javax.script.SimpleBindings;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
@@ -82,6 +82,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
+
+import javax.script.SimpleBindings;
 
 public class IrStandardOpProcessor extends StandardOpProcessor {
     protected Graph graph;

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/script/AntlrGremlinScriptEngine.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/script/AntlrGremlinScriptEngine.java
@@ -30,7 +30,9 @@ import com.alibaba.graphscope.grammar.GremlinGSLexer;
 import com.alibaba.graphscope.grammar.GremlinGSParser;
 import com.alibaba.graphscope.gremlin.antlr4.GremlinAntlrToJava;
 
-import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.DefaultErrorStrategy;
 import org.antlr.v4.runtime.atn.PredictionMode;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
@@ -43,7 +45,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Reader;
 
-import javax.script.*;
+import javax.script.AbstractScriptEngine;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.SimpleBindings;
 
 public class AntlrGremlinScriptEngine extends AbstractScriptEngine implements GremlinScriptEngine {
     private Logger logger = LoggerFactory.getLogger(AntlrGremlinScriptEngine.class);
@@ -54,7 +59,7 @@ public class AntlrGremlinScriptEngine extends AbstractScriptEngine implements Gr
         logger.debug("antlr-gremlin start to eval \"{}\"", script);
         Bindings globalBindings = ctx.getBindings(ScriptContext.ENGINE_SCOPE);
         GraphTraversalSource g = (GraphTraversalSource) globalBindings.get("g");
-        GremlinAntlrToJava antlrToJava = GremlinAntlrToJava.getInstance(g);
+        GremlinAntlrToJava antlrToJava = new GremlinAntlrToJava(g);
 
         GremlinGSLexer lexer = new GremlinGSLexer(CharStreams.fromString(script));
         // reset error listeners on lexer


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
make pegasus.XX settings configurable per query:
```
g.with(pegasus.worker.num, 2).V()
g.with(pegasus.batch.size, 64).V()
g.with(pegasus.output.capacity, 64).V()
```
the priority is : query > system env > system property > config file

<!-- Please give a short brief about these changes. -->

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #3318 

