### PR TITLE
fix(interactive): Check vertex existence whenever queried

### DIFF
--- a/interactive_engine/executor/store/global_query/src/store_impl/groot/global_graph.rs
+++ b/interactive_engine/executor/store/global_query/src/store_impl/groot/global_graph.rs
@@ -436,7 +436,7 @@ impl GraphPartitionManager for GlobalGraph {
 
     fn get_vertex_id_by_primary_key(&self, _label_id: u32, _key: &String) -> Option<(u32, i64)> {
         // TODO check
-        None
+        unimplemented!("get vertex id by primary key is not implemented")
     }
 
     fn get_vertex_id_by_primary_keys(&self, label_id: LabelId, pks: &[Property]) -> Option<VertexId> {


### PR DESCRIPTION
Previously, when query a vertex by pk, it doesn't check whether the vertex exists.
```
g.V().has('person', 'id', 1)
```
This PR will do a lookup in the database and return empty if not exists.


