### PR TITLE
fix(interactive): Fix Start Time Metric in Compiler Log

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/MetricsCollector.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/MetricsCollector.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.graphscope.gremlin.plugin;
 
-import com.alibaba.graphscope.gremlin.Utils;
 import com.codahale.metrics.Timer;
 
 import java.util.concurrent.TimeUnit;
@@ -24,11 +23,12 @@ import java.util.concurrent.TimeUnit;
 // collect metrics per gremlin query
 public class MetricsCollector {
     private final Timer.Context timeContext;
-    private long startMillis;
+    private final long startMillis;
     private long elapsedMillis;
 
     public MetricsCollector(Timer timer) {
         this.timeContext = timer.time();
+        this.startMillis = System.currentTimeMillis();
     }
 
     public long getStartMillis() {
@@ -40,9 +40,6 @@ public class MetricsCollector {
     }
 
     public void stop() {
-        this.startMillis =
-                TimeUnit.NANOSECONDS.toMillis(
-                        Utils.getFieldValue(Timer.Context.class, timeContext, "startTime"));
         this.elapsedMillis = TimeUnit.NANOSECONDS.toMillis(timeContext.stop());
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Use `System.currentTimeMillis()` to obtain the start time of a query execution, instead of `System.nanoTime()`. The latter should only be used to calculate elapsed time and is not related to any other notion of system or wall-clock time.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

