### PR TITLE
fix(interactive): Remove gcc option `-mno-avx512f` 

### DIFF
--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 
 set(DEFAULT_BUILD_TYPE "Release")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -mno-avx512f -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -fPIC")
 set(CMAKE_CXX_FLAGS_DEBUG "-g3 -O0")
 
 


### PR DESCRIPTION
Remove one gcc option `-mno-avx512f` for flex's CMakeLists.txt. Which cause `find_package(MPI)` error on macos arm arch.

Fix #3430