### PR TITLE
docs: Fix GIE Benchmark Readme bug

### DIFF
--- a/interactive_engine/benchmark/README.md
+++ b/interactive_engine/benchmark/README.md
@@ -14,7 +14,7 @@ The program uses a round-robin strategy to iterate all the **enabled** queries w
 - data
     - substitution_parameters           // query parameter files using to fill the query templates
 - queries                               // qurery templates including LDBC queries, K-hop queries and user-defined queries
-- utils
+- scripts
     - benchmark.sh                      // script for running benchmark
     - cal.py                            // script for calculating benchmark results
 - src                                   // source code of benchmark program
@@ -38,8 +38,8 @@ cd target
 tar -xvf gaia-benchmark-0.0.1-SNAPSHOT-dist.tar.gz
 cd gaia-benchmark-0.0.1-SNAPSHOT
 vim config/interactive-benchmark.properties # specify the gremlin endpoint of your server and modify running configurations
-chmod +x ./utils/benchmark.sh 
-./utils/benchmark.sh                      # run the benchmark program
+chmod +x ./scripts/benchmark.sh 
+./scripts/benchmark.sh                      # run the benchmark program
 ```
 
 Benchmark reports numbers as following:


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

The main fix was for the README quickstart module description in the GIE benchmark, where an error was found that was inconsistent with the current code directory structure.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #3388

