### PR TITLE
feat(interactive): Support more data types for vertex/edge property

### DIFF
--- a/.github/workflows/flex.yml
+++ b/.github/workflows/flex.yml
@@ -57,6 +57,12 @@ jobs:
         export FLEX_DATA_DIR=../../../../interactive/examples/modern_graph/
         ./run_grin_test 'flex://schema_file=../../../../interactive/examples/modern_graph/modern_graph.yaml&bulk_load_file=../../../../interactive/examples/modern_graph/bulk_load.yaml'
 
+    - name: Prepare test dataset
+      env:
+        GS_TEST_DIR: ${{ github.workspace }}/gstest/
+      run: |
+        git clone -b master --single-branch --depth=1 https://github.com/GraphScope/gstest.git ${GS_TEST_DIR}
+
     - name: Test Graph Loading on modern graph
       env:
         FLEX_DATA_DIR: ${{ github.workspace }}/flex/interactive/examples/modern_graph/
@@ -67,15 +73,26 @@ jobs:
         BULK_LOAD_FILE=../interactive/examples/modern_graph/bulk_load.yaml
         GLOG_v=10 ./bin/graph_loader  ${SCHEMA_FILE} ${BULK_LOAD_FILE} /tmp/csr-data-dir/
 
+    - name: Test Graph Loading on type_test graph
+    env:
+        GS_TEST_DIR: ${{ github.workspace }}/gstest/
+        FLEX_DATA_DIR: ${{ github.workspace }}/gstest/flex/type_test/
+    run: |
+        # remove modern graph indices
+        rm -rf /tmp/csr-data-dir/
+
+        cd ${GITHUB_WORKSPACE}/flex/build/
+        SCHEMA_FILE=${GS_TEST_DIR}/type_test/graph.yaml
+        BULK_LOAD_FILE=${GS_TEST_DIR}/type_test/import.yaml
+        GLOG_v=10 ./bin/graph_loader  ${SCHEMA_FILE} ${BULK_LOAD_FILE} /tmp/csr-data-dir/ 2
+
     - name: Test Graph Loading on LDBC SNB sf0.1
       env:
         GS_TEST_DIR: ${{ github.workspace }}/gstest/
         FLEX_DATA_DIR: ${{ github.workspace }}/gstest/flex/ldbc-sf01-long-date/
       run: |
-        # remove modern graph indices
+        # remove previous graph indices
         rm -rf /tmp/csr-data-dir/
-
-        git clone -b master --single-branch --depth=1 https://github.com/GraphScope/gstest.git ${GS_TEST_DIR}
 
         cd ${GITHUB_WORKSPACE}/flex/build/
         SCHEMA_FILE=${FLEX_DATA_DIR}/audit_graph_schema.yaml

--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -26,7 +26,9 @@ Within the `graph.yaml` file, vertices are delineated under the `vertex_types` s
     - id  
 ```
 
-Note: In the current version, only one single primary key can be specified, but we plan to support multiple primary keys in the future. 
+Note:
+- In the current version, only one single primary key can be specified, but we plan to support multiple primary keys in the future. 
+- The data type of primary key column must be one of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64` or `DT_UNSIGNED_INT64`.
 
 Edges are defined within the `edge_types` section, characterized by the mandatory fields: `type_name`, `vertex_type_pair_relations`, and `properties`. The type_name and properties fields function similarly to those in vertices. However, the vertex_type_pair_relations field is exclusive to edges, specifying the permissible source and destination vertex types, as well as the relationship detailing how many source and destination vertices can be linked by this edge. Here's an illustrative example:
 ```yaml
@@ -80,7 +82,3 @@ property_type:
       primitive_type: DT_UNSIGNED_INT64
       max_length: 10  # overflowed elements will be truncated
 ```
-
-## Primary Key for Vertex
-
-Currently, we only support using attribute columns with a data type of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64` or `DT_UNSIGNED_INT64` as the primary key column, and there can be only one primary key column.

--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -64,6 +64,8 @@ property_data_type:
   primitive_type: DT_STRING
 ```
 
+Currently, we only support using attribute columns with a data type of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64` or `DT_UNSIGNED_INT64` as the primary key column, and there can be only one primary key column.
+
 ### Array Types
 
 Array types are currently not supported, but are planned to be supported in the near future.

--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -11,17 +11,17 @@ The graph data encompasses two fundamental elements:
 
 Note: This graph model aligns with the property graph model, which offers a detailed explanation [here](https://subscription.packtpub.com/book/data/9781784393441/1/ch01lvl1sec09/the-property-graph-model). However, it's essential to note our terminology: we use "vertex" instead of "node" and "edge" instead of "relationship", and we only support **directed** edge instead of both directed and undirected edge. 
 
-Within the `gs_interactive_image.yaml` file, vertices are delineated under the `vertex_types` section. Each vertex type is structured with mandatory fields: `type_name`, `properties`, and `primary_keys`. For instance:
+Within the `graph.yaml` file, vertices are delineated under the `vertex_types` section. Each vertex type is structured with mandatory fields: `type_name`, `properties`, and `primary_keys`. For instance:
 
 ```yaml
 - type_name: person
   properties:
     - property_name: id
-      property_data_type:
-        primitive_type: DT_SIGNED_INT64
+      property_type:
+            primitive_type: DT_SIGNED_INT64
     - property_name: name
-      property_data_type:
-        primitive_type: DT_STRING
+      property_type:
+            primitive_type: DT_STRING
   primary_keys: # these must also be listed in the properties
     - id  
 ```
@@ -41,6 +41,7 @@ vertex_type_pair_relations:
 Note: 
 - A single edge type can have multiple `vertex_type_pair_relations`. For instance, a "knows" edge might connect one person to another, symbolizing their friendship. Alternatively, it could associate a person with a skill, indicating their proficiency in that skill.
 - The permissible relations include: `ONE_TO_ONE`, `ONE_TO_MANY`, `MANY_TO_ONE`, and `MANY_TO_MANY`. These relations can be utilized by the optimizer to generate more efficient execution plans.
+- Currently we only support at most one property for each edge triplet.
  
 
 ## Entity Data
@@ -58,24 +59,28 @@ Entity data pertains to the properties associated with vertices and edges. In Gr
 - DT_STRING
 - DT_DATE32
 
-In the `gs_interactive_image.yaml`, a primitive type, such as `DT_STRING`, can be written as:
+In the `graph.yaml`, a primitive type, such as `DT_STRING`, can be written as:
 ```yaml
-property_data_type:
+property_type:
   primitive_type: DT_STRING
 ```
 
-Currently, we only support using attribute columns with a data type of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64` or `DT_UNSIGNED_INT64` as the primary key column, and there can be only one primary key column.
+Please note that we currently do not support the use of string data type for properties on edges.
 
 ### Array Types
 
 Array types are currently not supported, but are planned to be supported in the near future.
 Once supported, albeit requiring that every element within the array adheres to one of the previously mentioned primitive types. 
-It's crucial that all elements within a single array share the same type. In `gs_interactive_image.yaml`, user can describe designating a property as an array of the `DT_STRING` type as:
+It's crucial that all elements within a single array share the same type. In `graph.yaml`, user can describe designating a property as an array of the `DT_STRING` type as:
 
 ```yaml
-property_data_type:
+property_type:
   array:
     component_type: 
       primitive_type: DT_UNSIGNED_INT64
       max_length: 10  # overflowed elements will be truncated
 ```
+
+## Primary Key for Vertex
+
+Currently, we only support using attribute columns with a data type of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64` or `DT_UNSIGNED_INT64` as the primary key column, and there can be only one primary key column.

--- a/flex/engines/graph_db/database/graph_db_session.cc
+++ b/flex/engines/graph_db/database/graph_db_session.cc
@@ -70,6 +70,21 @@ std::shared_ptr<RefColumnBase> GraphDBSession::get_vertex_id_column(
         dynamic_cast<const TypedColumn<int64_t>&>(
             db_.graph().lf_indexers_[label].get_keys()));
   } else if (db_.graph().lf_indexers_[label].get_type() ==
+             PropertyType::kInt32) {
+    return std::make_shared<TypedRefColumn<int32_t>>(
+        dynamic_cast<const TypedColumn<int32_t>&>(
+            db_.graph().lf_indexers_[label].get_keys()));
+  } else if (db_.graph().lf_indexers_[label].get_type() ==
+             PropertyType::kUInt64) {
+    return std::make_shared<TypedRefColumn<uint64_t>>(
+        dynamic_cast<const TypedColumn<uint64_t>&>(
+            db_.graph().lf_indexers_[label].get_keys()));
+  } else if (db_.graph().lf_indexers_[label].get_type() ==
+             PropertyType::kUInt32) {
+    return std::make_shared<TypedRefColumn<uint32_t>>(
+        dynamic_cast<const TypedColumn<uint32_t>&>(
+            db_.graph().lf_indexers_[label].get_keys()));
+  } else if (db_.graph().lf_indexers_[label].get_type() ==
              PropertyType::kString) {
     return std::make_shared<TypedRefColumn<std::string_view>>(
         dynamic_cast<const TypedColumn<std::string_view>&>(

--- a/flex/engines/graph_db/database/transaction_utils.h
+++ b/flex/engines/graph_db/database/transaction_utils.h
@@ -26,8 +26,14 @@ namespace gs {
 
 inline void serialize_field(grape::InArchive& arc, const Any& prop) {
   switch (prop.type) {
+  case PropertyType::kBool:
+    arc << prop.value.b;
+    break;
   case PropertyType::kInt32:
     arc << prop.value.i;
+    break;
+  case PropertyType::kUInt32:
+    arc << prop.value.ui;
     break;
   case PropertyType::kDate:
     arc << prop.value.d.milli_second;
@@ -40,8 +46,14 @@ inline void serialize_field(grape::InArchive& arc, const Any& prop) {
   case PropertyType::kInt64:
     arc << prop.value.l;
     break;
+  case PropertyType::kUInt64:
+    arc << prop.value.ul;
+    break;
   case PropertyType::kDouble:
     arc << prop.value.db;
+    break;
+  case PropertyType::kFloat:
+    arc << prop.value.f;
     break;
   default:
     LOG(FATAL) << "Unexpected property type";
@@ -50,8 +62,14 @@ inline void serialize_field(grape::InArchive& arc, const Any& prop) {
 
 inline void deserialize_field(grape::OutArchive& arc, Any& prop) {
   switch (prop.type) {
+  case PropertyType::kBool:
+    arc >> prop.value.b;
+    break;
   case PropertyType::kInt32:
     arc >> prop.value.i;
+    break;
+  case PropertyType::kUInt32:
+    arc >> prop.value.ui;
     break;
   case PropertyType::kDate:
     arc >> prop.value.d.milli_second;
@@ -64,8 +82,14 @@ inline void deserialize_field(grape::OutArchive& arc, Any& prop) {
   case PropertyType::kInt64:
     arc >> prop.value.l;
     break;
+  case PropertyType::kUInt64:
+    arc >> prop.value.ul;
+    break;
   case PropertyType::kDouble:
     arc >> prop.value.db;
+    break;
+  case PropertyType::kFloat:
+    arc >> prop.value.f;
     break;
   default:
     LOG(FATAL) << "Unexpected property type";

--- a/flex/engines/graph_db/database/update_transaction.cc
+++ b/flex/engines/graph_db/database/update_transaction.cc
@@ -41,6 +41,15 @@ UpdateTransaction::UpdateTransaction(MutablePropertyFragment& graph,
     if (graph_.lf_indexers_[idx].get_type() == PropertyType::kInt64) {
       added_vertices_.emplace_back(
           std::make_shared<IdIndexer<int64_t, vid_t>>());
+    } else if (graph_.lf_indexers_[idx].get_type() == PropertyType::kUInt64) {
+      added_vertices_.emplace_back(
+          std::make_shared<IdIndexer<uint64_t, vid_t>>());
+    } else if (graph_.lf_indexers_[idx].get_type() == PropertyType::kInt32) {
+      added_vertices_.emplace_back(
+          std::make_shared<IdIndexer<int32_t, vid_t>>());
+    } else if (graph_.lf_indexers_[idx].get_type() == PropertyType::kUInt32) {
+      added_vertices_.emplace_back(
+          std::make_shared<IdIndexer<uint32_t, vid_t>>());
     } else if (graph_.lf_indexers_[idx].get_type() == PropertyType::kString) {
       added_vertices_.emplace_back(
           std::make_shared<IdIndexer<std::string_view, vid_t>>());
@@ -431,11 +440,21 @@ void UpdateTransaction::IngestWal(MutablePropertyFragment& graph,
     if (graph.lf_indexers_[idx].get_type() == PropertyType::kInt64) {
       added_vertices.emplace_back(
           std::make_shared<IdIndexer<int64_t, vid_t>>());
+    } else if (graph.lf_indexers_[idx].get_type() == PropertyType::kUInt64) {
+      added_vertices.emplace_back(
+          std::make_shared<IdIndexer<uint64_t, vid_t>>());
+    } else if (graph.lf_indexers_[idx].get_type() == PropertyType::kInt32) {
+      added_vertices.emplace_back(
+          std::make_shared<IdIndexer<int32_t, vid_t>>());
+    } else if (graph.lf_indexers_[idx].get_type() == PropertyType::kUInt32) {
+      added_vertices.emplace_back(
+          std::make_shared<IdIndexer<uint32_t, vid_t>>());
     } else if (graph.lf_indexers_[idx].get_type() == PropertyType::kString) {
       added_vertices.emplace_back(
           std::make_shared<IdIndexer<std::string_view, vid_t>>());
     } else {
-      LOG(FATAL) << "Only int64 and string_view types for pk are supported..";
+      LOG(FATAL) << "Only int64, uint64, int32, uint32 and string_view types "
+                    "for pk are supported..";
     }
   }
 

--- a/flex/engines/graph_db/grin/predefine.h
+++ b/flex/engines/graph_db/grin/predefine.h
@@ -53,6 +53,7 @@ typedef enum {
   Date32 = 8,        ///< date
   Time32 = 9,        ///< Time32
   Timestamp64 = 10,  ///< Timestamp
+  Bool = 11,         ///< bool
 } GRIN_DATATYPE;
 
 /// Enumerates the error codes of grin

--- a/flex/engines/graph_db/grin/src/index/pk.cc
+++ b/flex/engines/graph_db/grin/src/index/pk.cc
@@ -39,15 +39,29 @@ GRIN_VERTEX grin_get_vertex_by_primary_keys_row(GRIN_GRAPH g,
     if (!_g->g.get_lid(label, oid, vid)) {
       return GRIN_NULL_VERTEX;
     }
-  } else if (type == gs::PropertyType::kString) {
-    auto oid = *static_cast<const std::string_view*>((*_r)[0]);
+  } else if (type == gs::PropertyType::kInt32) {
+    auto oid = *static_cast<const int32_t*>((*_r)[0]);
     if (!_g->g.get_lid(label, oid, vid)) {
       return GRIN_NULL_VERTEX;
     }
-  } else {
-    return GRIN_NULL_VERTEX;
+  } else if (type == gs::PropertyType::kUInt32) {
+    auto oid = *static_cast<const uint32_t*>((*_r)[0]);
+    if (!_g->g.get_lid(label, oid, vid)) {
+      return GRIN_NULL_VERTEX;
+    }
+  } else if (type == gs::PropertyType::kUInt64) {
+    auto oid = *static_cast<const uint64_t*>((*_r)[0]);
+    if (!_g->g.get_lid(label, oid, vid)) {
+      return GRIN_NULL_VERTEX;
+    } else if (type == gs::PropertyType::kString) {
+      auto oid = *static_cast<const std::string_view*>((*_r)[0]);
+      if (!_g->g.get_lid(label, oid, vid)) {
+        return GRIN_NULL_VERTEX;
+      }
+    } else {
+      return GRIN_NULL_VERTEX;
+    }
+    uint64_t v = ((label * 1ull) << 32) + vid;
+    return v;
   }
-  uint64_t v = ((label * 1ull) << 32) + vid;
-  return v;
-}
 #endif

--- a/flex/engines/graph_db/grin/src/index/pk.cc
+++ b/flex/engines/graph_db/grin/src/index/pk.cc
@@ -53,15 +53,16 @@ GRIN_VERTEX grin_get_vertex_by_primary_keys_row(GRIN_GRAPH g,
     auto oid = *static_cast<const uint64_t*>((*_r)[0]);
     if (!_g->g.get_lid(label, oid, vid)) {
       return GRIN_NULL_VERTEX;
-    } else if (type == gs::PropertyType::kString) {
-      auto oid = *static_cast<const std::string_view*>((*_r)[0]);
-      if (!_g->g.get_lid(label, oid, vid)) {
-        return GRIN_NULL_VERTEX;
-      }
-    } else {
+    }
+  } else if (type == gs::PropertyType::kString) {
+    auto oid = *static_cast<const std::string_view*>((*_r)[0]);
+    if (!_g->g.get_lid(label, oid, vid)) {
       return GRIN_NULL_VERTEX;
     }
-    uint64_t v = ((label * 1ull) << 32) + vid;
-    return v;
+  } else {
+    return GRIN_NULL_VERTEX;
   }
+  uint64_t v = ((label * 1ull) << 32) + vid;
+  return v;
+}
 #endif

--- a/flex/engines/graph_db/grin/src/predefine.cc
+++ b/flex/engines/graph_db/grin/src/predefine.cc
@@ -1,16 +1,24 @@
 #include "grin/src/predefine.h"
 
 GRIN_DATATYPE _get_data_type(const gs::PropertyType& type) {
-  if (type == gs::PropertyType::kInt32) {
+  if (type == gs::PropertyType::kBool) {
+    return GRIN_DATATYPE::Bool;
+  } else if (type == gs::PropertyType::kInt32) {
     return GRIN_DATATYPE::Int32;
+  } else if (type == gs::PropertyType::kUInt32) {
+    return GRIN_DATATYPE::UInt32;
   } else if (type == gs::PropertyType::kInt64) {
     return GRIN_DATATYPE::Int64;
+  } else if (type == gs::PropertyType::kUInt64) {
+    return GRIN_DATATYPE::UInt64;
   } else if (type == gs::PropertyType::kString) {
     return GRIN_DATATYPE::String;
   } else if (type == gs::PropertyType::kDate) {
     return GRIN_DATATYPE::Timestamp64;
   } else if (type == gs::PropertyType::kDouble) {
     return GRIN_DATATYPE::Double;
+  } else if (type == gs::PropertyType::kFloat) {
+    return GRIN_DATATYPE::Float;
   } else {
     return GRIN_DATATYPE::Undefined;
   }
@@ -32,6 +40,18 @@ void init_cache(GRIN_GRAPH_T* g) {
         tmp.emplace_back(std::dynamic_pointer_cast<gs::LongColumn>(
                              table.get_column_by_id(idx))
                              .get());
+      } else if (type == gs::PropertyType::kUInt32) {
+        tmp.emplace_back(std::dynamic_pointer_cast<gs::UIntColumn>(
+                             table.get_column_by_id(idx))
+                             .get());
+      } else if (type == gs::PropertyType::kUInt64) {
+        tmp.emplace_back(std::dynamic_pointer_cast<gs::ULongColumn>(
+                             table.get_column_by_id(idx))
+                             .get());
+      } else if (type == gs::PropertyType::kBool) {
+        tmp.emplace_back(std::dynamic_pointer_cast<gs::BoolColumn>(
+                             table.get_column_by_id(idx))
+                             .get());
       } else if (type == gs::PropertyType::kString) {
         tmp.emplace_back(std::dynamic_pointer_cast<gs::StringColumn>(
                              table.get_column_by_id(idx))
@@ -42,6 +62,10 @@ void init_cache(GRIN_GRAPH_T* g) {
                              .get());
       } else if (type == gs::PropertyType::kDouble) {
         tmp.emplace_back(std::dynamic_pointer_cast<gs::DoubleColumn>(
+                             table.get_column_by_id(idx))
+                             .get());
+      } else if (type == gs::PropertyType::kFloat) {
+        tmp.emplace_back(std::dynamic_pointer_cast<gs::FloatColumn>(
                              table.get_column_by_id(idx))
                              .get());
       } else {

--- a/flex/engines/graph_db/grin/src/property/primarykey.cc
+++ b/flex/engines/graph_db/grin/src/property/primarykey.cc
@@ -36,6 +36,12 @@ GRIN_VERTEX_PROPERTY_LIST grin_get_primary_keys_by_vertex_type(
   vp += (label * 1u) << 8;
   if (type == gs::PropertyType::kInt64) {
     vp += (GRIN_DATATYPE::Int64 * 1u) << 16;
+  } else if (type == gs::PropertyType::kInt32) {
+    vp += (GRIN_DATATYPE::Int32 * 1u) << 16;
+  } else if (type == gs::PropertyType::kUInt64) {
+    vp += (GRIN_DATATYPE::UInt64 * 1u) << 16;
+  } else if (type == gs::PropertyType::kUInt32) {
+    vp += (GRIN_DATATYPE::UInt32 * 1u) << 16;
   } else if (type == gs::PropertyType::kString) {
     vp += (GRIN_DATATYPE::String * 1u) << 16;
   } else {

--- a/flex/engines/graph_db/grin/src/property/property.cc
+++ b/flex/engines/graph_db/grin/src/property/property.cc
@@ -403,6 +403,7 @@ unsigned long long int grin_get_edge_property_value_of_uint64(
     grin_error_code = INVALID_VALUE;
     return 0;
   }
+  return _e->data.value.ul;
 }
 
 float grin_get_edge_property_value_of_float(GRIN_GRAPH g, GRIN_EDGE e,
@@ -413,6 +414,7 @@ float grin_get_edge_property_value_of_float(GRIN_GRAPH g, GRIN_EDGE e,
     grin_error_code = INVALID_VALUE;
     return 0.0f;
   }
+  return _e->data.value.f;
 }
 double grin_get_edge_property_value_of_double(GRIN_GRAPH g, GRIN_EDGE e,
                                               GRIN_EDGE_PROPERTY ep) {

--- a/flex/engines/graph_db/grin/src/property/property.cc
+++ b/flex/engines/graph_db/grin/src/property/property.cc
@@ -88,7 +88,7 @@ void grin_destroy_vertex_property(GRIN_GRAPH g, GRIN_VERTEX_PROPERTY vp) {}
  */
 GRIN_DATATYPE grin_get_vertex_property_datatype(GRIN_GRAPH g,
                                                 GRIN_VERTEX_PROPERTY vp) {
-  return (GRIN_DATATYPE) (vp >> 16);
+  return (GRIN_DATATYPE)(vp >> 16);
 }
 
 int grin_get_vertex_property_value_of_int32(GRIN_GRAPH g, GRIN_VERTEX v,
@@ -296,12 +296,24 @@ const void* grin_get_vertex_property_value(GRIN_GRAPH g, GRIN_VERTEX v,
   auto vid = v & (0xffffffff);
 
   switch (type) {
+  case GRIN_DATATYPE::Bool: {
+    auto _col = static_cast<const gs::BoolColumn*>(col);
+    return _col->buffer().data() + vid;
+  }
   case GRIN_DATATYPE::Int32: {
     auto _col = static_cast<const gs::IntColumn*>(col);
     return _col->buffer().data() + vid;
   }
+  case GRIN_DATATYPE::UInt32: {
+    auto _col = static_cast<const gs::UIntColumn*>(col);
+    return _col->buffer().data() + vid;
+  }
   case GRIN_DATATYPE::Int64: {
     auto _col = static_cast<const gs::LongColumn*>(col);
+    return _col->buffer().data() + vid;
+  }
+  case GRIN_DATATYPE::UInt64: {
+    auto _col = static_cast<const gs::ULongColumn*>(col);
     return _col->buffer().data() + vid;
   }
   case GRIN_DATATYPE::String: {
@@ -314,6 +326,10 @@ const void* grin_get_vertex_property_value(GRIN_GRAPH g, GRIN_VERTEX v,
   }
   case GRIN_DATATYPE::Double: {
     auto _col = static_cast<const gs::DoubleColumn*>(col);
+    return _col->buffer().data() + vid;
+  }
+  case GRIN_DATATYPE::Float: {
+    auto _col = static_cast<const gs::FloatColumn*>(col);
     return _col->buffer().data() + vid;
   }
   default:
@@ -359,8 +375,13 @@ int grin_get_edge_property_value_of_int32(GRIN_GRAPH g, GRIN_EDGE e,
 
 unsigned int grin_get_edge_property_value_of_uint32(GRIN_GRAPH g, GRIN_EDGE e,
                                                     GRIN_EDGE_PROPERTY ep) {
-  grin_error_code = INVALID_VALUE;
-  return 0;
+  auto _e = static_cast<GRIN_EDGE_T*>(e);
+  auto idx = ep >> 24;
+  if (idx > 0 || _get_data_type(_e->data.type) != GRIN_DATATYPE::UInt32) {
+    grin_error_code = INVALID_VALUE;
+    return 0;
+  }
+  return _e->data.value.ui;
 }
 
 long long int grin_get_edge_property_value_of_int64(GRIN_GRAPH g, GRIN_EDGE e,
@@ -376,14 +397,22 @@ long long int grin_get_edge_property_value_of_int64(GRIN_GRAPH g, GRIN_EDGE e,
 
 unsigned long long int grin_get_edge_property_value_of_uint64(
     GRIN_GRAPH g, GRIN_EDGE e, GRIN_EDGE_PROPERTY ep) {
-  grin_error_code = INVALID_VALUE;
-  return 0;
+  auto _e = static_cast<GRIN_EDGE_T*>(e);
+  auto idx = ep >> 24;
+  if (idx > 0 || _get_data_type(_e->data.type) != GRIN_DATATYPE::UInt64) {
+    grin_error_code = INVALID_VALUE;
+    return 0;
+  }
 }
 
 float grin_get_edge_property_value_of_float(GRIN_GRAPH g, GRIN_EDGE e,
                                             GRIN_EDGE_PROPERTY ep) {
-  grin_error_code = INVALID_VALUE;
-  return 0.0;
+  auto _e = static_cast<GRIN_EDGE_T*>(e);
+  auto idx = ep >> 24;
+  if (idx > 0 || _get_data_type(_e->data.type) != GRIN_DATATYPE::Float) {
+    grin_error_code = INVALID_VALUE;
+    return 0.0f;
+  }
 }
 double grin_get_edge_property_value_of_double(GRIN_GRAPH g, GRIN_EDGE e,
                                               GRIN_EDGE_PROPERTY ep) {

--- a/flex/engines/graph_db/grin/src/property/row.cc
+++ b/flex/engines/graph_db/grin/src/property/row.cc
@@ -147,6 +147,8 @@ const void* grin_get_value_from_row(GRIN_GRAPH g, GRIN_ROW r, GRIN_DATATYPE dt,
                                     size_t idx) {
   auto _r = static_cast<GRIN_ROW_T*>(r);
   switch (dt) {
+  case GRIN_DATATYPE::Bool:
+    return static_cast<const bool*>((*_r)[idx]);
   case GRIN_DATATYPE::Int32:
     return static_cast<const int32_t*>((*_r)[idx]);
   case GRIN_DATATYPE::UInt32:
@@ -192,6 +194,11 @@ GRIN_ROW grin_get_vertex_row(GRIN_GRAPH g, GRIN_VERTEX v) {
     auto col = _g->vproperties[label][prop_id];
     auto type = _get_data_type(types[prop_id]);
     switch (type) {
+    case GRIN_DATATYPE::Bool: {
+      auto _col = static_cast<const gs::BoolColumn*>(col);
+      r->emplace_back(_col->buffer().data() + vid);
+      break;
+    }
     case GRIN_DATATYPE::Int32: {
       auto _col = static_cast<const gs::IntColumn*>(col);
       r->emplace_back(_col->buffer().data() + vid);
@@ -199,6 +206,16 @@ GRIN_ROW grin_get_vertex_row(GRIN_GRAPH g, GRIN_VERTEX v) {
     }
     case GRIN_DATATYPE::Int64: {
       auto _col = static_cast<const gs::LongColumn*>(col);
+      r->emplace_back(_col->buffer().data() + vid);
+      break;
+    }
+    case GRIN_DATATYPE::UInt32: {
+      auto _col = static_cast<const gs::UIntColumn*>(col);
+      r->emplace_back(_col->buffer().data() + vid);
+      break;
+    }
+    case GRIN_DATATYPE::UInt64: {
+      auto _col = static_cast<const gs::ULongColumn*>(col);
       r->emplace_back(_col->buffer().data() + vid);
       break;
     }
@@ -221,6 +238,11 @@ GRIN_ROW grin_get_vertex_row(GRIN_GRAPH g, GRIN_VERTEX v) {
       r->emplace_back(_col->buffer().data() + vid);
       break;
     }
+    case GRIN_DATATYPE::Float: {
+      auto _col = static_cast<const gs::FloatColumn*>(col);
+      r->emplace_back(_col->buffer().data() + vid);
+      break;
+    }
     default:
       r->emplace_back(static_cast<const void*>(NULL));
     }
@@ -235,12 +257,24 @@ GRIN_ROW grin_get_edge_row(GRIN_GRAPH g, GRIN_EDGE e) {
   auto type = _get_data_type(_e->data.type);
   GRIN_ROW_T* r = new GRIN_ROW_T();
   switch (type) {
+  case GRIN_DATATYPE::Bool: {
+    r->emplace_back(new bool(_e->data.value.b));
+    break;
+  }
   case GRIN_DATATYPE::Int32: {
     r->emplace_back(new int(_e->data.value.i));
     break;
   }
   case GRIN_DATATYPE::Int64: {
     r->emplace_back(new int64_t(_e->data.value.l));
+    break;
+  }
+  case GRIN_DATATYPE::UInt32: {
+    r->emplace_back(new uint32_t(_e->data.value.ui));
+    break;
+  }
+  case GRIN_DATATYPE::UInt64: {
+    r->emplace_back(new uint64_t(_e->data.value.ul));
     break;
   }
   case GRIN_DATATYPE::String: {
@@ -258,6 +292,10 @@ GRIN_ROW grin_get_edge_row(GRIN_GRAPH g, GRIN_EDGE e) {
   }
   case GRIN_DATATYPE::Double: {
     r->emplace_back(new double(_e->data.value.db));
+    break;
+  }
+  case GRIN_DATATYPE::Float: {
+    r->emplace_back(new float(_e->data.value.f));
     break;
   }
   default:

--- a/flex/engines/graph_db/grin/src/topology/structure.cc
+++ b/flex/engines/graph_db/grin/src/topology/structure.cc
@@ -144,14 +144,26 @@ const void* grin_get_edge_data_value(GRIN_GRAPH, GRIN_EDGE e) {
   auto _e = static_cast<GRIN_EDGE_T*>(e);
   auto type = _e->data.type;
   switch (_get_data_type(type)) {
+  case GRIN_DATATYPE::Bool: {
+    return new bool(_e->data.value.b);
+  }
   case GRIN_DATATYPE::Int32: {
     return new int32_t(_e->data.value.i);
   }
   case GRIN_DATATYPE::Int64: {
     return new int64_t(_e->data.value.l);
   }
+  case GRIN_DATATYPE::UInt32: {
+    return new uint32_t(_e->data.value.ui);
+  }
+  case GRIN_DATATYPE::UInt64: {
+    return new uint64_t(_e->data.value.ul);
+  }
   case GRIN_DATATYPE::Double: {
     return new double(_e->data.value.db);
+  }
+  case GRIN_DATATYPE::Float: {
+    return new float(_e->data.value.f);
   }
   case GRIN_DATATYPE::String: {
     auto s = _e->data.value.s;

--- a/flex/engines/hqps_db/core/operator/sink.h
+++ b/flex/engines/hqps_db/core/operator/sink.h
@@ -180,11 +180,24 @@ void template_set_tuple_value(results::Collection* collection,
 
 void set_any_to_common_value(const Any& any, common::Value* value) {
   switch (any.type) {
+  case gs::PropertyType::kBool:
+    value->set_boolean(any.value.b);
+    break;
   case gs::PropertyType::kInt32:
-    value->set_i64(any.value.i);
+    value->set_i32(any.value.i);
     break;
   case gs::PropertyType::kInt64:
     value->set_i64(any.value.l);
+    break;
+  case gs::PropertyType::kUInt32:
+    // FIXME(zhanglei): temporarily use i64, fix this after common.proto is
+    // changed
+    value->set_i32(any.value.ui);
+    break;
+  case gs::PropertyType::kUInt64:
+    // FIXME(zhanglei): temporarily use i64, fix this after common.proto is
+    // changed
+    value->set_i64(any.value.ul);
     break;
   case gs::PropertyType::kDate:
     value->set_i64(any.value.d.milli_second);
@@ -194,6 +207,9 @@ void set_any_to_common_value(const Any& any, common::Value* value) {
     break;
   case gs::PropertyType::kDouble:
     value->set_f64(any.value.db);
+    break;
+  case gs::PropertyType::kFloat:
+    value->set_f64(any.value.f);
     break;
   default:
     LOG(WARNING) << "Unsupported type: " << any.type;

--- a/flex/engines/hqps_db/database/mutable_csr_interface.h
+++ b/flex/engines/hqps_db/database/mutable_csr_interface.h
@@ -821,18 +821,30 @@ class MutableCSRInterface {
   std::shared_ptr<RefColumnBase> create_ref_column(
       std::shared_ptr<ColumnBase> column) const {
     auto type = column->type();
-    if (type == PropertyType::kInt32) {
+    if (type == PropertyType::kBool) {
+      return std::make_shared<TypedRefColumn<bool>>(
+          *std::dynamic_pointer_cast<TypedColumn<bool>>(column));
+    } else if (type == PropertyType::kInt32) {
       return std::make_shared<TypedRefColumn<int>>(
           *std::dynamic_pointer_cast<TypedColumn<int>>(column));
     } else if (type == PropertyType::kInt64) {
       return std::make_shared<TypedRefColumn<int64_t>>(
           *std::dynamic_pointer_cast<TypedColumn<int64_t>>(column));
+    } else if (type == PropertyType::kUInt32) {
+      return std::make_shared<TypedRefColumn<uint32_t>>(
+          *std::dynamic_pointer_cast<TypedColumn<uint32_t>>(column));
+    } else if (type == PropertyType::kUInt64) {
+      return std::make_shared<TypedRefColumn<uint64_t>>(
+          *std::dynamic_pointer_cast<TypedColumn<uint64_t>>(column));
     } else if (type == PropertyType::kDate) {
       return std::make_shared<TypedRefColumn<Date>>(
           *std::dynamic_pointer_cast<TypedColumn<Date>>(column));
     } else if (type == PropertyType::kString) {
       return std::make_shared<TypedRefColumn<std::string_view>>(
           *std::dynamic_pointer_cast<TypedColumn<std::string_view>>(column));
+    } else if (type == PropertyType::kFloat) {
+      return std::make_shared<TypedRefColumn<float>>(
+          *std::dynamic_pointer_cast<TypedColumn<float>>(column));
     } else {
       LOG(FATAL) << "unexpected type to create column, "
                  << static_cast<int>(type);

--- a/flex/engines/hqps_db/structures/multi_edge_set/untyped_edge_set.h
+++ b/flex/engines/hqps_db/structures/multi_edge_set/untyped_edge_set.h
@@ -248,7 +248,7 @@ class UnTypedEdgeSet {
     while (iter != end_iter) {
       auto edata = iter.GetData();
       PropT prop;
-      if (edata.type == CppTypeToPropertyType<PropT>::value) {
+      if (edata.type == TypeConverter<PropT>::property_type) {
         ConvertAny<PropT>::to(edata, prop);
       }
       CHECK(cur_ind < sum) << "cur: " << cur_ind << ", sum: " << sum;

--- a/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
@@ -443,14 +443,14 @@ static void append_edges(
     CHECK(src_col->length() == edata_col->length());
     size_t cur_ind = old_size;
     auto type = edata_col->type();
-    if (type != CppTypeToArrowType<EDATA_T>::TypeValue()) {
+    if (type != TypeConverter<EDATA_T>::ArrowTypeValue()) {
       LOG(FATAL) << "Inconsistent data type, expect "
-                 << CppTypeToArrowType<EDATA_T>::TypeValue()->ToString()
+                 << TypeConverter<EDATA_T>::ArrowTypeValue()->ToString()
                  << ", but got " << type->ToString();
     }
 
     using arrow_array_type =
-        typename gs::CppTypeToArrowType<EDATA_T>::ArrayType;
+        typename gs::TypeConverter<EDATA_T>::ArrowArrayType;
     // cast chunk to EDATA_T array
     auto data = std::static_pointer_cast<arrow_array_type>(edata_col);
     for (auto j = 0; j < edata_col->length(); ++j) {
@@ -595,7 +595,7 @@ static void append_edges(
       auto type = edata_col->type();
 
       using arrow_array_type =
-          typename gs::CppTypeToArrowType<EDATA_T>::ArrayType;
+          typename gs::TypeConverter<EDATA_T>::ArrowArrayType;
       if (type->Equals(arrow::timestamp(arrow::TimeUnit::MILLI))) {
         for (auto i = 0; i < edata_col->num_chunks(); ++i) {
           auto chunk = edata_col->chunk(i);
@@ -745,8 +745,8 @@ struct _add_vertex {
     vid_t vid;
     if constexpr (!std::is_same<std::string_view, KEY_T>::value) {
       // for non-string value
-      auto expected_type = gs::CppTypeToArrowType<KEY_T>::TypeValue();
-      using arrow_array_t = typename gs::CppTypeToArrowType<KEY_T>::ArrayType;
+      auto expected_type = gs::TypeConverter<KEY_T>::ArrowTypeValue();
+      using arrow_array_t = typename gs::TypeConverter<KEY_T>::ArrowArrayType;
       if (col->type() != expected_type) {
         LOG(FATAL) << "Inconsistent data type, expect "
                    << expected_type->ToString() << ", but got "
@@ -834,9 +834,9 @@ struct _add_vertex_chunk {
     vid_t vid;
 
     if constexpr (!std::is_same<std::string_view, KEY_T>::value) {
-      auto expected_type = gs::CppTypeToArrowType<KEY_T>::TypeValue();
+      auto expected_type = gs::TypeConverter<KEY_T>::ArrowTypeValue();
       using arrow_array_type =
-          typename gs::CppTypeToArrowType<KEY_T>::ArrayType;
+          typename gs::TypeConverter<KEY_T>::ArrowArrayType;
       if (col->type() != expected_type) {
         LOG(FATAL) << "Inconsistent data type, expect "
                    << expected_type->ToString() << ", but got "

--- a/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/csv_fragment_loader.cc
@@ -18,10 +18,10 @@
 
 namespace gs {
 
-
 static std::vector<std::string> read_header(const std::string& file_name,
                                             char delimiter) {
- // read the header line of the file, and split into vector to string by delimiter
+  // read the header line of the file, and split into vector to string by
+  // delimiter
   std::vector<std::string> res_vec;
   std::ifstream file(file_name);
   std::string line;
@@ -30,12 +30,11 @@ static std::vector<std::string> read_header(const std::string& file_name,
       std::stringstream ss(line);
       std::string token;
       while (std::getline(ss, token, delimiter)) {
-        //trim the token
+        // trim the token
         token.erase(token.find_last_not_of(" \n\r\t") + 1);
         res_vec.push_back(token);
       }
-    }
-    else {
+    } else {
       LOG(FATAL) << "Fail to read header line of file: " << file_name;
     }
     file.close();
@@ -179,7 +178,18 @@ static void set_vertex_properties(gs::ColumnBase* col,
   auto type = array->type();
   auto col_type = col->type();
   size_t cur_ind = 0;
-  if (col_type == PropertyType::kInt64) {
+  if (col_type == PropertyType::kBool) {
+    CHECK(type == arrow::boolean())
+        << "Inconsistent data type, expect bool, but got " << type->ToString();
+    for (auto j = 0; j < array->num_chunks(); ++j) {
+      auto casted =
+          std::static_pointer_cast<arrow::BooleanArray>(array->chunk(j));
+      for (auto k = 0; k < casted->length(); ++k) {
+        col->set_any(vids[cur_ind++],
+                     std::move(AnyConverter<bool>::to_any(casted->Value(k))));
+      }
+    }
+  } else if (col_type == PropertyType::kInt64) {
     CHECK(type == arrow::int64())
         << "Inconsistent data type, expect int64, but got " << type->ToString();
     for (auto j = 0; j < array->num_chunks(); ++j) {
@@ -203,6 +213,32 @@ static void set_vertex_properties(gs::ColumnBase* col,
             std::move(AnyConverter<int32_t>::to_any(casted->Value(k))));
       }
     }
+  } else if (col_type == PropertyType::kUInt64) {
+    CHECK(type == arrow::uint64())
+        << "Inconsistent data type, expect uint64, but got "
+        << type->ToString();
+    for (auto j = 0; j < array->num_chunks(); ++j) {
+      auto casted =
+          std::static_pointer_cast<arrow::UInt64Array>(array->chunk(j));
+      for (auto k = 0; k < casted->length(); ++k) {
+        col->set_any(
+            vids[cur_ind++],
+            std::move(AnyConverter<uint64_t>::to_any(casted->Value(k))));
+      }
+    }
+  } else if (col_type == PropertyType::kUInt32) {
+    CHECK(type == arrow::uint32())
+        << "Inconsistent data type, expect uint32, but got "
+        << type->ToString();
+    for (auto j = 0; j < array->num_chunks(); ++j) {
+      auto casted =
+          std::static_pointer_cast<arrow::UInt32Array>(array->chunk(j));
+      for (auto k = 0; k < casted->length(); ++k) {
+        col->set_any(
+            vids[cur_ind++],
+            std::move(AnyConverter<uint32_t>::to_any(casted->Value(k))));
+      }
+    }
   } else if (col_type == PropertyType::kDouble) {
     CHECK(type == arrow::float64())
         << "Inconsistent data type, expect double, but got "
@@ -213,6 +249,17 @@ static void set_vertex_properties(gs::ColumnBase* col,
       for (auto k = 0; k < casted->length(); ++k) {
         col->set_any(vids[cur_ind++],
                      std::move(AnyConverter<double>::to_any(casted->Value(k))));
+      }
+    }
+  } else if (col_type == PropertyType::kFloat) {
+    CHECK(type == arrow::float32())
+        << "Inconsistent data type, expect float, but got " << type->ToString();
+    for (auto j = 0; j < array->num_chunks(); ++j) {
+      auto casted =
+          std::static_pointer_cast<arrow::FloatArray>(array->chunk(j));
+      for (auto k = 0; k < casted->length(); ++k) {
+        col->set_any(vids[cur_ind++],
+                     std::move(AnyConverter<float>::to_any(casted->Value(k))));
       }
     }
   } else if (col_type == PropertyType::kString) {
@@ -272,19 +319,24 @@ static void append_edges(
     std::vector<std::tuple<vid_t, vid_t, EDATA_T>>& parsed_edges,
     std::vector<int32_t>& ie_degree, std::vector<int32_t>& oe_degree) {
   CHECK(src_col->length() == dst_col->length());
-  if (src_indexer.get_type() == PropertyType::kInt64) {
-    CHECK(src_col->type() == arrow::int64());
-  } else if (src_indexer.get_type() == PropertyType::kString) {
-    CHECK(src_col->type() == arrow::utf8() ||
-          src_col->type() == arrow::large_utf8());
-  }
+  auto indexer_check_lambda = [](const LFIndexer<vid_t>& cur_indexer,
+                                 const std::shared_ptr<arrow::Array>& cur_col) {
+    if (cur_indexer.get_type() == PropertyType::kInt64) {
+      CHECK(cur_col->type() == arrow::int64());
+    } else if (cur_indexer.get_type() == PropertyType::kString) {
+      CHECK(cur_col->type() == arrow::utf8() ||
+            cur_col->type() == arrow::large_utf8());
+    } else if (cur_indexer.get_type() == PropertyType::kInt32) {
+      CHECK(cur_col->type() == arrow::int32());
+    } else if (cur_indexer.get_type() == PropertyType::kUInt32) {
+      CHECK(cur_col->type() == arrow::uint32());
+    } else if (cur_indexer.get_type() == PropertyType::kUInt64) {
+      CHECK(cur_col->type() == arrow::uint64());
+    }
+  };
 
-  if (dst_indexer.get_type() == PropertyType::kInt64) {
-    CHECK(dst_col->type() == arrow::int64());
-  } else if (dst_indexer.get_type() == PropertyType::kString) {
-    CHECK(dst_col->type() == arrow::utf8() ||
-          dst_col->type() == arrow::large_utf8());
-  }
+  indexer_check_lambda(src_indexer, src_col);
+  indexer_check_lambda(dst_indexer, dst_col);
   auto old_size = parsed_edges.size();
   parsed_edges.resize(old_size + src_col->length());
   VLOG(10) << "resize parsed_edges from" << old_size << " to "
@@ -379,20 +431,24 @@ static void append_edges(
     std::vector<std::tuple<vid_t, vid_t, EDATA_T>>& parsed_edges,
     std::vector<int32_t>& ie_degree, std::vector<int32_t>& oe_degree) {
   CHECK(src_col->length() == dst_col->length());
-  if (src_indexer.get_type() == PropertyType::kInt64) {
-    CHECK(src_col->type() == arrow::int64());
-  } else if (src_indexer.get_type() == PropertyType::kString) {
-    CHECK(src_col->type() == arrow::utf8() ||
-          src_col->type() == arrow::large_utf8());
-  }
-
-  if (dst_indexer.get_type() == PropertyType::kInt64) {
-    CHECK(dst_col->type() == arrow::int64());
-  } else if (dst_indexer.get_type() == PropertyType::kString) {
-    CHECK(dst_col->type() == arrow::utf8() ||
-          dst_col->type() == arrow::large_utf8());
-  }
-
+  auto indexer_check_lambda =
+      [](const LFIndexer<vid_t>& cur_indexer,
+         const std::shared_ptr<arrow::ChunkedArray>& cur_col) {
+        if (cur_indexer.get_type() == PropertyType::kInt64) {
+          CHECK(cur_col->type() == arrow::int64());
+        } else if (cur_indexer.get_type() == PropertyType::kString) {
+          CHECK(cur_col->type() == arrow::utf8() ||
+                cur_col->type() == arrow::large_utf8());
+        } else if (cur_indexer.get_type() == PropertyType::kInt32) {
+          CHECK(cur_col->type() == arrow::int32());
+        } else if (cur_indexer.get_type() == PropertyType::kUInt32) {
+          CHECK(cur_col->type() == arrow::uint32());
+        } else if (cur_indexer.get_type() == PropertyType::kUInt64) {
+          CHECK(cur_col->type() == arrow::uint64());
+        }
+      };
+  indexer_check_lambda(src_indexer, src_col);
+  indexer_check_lambda(dst_indexer, dst_col);
   auto old_size = parsed_edges.size();
   parsed_edges.resize(old_size + src_col->length());
   VLOG(10) << "resize parsed_edges from" << old_size << " to "
@@ -919,9 +975,12 @@ void CSVFragmentLoader::addVertices(label_t v_label_id,
     LOG(FATAL) << "Only support one primary key for vertex.";
   }
   auto type = std::get<0>(primary_keys[0]);
-  if (type != PropertyType::kInt64 && type != PropertyType::kString) {
+  if (type != PropertyType::kInt64 && type != PropertyType::kString &&
+      type != PropertyType::kInt32 && type != PropertyType::kUInt32 &&
+      type != PropertyType::kUInt64) {
     LOG(FATAL)
-        << "Only support int64_t and string_view primary key for vertex.";
+        << "Only support int64_t, uint64_t, int32_t, uint32_t and string "
+           "primary key for vertex.";
   }
 
   std::string v_label_name = schema_.get_vertex_label_name(v_label_id);
@@ -929,24 +988,41 @@ void CSVFragmentLoader::addVertices(label_t v_label_id,
            << v_files.size() << " files.";
   if (type == PropertyType::kInt64) {
     IdIndexer<int64_t, vid_t> indexer;
-
     addVerticesImpl<int64_t>(v_label_id, v_label_name, v_files, indexer);
-
     if (indexer.bucket_count() == 0) {
       indexer._rehash(schema_.get_max_vnum(v_label_name));
     }
     basic_fragment_loader_.FinishAddingVertex<int64_t>(v_label_id, indexer);
   } else if (type == PropertyType::kString) {
     IdIndexer<std::string_view, vid_t> indexer;
-
     addVerticesImpl<std::string_view>(v_label_id, v_label_name, v_files,
                                       indexer);
-
     if (indexer.bucket_count() == 0) {
       indexer._rehash(schema_.get_max_vnum(v_label_name));
     }
     basic_fragment_loader_.FinishAddingVertex<std::string_view>(v_label_id,
                                                                 indexer);
+  } else if (type == PropertyType::kInt32) {
+    IdIndexer<int32_t, vid_t> indexer;
+    addVerticesImpl<int32_t>(v_label_id, v_label_name, v_files, indexer);
+    if (indexer.bucket_count() == 0) {
+      indexer._rehash(schema_.get_max_vnum(v_label_name));
+    }
+    basic_fragment_loader_.FinishAddingVertex<int32_t>(v_label_id, indexer);
+  } else if (type == PropertyType::kUInt32) {
+    IdIndexer<uint32_t, vid_t> indexer;
+    addVerticesImpl<uint32_t>(v_label_id, v_label_name, v_files, indexer);
+    if (indexer.bucket_count() == 0) {
+      indexer._rehash(schema_.get_max_vnum(v_label_name));
+    }
+    basic_fragment_loader_.FinishAddingVertex<uint32_t>(v_label_id, indexer);
+  } else if (type == PropertyType::kUInt64) {
+    IdIndexer<uint64_t, vid_t> indexer;
+    addVerticesImpl<uint64_t>(v_label_id, v_label_name, v_files, indexer);
+    if (indexer.bucket_count() == 0) {
+      indexer._rehash(schema_.get_max_vnum(v_label_name));
+    }
+    basic_fragment_loader_.FinishAddingVertex<uint64_t>(v_label_id, indexer);
   }
   VLOG(10) << "Finish init vertices for label " << v_label_name;
 }
@@ -1179,6 +1255,13 @@ void CSVFragmentLoader::addEdges(label_t src_label_i, label_t dst_label_i,
       addEdgesImpl<grape::EmptyType>(src_label_i, dst_label_i, edge_label_i,
                                      filenames);
     }
+  } else if (property_types[0] == PropertyType::kBool) {
+    if (filenames.empty()) {
+      basic_fragment_loader_.AddNoPropEdgeBatch<bool>(src_label_i, dst_label_i,
+                                                      edge_label_i);
+    } else {
+      addEdgesImpl<bool>(src_label_i, dst_label_i, edge_label_i, filenames);
+    }
   } else if (property_types[0] == PropertyType::kDate) {
     if (filenames.empty()) {
       basic_fragment_loader_.AddNoPropEdgeBatch<Date>(src_label_i, dst_label_i,
@@ -1188,10 +1271,17 @@ void CSVFragmentLoader::addEdges(label_t src_label_i, label_t dst_label_i,
     }
   } else if (property_types[0] == PropertyType::kInt32) {
     if (filenames.empty()) {
-      basic_fragment_loader_.AddNoPropEdgeBatch<int>(src_label_i, dst_label_i,
-                                                     edge_label_i);
+      basic_fragment_loader_.AddNoPropEdgeBatch<int32_t>(
+          src_label_i, dst_label_i, edge_label_i);
     } else {
-      addEdgesImpl<int>(src_label_i, dst_label_i, edge_label_i, filenames);
+      addEdgesImpl<int32_t>(src_label_i, dst_label_i, edge_label_i, filenames);
+    }
+  } else if (property_types[0] == PropertyType::kUInt32) {
+    if (filenames.empty()) {
+      basic_fragment_loader_.AddNoPropEdgeBatch<uint32_t>(
+          src_label_i, dst_label_i, edge_label_i);
+    } else {
+      addEdgesImpl<uint32_t>(src_label_i, dst_label_i, edge_label_i, filenames);
     }
   } else if (property_types[0] == PropertyType::kInt64) {
     if (filenames.empty()) {
@@ -1199,6 +1289,13 @@ void CSVFragmentLoader::addEdges(label_t src_label_i, label_t dst_label_i,
           src_label_i, dst_label_i, edge_label_i);
     } else {
       addEdgesImpl<int64_t>(src_label_i, dst_label_i, edge_label_i, filenames);
+    }
+  } else if (property_types[0] == PropertyType::kUInt64) {
+    if (filenames.empty()) {
+      basic_fragment_loader_.AddNoPropEdgeBatch<uint64_t>(
+          src_label_i, dst_label_i, edge_label_i);
+    } else {
+      addEdgesImpl<uint64_t>(src_label_i, dst_label_i, edge_label_i, filenames);
     }
   } else if (property_types[0] == PropertyType::kString) {
     if (filenames.empty()) {
@@ -1213,6 +1310,13 @@ void CSVFragmentLoader::addEdges(label_t src_label_i, label_t dst_label_i,
           src_label_i, dst_label_i, edge_label_i);
     } else {
       addEdgesImpl<double>(src_label_i, dst_label_i, edge_label_i, filenames);
+    }
+  } else if (property_types[0] == PropertyType::kFloat) {
+    if (filenames.empty()) {
+      basic_fragment_loader_.AddNoPropEdgeBatch<float>(src_label_i, dst_label_i,
+                                                       edge_label_i);
+    } else {
+      addEdgesImpl<float>(src_label_i, dst_label_i, edge_label_i, filenames);
     }
   } else {
     LOG(FATAL) << "Unsupported edge property type." << property_types[0];

--- a/flex/storages/rt_mutable_graph/mutable_csr.cc
+++ b/flex/storages/rt_mutable_graph/mutable_csr.cc
@@ -158,8 +158,14 @@ void SingleMutableCsr<EDATA_T>::Deserialize(const std::string& path) {
 template class SingleMutableCsr<grape::EmptyType>;
 template class MutableCsr<grape::EmptyType>;
 
-template class SingleMutableCsr<int>;
-template class MutableCsr<int>;
+template class SingleMutableCsr<bool>;
+template class MutableCsr<bool>;
+
+template class SingleMutableCsr<int32_t>;
+template class MutableCsr<int32_t>;
+
+template class SingleMutableCsr<uint32_t>;
+template class MutableCsr<uint32_t>;
 
 template class SingleMutableCsr<Date>;
 template class MutableCsr<Date>;
@@ -170,7 +176,12 @@ template class MutableCsr<std::string>;
 template class SingleMutableCsr<int64_t>;
 template class MutableCsr<int64_t>;
 
+template class SingleMutableCsr<uint64_t>;
+template class MutableCsr<uint64_t>;
+
 template class SingleMutableCsr<double>;
 template class MutableCsr<double>;
 
+template class SingleMutableCsr<float>;
+template class MutableCsr<float>;
 }  // namespace gs

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -104,6 +104,14 @@ inline MutableCsrBase* create_csr(EdgeStrategy es,
     } else if (es == EdgeStrategy::kNone) {
       return new EmptyCsr<grape::EmptyType>();
     }
+  } else if (properties[0] == PropertyType::kBool) {
+    if (es == EdgeStrategy::kSingle) {
+      return new SingleMutableCsr<bool>();
+    } else if (es == EdgeStrategy::kMultiple) {
+      return new MutableCsr<bool>();
+    } else if (es == EdgeStrategy::kNone) {
+      return new EmptyCsr<bool>();
+    }
   } else if (properties[0] == PropertyType::kInt32) {
     if (es == EdgeStrategy::kSingle) {
       return new SingleMutableCsr<int>();
@@ -111,6 +119,14 @@ inline MutableCsrBase* create_csr(EdgeStrategy es,
       return new MutableCsr<int>();
     } else if (es == EdgeStrategy::kNone) {
       return new EmptyCsr<int>();
+    }
+  } else if (properties[0] == PropertyType::kUInt32) {
+    if (es == EdgeStrategy::kSingle) {
+      return new SingleMutableCsr<unsigned int>();
+    } else if (es == EdgeStrategy::kMultiple) {
+      return new MutableCsr<unsigned int>();
+    } else if (es == EdgeStrategy::kNone) {
+      return new EmptyCsr<unsigned int>();
     }
   } else if (properties[0] == PropertyType::kDate) {
     if (es == EdgeStrategy::kSingle) {
@@ -128,6 +144,14 @@ inline MutableCsrBase* create_csr(EdgeStrategy es,
     } else if (es == EdgeStrategy::kNone) {
       return new EmptyCsr<int64_t>();
     }
+  } else if (properties[0] == PropertyType::kUInt64) {
+    if (es == EdgeStrategy::kSingle) {
+      return new SingleMutableCsr<uint64_t>();
+    } else if (es == EdgeStrategy::kMultiple) {
+      return new MutableCsr<uint64_t>();
+    } else if (es == EdgeStrategy::kNone) {
+      return new EmptyCsr<uint64_t>();
+    }
   } else if (properties[0] == PropertyType::kDouble) {
     if (es == EdgeStrategy::kSingle) {
       return new SingleMutableCsr<double>();
@@ -136,7 +160,16 @@ inline MutableCsrBase* create_csr(EdgeStrategy es,
     } else if (es == EdgeStrategy::kNone) {
       return new EmptyCsr<double>();
     }
+  } else if (properties[0] == PropertyType::kFloat) {
+    if (es == EdgeStrategy::kSingle) {
+      return new SingleMutableCsr<float>();
+    } else if (es == EdgeStrategy::kMultiple) {
+      return new MutableCsr<float>();
+    } else if (es == EdgeStrategy::kNone) {
+      return new EmptyCsr<float>();
+    }
   }
+
   LOG(FATAL) << "not support edge strategy or edge data type";
   return nullptr;
 }

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -572,7 +572,10 @@ static bool parse_vertex_schema(YAML::Node node, Schema& schema) {
       return false;
     }
     if (property_types[primary_key_inds[i]] != PropertyType::kInt64 &&
-        property_types[primary_key_inds[i]] != PropertyType::kString) {
+        property_types[primary_key_inds[i]] != PropertyType::kString &&
+        property_types[primary_key_inds[i]] != PropertyType::kUInt64 &&
+        property_types[primary_key_inds[i]] != PropertyType::kInt32 &&
+        property_types[primary_key_inds[i]] != PropertyType::kUInt32) {
       LOG(ERROR) << "Primary key " << primary_key_name
                  << " should be int64 or string";
       return false;

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -371,6 +371,10 @@ namespace config_parsing {
 static PropertyType StringToPropertyType(const std::string& str) {
   if (str == "int32" || str == DT_SIGNED_INT32) {
     return PropertyType::kInt32;
+  } else if (str == "uint32" || str == DT_UNSIGNED_INT32) {
+    return PropertyType::kUInt32;
+  } else if (str == "bool" || str == DT_BOOL) {
+    return PropertyType::kBool;
   } else if (str == "Date" || str == DT_DATE) {
     return PropertyType::kDate;
   } else if (str == "String" || str == DT_STRING) {
@@ -379,6 +383,10 @@ static PropertyType StringToPropertyType(const std::string& str) {
     return PropertyType::kEmpty;
   } else if (str == "int64" || str == DT_SIGNED_INT64) {
     return PropertyType::kInt64;
+  } else if (str == "uint64" || str == DT_UNSIGNED_INT64) {
+    return PropertyType::kUInt64;
+  } else if (str == "float" || str == DT_FLOAT) {
+    return PropertyType::kFloat;
   } else if (str == "double" || str == DT_DOUBLE) {
     return PropertyType::kDouble;
   } else {

--- a/flex/storages/rt_mutable_graph/types.h
+++ b/flex/storages/rt_mutable_graph/types.h
@@ -31,7 +31,11 @@ using vid_t = uint32_t;
 using label_t = uint8_t;
 
 static constexpr const char* DT_SIGNED_INT32 = "DT_SIGNED_INT32";
+static constexpr const char* DT_UNSIGNED_INT32 = "DT_UNSIGNED_INT32";
 static constexpr const char* DT_SIGNED_INT64 = "DT_SIGNED_INT64";
+static constexpr const char* DT_UNSIGNED_INT64 = "DT_UNSIGNED_INT64";
+static constexpr const char* DT_BOOL = "DT_BOOL";
+static constexpr const char* DT_FLOAT = "DT_FLOAT";
 static constexpr const char* DT_DOUBLE = "DT_DOUBLE";
 static constexpr const char* DT_STRING = "DT_STRING";
 static constexpr const char* DT_DATE = "DT_DATE32";

--- a/flex/utils/arrow_utils.cc
+++ b/flex/utils/arrow_utils.cc
@@ -46,7 +46,7 @@ std::shared_ptr<arrow::DataType> PropertyTypeToArrowType(PropertyType type) {
 template <typename T>
 void emplace_into_vector(const std::shared_ptr<arrow::ChunkedArray>& array,
                          std::vector<Any>& vec) {
-  using arrow_array_type = typename gs::CppTypeToArrowType<T>::ArrayType;
+  using arrow_array_type = typename gs::TypeConverter<T>::ArrowArrayType;
   for (auto i = 0; i < array->num_chunks(); ++i) {
     auto casted = std::static_pointer_cast<arrow_array_type>(array->chunk(i));
     for (auto k = 0; k < casted->length(); ++k) {

--- a/flex/utils/arrow_utils.cc
+++ b/flex/utils/arrow_utils.cc
@@ -17,12 +17,20 @@
 namespace gs {
 std::shared_ptr<arrow::DataType> PropertyTypeToArrowType(PropertyType type) {
   switch (type) {
+  case PropertyType::kBool:
+    return arrow::boolean();
   case PropertyType::kInt32:
     return arrow::int32();
   case PropertyType::kInt64:
     return arrow::int64();
+  case PropertyType::kUInt32:
+    return arrow::uint32();
+  case PropertyType::kUInt64:
+    return arrow::uint64();
   case PropertyType::kDouble:
     return arrow::float64();
+  case PropertyType::kFloat:
+    return arrow::float32();
   case PropertyType::kDate:
     return arrow::timestamp(arrow::TimeUnit::MILLI);
   case PropertyType::kString:

--- a/flex/utils/arrow_utils.h
+++ b/flex/utils/arrow_utils.h
@@ -183,10 +183,28 @@ template <typename T>
 struct CppTypeToArrowType {};
 
 template <>
+struct CppTypeToArrowType<bool> {
+  using Type = arrow::BooleanType;
+  using ArrayType = arrow::BooleanArray;
+  static std::shared_ptr<arrow::DataType> TypeValue() {
+    return arrow::boolean();
+  }
+};
+
+template <>
 struct CppTypeToArrowType<int64_t> {
   using Type = arrow::Int64Type;
   using ArrayType = arrow::Int64Array;
   static std::shared_ptr<arrow::DataType> TypeValue() { return arrow::int64(); }
+};
+
+template <>
+struct CppTypeToArrowType<uint64_t> {
+  using Type = arrow::UInt64Type;
+  using ArrayType = arrow::UInt64Array;
+  static std::shared_ptr<arrow::DataType> TypeValue() {
+    return arrow::uint64();
+  }
 };
 
 template <>
@@ -197,11 +215,29 @@ struct CppTypeToArrowType<int32_t> {
 };
 
 template <>
+struct CppTypeToArrowType<uint32_t> {
+  using Type = arrow::UInt32Type;
+  using ArrayType = arrow::UInt32Array;
+  static std::shared_ptr<arrow::DataType> TypeValue() {
+    return arrow::uint32();
+  }
+};
+
+template <>
 struct CppTypeToArrowType<double> {
   using Type = arrow::DoubleType;
   using ArrayType = arrow::DoubleArray;
   static std::shared_ptr<arrow::DataType> TypeValue() {
     return arrow::float64();
+  }
+};
+
+template <>
+struct CppTypeToArrowType<float> {
+  using Type = arrow::FloatType;
+  using ArrayType = arrow::FloatArray;
+  static std::shared_ptr<arrow::DataType> TypeValue() {
+    return arrow::float32();
   }
 };
 
@@ -218,8 +254,18 @@ template <typename T>
 struct CppTypeToPropertyType;
 
 template <>
+struct CppTypeToPropertyType<bool> {
+  static constexpr PropertyType value = PropertyType::kBool;
+};
+
+template <>
 struct CppTypeToPropertyType<int32_t> {
   static constexpr PropertyType value = PropertyType::kInt32;
+};
+
+template <>
+struct CppTypeToPropertyType<uint32_t> {
+  static constexpr PropertyType value = PropertyType::kUInt32;
 };
 
 template <>
@@ -228,10 +274,19 @@ struct CppTypeToPropertyType<int64_t> {
 };
 
 template <>
+struct CppTypeToPropertyType<uint64_t> {
+  static constexpr PropertyType value = PropertyType::kUInt64;
+};
+
+template <>
 struct CppTypeToPropertyType<double> {
   static constexpr PropertyType value = PropertyType::kDouble;
 };
 
+template <>
+struct CppTypeToPropertyType<float> {
+  static constexpr PropertyType value = PropertyType::kFloat;
+};
 template <>
 struct CppTypeToPropertyType<std::string> {
   static constexpr PropertyType value = PropertyType::kString;

--- a/flex/utils/arrow_utils.h
+++ b/flex/utils/arrow_utils.h
@@ -180,121 +180,105 @@ class LDBCLongDateParser : public arrow::TimestampParser {
 
 // convert c++ type to arrow type. support other types likes emptyType, Date
 template <typename T>
-struct CppTypeToArrowType {};
+struct TypeConverter;
 
 template <>
-struct CppTypeToArrowType<bool> {
-  using Type = arrow::BooleanType;
-  using ArrayType = arrow::BooleanArray;
-  static std::shared_ptr<arrow::DataType> TypeValue() {
+struct TypeConverter<bool> {
+  static constexpr PropertyType property_type = PropertyType::kBool;
+  using ArrowType = arrow::BooleanType;
+  using ArrowArrayType = arrow::BooleanArray;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
     return arrow::boolean();
   }
 };
 
 template <>
-struct CppTypeToArrowType<int64_t> {
-  using Type = arrow::Int64Type;
-  using ArrayType = arrow::Int64Array;
-  static std::shared_ptr<arrow::DataType> TypeValue() { return arrow::int64(); }
-};
-
-template <>
-struct CppTypeToArrowType<uint64_t> {
-  using Type = arrow::UInt64Type;
-  using ArrayType = arrow::UInt64Array;
-  static std::shared_ptr<arrow::DataType> TypeValue() {
-    return arrow::uint64();
+struct TypeConverter<int32_t> {
+  static constexpr PropertyType property_type = PropertyType::kInt32;
+  using ArrowType = arrow::Int32Type;
+  using ArrowArrayType = arrow::Int32Array;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
+    return arrow::int32();
   }
 };
 
 template <>
-struct CppTypeToArrowType<int32_t> {
-  using Type = arrow::Int32Type;
-  using ArrayType = arrow::Int32Array;
-  static std::shared_ptr<arrow::DataType> TypeValue() { return arrow::int32(); }
-};
-
-template <>
-struct CppTypeToArrowType<uint32_t> {
-  using Type = arrow::UInt32Type;
-  using ArrayType = arrow::UInt32Array;
-  static std::shared_ptr<arrow::DataType> TypeValue() {
+struct TypeConverter<uint32_t> {
+  static constexpr PropertyType property_type = PropertyType::kUInt32;
+  using ArrowType = arrow::UInt32Type;
+  using ArrowArrayType = arrow::UInt32Array;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
     return arrow::uint32();
   }
 };
 
 template <>
-struct CppTypeToArrowType<double> {
-  using Type = arrow::DoubleType;
-  using ArrayType = arrow::DoubleArray;
-  static std::shared_ptr<arrow::DataType> TypeValue() {
+struct TypeConverter<int64_t> {
+  static constexpr PropertyType property_type = PropertyType::kInt64;
+  using ArrowType = arrow::Int64Type;
+  using ArrowArrayType = arrow::Int64Array;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
+    return arrow::int64();
+  }
+};
+
+template <>
+struct TypeConverter<uint64_t> {
+  static constexpr PropertyType property_type = PropertyType::kUInt64;
+  using ArrowType = arrow::UInt64Type;
+  using ArrowArrayType = arrow::UInt64Array;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
+    return arrow::uint64();
+  }
+};
+
+template <>
+struct TypeConverter<double> {
+  static constexpr PropertyType property_type = PropertyType::kDouble;
+  using ArrowType = arrow::DoubleType;
+  using ArrowArrayType = arrow::DoubleArray;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
     return arrow::float64();
   }
 };
 
 template <>
-struct CppTypeToArrowType<float> {
-  using Type = arrow::FloatType;
-  using ArrayType = arrow::FloatArray;
-  static std::shared_ptr<arrow::DataType> TypeValue() {
+struct TypeConverter<float> {
+  static constexpr PropertyType property_type = PropertyType::kFloat;
+  using ArrowType = arrow::FloatType;
+  using ArrowArrayType = arrow::FloatArray;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
     return arrow::float32();
   }
 };
-
 template <>
-struct CppTypeToArrowType<Date> {
-  using Type = arrow::TimestampType;
-  using ArrayType = arrow::TimestampArray;
-  static std::shared_ptr<arrow::DataType> TypeValue() {
-    return arrow::timestamp(arrow::TimeUnit::MILLI);
+struct TypeConverter<std::string> {
+  static constexpr PropertyType property_type = PropertyType::kString;
+  using ArrowType = arrow::LargeStringType;
+  using ArrowArrayType = arrow::LargeStringArray;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
+    return arrow::large_utf8();
   }
 };
 
-template <typename T>
-struct CppTypeToPropertyType;
-
 template <>
-struct CppTypeToPropertyType<bool> {
-  static constexpr PropertyType value = PropertyType::kBool;
+struct TypeConverter<std::string_view> {
+  static constexpr PropertyType property_type = PropertyType::kString;
+  using ArrowType = arrow::LargeStringType;
+  using ArrowArrayType = arrow::LargeStringArray;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
+    return arrow::large_utf8();
+  }
 };
 
 template <>
-struct CppTypeToPropertyType<int32_t> {
-  static constexpr PropertyType value = PropertyType::kInt32;
-};
-
-template <>
-struct CppTypeToPropertyType<uint32_t> {
-  static constexpr PropertyType value = PropertyType::kUInt32;
-};
-
-template <>
-struct CppTypeToPropertyType<int64_t> {
-  static constexpr PropertyType value = PropertyType::kInt64;
-};
-
-template <>
-struct CppTypeToPropertyType<uint64_t> {
-  static constexpr PropertyType value = PropertyType::kUInt64;
-};
-
-template <>
-struct CppTypeToPropertyType<double> {
-  static constexpr PropertyType value = PropertyType::kDouble;
-};
-
-template <>
-struct CppTypeToPropertyType<float> {
-  static constexpr PropertyType value = PropertyType::kFloat;
-};
-template <>
-struct CppTypeToPropertyType<std::string> {
-  static constexpr PropertyType value = PropertyType::kString;
-};
-
-template <>
-struct CppTypeToPropertyType<std::string_view> {
-  static constexpr PropertyType value = PropertyType::kString;
+struct TypeConverter<Date> {
+  static constexpr PropertyType property_type = PropertyType::kDate;
+  using ArrowType = arrow::TimestampType;
+  using ArrowArrayType = arrow::TimestampArray;
+  static std::shared_ptr<arrow::DataType> ArrowTypeValue() {
+    return arrow::timestamp(arrow::TimeUnit::MILLI);
+  }
 };
 
 std::shared_ptr<arrow::DataType> PropertyTypeToArrowType(PropertyType type);

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -774,55 +774,27 @@ class IdIndexer : public IdIndexerBase<INDEX_T> {
 template <typename KEY_T, typename INDEX_T>
 struct _move_data {
   using key_buffer_t = typename id_indexer_impl::KeyBuffer<KEY_T>::type;
-  void operator()(const key_buffer_t& input, ColumnBase& lf, size_t size) {
-    LOG(FATAL) << "Not implemented";
-  }
-};
-
-template <typename INDEX_T>
-struct _move_data<int64_t, INDEX_T> {
-  using key_buffer_t = typename id_indexer_impl::KeyBuffer<int64_t>::type;
   void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    auto& buffer = dynamic_cast<TypedColumn<int64_t>&>(col);
-    memcpy(buffer.buffer().data(), input.data(), sizeof(int64_t) * size);
-  }
-};
-
-template <typename INDEX_T>
-struct _move_data<uint64_t, INDEX_T> {
-  using key_buffer_t = typename id_indexer_impl::KeyBuffer<uint64_t>::type;
-  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    auto& buffer = dynamic_cast<TypedColumn<uint64_t>&>(col);
-    memcpy(buffer.buffer().data(), input.data(), sizeof(uint64_t) * size);
-  }
-};
-
-template <typename INDEX_T>
-struct _move_data<int32_t, INDEX_T> {
-  using key_buffer_t = typename id_indexer_impl::KeyBuffer<int32_t>::type;
-  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    auto& buffer = dynamic_cast<TypedColumn<int32_t>&>(col);
-    memcpy(buffer.buffer().data(), input.data(), sizeof(int32_t) * size);
-  }
-};
-
-template <typename INDEX_T>
-struct _move_data<uint32_t, INDEX_T> {
-  using key_buffer_t = typename id_indexer_impl::KeyBuffer<uint32_t>::type;
-  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    auto& buffer = dynamic_cast<TypedColumn<uint32_t>&>(col);
-    memcpy(buffer.buffer().data(), input.data(), sizeof(uint32_t) * size);
-  }
-};
-
-template <typename INDEX_T>
-struct _move_data<std::string_view, INDEX_T> {
-  using key_buffer_t =
-      typename id_indexer_impl::KeyBuffer<std::string_view>::type;
-  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    auto& keys = dynamic_cast<TypedColumn<std::string_view>&>(col);
-    for (size_t idx = 0; idx < size; ++idx) {
-      keys.set_value(idx, input[idx]);
+    if constexpr (std::is_same<KEY_T, int64_t>::value) {
+      auto& buffer = dynamic_cast<TypedColumn<int64_t>&>(col);
+      memcpy(buffer.buffer().data(), input.data(), sizeof(int64_t) * size);
+    } else if constexpr (std::is_same<KEY_T, uint64_t>::value) {
+      auto& buffer = dynamic_cast<TypedColumn<uint64_t>&>(col);
+      memcpy(buffer.buffer().data(), input.data(), sizeof(uint64_t) * size);
+    } else if constexpr (std::is_same<KEY_T, int32_t>::value) {
+      auto& buffer = dynamic_cast<TypedColumn<int32_t>&>(col);
+      memcpy(buffer.buffer().data(), input.data(), sizeof(int32_t) * size);
+    } else if constexpr (std::is_same<KEY_T, uint32_t>::value) {
+      auto& buffer = dynamic_cast<TypedColumn<uint32_t>&>(col);
+      memcpy(buffer.buffer().data(), input.data(), sizeof(uint32_t) * size);
+    } else if constexpr (std::is_same<KEY_T, std::string_view>::value) {
+      auto& keys = dynamic_cast<TypedColumn<std::string_view>&>(col);
+      for (size_t idx = 0; idx < size; ++idx) {
+        keys.set_value(idx, input[idx]);
+      }
+    } else {
+      LOG(FATAL) << "Not support type [" << AnyConverter<KEY_T>::type
+                 << "] as pk type ..";
     }
   }
 };

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -157,6 +157,17 @@ struct GHash<int64_t> {
 };
 
 template <>
+struct GHash<uint64_t> {
+  size_t operator()(const uint64_t& val) const {
+    uint64_t x = static_cast<uint64_t>(val);
+    x = (x ^ (x >> 30)) * UINT64_C(0xbf58476d1ce4e5b9);
+    x = (x ^ (x >> 27)) * UINT64_C(0x94d049bb133111eb);
+    x = x ^ (x >> 31);
+    return x;
+  }
+};
+
+template <>
 struct GHash<Any> {
   size_t operator()(const Any& val) const {
     if (val.type == PropertyType::kInt64) {
@@ -763,7 +774,9 @@ class IdIndexer : public IdIndexerBase<INDEX_T> {
 template <typename KEY_T, typename INDEX_T>
 struct _move_data {
   using key_buffer_t = typename id_indexer_impl::KeyBuffer<KEY_T>::type;
-  void operator()(const key_buffer_t& input, ColumnBase& lf, size_t size) {}
+  void operator()(const key_buffer_t& input, ColumnBase& lf, size_t size) {
+    LOG(FATAL) << "Not implemented";
+  }
 };
 
 template <typename INDEX_T>
@@ -773,6 +786,36 @@ struct _move_data<int64_t, INDEX_T> {
     // size_t size = input.keys_.size();
     auto& buffer = dynamic_cast<TypedColumn<int64_t>&>(col);
     memcpy(buffer.buffer().data(), input.data(), sizeof(int64_t) * size);
+  }
+};
+
+template <typename INDEX_T>
+struct _move_data<uint64_t, INDEX_T> {
+  using key_buffer_t = typename id_indexer_impl::KeyBuffer<uint64_t>::type;
+  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
+    // size_t size = input.keys_.size();
+    auto& buffer = dynamic_cast<TypedColumn<uint64_t>&>(col);
+    memcpy(buffer.buffer().data(), input.data(), sizeof(uint64_t) * size);
+  }
+};
+
+template <typename INDEX_T>
+struct _move_data<int32_t, INDEX_T> {
+  using key_buffer_t = typename id_indexer_impl::KeyBuffer<int32_t>::type;
+  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
+    // size_t size = input.keys_.size();
+    auto& buffer = dynamic_cast<TypedColumn<int32_t>&>(col);
+    memcpy(buffer.buffer().data(), input.data(), sizeof(int32_t) * size);
+  }
+};
+
+template <typename INDEX_T>
+struct _move_data<uint32_t, INDEX_T> {
+  using key_buffer_t = typename id_indexer_impl::KeyBuffer<uint32_t>::type;
+  void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
+    // size_t size = input.keys_.size();
+    auto& buffer = dynamic_cast<TypedColumn<uint32_t>&>(col);
+    memcpy(buffer.buffer().data(), input.data(), sizeof(uint32_t) * size);
   }
 };
 

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -783,7 +783,6 @@ template <typename INDEX_T>
 struct _move_data<int64_t, INDEX_T> {
   using key_buffer_t = typename id_indexer_impl::KeyBuffer<int64_t>::type;
   void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    // size_t size = input.keys_.size();
     auto& buffer = dynamic_cast<TypedColumn<int64_t>&>(col);
     memcpy(buffer.buffer().data(), input.data(), sizeof(int64_t) * size);
   }
@@ -793,7 +792,6 @@ template <typename INDEX_T>
 struct _move_data<uint64_t, INDEX_T> {
   using key_buffer_t = typename id_indexer_impl::KeyBuffer<uint64_t>::type;
   void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    // size_t size = input.keys_.size();
     auto& buffer = dynamic_cast<TypedColumn<uint64_t>&>(col);
     memcpy(buffer.buffer().data(), input.data(), sizeof(uint64_t) * size);
   }
@@ -803,7 +801,6 @@ template <typename INDEX_T>
 struct _move_data<int32_t, INDEX_T> {
   using key_buffer_t = typename id_indexer_impl::KeyBuffer<int32_t>::type;
   void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    // size_t size = input.keys_.size();
     auto& buffer = dynamic_cast<TypedColumn<int32_t>&>(col);
     memcpy(buffer.buffer().data(), input.data(), sizeof(int32_t) * size);
   }
@@ -813,7 +810,6 @@ template <typename INDEX_T>
 struct _move_data<uint32_t, INDEX_T> {
   using key_buffer_t = typename id_indexer_impl::KeyBuffer<uint32_t>::type;
   void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    // size_t size = input.keys_.size();
     auto& buffer = dynamic_cast<TypedColumn<uint32_t>&>(col);
     memcpy(buffer.buffer().data(), input.data(), sizeof(uint32_t) * size);
   }
@@ -824,7 +820,6 @@ struct _move_data<std::string_view, INDEX_T> {
   using key_buffer_t =
       typename id_indexer_impl::KeyBuffer<std::string_view>::type;
   void operator()(const key_buffer_t& input, ColumnBase& col, size_t size) {
-    // size_t size = input.keys_.size();
     auto& keys = dynamic_cast<TypedColumn<std::string_view>&>(col);
     for (size_t idx = 0; idx < size; ++idx) {
       keys.set_value(idx, input[idx]);

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -161,6 +161,12 @@ struct GHash<Any> {
   size_t operator()(const Any& val) const {
     if (val.type == PropertyType::kInt64) {
       return GHash<int64_t>()(val.AsInt64());
+    } else if (val.type == PropertyType::kInt32) {
+      return GHash<int32_t>()(val.AsInt32());
+    } else if (val.type == PropertyType::kUInt64) {
+      return GHash<uint64_t>()(val.AsUInt64());
+    } else if (val.type == PropertyType::kUInt32) {
+      return GHash<uint32_t>()(val.AsUInt32());
     } else {
       return GHash<std::string_view>()(val.AsString());
     }
@@ -204,6 +210,12 @@ class LFIndexer {
     keys_ = nullptr;
     if (type == PropertyType::kInt64) {
       keys_ = new TypedColumn<int64_t>(StorageStrategy::kMem);
+    } else if (type == PropertyType::kInt32) {
+      keys_ = new TypedColumn<int32_t>(StorageStrategy::kMem);
+    } else if (type == PropertyType::kUInt64) {
+      keys_ = new TypedColumn<uint64_t>(StorageStrategy::kMem);
+    } else if (type == PropertyType::kUInt32) {
+      keys_ = new TypedColumn<uint32_t>(StorageStrategy::kMem);
     } else if (type == PropertyType::kString) {
       keys_ = new TypedColumn<std::string_view>(StorageStrategy::kMem);
     } else {

--- a/flex/utils/property/column.cc
+++ b/flex/utils/property/column.cc
@@ -58,31 +58,57 @@ class TypedEmptyColumn : public ColumnBase {
   }
 };
 
-using IntEmptyColumn = TypedEmptyColumn<int>;
+using IntEmptyColumn = TypedEmptyColumn<int32_t>;
+using UIntEmptyColumn = TypedEmptyColumn<uint32_t>;
 using LongEmptyColumn = TypedEmptyColumn<int64_t>;
+using ULongEmptyColumn = TypedEmptyColumn<uint64_t>;
 using DateEmptyColumn = TypedEmptyColumn<Date>;
+using BoolEmptyColumn = TypedEmptyColumn<bool>;
+using FloatEmptyColumn = TypedEmptyColumn<float>;
+using DoubleEmptyColumn = TypedEmptyColumn<double>;
+using StringEmptyColumn = TypedEmptyColumn<std::string_view>;
 
 std::shared_ptr<ColumnBase> CreateColumn(PropertyType type,
                                          StorageStrategy strategy) {
   if (strategy == StorageStrategy::kNone) {
-    if (type == PropertyType::kInt32) {
+    if (type == PropertyType::kBool) {
+      return std::make_shared<BoolEmptyColumn>();
+    } else if (type == PropertyType::kInt32) {
       return std::make_shared<IntEmptyColumn>();
     } else if (type == PropertyType::kInt64) {
       return std::make_shared<LongEmptyColumn>();
+    } else if (type == PropertyType::kUInt32) {
+      return std::make_shared<UIntEmptyColumn>();
+    } else if (type == PropertyType::kUInt64) {
+      return std::make_shared<ULongEmptyColumn>();
+    } else if (type == PropertyType::kDouble) {
+      return std::make_shared<DoubleEmptyColumn>();
+    } else if (type == PropertyType::kFloat) {
+      return std::make_shared<FloatEmptyColumn>();
     } else if (type == PropertyType::kDate) {
       return std::make_shared<DateEmptyColumn>();
     } else if (type == PropertyType::kString) {
-      return std::make_shared<TypedEmptyColumn<std::string_view>>();
+      return std::make_shared<StringEmptyColumn>();
     } else {
       LOG(FATAL) << "unexpected type to create column, "
                  << static_cast<int>(type);
       return nullptr;
     }
   } else {
-    if (type == PropertyType::kInt32) {
+    if (type == PropertyType::kBool) {
+      return std::make_shared<BoolColumn>(strategy);
+    } else if (type == PropertyType::kInt32) {
       return std::make_shared<IntColumn>(strategy);
     } else if (type == PropertyType::kInt64) {
       return std::make_shared<LongColumn>(strategy);
+    } else if (type == PropertyType::kUInt32) {
+      return std::make_shared<UIntColumn>(strategy);
+    } else if (type == PropertyType::kUInt64) {
+      return std::make_shared<ULongColumn>(strategy);
+    } else if (type == PropertyType::kDouble) {
+      return std::make_shared<DoubleColumn>(strategy);
+    } else if (type == PropertyType::kFloat) {
+      return std::make_shared<FloatColumn>(strategy);
     } else if (type == PropertyType::kDate) {
       return std::make_shared<DateColumn>(strategy);
     } else if (type == PropertyType::kString) {

--- a/flex/utils/property/column.h
+++ b/flex/utils/property/column.h
@@ -103,11 +103,15 @@ class TypedColumn : public ColumnBase {
   StorageStrategy strategy_;
 };
 
-using IntColumn = TypedColumn<int>;
+using BoolColumn = TypedColumn<bool>;
+using IntColumn = TypedColumn<int32_t>;
+using UIntColumn = TypedColumn<uint32_t>;
 using LongColumn = TypedColumn<int64_t>;
+using ULongColumn = TypedColumn<uint64_t>;
 using DateColumn = TypedColumn<Date>;
 using StringColumn = TypedColumn<std::string_view>;
 using DoubleColumn = TypedColumn<double>;
+using FloatColumn = TypedColumn<float>;
 
 std::shared_ptr<ColumnBase> CreateColumn(
     PropertyType type, StorageStrategy strategy = StorageStrategy::kMem);

--- a/flex/utils/property/types.cc
+++ b/flex/utils/property/types.cc
@@ -22,11 +22,20 @@ namespace gs {
 
 grape::InArchive& operator<<(grape::InArchive& in_archive, const Any& value) {
   switch (value.type) {
+  case PropertyType::kBool:
+    in_archive << value.type << value.value.b;
+    break;
   case PropertyType::kInt32:
     in_archive << value.type << value.value.i;
     break;
   case PropertyType::kInt64:
     in_archive << value.type << value.value.l;
+    break;
+  case PropertyType::kUInt32:
+    in_archive << value.type << value.value.ui;
+    break;
+  case PropertyType::kUInt64:
+    in_archive << value.type << value.value.ul;
     break;
   case PropertyType::kDate:
     in_archive << value.type << value.value.d.milli_second;
@@ -36,6 +45,9 @@ grape::InArchive& operator<<(grape::InArchive& in_archive, const Any& value) {
     break;
   case PropertyType::kDouble:
     in_archive << value.type << value.value.db;
+    break;
+  case PropertyType::kFloat:
+    in_archive << value.type << value.value.f;
     break;
   default:
     in_archive << PropertyType::kEmpty;
@@ -48,11 +60,20 @@ grape::InArchive& operator<<(grape::InArchive& in_archive, const Any& value) {
 grape::OutArchive& operator>>(grape::OutArchive& out_archive, Any& value) {
   out_archive >> value.type;
   switch (value.type) {
+  case PropertyType::kBool:
+    out_archive >> value.value.b;
+    break;
   case PropertyType::kInt32:
     out_archive >> value.value.i;
     break;
   case PropertyType::kInt64:
     out_archive >> value.value.l;
+    break;
+  case PropertyType::kUInt32:
+    out_archive >> value.value.ui;
+    break;
+  case PropertyType::kUInt64:
+    out_archive >> value.value.ul;
     break;
   case PropertyType::kDate:
     out_archive >> value.value.d.milli_second;
@@ -62,6 +83,9 @@ grape::OutArchive& operator>>(grape::OutArchive& out_archive, Any& value) {
     break;
   case PropertyType::kDouble:
     out_archive >> value.value.db;
+    break;
+  case PropertyType::kFloat:
+    out_archive >> value.value.f;
     break;
   default:
     break;

--- a/flex/utils/property/types.h
+++ b/flex/utils/property/types.h
@@ -39,6 +39,10 @@ enum class PropertyType {
   kEmpty,
   kInt64,
   kDouble,
+  kUInt32,
+  kUInt64,
+  kBool,
+  kFloat,
 };
 
 struct Date {
@@ -55,8 +59,12 @@ union AnyValue {
   AnyValue() {}
   ~AnyValue() {}
 
-  int i;
+  bool b;
+  int32_t i;
+  uint32_t ui;
+  float f;
   int64_t l;
+  uint64_t ul;
   Date d;
   std::string_view s;
   double db;
@@ -81,14 +89,29 @@ struct Any {
     return value.l;
   }
 
-  void set_integer(int v) {
+  void set_bool(bool v) {
+    type = PropertyType::kBool;
+    value.b = v;
+  }
+
+  void set_signed_integer(int32_t v) {
     type = PropertyType::kInt32;
     value.i = v;
   }
 
-  void set_long(int64_t v) {
+  void set_unsigned_integer(uint32_t v) {
+    type = PropertyType::kUInt32;
+    value.ui = v;
+  }
+
+  void set_signed_long(int64_t v) {
     type = PropertyType::kInt64;
     value.l = v;
+  }
+
+  void set_unsigned_long(uint64_t v) {
+    type = PropertyType::kUInt64;
+    value.ul = v;
   }
 
   void set_date(int64_t v) {
@@ -105,6 +128,11 @@ struct Any {
     value.s = v;
   }
 
+  void set_float(float v) {
+    type = PropertyType::kFloat;
+    value.f = v;
+  }
+
   void set_double(double db) {
     type = PropertyType::kDouble;
     value.db = db;
@@ -117,13 +145,20 @@ struct Any {
       return std::to_string(value.l);
     } else if (type == PropertyType::kString) {
       return std::string(value.s.data(), value.s.size());
-      //      return value.s.to_string();
     } else if (type == PropertyType::kDate) {
       return value.d.to_string();
     } else if (type == PropertyType::kEmpty) {
       return "NULL";
     } else if (type == PropertyType::kDouble) {
       return std::to_string(value.db);
+    } else if (type == PropertyType::kUInt32) {
+      return std::to_string(value.ui);
+    } else if (type == PropertyType::kUInt64) {
+      return std::to_string(value.ul);
+    } else if (type == PropertyType::kBool) {
+      return value.b ? "true" : "false";
+    } else if (type == PropertyType::kFloat) {
+      return std::to_string(value.f);
     } else {
       LOG(FATAL) << "Unexpected property type: " << static_cast<int>(type);
       return "";
@@ -140,9 +175,34 @@ struct Any {
     return value.l;
   }
 
+  uint64_t AsUInt64() const {
+    assert(type == PropertyType::kUInt64);
+    return value.ul;
+  }
+
+  int32_t AsInt32() const {
+    assert(type == PropertyType::kInt32);
+    return value.i;
+  }
+
+  uint32_t AsUInt32() const {
+    assert(type == PropertyType::kUInt32);
+    return value.ui;
+  }
+
+  bool AsBool() const {
+    assert(type == PropertyType::kBool);
+    return value.b;
+  }
+
   double AsDouble() const {
     assert(type == PropertyType::kDouble);
     return value.db;
+  }
+
+  float AsFloat() const {
+    assert(type == PropertyType::kFloat);
+    return value.f;
   }
 
   const std::string_view& AsStringView() const {
@@ -174,6 +234,14 @@ struct Any {
         return true;
       } else if (type == PropertyType::kDouble) {
         return value.db == other.value.db;
+      } else if (type == PropertyType::kUInt32) {
+        return value.ui == other.value.ui;
+      } else if (type == PropertyType::kUInt64) {
+        return value.ul == other.value.ul;
+      } else if (type == PropertyType::kBool) {
+        return value.b == other.value.b;
+      } else if (type == PropertyType::kFloat) {
+        return value.f == other.value.f;
       } else {
         return false;
       }
@@ -196,6 +264,14 @@ struct Any {
         return false;
       } else if (type == PropertyType::kDouble) {
         return value.db < other.value.db;
+      } else if (type == PropertyType::kUInt32) {
+        return value.ui < other.value.ui;
+      } else if (type == PropertyType::kUInt64) {
+        return value.ul < other.value.ul;
+      } else if (type == PropertyType::kBool) {
+        return value.b < other.value.b;
+      } else if (type == PropertyType::kFloat) {
+        return value.f < other.value.f;
       } else {
         return false;
       }
@@ -217,10 +293,26 @@ struct ConvertAny {
 };
 
 template <>
-struct ConvertAny<int> {
-  static void to(const Any& value, int& out) {
+struct ConvertAny<bool> {
+  static void to(const Any& value, bool& out) {
+    CHECK(value.type == PropertyType::kBool);
+    out = value.value.b;
+  }
+};
+
+template <>
+struct ConvertAny<int32_t> {
+  static void to(const Any& value, int32_t& out) {
     CHECK(value.type == PropertyType::kInt32);
     out = value.value.i;
+  }
+};
+
+template <>
+struct ConvertAny<uint32_t> {
+  static void to(const Any& value, uint32_t& out) {
+    CHECK(value.type == PropertyType::kUInt32);
+    out = value.value.ui;
   }
 };
 
@@ -229,6 +321,14 @@ struct ConvertAny<int64_t> {
   static void to(const Any& value, int64_t& out) {
     CHECK(value.type == PropertyType::kInt64);
     out = value.value.l;
+  }
+};
+
+template <>
+struct ConvertAny<uint64_t> {
+  static void to(const Any& value, uint64_t& out) {
+    CHECK(value.type == PropertyType::kUInt64);
+    out = value.value.ul;
   }
 };
 
@@ -256,6 +356,14 @@ struct ConvertAny<std::string> {
 };
 
 template <>
+struct ConvertAny<float> {
+  static void to(const Any& value, float& out) {
+    CHECK(value.type == PropertyType::kFloat);
+    out = value.value.f;
+  }
+};
+
+template <>
 struct ConvertAny<double> {
   static void to(const Any& value, double& out) {
     CHECK(value.type == PropertyType::kDouble);
@@ -266,28 +374,81 @@ struct ConvertAny<double> {
 template <typename T>
 struct AnyConverter {};
 
+// specialization for bool
 template <>
-struct AnyConverter<int> {
-  static constexpr PropertyType type = PropertyType::kInt32;
+struct AnyConverter<bool> {
+  static constexpr PropertyType type = PropertyType::kBool;
 
-  static Any to_any(const int& value) {
+  static Any to_any(const bool& value) {
     Any ret;
-    ret.set_integer(value);
+    ret.set_bool(value);
     return ret;
   }
 
-  static AnyValue to_any_value(const int& value) {
+  static AnyValue to_any_value(const bool& value) {
+    AnyValue ret;
+    ret.b = value;
+    return ret;
+  }
+
+  static const bool& from_any(const Any& value) {
+    CHECK(value.type == PropertyType::kBool);
+    return value.value.b;
+  }
+
+  static const bool& from_any_value(const AnyValue& value) { return value.b; }
+};
+
+template <>
+struct AnyConverter<int32_t> {
+  static constexpr PropertyType type = PropertyType::kInt32;
+
+  static Any to_any(const int32_t& value) {
+    Any ret;
+    ret.set_signed_integer(value);
+    return ret;
+  }
+
+  static AnyValue to_any_value(const int32_t& value) {
     AnyValue ret;
     ret.i = value;
     return ret;
   }
 
-  static const int& from_any(const Any& value) {
+  static const int32_t& from_any(const Any& value) {
     CHECK(value.type == PropertyType::kInt32);
     return value.value.i;
   }
 
-  static const int& from_any_value(const AnyValue& value) { return value.i; }
+  static const int32_t& from_any_value(const AnyValue& value) {
+    return value.i;
+  }
+};
+
+template <>
+struct AnyConverter<uint32_t> {
+  static constexpr PropertyType type = PropertyType::kUInt32;
+
+  static Any to_any(const uint32_t& value) {
+    Any ret;
+    ret.set_unsigned_integer(value);
+    return ret;
+  }
+
+  static AnyValue to_any_value(const uint32_t& value) {
+    AnyValue ret;
+    ret.ui = value;
+    return ret;
+  }
+
+  static const uint32_t& from_any(const Any& value) {
+    CHECK(value.type == PropertyType::kUInt32);
+    return value.value.ui;
+  }
+
+  static const uint32_t& from_any_value(const AnyValue& value) {
+    return value.ui;
+  }
 };
 
 template <>
@@ -296,7 +457,7 @@ struct AnyConverter<int64_t> {
 
   static Any to_any(const int64_t& value) {
     Any ret;
-    ret.set_long(value);
+    ret.set_signed_long(value);
     return ret;
   }
 
@@ -313,6 +474,32 @@ struct AnyConverter<int64_t> {
 
   static const int64_t& from_any_value(const AnyValue& value) {
     return value.l;
+  }
+};
+
+template <>
+struct AnyConverter<uint64_t> {
+  static constexpr PropertyType type = PropertyType::kUInt64;
+
+  static Any to_any(const uint64_t& value) {
+    Any ret;
+    ret.set_unsigned_long(value);
+    return ret;
+  }
+
+  static AnyValue to_any_value(const uint64_t& value) {
+    AnyValue ret;
+    ret.ul = value;
+    return ret;
+  }
+
+  static const uint64_t& from_any(const Any& value) {
+    CHECK(value.type == PropertyType::kUInt64);
+    return value.value.ul;
+  }
+
+  static const uint64_t& from_any_value(const AnyValue& value) {
+    return value.ul;
   }
 };
 
@@ -448,6 +635,31 @@ struct AnyConverter<double> {
   }
 };
 
+// specilization for float
+template <>
+struct AnyConverter<float> {
+  static constexpr PropertyType type = PropertyType::kFloat;
+
+  static Any to_any(const float& value) {
+    Any ret;
+    ret.set_float(value);
+    return ret;
+  }
+
+  static AnyValue to_any_value(const float& value) {
+    AnyValue ret;
+    ret.f = value;
+    return ret;
+  }
+
+  static const float& from_any(const Any& value) {
+    CHECK(value.type == PropertyType::kFloat);
+    return value.value.f;
+  }
+
+  static const float& from_any_value(const AnyValue& value) { return value.f; }
+};
+
 grape::InArchive& operator<<(grape::InArchive& in_archive, const Any& value);
 grape::OutArchive& operator>>(grape::OutArchive& out_archive, Any& value);
 
@@ -459,7 +671,6 @@ grape::OutArchive& operator>>(grape::OutArchive& out_archive,
 }  // namespace gs
 
 namespace std {
-
 inline ostream& operator<<(ostream& os, const gs::Date& dt) {
   os << dt.to_string();
   return os;
@@ -467,11 +678,20 @@ inline ostream& operator<<(ostream& os, const gs::Date& dt) {
 
 inline ostream& operator<<(ostream& os, gs::PropertyType pt) {
   switch (pt) {
+  case gs::PropertyType::kBool:
+    os << "bool";
+    break;
   case gs::PropertyType::kInt32:
     os << "int32";
     break;
+  case gs::PropertyType::kUInt32:
+    os << "uint32";
+    break;
   case gs::PropertyType::kInt64:
     os << "int64";
+    break;
+  case gs::PropertyType::kUInt64:
+    os << "uint64";
     break;
   case gs::PropertyType::kDate:
     os << "Date";
@@ -484,6 +704,9 @@ inline ostream& operator<<(ostream& os, gs::PropertyType pt) {
     break;
   case gs::PropertyType::kDouble:
     os << "double";
+    break;
+  case gs::PropertyType::kFloat:
+    os << "float";
     break;
   default:
     os << "Unknown";


### PR DESCRIPTION
Add more data type support for vertex/edge property, now we support the following types.
- DT_SIGNED_INT32
- DT_UNSIGNED_INT32
- DT_SIGNED_INT64
- DT_UNSIGNED_INT64
- DT_BOOL
- DT_FLOAT
- DT_DOUBLE
- DT_STRING
- DT_DATE32

The vertex property column of following types can be used as primary key column
- DT_SIGNED_INT32
- DT_UNSIGNED_INT32
- DT_SIGNED_INT64
- DT_UNSIGNED_INT64
- DT_STRING
