### PR TITLE
fix(interactive): Fix a bug for CSVFragmentLoader

### DIFF
--- a/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
@@ -41,9 +41,9 @@ static std::vector<std::string> read_header(const std::string& file_name,
   preprocess_line(line_buf);
   const char* cur = line_buf;
   std::vector<std::string> res_vec;
-  while (*cur != '\0') {
+  while (*cur != '\0' && *cur != '\n' && *cur != '\r') {
     const char* tmp = cur;
-    while (*tmp != '\0' && *tmp != delimiter) {
+    while (*tmp != '\0' && *cur != '\n' && *cur != '\r' && *tmp != delimiter) {
       ++tmp;
     }
 

--- a/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
@@ -18,38 +18,27 @@
 
 namespace gs {
 
-static void preprocess_line(char* line) {
-  size_t len = strlen(line);
-  while (len >= 0) {
-    if (line[len] != '\0' && line[len] != '\n' && line[len] != '\r' &&
-        line[len] != ' ' && line[len] != '\t') {
-      break;
-    } else {
-      --len;
-    }
-  }
-  line[len + 1] = '\0';
-}
 
 static std::vector<std::string> read_header(const std::string& file_name,
                                             char delimiter) {
-  char line_buf[4096];
-  FILE* fin = fopen(file_name.c_str(), "r");
-  if (fgets(line_buf, 4096, fin) == NULL) {
-    LOG(FATAL) << "Failed to read header from file: " << file_name;
-  }
-  preprocess_line(line_buf);
-  const char* cur = line_buf;
+ // read the header line of the file, and split into vector to string by delimiter
   std::vector<std::string> res_vec;
-  while (*cur != '\0' && *cur != '\n' && *cur != '\r') {
-    const char* tmp = cur;
-    while (*tmp != '\0' && *cur != '\n' && *cur != '\r' && *tmp != delimiter) {
-      ++tmp;
+  std::ifstream file(file_name);
+  std::string line;
+  if (file.is_open()) {
+    if (std::getline(file, line)) {
+      std::stringstream ss(line);
+      std::string token;
+      while (std::getline(ss, token, delimiter)) {
+        res_vec.push_back(token);
+      }
     }
-
-    std::string_view sv(cur, tmp - cur);
-    res_vec.emplace_back(sv);
-    cur = tmp + 1;
+    else {
+      LOG(FATAL) << "Fail to read header line of file: " << file_name;
+    }
+    file.close();
+  } else {
+    LOG(FATAL) << "Fail to open file: " << file_name;
   }
   return res_vec;
 }

--- a/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
@@ -30,6 +30,8 @@ static std::vector<std::string> read_header(const std::string& file_name,
       std::stringstream ss(line);
       std::string token;
       while (std::getline(ss, token, delimiter)) {
+        //trim the token
+        token.erase(token.find_last_not_of(" \n\r\t") + 1);
         res_vec.push_back(token);
       }
     }


### PR DESCRIPTION
Fix a bug in CSVFragmentLoader.  Previous implementation fails to parse header to some files if the header lines contains more than one spaces or other characters.