### PR TITLE
fix(interactive): Fix passing `Array` to stored procedures for interactive.

### DIFF
--- a/flex/engines/graph_db/database/graph_db_session.cc
+++ b/flex/engines/graph_db/database/graph_db_session.cc
@@ -36,6 +36,30 @@ void put_argment(Encoder& encoder, const query::Argument& argment) {
   case common::Value::kStr:
     encoder.put_string(value.str());
     break;
+  case common::Value::kStrArray:
+    encoder.put_int(value.str_array().item_size());
+    for (auto i = 0; i < value.str_array().item_size(); ++i) {
+      encoder.put_string(value.str_array().item(i));
+    }
+    break;
+  case common::Value::kF64Array:
+    encoder.put_int(value.f64_array().item_size());
+    for (auto i = 0; i < value.f64_array().item_size(); ++i) {
+      encoder.put_double(value.f64_array().item(i));
+    }
+    break;
+  case common::Value::kI32Array:
+    encoder.put_int(value.i32_array().item_size());
+    for (auto i = 0; i < value.i32_array().item_size(); ++i) {
+      encoder.put_int(value.i32_array().item(i));
+    }
+    break;
+  case common::Value::kI64Array:
+    encoder.put_int(value.i64_array().item_size());
+    for (auto i = 0; i < value.i64_array().item_size(); ++i) {
+      encoder.put_long(value.i64_array().item(i));
+    }
+    break;
   default:
     LOG(ERROR) << "Not recognizable param type" << static_cast<int>(item_case);
   }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/StoredProcedureMeta.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/StoredProcedureMeta.java
@@ -17,11 +17,12 @@
 package com.alibaba.graphscope.common.ir.meta.procedure;
 
 import com.alibaba.graphscope.common.config.Configs;
+import com.alibaba.graphscope.common.config.FrontendConfig;
+import com.alibaba.graphscope.common.ir.type.GraphTypeFactoryImpl;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.*;
 import org.yaml.snakeyaml.Yaml;
 
@@ -33,7 +34,11 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class StoredProcedureMeta {
-    private static final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    private static final RelDataTypeFactory typeFactory =
+            new GraphTypeFactoryImpl(
+                    new Configs(
+                            ImmutableMap.of(
+                                    FrontendConfig.CALCITE_DEFAULT_CHARSET.getKey(), "UTF-8")));
 
     private final String name;
     private final RelDataType returnType;

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/reader/LocalMetaDataReader.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/reader/LocalMetaDataReader.java
@@ -76,6 +76,10 @@ public class LocalMetaDataReader implements MetaDataReader {
                     getProcedureNameWithInputStream(procedureDir);
             for (String enableProcedure : enableProcedureList) {
                 InputStream enableInput = procedureInputMap.get(enableProcedure);
+                if (enableInput == null) {
+                    logger.error("procedure not found {}", enableProcedure);
+                    continue;
+                }
                 Preconditions.checkArgument(
                         enableInput != null,
                         "can not find procedure with name=%s under directory=%s, candidates are %s",

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
@@ -161,7 +161,7 @@ public class GraphPlanner {
                     throw new RuntimeException(e);
                 }
             } else {
-                return new ProcedurePhysicalBuilder(logicalPlan).build();
+                return new ProcedurePhysicalBuilder(graphConfig, irMeta, logicalPlan).build();
             }
         }
     }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/result/CypherRecordParser.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/result/CypherRecordParser.java
@@ -84,12 +84,19 @@ public class CypherRecordParser implements RecordParser<AnyValue> {
         switch (dataType.getSqlTypeName()) {
             case MULTISET:
             case ARRAY:
-                if (dataType instanceof ArbitraryArrayType) {
-                    return parseCollection(
-                            entry.getCollection(),
-                            ((ArbitraryArrayType) dataType).getComponentTypes());
-                } else {
-                    return parseCollection(entry.getCollection(), dataType.getComponentType());
+                switch (entry.getInnerCase()) {
+                    case COLLECTION:
+                        if (dataType instanceof ArbitraryArrayType) {
+                            return parseCollection(
+                                    entry.getCollection(),
+                                    ((ArbitraryArrayType) dataType).getComponentTypes());
+                        } else {
+                            return parseCollection(
+                                    entry.getCollection(), dataType.getComponentType());
+                        }
+                    case ELEMENT:
+                    default:
+                        return parseElement(entry.getElement(), dataType.getComponentType());
                 }
             case MAP:
                 if (dataType instanceof ArbitraryMapType) {

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/runtime/FfiLogicalPlanTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/runtime/FfiLogicalPlanTest.java
@@ -154,7 +154,8 @@ public class FfiLogicalPlanTest {
         LogicalPlan logicalPlan =
                 com.alibaba.graphscope.cypher.antlr4.Utils.evalLogicalPlan(
                         "Call ldbc_ic2(10l, 20120112l)");
-        try (PhysicalBuilder ffiBuilder = new ProcedurePhysicalBuilder(logicalPlan)) {
+        try (PhysicalBuilder ffiBuilder =
+                new ProcedurePhysicalBuilder(getMockGraphConfig(), Utils.schemaMeta, logicalPlan)) {
             PhysicalPlan plan = ffiBuilder.build();
             Assert.assertEquals(
                     FileUtils.readJsonFromResource("call_procedure.json"), plan.explain());


### PR DESCRIPTION
Neo4j itself supports stored procedures with variably sized arrays as input, and we have also added support for this feature in this PR. However, currently, we only support C++ procedures that read inputs through their own decoder. TODO: Enable interactive full pipeline support for variably sized arrays as input.