### PR TITLE
feat(interactive): Refactor and fix some bugs for `AdminService`

### DIFF
--- a/docs/flex/interactive/development/admin_service.md
+++ b/docs/flex/interactive/development/admin_service.md
@@ -9,22 +9,24 @@ Welcome to the GraphScope Interactive Admin Service documentation. This guide is
 The table below provides an overview of the available APIs:
 
 
-| API name        | Method and URL                        | Explanation                                                        |
-|-----------------|---------------------------------------|--------------------------------------------------------------------|
-| ListGraphs      | GET /v1/graph                             | Get all graphs in current interactive service, the schema for each graph is returned. |
-| GetGraphSchema  | GET /v1/graph/{graph}/schema          | Get the schema for the specified graph.                            |
-| CreateGraph     | POST /v1/graph                             | Create an empty graph with the specified schema.                    |
-| DeleteGraph     | DELETE /v1/graph/{graph}                 | Delete the specified graph.                                        |
-| ImportGraph     | POST /v1/graph/{graph}/dataloading     | Import data to graph.                                              |
-| CreateProcedure | POST /v1/graph/{graph}/procedure      | Create a new stored procedure bound to a graph.                    |
-| ShowProcedures  | GET /v1/graph/{graph}/procedure      | Get all procedures bound to the specified graph.                   |
-| GetProcedure    | GET /v1/graph/{graph}/procedure/{proc_name} | Get the metadata of the procedure.                                 |
-| DeleteProcedure | DELETE /v1/graph/{graph}/procedure/{proc_name} | Delete the specified procedure.                                   |
-| UpdateProcedure | PUT /v1/graph/{graph}/procedure/{proc_name} | Update some metadata for the specified procedure, i.e. update description, enable/disable. |
-| StartService   | POST /v1/service/start                     | Start the service on the graph specified in request body.          |
-| ServiceStatus  | GET /v1/service/status                    | Get current service status.                                        |
-| SystemMetrics     | GET /v1/node/status                       | Get the system metrics of current host/pod, i.e. CPU usage, memory usages.                    |
-
+| API name        | Method and URL                                 | Explanation                                                        |
+|-----------------|------------------------------------------------|--------------------------------------------------------------------|
+| ListGraphs      | GET /v1/graph                                  | Get all graphs in current interactive service, the schema for each graph is returned. |
+| GetGraphSchema  | GET /v1/graph/{graph}/schema                   | Get the schema for the specified graph.                            |
+| CreateGraph     | POST /v1/graph                                 | Create an empty graph with the specified schema.                   |
+| DeleteGraph     | DELETE /v1/graph/{graph}                       | Delete the specified graph.                                        |
+| ImportGraph     | POST /v1/graph/{graph}/dataloading             | Import data to graph.                                               |
+| CreateProcedure | POST /v1/graph/{graph}/procedure               | Create a new stored procedure bound to a graph.                    |
+| ShowProcedures  | GET /v1/graph/{graph}/procedure                | Get all procedures bound to the specified graph.                   |
+| GetProcedure    | GET /v1/graph/{graph}/procedure/{proc_name}    | Get the metadata of the procedure.                                 |
+| DeleteProcedure | DELETE /v1/graph/{graph}/procedure/{proc_name} | Delete the specified procedure.                                    |
+| UpdateProcedure | PUT /v1/graph/{graph}/procedure/{proc_name}    | Update some metadata for the specified procedure, i.e. update description, enable/disable. |
+| StartService    | POST /v1/service/start                         | Start the service on the graph specified in request body.          |
+| ServiceStatus   | GET /v1/service/status                         | Get current service status.                                        |
+| SystemMetrics   | GET /v1/node/status                            | Get the system metrics of current host/pod, i.e. CPU usage, memory usages.                    |
+| GetJobById      | GET /v1/job/{job_id}                           | Get the metadata for the specified job.               |
+| GetAllJobs      | GET /v1/job/                                   | Get all jobs's metadata.                | 
+| CancelJob       | DELETE /v1/job/{job_id}                        | Cancel the job with the specified job_id.                           |
 
 ## Detailed API Documentation
 
@@ -360,113 +362,110 @@ curl -X GET  -H "Content-Type: application/json" "http://[host]/v1/graph/{graph_
 - **Body**:
 ```json
 {
-    "name": "modern",
-    "schema": {
-        "vertex_types": [
-            {
-                "type_id": 0,
-                "type_name": "person",
-                "properties": [
-                    {
-                        "property_id": 0,
-                        "property_name": "id",
-                        "property_type": {
-                            "primitive_type": "DT_SIGNED_INT64"
-                        }
-                    },
-                    {
-                        "property_id": 1,
-                        "property_name": "name",
-                        "property_type": {
-                            "primitive_type": "DT_STRING"
-                        }
-                    },
-                    {
-                        "property_id": 2,
-                        "property_name": "age",
-                        "property_type": {
-                            "primitive_type": "DT_SIGNED_INT32"
-                        }
-                    }
-                ],
-                "primary_keys": [
-                    "id"
-                ]
-            },
-            {
-                "type_id": 1,
-                "type_name": "software",
-                "properties": [
-                    {
-                        "property_id": 0,
-                        "property_name": "id",
-                        "property_type": {
-                            "primitive_type": "DT_SIGNED_INT64"
-                        }
-                    },
-                    {
-                        "property_id": 1,
-                        "property_name": "name",
-                        "property_type": {
-                            "primitive_type": "DT_STRING"
-                        }
-                    },
-                    {
-                        "property_id": 2,
-                        "property_name": "lang",
-                        "property_type": {
-                            "primitive_type": "DT_STRING"
-                        }
-                    }
-                ],
-                "primary_keys": [
-                    "id"
-                ]
-            }
-        ],
-        "edge_types": [
-            {
-                "type_id": 0,
-                "type_name": "knows",
-                "vertex_type_pair_relations": [
-                    {
-                        "source_vertex": "person",
-                        "destination_vertex": "person",
-                        "relation": "MANY_TO_MANY",
-                    }
-                ],
-                "properties": [
-                    {
-                        "property_id": 0,
-                        "property_name": "weight",
-                        "property_type": {
-                            "primitive_type": "DT_DOUBLE"
-                        }
-                    }
-                ]
-            },
-            {
-                "type_id": 1,
-                "type_name": "created",
-                "vertex_type_pair_relations": [
-                    {
-                        "source_vertex": "person",
-                        "destination_vertex": "software",
-                        "relation": "ONE_TO_MANY",
-                    }
-                ],
-                "properties": [
-                    {
-                        "property_id": 0,
-                        "property_name": "weight",
-                        "property_type": {
-                            "primitive_type": "DT_DOUBLE"
-                        }
-                    }
-                ]
-            }
-        ]
-    }
+  "vertex_types": [
+      {
+          "type_id": 0,
+          "type_name": "person",
+          "properties": [
+              {
+                  "property_id": 0,
+                  "property_name": "id",
+                  "property_type": {
+                      "primitive_type": "DT_SIGNED_INT64"
+                  }
+              },
+              {
+                  "property_id": 1,
+                  "property_name": "name",
+                  "property_type": {
+                      "primitive_type": "DT_STRING"
+                  }
+              },
+              {
+                  "property_id": 2,
+                  "property_name": "age",
+                  "property_type": {
+                      "primitive_type": "DT_SIGNED_INT32"
+                  }
+              }
+          ],
+          "primary_keys": [
+              "id"
+          ]
+      },
+      {
+          "type_id": 1,
+          "type_name": "software",
+          "properties": [
+              {
+                  "property_id": 0,
+                  "property_name": "id",
+                  "property_type": {
+                      "primitive_type": "DT_SIGNED_INT64"
+                  }
+              },
+              {
+                  "property_id": 1,
+                  "property_name": "name",
+                  "property_type": {
+                      "primitive_type": "DT_STRING"
+                  }
+              },
+              {
+                  "property_id": 2,
+                  "property_name": "lang",
+                  "property_type": {
+                      "primitive_type": "DT_STRING"
+                  }
+              }
+          ],
+          "primary_keys": [
+              "id"
+          ]
+      }
+  ],
+  "edge_types": [
+      {
+          "type_id": 0,
+          "type_name": "knows",
+          "vertex_type_pair_relations": [
+              {
+                  "source_vertex": "person",
+                  "destination_vertex": "person",
+                  "relation": "MANY_TO_MANY",
+              }
+          ],
+          "properties": [
+              {
+                  "property_id": 0,
+                  "property_name": "weight",
+                  "property_type": {
+                      "primitive_type": "DT_DOUBLE"
+                  }
+              }
+          ]
+      },
+      {
+          "type_id": 1,
+          "type_name": "created",
+          "vertex_type_pair_relations": [
+              {
+                  "source_vertex": "person",
+                  "destination_vertex": "software",
+                  "relation": "ONE_TO_MANY",
+              }
+          ],
+          "properties": [
+              {
+                  "property_id": 0,
+                  "property_name": "weight",
+                  "property_type": {
+                      "primitive_type": "DT_DOUBLE"
+                  }
+              }
+          ]
+      }
+  ]
 }
 ```
 
@@ -479,7 +478,9 @@ curl -X GET  -H "Content-Type: application/json" "http://[host]/v1/graph/{graph_
 
 #### Description
 
-Import data to empty graph.
+Import data to empty graph. This is a non-blocking API as it will directly return the job id after the bulk loading job is created.
+Client can use the returned job_id to [query the status of job](#getjobbyid-jobmanagement-category) or [cancel a runing job](#canceljobbyid-jobmanagement-category).
+
 
 #### HTTP Request
 
@@ -492,8 +493,8 @@ Import data to empty graph.
   "graph": "graph",
   "loading_config": {
     "data_source": {
-      "scheme": "file"
-	  "location": {path_to_file},
+      "scheme": "file",
+	    "location": "path_to_file",
     },
     "format": {
       "metadata": {
@@ -986,6 +987,70 @@ curl -X POST -H "Content-Type: application/json" "http://[host]/v1/service/start
 - `200 OK`: Request successful.
 - `500 Internal Error`: Server internal Error.
 
+### RestartService (ServiceManagement Category)
+
+#### Description
+
+Restart the graph query service on current running graph.
+
+#### HTTP Request
+- **Method**: POST
+- **Endpoint**: `/v1/service/restart`
+- **Content-type**: `application/json`
+- **Body**: EmptyBody.
+
+#### Curl Command Example
+```bash
+curl -X POST "http://[host]/v1/service/restart"
+```
+
+#### Expected Response
+- **Format**: application/json
+- **Body**:
+```text
+Successfully started service
+```
+
+#### Status Codes
+- `200 OK`: Request successful.
+- `500 Internal Error`: Server internal Error.
+
+
+### StopService (ServiceManagement Category)
+
+#### Description
+
+Stop the graph query service. Note that after service is stopped, the query server is still running, you still can submit queries to the endpoint, 
+but you will receive the following error message to each request:
+```json
+{
+  "code": 500,
+  "message" : "Unable to send message, the target actor has been canceled!"
+}
+```
+
+#### HTTP Request
+- **Method**: POST
+- **Endpoint**: `/v1/service/stop`
+- **Content-type**: `application/json`
+- **Body**: EmptyBody.
+
+#### Curl Command Example
+```bash
+curl -X POST "http://[host]/v1/service/stop"
+```
+
+#### Expected Response
+- **Format**: application/json
+- **Body**:
+```text
+Successfully stop service
+```
+
+#### Status Codes
+- `200 OK`: Request successful.
+- `500 Internal Error`: Server internal Error.
+
 ### ServiceStatus
 
 #### Description
@@ -1011,7 +1076,6 @@ Get the status of current service.
 #### Status Codes
 - `200 OK`: Request successful.
 - `500 Internal Error`: Server internal Error.
-
 
 ### SystemMetrics (NodeMetrics Category)
 
@@ -1043,6 +1107,124 @@ curl -X GET  -H "Content-Type: application/json" "http://[host]/v1/node/status"
 - `200 OK`: Request successful.
 - `500 Internal Error`: Server internal Error.
 
+
+###  GetJobById (JobManagement Category)
+
+#### Description
+
+Get the metadata of a job with a unique job id.
+The job id is received when you [launch a bulk loading job](#importgraph-graphmanagement-category)
+
+#### HTTP Request
+- **Method**: GET
+- **Endpoint**: `/v1/job/{job_id}`
+- **Content-type**: `application/json`
+- **Body** : EmptyBody
+
+#### Curl Command Example
+```bash
+curl -X GET "http://[host]/v1/job/{job_id}"
+```
+
+#### Expected Response
+- **Format**: application/json
+- **Body**:
+```json
+{
+  "detail": {
+    "graph_name": "graph_name"
+  },
+  "job_id": "job_{graph_name}_{create_timestamp}_{process_id}",
+  "log": "line1\nlin2...\n",
+  "start_time": 1706786404768, // create_timestamp
+  "status": "CANCELLED/RUNNING/SUCCESS/FAILED",
+  "type": "bulk_loading"
+}
+```
+
+#### Status Codes
+- `200 OK`: Request successful.
+- `500 Internal Error`: Server internal Error.
+- `404 Not Found`: Job not found
+
+
+###  GetAllJobs (JobManagement category)
+
+#### Description
+
+Get the metadata of all running/cancelled/success/failed jobs.
+
+#### HTTP Request
+- **Method**: GET
+- **Endpoint**: `/v1/job/`
+- **Content-type**: `application/json`
+- **Body** : EmptyBody
+
+#### Curl Command Example
+```bash
+curl -X GET "http://[host]/v1/job/"
+```
+
+#### Expected Response
+- **Format**: application/json
+- **Body**:
+```json
+[
+  {
+  "detail": {
+    "graph_name": "graph_name"
+  },
+  "job_id": "job_{graph_name}_{create_timestamp}_{process_id}",
+  "log": "line1\nlin2...\n",
+  "start_time": 1706786404768, // create_timestamp
+  "status": "CANCELLED/RUNNING/SUCCESS/FAILED",
+  "type": "bulk_loading"
+  }
+]
+```
+
+#### Status Codes
+- `200 OK`: Request successful.
+- `500 Internal Error`: Server internal Error.
+
+
+###  CancelJobById (JobManagement category)
+
+#### Description
+
+Cancel a job according to the give job_id.
+
+#### HTTP Request
+- **Method**: DELETE
+- **Endpoint**: `/v1/job/{job_id}`
+- **Content-type**: `application/json`
+- **Body** : EmptyBody
+
+#### Curl Command Example
+```bash
+curl -X DELETE "http://[host]/v1/job/{job_id}"
+```
+
+#### Expected Response
+- **Format**: application/json
+- **Body**:
+
+
+Fail:
+```text
+Job is not running, can not cancel: {job_id}
+```
+
+Success
+```
+Successfully cancelled job: {job_id}
+```
+
+
+#### Status Codes
+- `200 OK`: Request successful.
+- `500 Internal Error`: Server internal Error.
+
 ## Enable AdminService in development
 
 To start admin service in development, use the command line argument `--enable-admin-service true`. `${ENGINE_CONFIG}` specifies the configuration for interactive query engine, see [engine-configuration](https://graphscope.io/docs/flex/interactive/configuration). `${WORKSPACE}` points to the directory where interactive related data is maintaned.
@@ -1056,3 +1238,4 @@ The Compiler service could be started as a subprocess of the AdminService. This 
 
 ```bash
 ./bin/interactive_server -c ${ENGINE_CONFIG} -w ${WORKSPACE} --enable-admin-service true --start-compiler true
+```

--- a/flex/engines/http_server/actor/codegen_actor.act.cc
+++ b/flex/engines/http_server/actor/codegen_actor.act.cc
@@ -43,14 +43,14 @@ seastar::future<query_result> codegen_actor::do_codegen(query_param&& param) {
   // plan
   auto& str = param.content;
   if (str.size() <= 0) {
-    LOG(INFO) << "Empty query";
+    VLOG(10) << "Empty query";
     return seastar::make_exception_future<query_result>(
         std::runtime_error("Empty query string"));
   }
 
   const char* str_data = str.data();
   size_t str_length = str.size();
-  LOG(INFO) << "Deserialize physical job request" << str_length;
+  VLOG(10) << "Deserialize physical job request" << str_length;
 
   physical::PhysicalPlan plan;
   bool ret = plan.ParseFromArray(str_data, str_length);
@@ -74,10 +74,10 @@ seastar::future<query_result> codegen_actor::do_codegen(query_param&& param) {
                 std::runtime_error("Fail to parse job id from codegen proxy"));
           }
           // 1. load and run.
-          LOG(INFO) << "Okay, try to run the query of lib path: "
-                    << job_id_and_lib_path.second
-                    << ", job id: " << job_id_and_lib_path.first
-                    << "local shard id: " << hiactor::local_shard_id();
+          VLOG(10) << "Okay, try to run the query of lib path: "
+                   << job_id_and_lib_path.second
+                   << ", job id: " << job_id_and_lib_path.first
+                   << "local shard id: " << hiactor::local_shard_id();
           return seastar::make_ready_future<query_result>(
               std::move(job_id_and_lib_path.second));
         });

--- a/flex/engines/http_server/actor/executor.act.cc
+++ b/flex/engines/http_server/actor/executor.act.cc
@@ -43,7 +43,7 @@ seastar::future<query_result> executor::run_graph_db_query(
   if (!ret.ok()) {
     LOG(ERROR) << "Eval failed: " << ret.status().error_message();
     return seastar::make_exception_future<query_result>(
-      "Query failed: " + ret.status().error_message());
+        "Query failed: " + ret.status().error_message());
   }
   auto result = ret.value();
   seastar::sstring content(result.data(), result.size());

--- a/flex/engines/http_server/options.cc
+++ b/flex/engines/http_server/options.cc
@@ -24,5 +24,6 @@ uint32_t shard_admin_graph_concurrency = 1;
 uint32_t shard_admin_procedure_concurrency = 1;
 uint32_t shard_admin_node_concurrency = 1;
 uint32_t shard_admin_service_concurrency = 1;
+uint32_t shard_admin_job_concurrency = 1;
 
 }  // namespace server

--- a/flex/engines/http_server/options.h
+++ b/flex/engines/http_server/options.h
@@ -40,6 +40,7 @@ extern uint32_t shard_admin_graph_concurrency;
 extern uint32_t shard_admin_node_concurrency;
 extern uint32_t shard_admin_service_concurrency;
 extern uint32_t shard_admin_procedure_concurrency;
+extern uint32_t shard_admin_job_concurrency;
 
 }  // namespace server
 

--- a/flex/engines/http_server/server_utils.cc
+++ b/flex/engines/http_server/server_utils.cc
@@ -1,0 +1,90 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flex/engines/http_server/server_utils.h"
+
+namespace server {
+seastar::httpd::reply::status_type status_code_to_http_code(
+    gs::StatusCode code) {
+  switch (code) {
+  case gs::StatusCode::OK:
+    return seastar::httpd::reply::status_type::ok;
+  case gs::StatusCode::InValidArgument:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::UnsupportedOperator:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::AlreadyExists:
+    return seastar::httpd::reply::status_type::conflict;
+  case gs::StatusCode::NotExists:
+    return seastar::httpd::reply::status_type::not_found;
+  case gs::StatusCode::CodegenError:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  case gs::StatusCode::UninitializedStatus:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  case gs::StatusCode::InvalidSchema:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::PermissionError:
+    return seastar::httpd::reply::status_type::forbidden;
+  case gs::StatusCode::IllegalOperation:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::InternalError:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  case gs::StatusCode::InvalidImportFile:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::IOError:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  case gs::StatusCode::NotFound:
+    return seastar::httpd::reply::status_type::not_found;
+  case gs::StatusCode::QueryFailed:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  default:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  }
+}
+
+seastar::future<std::unique_ptr<seastar::httpd::reply>>
+catch_exception_and_return_reply(std::unique_ptr<seastar::httpd::reply> rep,
+                                 std::exception_ptr ex) {
+  try {
+    std::rethrow_exception(ex);
+  } catch (std::exception& e) {
+    LOG(ERROR) << "Exception: " << e.what();
+    seastar::sstring what = e.what();
+    rep->write_body("application/json", std::move(what));
+    rep->set_status(seastar::httpd::reply::status_type::bad_request);
+    rep->done();
+    return seastar::make_ready_future<std::unique_ptr<seastar::httpd::reply>>(
+        std::move(rep));
+  }
+}
+
+seastar::future<std::unique_ptr<seastar::httpd::reply>>
+return_reply_with_result(std::unique_ptr<seastar::httpd::reply> rep,
+                         admin_query_result&& result) {
+  auto status_code =
+      status_code_to_http_code(result.content.status().error_code());
+  rep->set_status(status_code);
+  if (status_code == seastar::httpd::reply::status_type::ok) {
+    rep->write_body("application/json", std::move(result.content.value()));
+  } else {
+    rep->write_body("application/json",
+                    seastar::sstring(result.content.status().error_message()));
+  }
+  rep->done();
+  return seastar::make_ready_future<std::unique_ptr<seastar::httpd::reply>>(
+      std::move(rep));
+}
+
+}  // namespace server

--- a/flex/engines/http_server/server_utils.h
+++ b/flex/engines/http_server/server_utils.h
@@ -12,35 +12,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#ifndef ENGINES_HTTP_SERVER_HANDLER_ADMIN_HTTP_HANDLER_H_
-#define ENGINES_HTTP_SERVER_HANDLER_ADMIN_HTTP_HANDLER_H_
-
-#include <boost/property_tree/json_parser.hpp>
-#include <seastar/http/httpd.hh>
-#include <string>
-#include "flex/engines/http_server/server_utils.h"
 #include "flex/engines/http_server/types.h"
-#include "flex/utils/service_utils.h"
+#include "flex/utils/result.h"
+#include "seastar/http/reply.hh"
+
+#ifndef ENGINES_HTTP_SERVER_SERVER_UTILS_H_
+#define ENGINES_HTTP_SERVER_SERVER_UTILS_H_
 
 namespace server {
+seastar::httpd::reply::status_type status_code_to_http_code(
+    gs::StatusCode code);
 
-class InteractiveAdminService;
-class admin_http_handler {
- public:
-  admin_http_handler(uint16_t http_port);
+seastar::future<std::unique_ptr<seastar::httpd::reply>>
+catch_exception_and_return_reply(std::unique_ptr<seastar::httpd::reply> rep,
+                                 std::exception_ptr ex);
 
-  void start();
-  void stop();
-
- private:
-  seastar::future<> set_routes();
-
- private:
-  const uint16_t http_port_;
-  seastar::httpd::http_server_control server_;
-};
+seastar::future<std::unique_ptr<seastar::httpd::reply>>
+return_reply_with_result(std::unique_ptr<seastar::httpd::reply> rep,
+                         admin_query_result&& result);
 
 }  // namespace server
 
-#endif  // ENGINES_HTTP_SERVER_HANDLER_ADMIN_HTTP_HANDLER_H_
+#endif  // ENGINES_HTTP_SERVER_SERVER_UTILS_H_

--- a/flex/engines/http_server/service/hqps_service.h
+++ b/flex/engines/http_server/service/hqps_service.h
@@ -52,7 +52,6 @@ struct ServiceConfig {
   // Those has not default value
   std::string default_graph;
   std::string engine_config_path;  // used for codegen.
-
   ServiceConfig();
 };
 

--- a/flex/engines/http_server/types.h
+++ b/flex/engines/http_server/types.h
@@ -20,6 +20,7 @@
 #include <hiactor/net/serializable_queue.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
+#include "flex/utils/result.h"
 #include "flex/utils/service_utils.h"
 
 #include <string>

--- a/flex/interactive/docker/interactive-runtime.Dockerfile
+++ b/flex/interactive/docker/interactive-runtime.Dockerfile
@@ -84,6 +84,7 @@ COPY --from=builder /home/graphscope/GraphScope/flex/interactive/docker/entrypoi
 RUN sed -i 's/name: modern_graph/name: gs_interactive_default_graph/g' /opt/flex/share/gs_interactive_default_graph/graph.yaml
 # change the default graph name.
 RUN sed -i 's/default_graph: ldbc/default_graph: gs_interactive_default_graph/g' /opt/flex/share/engine_config.yaml
+RUN chown -R graphscope:graphscope /opt/flex
 
 # remove bin/run_app
 RUN rm -rf /opt/flex/bin/run_app

--- a/flex/tests/hqps/hqps_admin_test.sh
+++ b/flex/tests/hqps/hqps_admin_test.sh
@@ -46,7 +46,6 @@ fi
 GRAPH_SCHEMA_YAML=${GS_TEST_DIR}/flex/movies/movies_schema.yaml
 GRAPH_BULK_LOAD_YAML=${GS_TEST_DIR}/flex/movies/movies_import.yaml
 RAW_CSV_FILES=${FLEX_HOME}/interactive/examples/movies/
-GRAPH_CSR_DATA_DIR=${HOME}/csr-data-dir/
 TEST_CYPHER_QUERIES="${FLEX_HOME}/interactive/examples/movies/0_get_user.cypher ${FLEX_HOME}/interactive/examples/movies/5_recommend_rule.cypher"
 
 


### PR DESCRIPTION
In this PR, we refactor some of the Interactive `AdminService` and fix some bugs.

2. Limit the maximum number of bulk loading jobs via `bulk_loading_job_count_`.
3. Let all `AdminActor` APIs return `seastar::future<gs::Result<seastar::sstring>>`, with a mapping between `gs::StatusCode` and http status code, we can remove a lot of dummy code handling exception/unexpected behaviors. 
8. Update the unit test for admin service.
10. Refine the returned HTTP code, previously we returns a generic 500 error regardless of the specific error encountered.

Fix #3515 