### PR TITLE
fix(interactive): extension use hash(srcId, dstId, edgeLabelId, edgePks) instead of increase eid

### DIFF
--- a/charts/graphscope-store-one-pod/templates/configmap.yaml
+++ b/charts/graphscope-store-one-pod/templates/configmap.yaml
@@ -31,6 +31,7 @@ data:
 
     ## Frontend Config
     frontend.server.num=1
+    enable.hash.generate.eid={{ .Values.enableHashGenerateEid }}
 
     ## Ingestor Config
     ingestor.queue.buffer.size={{ .Values.ingestorQueueBufferSize }}

--- a/charts/graphscope-store-one-pod/values.yaml
+++ b/charts/graphscope-store-one-pod/values.yaml
@@ -362,6 +362,9 @@ snapshotIncreaseIntervalMs: 1000
 offsetsPersistIntervalMs: 3000
 fileMetaStorePath: "/var/lib/graphscope-store/meta"
 
+## Frontend config
+enableHashGenerateEid: false
+
 ## Store Config
 storeDataPath: "/var/lib/graphscope-store"
 storeWriteThreadCount: 1

--- a/charts/graphscope-store/templates/configmap.yaml
+++ b/charts/graphscope-store/templates/configmap.yaml
@@ -33,6 +33,7 @@ data:
     frontend.service.port=55556
     frontend.server.id=INDEX
     frontend.server.num={{ .Values.frontend.replicaCount }}
+    enable.hash.generate.eid={{ .Values.enableHashGenerateEid }}
 
     ## Ingestor Config
     ingestor.queue.buffer.size={{ .Values.ingestorQueueBufferSize }}

--- a/charts/graphscope-store/values.yaml
+++ b/charts/graphscope-store/values.yaml
@@ -522,6 +522,7 @@ kafkaTopic: "graphscope"
 kafkaProducerCustomConfigs: ""
 
 ## Frontend Config
+enableHashGenerateEid: false
 # gremlinServerPort: 12312
 
 executorWorkerPerProcess: 2

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/config/FrontendConfig.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/config/FrontendConfig.java
@@ -25,4 +25,7 @@ public class FrontendConfig {
             Config.intConfig(
                     "frontend.service.thread.count",
                     Math.max(Math.min(Runtime.getRuntime().availableProcessors() / 2, 64), 4));
+
+    public static final Config<Boolean> ENABLE_HASH_GENERATE_EID =
+            Config.boolConfig("enable.hash.generate.eid", false);
 }

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/impl/DefaultGraphEdge.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/impl/DefaultGraphEdge.java
@@ -139,8 +139,10 @@ public class DefaultGraphEdge implements GraphEdge {
     @Override
     public List<GraphProperty> getPrimaryKeyList() {
         List<GraphProperty> props = new ArrayList<>();
-        for (String name : primaryKeyList) {
-            props.add(getProperty(name));
+        if (this.primaryKeyList != null) {
+            for (String name : primaryKeyList) {
+                props.add(getProperty(name));
+            }
         }
         return props;
     }

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/impl/DefaultGraphEdge.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/impl/DefaultGraphEdge.java
@@ -21,6 +21,7 @@ import com.alibaba.graphscope.groot.common.schema.api.GraphProperty;
 import com.alibaba.graphscope.groot.common.schema.wrapper.TypeDef;
 import com.google.common.base.MoreObjects;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -29,6 +30,7 @@ public class DefaultGraphEdge implements GraphEdge {
     private String label;
     private List<GraphProperty> propertyList;
     private List<EdgeRelation> relationList;
+    private List<String> primaryKeyList;
 
     private final int versionId;
 
@@ -45,11 +47,35 @@ public class DefaultGraphEdge implements GraphEdge {
             String label,
             List<GraphProperty> propertyList,
             List<EdgeRelation> relationList,
+            List<String> primaryKeyList) {
+        this(id, label, propertyList, relationList, primaryKeyList, 0);
+    }
+
+    public DefaultGraphEdge(
+            int id,
+            String label,
+            List<GraphProperty> propertyList,
+            List<EdgeRelation> relationList,
             int versionId) {
         this.id = id;
         this.label = label;
         this.propertyList = propertyList;
         this.relationList = relationList;
+        this.versionId = versionId;
+    }
+
+    public DefaultGraphEdge(
+            int id,
+            String label,
+            List<GraphProperty> propertyList,
+            List<EdgeRelation> relationList,
+            List<String> primaryKeyList,
+            int versionId) {
+        this.id = id;
+        this.label = label;
+        this.propertyList = propertyList;
+        this.relationList = relationList;
+        this.primaryKeyList = primaryKeyList;
         this.versionId = versionId;
     }
 
@@ -59,6 +85,7 @@ public class DefaultGraphEdge implements GraphEdge {
                 typeDef.getLabel(),
                 typeDef.getPropertyList(),
                 edgeRelations,
+                typeDef.getPrimaryKeyNameList(),
                 typeDef.getVersionId());
     }
 
@@ -111,12 +138,16 @@ public class DefaultGraphEdge implements GraphEdge {
 
     @Override
     public List<GraphProperty> getPrimaryKeyList() {
-        return null;
+        List<GraphProperty> props = new ArrayList<>();
+        for (String name : primaryKeyList) {
+            props.add(getProperty(name));
+        }
+        return props;
     }
 
     @Override
     public List<String> getPrimaryKeyNameList() {
-        return null;
+        return primaryKeyList;
     }
 
     @Override

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/impl/DefaultGraphSchema.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/impl/DefaultGraphSchema.java
@@ -187,22 +187,15 @@ public class DefaultGraphSchema implements GraphSchema {
                     }
 
                     if (type.equalsIgnoreCase("VERTEX")) {
-                        List<String> primaryKeyList = Lists.newArrayList();
-
-                        JsonNode indexArray = typeObject.get("indexes");
-                        if (indexArray != null) {
-                            for (JsonNode indexObject : indexArray) {
-                                JsonNode priNameList = indexObject.get("propertyNames");
-                                for (JsonNode pri : priNameList) {
-                                    primaryKeyList.add(pri.asText());
-                                }
-                            }
-                        }
+                        List<String> primaryKeyList = getPrimaryKeyList(typeObject.get("indexes"));
                         DefaultGraphVertex graphVertex =
                                 new DefaultGraphVertex(
                                         labelId, label, propertyList, primaryKeyList);
                         vertexList.put(label, graphVertex);
                     } else {
+                        // get edge pk name list
+                        List<String> primaryKeyList = getPrimaryKeyList(typeObject.get("indexes"));
+
                         List<EdgeRelation> relationList = Lists.newArrayList();
                         JsonNode relationArray = typeObject.get("rawRelationShips");
                         if (null != relationArray) {
@@ -218,7 +211,7 @@ public class DefaultGraphSchema implements GraphSchema {
                             logger.warn("There's no relation def in edge " + label);
                         }
                         DefaultGraphEdge graphEdge =
-                                new DefaultGraphEdge(labelId, label, propertyList, relationList);
+                                new DefaultGraphEdge(labelId, label, propertyList, relationList, primaryKeyList);
                         edgeList.put(label, graphEdge);
                     }
                 }
@@ -231,6 +224,19 @@ public class DefaultGraphSchema implements GraphSchema {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static List<String> getPrimaryKeyList(JsonNode indexArray) {
+        List<String> primaryKeyList = Lists.newArrayList();
+        if (indexArray != null) {
+            for (JsonNode indexObject : indexArray) {
+                JsonNode priNameList = indexObject.get("propertyNames");
+                for (JsonNode pri : priNameList) {
+                    primaryKeyList.add(pri.asText());
+                }
+            }
+        }
+        return primaryKeyList;
     }
 
     public static void main(String[] args) throws JsonProcessingException {

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/impl/DefaultGraphSchema.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/impl/DefaultGraphSchema.java
@@ -211,7 +211,8 @@ public class DefaultGraphSchema implements GraphSchema {
                             logger.warn("There's no relation def in edge " + label);
                         }
                         DefaultGraphEdge graphEdge =
-                                new DefaultGraphEdge(labelId, label, propertyList, relationList, primaryKeyList);
+                                new DefaultGraphEdge(
+                                        labelId, label, propertyList, relationList, primaryKeyList);
                         edgeList.put(label, graphEdge);
                     }
                 }

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/EdgeTypeMapper.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/EdgeTypeMapper.java
@@ -93,7 +93,8 @@ public class EdgeTypeMapper extends SchemaElementMapper {
         List<String> primaryKeyList = new ArrayList<>();
         if (indexes != null && indexes.size() > 0) {
             if (indexes.size() > 1) {
-                throw new IllegalArgumentException("Only support primary key now for " + this.indexes);
+                throw new IllegalArgumentException(
+                        "Only support primary key now for " + this.indexes);
             }
             primaryKeyList = indexes.get(0).getPropertyNames();
         }

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/EdgeTypeMapper.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/EdgeTypeMapper.java
@@ -30,12 +30,21 @@ import java.util.stream.Collectors;
 public class EdgeTypeMapper extends SchemaElementMapper {
     private List<EdgeRelationMapper> relationShips;
 
+    private List<ElementIndexMapper> indexes;
+
     public static SchemaElementMapper parseFromEdgeType(GraphEdge graphEdge) {
         EdgeTypeMapper edgeTypeMapper = new EdgeTypeMapper();
         edgeTypeMapper.setId(graphEdge.getLabelId());
         edgeTypeMapper.setLabel(graphEdge.getLabel());
         edgeTypeMapper.setType(TypeEnum.EDGE.toString());
 
+        ElementIndexMapper elementIndexMapper = new ElementIndexMapper();
+        elementIndexMapper.setName("primary_key");
+        elementIndexMapper.setIndexType("PRIMARY_KEY");
+        elementIndexMapper.setPropertyNames(graphEdge.getPrimaryKeyNameList());
+        ArrayList<ElementIndexMapper> elementIndexMapperList = new ArrayList<>();
+        elementIndexMapperList.add(elementIndexMapper);
+        edgeTypeMapper.setIndexes(elementIndexMapperList);
         List<EdgeRelationMapper> relationMapperList = new ArrayList<>();
         for (EdgeRelation edgeRelation : graphEdge.getRelationList()) {
             relationMapperList.add(
@@ -54,6 +63,14 @@ public class EdgeTypeMapper extends SchemaElementMapper {
 
     public List<EdgeRelationMapper> getRelationShips() {
         return relationShips;
+    }
+
+    public List<ElementIndexMapper> getIndexes() {
+        return indexes;
+    }
+
+    public void setIndexes(List<ElementIndexMapper> indexes) {
+        this.indexes = indexes;
     }
 
     public void setRelationShips(List<EdgeRelationMapper> relationShips) {

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/EdgeTypeMapper.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/EdgeTypeMapper.java
@@ -90,11 +90,20 @@ public class EdgeTypeMapper extends SchemaElementMapper {
                 relationList.add(relationMapper.toEdgeRelation(vertexTypeMap));
             }
         }
+        List<String> primaryKeyList = new ArrayList<>();
+        if (indexes != null && indexes.size() > 0) {
+            if (indexes.size() > 1) {
+                throw new IllegalArgumentException("Only support primary key now for " + this.indexes);
+            }
+            primaryKeyList = indexes.get(0).getPropertyNames();
+        }
+
         return new DefaultGraphEdge(
                 this.getId(),
                 this.getLabel(),
                 graphPropertyList,
                 relationList,
+                primaryKeyList,
                 this.getVersionId());
     }
 }

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/ElementIndexMapper.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/ElementIndexMapper.java
@@ -18,7 +18,7 @@ import com.alibaba.graphscope.groot.common.schema.api.GraphProperty;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class VertexIndexMapper {
+public class ElementIndexMapper {
     private String name;
     private String indexType;
     private List<String> propertyNames;

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/VertexTypeMapper.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/schema/mapper/VertexTypeMapper.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VertexTypeMapper extends SchemaElementMapper {
-    private List<VertexIndexMapper> indexes;
+    private List<ElementIndexMapper> indexes;
     private long tableId;
 
     public static VertexTypeMapper parseFromVertexType(GraphVertex graphVertex) {
@@ -34,13 +34,13 @@ public class VertexTypeMapper extends SchemaElementMapper {
         vertexTypeMapper.setLabel(graphVertex.getLabel());
         vertexTypeMapper.setType(TypeEnum.VERTEX.toString());
 
-        VertexIndexMapper vertexIndexMapper = new VertexIndexMapper();
-        vertexIndexMapper.setName("primary_key");
-        vertexIndexMapper.setIndexType("PRIMARY_KEY");
-        vertexIndexMapper.setPropertyNames(graphVertex.getPrimaryKeyNameList());
-        ArrayList<VertexIndexMapper> vertexIndexMapperList = new ArrayList<>();
-        vertexIndexMapperList.add(vertexIndexMapper);
-        vertexTypeMapper.setIndexes(vertexIndexMapperList);
+        ElementIndexMapper elementIndexMapper = new ElementIndexMapper();
+        elementIndexMapper.setName("primary_key");
+        elementIndexMapper.setIndexType("PRIMARY_KEY");
+        elementIndexMapper.setPropertyNames(graphVertex.getPrimaryKeyNameList());
+        ArrayList<ElementIndexMapper> elementIndexMapperList = new ArrayList<>();
+        elementIndexMapperList.add(elementIndexMapper);
+        vertexTypeMapper.setIndexes(elementIndexMapperList);
         List<GraphPropertyMapper> propertyMapperList = new ArrayList<>();
         for (GraphProperty graphProperty : graphVertex.getPropertyList()) {
             propertyMapperList.add(GraphPropertyMapper.parseFromGraphProperty(graphProperty));
@@ -51,11 +51,11 @@ public class VertexTypeMapper extends SchemaElementMapper {
         return vertexTypeMapper;
     }
 
-    public List<VertexIndexMapper> getIndexes() {
+    public List<ElementIndexMapper> getIndexes() {
         return indexes;
     }
 
-    public void setIndexes(List<VertexIndexMapper> indexes) {
+    public void setIndexes(List<ElementIndexMapper> indexes) {
         this.indexes = indexes;
     }
 

--- a/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/util/PkHashUtils.java
+++ b/interactive_engine/common/src/main/java/com/alibaba/graphscope/groot/common/util/PkHashUtils.java
@@ -42,6 +42,31 @@ public final class PkHashUtils {
         return hash64(buffer.array(), buffer.limit());
     }
 
+    public static long hash(long srcId, long dstId, int labelId, List<byte[]> pks) {
+        ByteBuffer buffer = THREAD_BUFFER.get();
+        clear(buffer);
+        buffer.putLong(srcId);
+        buffer.putLong(dstId);
+        buffer.putInt(labelId);
+        for (byte[] pk : pks) {
+            buffer.putInt(pk.length);
+            buffer.put(pk);
+        }
+        flip(buffer);
+        return hash64(buffer.array(), buffer.limit());
+    }
+
+    public static long hash(long srcId, long dstId, int labelId, long nanoTime) {
+        ByteBuffer buffer = THREAD_BUFFER.get();
+        clear(buffer);
+        buffer.putLong(srcId);
+        buffer.putLong(dstId);
+        buffer.putInt(labelId);
+        buffer.putLong(nanoTime);
+        flip(buffer);
+        return hash64(buffer.array(), buffer.limit());
+    }
+
     /**
      * Generates 64-bit hash from byte array of the given length and seed.
      *

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
@@ -17,6 +17,7 @@ import com.alibaba.graphscope.groot.common.config.DataLoadConfig;
 import com.alibaba.graphscope.groot.common.schema.api.GraphSchema;
 import com.alibaba.graphscope.groot.common.schema.mapper.GraphSchemaMapper;
 import com.alibaba.graphscope.groot.common.schema.wrapper.GraphDef;
+import com.alibaba.graphscope.groot.common.util.JSON;
 import com.alibaba.graphscope.groot.common.util.UuidUtils;
 import com.alibaba.graphscope.groot.dataload.util.OSSFS;
 import com.alibaba.graphscope.groot.dataload.util.VolumeFS;
@@ -72,6 +73,7 @@ public class OfflineBuildOdps {
         GraphDefPb graphDefPb = client.prepareDataLoad(targets);
         System.out.println("GraphDef: " + graphDefPb);
         GraphSchema schema = GraphDef.parseProto(graphDefPb);
+        System.out.println("GraphSchema: " + JSON.toJson(schema));
 
         // number of reduce task
         int partitionNum = client.getPartitionNum();
@@ -124,6 +126,7 @@ public class OfflineBuildOdps {
         }
 
         String schemaJson = GraphSchemaMapper.parseFromSchema(schema).toJsonString();
+        System.out.println("schemaJson is :" + schemaJson);
         Map<String, ColumnMappingInfo> info = Utils.getMappingInfo(odps, schema, mappingConfig);
         ObjectMapper mapper = new ObjectMapper();
 

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
@@ -128,7 +128,6 @@ public class OfflineBuildOdps {
         String schemaJson = GraphSchemaMapper.parseFromSchema(schema).toJsonString();
         System.out.println("schemaJson is :" + schemaJson);
         Map<String, ColumnMappingInfo> info = Utils.getMappingInfo(odps, schema, mappingConfig);
-        System.out.println(JSON.toJson(info));
         ObjectMapper mapper = new ObjectMapper();
 
         Map<String, String> outputMeta = new HashMap<>();

--- a/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
+++ b/interactive_engine/data-load-tool/src/main/java/com/alibaba/graphscope/groot/dataload/databuild/OfflineBuildOdps.java
@@ -128,6 +128,7 @@ public class OfflineBuildOdps {
         String schemaJson = GraphSchemaMapper.parseFromSchema(schema).toJsonString();
         System.out.println("schemaJson is :" + schemaJson);
         Map<String, ColumnMappingInfo> info = Utils.getMappingInfo(odps, schema, mappingConfig);
+        System.out.println(JSON.toJson(info));
         ObjectMapper mapper = new ObjectMapper();
 
         Map<String, String> outputMeta = new HashMap<>();

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/DefaultEdgeIdGenerator.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/DefaultEdgeIdGenerator.java
@@ -3,9 +3,11 @@ package com.alibaba.graphscope.groot.frontend.write;
 import com.alibaba.graphscope.groot.common.RoleType;
 import com.alibaba.graphscope.groot.common.config.CommonConfig;
 import com.alibaba.graphscope.groot.common.config.Configs;
+import com.alibaba.graphscope.groot.common.util.PkHashUtils;
 import com.alibaba.graphscope.groot.rpc.ChannelManager;
 import com.alibaba.graphscope.groot.rpc.RoleClients;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class DefaultEdgeIdGenerator extends RoleClients<IdAllocateClient>
@@ -33,6 +35,14 @@ public class DefaultEdgeIdGenerator extends RoleClients<IdAllocateClient>
             }
         }
         return getNextId();
+    }
+
+    @Override
+    public long getHashId(long srcId, long dstId, int labelId, List<byte[]> pks) {
+        if (pks != null && pks.size() > 0) {
+            return PkHashUtils.hash(srcId, dstId, labelId, pks);
+        }
+        return PkHashUtils.hash(srcId, dstId, labelId, System.nanoTime());
     }
 
     private void allocateNewIds() {

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/EdgeIdGenerator.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/EdgeIdGenerator.java
@@ -1,6 +1,10 @@
 package com.alibaba.graphscope.groot.frontend.write;
 
+import java.util.List;
+
 public interface EdgeIdGenerator {
 
     long getNextId();
+
+    long getHashId(long srcId, long dstId, int labelId, List<byte[]> pks);
 }

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/GraphWriter.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/GraphWriter.java
@@ -27,6 +27,7 @@ import com.alibaba.graphscope.groot.operation.OperationType;
 import com.alibaba.graphscope.groot.operation.VertexId;
 import com.alibaba.graphscope.groot.operation.dml.*;
 import com.alibaba.graphscope.groot.rpc.RoleClients;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -386,10 +387,17 @@ public class GraphWriter implements MetricsAgent {
                     parseRawProperties(dstVertexDef, dstVertexRecordKey.getProperties());
             long dstVertexHashId =
                     getPrimaryKeysHashId(dstVertexDef.getLabelId(), dstVertexPkVals, dstVertexDef);
-//            long edgeInnerId =
-//                    overwrite ? edgeIdGenerator.getNextId() : edgeRecordKey.getEdgeInnerId();
+            //            long edgeInnerId =
+            //                    overwrite ? edgeIdGenerator.getNextId() :
+            // edgeRecordKey.getEdgeInnerId();
             long edgeInnerId =
-                    getEdgeInnerId(srcVertexHashId, dstVertexHashId, overwrite, edgeRecordKey, schema, dataRecord);
+                    getEdgeInnerId(
+                            srcVertexHashId,
+                            dstVertexHashId,
+                            overwrite,
+                            edgeRecordKey,
+                            schema,
+                            dataRecord);
             return new EdgeId(
                     new VertexId(srcVertexHashId), new VertexId(dstVertexHashId), edgeInnerId);
         }
@@ -407,16 +415,26 @@ public class GraphWriter implements MetricsAgent {
      * @return eid
      */
     private long getEdgeInnerId(
-            long srcId, long dstId, boolean overwrite,
-            EdgeRecordKey edgeRecordKey, GraphSchema schema, DataRecord dataRecord) {
+            long srcId,
+            long dstId,
+            boolean overwrite,
+            EdgeRecordKey edgeRecordKey,
+            GraphSchema schema,
+            DataRecord dataRecord) {
         long edgeInnerId;
         if (this.enableHashEid) {
             GraphElement edgeDef = schema.getElement(edgeRecordKey.getLabel());
-            Map<Integer, PropertyValue> edgePkVals = parseRawProperties(edgeDef, dataRecord.getProperties());
+            Map<Integer, PropertyValue> edgePkVals =
+                    parseRawProperties(edgeDef, dataRecord.getProperties());
             List<byte[]> edgePkBytes = getPkBytes(edgePkVals, edgeDef);
             int edgeLabelId = edgeDef.getLabelId();
             long eid = edgeIdGenerator.getHashId(srcId, dstId, edgeLabelId, edgePkBytes);
-            edgeInnerId = overwrite ? eid : (edgeRecordKey.getEdgeInnerId() == 0 ? eid : edgeRecordKey.getEdgeInnerId());
+            edgeInnerId =
+                    overwrite
+                            ? eid
+                            : (edgeRecordKey.getEdgeInnerId() == 0
+                                    ? eid
+                                    : edgeRecordKey.getEdgeInnerId());
         } else {
             edgeInnerId = overwrite ? edgeIdGenerator.getNextId() : edgeRecordKey.getEdgeInnerId();
         }
@@ -452,7 +470,8 @@ public class GraphWriter implements MetricsAgent {
         return PkHashUtils.hash(labelId, getPkBytes(properties, graphElement));
     }
 
-    public static List<byte[]> getPkBytes(Map<Integer, PropertyValue> properties, GraphElement graphElement) {
+    public static List<byte[]> getPkBytes(
+            Map<Integer, PropertyValue> properties, GraphElement graphElement) {
         List<GraphProperty> pklist = graphElement.getPrimaryKeyList();
         List<byte[]> pks = new ArrayList<>(pklist.size());
         for (GraphProperty pk : pklist) {

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/GraphWriter.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/frontend/write/GraphWriter.java
@@ -134,7 +134,6 @@ public class GraphWriter implements MetricsAgent {
         for (WriteRequest writeRequest : writeRequests) {
             OperationType operationType = writeRequest.getOperationType();
             DataRecord dataRecord = writeRequest.getDataRecord();
-            logger.info("WriteRequest is {}", writeRequest);
             switch (operationType) {
                 case OVERWRITE_VERTEX:
                     addOverwriteVertexOperation(batchBuilder, schema, dataRecord);
@@ -238,7 +237,6 @@ public class GraphWriter implements MetricsAgent {
             // such a edge
             edgeId.id = edgeIdGenerator.getNextId();
         }
-        logger.info("get eid is {} ", edgeId.id);
         EdgeKind edgeKind = getEdgeKind(schema, dataRecord);
         GraphElement edgeDef = schema.getElement(edgeKind.getEdgeLabelId().getId());
 
@@ -412,14 +410,12 @@ public class GraphWriter implements MetricsAgent {
             long srcId, long dstId, boolean overwrite,
             EdgeRecordKey edgeRecordKey, GraphSchema schema, DataRecord dataRecord) {
         long edgeInnerId;
-        logger.info("enableHashEid is : {}, overwrite is : {}", this.enableHashEid, overwrite);
         if (this.enableHashEid) {
             GraphElement edgeDef = schema.getElement(edgeRecordKey.getLabel());
             Map<Integer, PropertyValue> edgePkVals = parseRawProperties(edgeDef, dataRecord.getProperties());
             List<byte[]> edgePkBytes = getPkBytes(edgePkVals, edgeDef);
             int edgeLabelId = edgeDef.getLabelId();
             long eid = edgeIdGenerator.getHashId(srcId, dstId, edgeLabelId, edgePkBytes);
-            logger.info("eid = {}: srcId:{}, dstId:{}, edgeLabelId:{}, edgePkBytes:{}", eid, srcId, dstId, edgeLabelId, edgePkBytes);
             edgeInnerId = overwrite ? eid : (edgeRecordKey.getEdgeInnerId() == 0 ? eid : edgeRecordKey.getEdgeInnerId());
         } else {
             edgeInnerId = overwrite ? edgeIdGenerator.getNextId() : edgeRecordKey.getEdgeInnerId();

--- a/interactive_engine/groot-server/src/main/java/com/alibaba/graphscope/groot/servers/Frontend.java
+++ b/interactive_engine/groot-server/src/main/java/com/alibaba/graphscope/groot/servers/Frontend.java
@@ -141,7 +141,8 @@ public class Frontend extends NodeBase {
                         edgeIdGenerator,
                         this.metaService,
                         ingestorWriteClients,
-                        metricsCollector);
+                        metricsCollector,
+                        configs);
         WriteSessionGenerator writeSessionGenerator = new WriteSessionGenerator(configs);
         ClientWriteService clientWriteService =
                 new ClientWriteService(writeSessionGenerator, graphWriter);


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
extension use hash(srcId, dstId, edgeLabelId, edgePks) to generate eid.
It can support edge update scenarios where eid is not known in advance.
Compatible with the original way of generating eid, use "enable.hash.generate.eid parameter" to judge
if enable.hash.generate.eid parameter=true:
    use hash generate
else:
    use increase generate

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

