### PR TITLE
feat(interactive): Support implicit type conversion for vertex index scan

### DIFF
--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -142,6 +142,77 @@ struct KeyBuffer<std::string_view> {
   }
 };
 
+// Implicit conversion for OID_T
+// For example, we need to convert int64_t to int32_t, or int32_t to int64_t.
+struct ConvertHelper {
+  static inline bool convert(const Any& from, PropertyType to_type, Any& to) {
+    // currently only support convert primary key types.
+    // int32_t to int64_t, uint32_t, uint64_t,
+
+    // uint32_t to uint64_t, int64_t, int32_t,
+    // uint64_t to uint32_t, int64_t, int32_t,
+    if (from.type == to.type) {
+      to = from;
+      return true;
+    }
+    if (from.type == PropertyType::kInt32) {
+      if (to_type == PropertyType::kInt64) {
+        to = Any::From(static_cast<int64_t>(from.value.i));
+        return true;
+      } else if (to_type == PropertyType::kUInt32) {
+        to = Any::From(static_cast<uint32_t>(from.value.i));
+        return true;
+      } else if (to_type == PropertyType::kUInt64) {
+        to = Any::From(static_cast<uint64_t>(from.value.i));
+        return true;
+      }
+      return false;
+    } else if (from.type == PropertyType::kInt64) {
+      // int64_t to int32_t, uint32_t, uint64_t,
+      if (to_type == PropertyType::kInt32) {
+        to = Any::From(static_cast<int32_t>(from.value.l));
+        return true;
+      } else if (to_type == PropertyType::kUInt32) {
+        to = Any::From(static_cast<uint32_t>(from.value.l));
+        return true;
+      } else if (to_type == PropertyType::kUInt64) {
+        to = Any::From(static_cast<uint64_t>(from.value.l));
+        return true;
+      } else {
+        return false;
+      }
+    } else if (from.type == PropertyType::kUInt32) {
+      if (to_type == PropertyType::kInt32) {
+        to = Any::From(static_cast<int32_t>(from.value.ui));
+        return true;
+      } else if (to_type == PropertyType::kInt64) {
+        to = Any::From(static_cast<int64_t>(from.value.ui));
+        return true;
+      } else if (to_type == PropertyType::kUInt64) {
+        to = Any::From(static_cast<uint64_t>(from.value.ui));
+        return true;
+      } else {
+        return false;
+      }
+    } else if (from.type == PropertyType::kUInt64) {
+      if (to_type == PropertyType::kInt32) {
+        to = Any::From(static_cast<int32_t>(from.value.ul));
+        return true;
+      } else if (to_type == PropertyType::kInt64) {
+        to = Any::From(static_cast<int64_t>(from.value.ul));
+        return true;
+      } else if (to_type == PropertyType::kUInt32) {
+        to = Any::From(static_cast<uint32_t>(from.value.ul));
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+};
+
 }  // namespace id_indexer_impl
 
 template <typename T>
@@ -297,15 +368,26 @@ class LFIndexer {
   }
 
   INDEX_T get_index(const Any& oid) const {
-    assert(oid.type == get_type());
+    Any real_oid = oid;
+    if (oid.type != get_type()) {
+      // First try implicit conversion.
+      // If it fails, throw an exception.
+      if (!id_indexer_impl::ConvertHelper::convert(oid, get_type(), real_oid)) {
+        throw std::runtime_error("oid type not match: " +
+                                 std::to_string(static_cast<int>(oid.type)) +
+                                 std::string(" vs ") +
+                                 std::to_string(static_cast<int>(get_type())));
+      }
+    }
     size_t index =
-        hash_policy_.index_for_hash(hasher_(oid), num_slots_minus_one_);
+        hash_policy_.index_for_hash(hasher_(real_oid), num_slots_minus_one_);
     static constexpr INDEX_T sentinel = std::numeric_limits<INDEX_T>::max();
     while (true) {
       INDEX_T ind = indices_.get(index);
       if (ind == sentinel) {
-        LOG(FATAL) << "cannot find " << oid.to_string() << " in lf_indexer";
-      } else if (keys_->get(ind) == oid) {
+        LOG(FATAL) << "cannot find " << real_oid.to_string()
+                   << " in lf_indexer";
+      } else if (keys_->get(ind) == real_oid) {
         return ind;
       } else {
         index = (index + 1) % (num_slots_minus_one_ + 1);
@@ -314,15 +396,24 @@ class LFIndexer {
   }
 
   bool get_index(const Any& oid, INDEX_T& ret) const {
-    assert(oid.type == get_type());
+    Any real_oid = oid;
+    if (oid.type != get_type()) {
+      if (!id_indexer_impl::ConvertHelper::convert(oid, get_type(), real_oid)) {
+        throw std::runtime_error("oid type not match: " +
+                                 std::to_string(static_cast<int>(oid.type)) +
+                                 std::string(" vs ") +
+                                 std::to_string(static_cast<int>(get_type())));
+      }
+      return false;
+    }
     size_t index =
-        hash_policy_.index_for_hash(hasher_(oid), num_slots_minus_one_);
+        hash_policy_.index_for_hash(hasher_(real_oid), num_slots_minus_one_);
     static constexpr INDEX_T sentinel = std::numeric_limits<INDEX_T>::max();
     while (true) {
       INDEX_T ind = indices_.get(index);
       if (ind == sentinel) {
         return false;
-      } else if (keys_->get(ind) == oid) {
+      } else if (keys_->get(ind) == real_oid) {
         ret = ind;
         return true;
       } else {


### PR DESCRIPTION
For Interactive compute engine, we need to provide the ability for implicit type conversion in predicate. (The only scenario where the type conversion may happen).

For most of the predicates, we convert it to a c++ expression, and the implicit conversion if down by C++ compiler. For example.
```cypher
MATCH(p : Person) where p.creditCardId = 1234 return p;
```
will be convert into an expression
```c++
bool predicate(int64_t creditCardId, int32_t target_value) {
    return creditCardId == target_value; // compare between a int64_t and int32_t.
}
```

However, when the query perform index scan for the vertex, we use indices for faster scan.

```cypher
MATCH(p: Person { id : 1234}) return p;
```

will be compiled to 
```c++
auto vertexSet = graph.ScanVertexFromOid(person_label_id, Any::From(1234));
```

Which will cause runtime error.


So, In this PR, we enable `id_indexer` support implicit type conversion between currently supported primary keys:
- uint32_t
- uint64_t
- int32_t
- uint32_t

Note that conversion between String and other type are not supported, since compiler will throw the error before compiling to a physical plan.