### PR TITLE
fix(interactive): Fix bugs of Groot Bulk Load When Retrying to Download Source Files

### DIFF
--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -44,6 +44,14 @@ Note:
 - A single edge type can have multiple `vertex_type_pair_relations`. For instance, a "knows" edge might connect one person to another, symbolizing their friendship. Alternatively, it could associate a person with a skill, indicating their proficiency in that skill.
 - The permissible relations include: `ONE_TO_ONE`, `ONE_TO_MANY`, `MANY_TO_ONE`, and `MANY_TO_MANY`. These relations can be utilized by the optimizer to generate more efficient execution plans.
 - Currently we only support at most one property for each edge triplet.
+- All implementation related configuration are put under `x_csr_params`.
+  - `max_vertex_num` limit the number of vertices of this type:
+    - The limit number is used to `mmap` memory, so it only takes virtual memory before vertices are actually inserted.
+    - If `max_vertex_num` is not set, a default large number (e.g.: 2^48) will be used.
+  - `edge_storage_strategy` specifies the storing strategy of the incoming or outgoing edges of this type, there are 3 kinds of strategies
+    - `ONLY_IN`: Only incoming edges are stored.
+    - `ONLY_OUT`: Only outgoing edges are stored.
+    - `BOTH_OUT_IN`(default): Both direction of edges are stored.
  
 
 ## Entity Data

--- a/flex/interactive/examples/modern_graph/modern_graph.yaml
+++ b/flex/interactive/examples/modern_graph/modern_graph.yaml
@@ -47,9 +47,6 @@ schema:
         - source_vertex: person
           destination_vertex: person
           relation: MANY_TO_MANY
-          x_csr_params:
-            incoming_edge_strategy: Multiple
-            outgoing_edge_strategy: Multiple
       properties:
         - property_id: 0
           property_name: weight
@@ -60,10 +57,7 @@ schema:
       vertex_type_pair_relations:
         - source_vertex: person
           destination_vertex: software
-          relation: ONE_TO_MANY
-          x_csr_params:
-            incoming_edge_strategy: Multiple
-            outgoing_edge_strategy: Single
+          relation: MANY_TO_MANY
       properties:
         - property_id: 0
           property_name: weight

--- a/flex/storages/rt_mutable_graph/README.md
+++ b/flex/storages/rt_mutable_graph/README.md
@@ -59,7 +59,6 @@ schema:
           property_name: id
           property_type:
             primitive_type: DT_SIGNED_INT64
-          x_csr_params:
         - property_id: 1
           property_name: name
           property_type:
@@ -77,8 +76,7 @@ schema:
         destination_vertex: person
         relation: MANY_TO_MANY
         x_csr_params:
-          incoming_edge_strategy: Multiple
-          outgoing_edge_strategy: Multiple
+          edge_storage_strategy: BOTH_OUT_IN
       properties:
         - property_id: 0
           property_name: weight
@@ -88,10 +86,7 @@ schema:
       vertex_type_pair_relations:
         source_vertex: person
         destination_vertex: software
-        relation: ONE_TO_MANY
-        x_csr_params: 
-          incoming_edge_strategy: Multiple
-          outgoing_edge_strategy: Single
+        relation: ONE_TO_MANY 
       properties:
         - property_id: 0
           property_name: weight
@@ -106,10 +101,10 @@ Notes:
   - `max_vertex_num` limit the number of vertices of this type:
     - The limit number is used to `mmap` memory, so it only takes virtual memory before vertices are actually inserted.
     - If `max_vertex_num` is not set, a default large number (e.g.: 2^48) will be used.
-  - `incoming/outgoing_edge_strategy` specifies the storing strategy of the incoming or outgoing edges of this type, there are 3 kinds of strategies
-    - None: no edge will be stored
-    - Single: only one edge will be stored
-    - Multiple(default): multiple edges will be stored
+  - `edge_storage_strategy` specifies the storing strategy of the incoming or outgoing edges of this type, there are 3 kinds of strategies
+    - `ONLY_IN`: Only incoming edges are stored.
+    - `ONLY_OUT`: Only outgoing edges are stored.
+    - `BOTH_OUT_IN`(default): Both direction of edges are stored.
 
 ## 3. Vertex Management
 

--- a/flex/storages/rt_mutable_graph/types.h
+++ b/flex/storages/rt_mutable_graph/types.h
@@ -17,6 +17,7 @@ limitations under the License.
 #define STORAGES_RT_MUTABLE_GRAPH_TYPES_H_
 
 #include <stdint.h>
+#include <iostream>
 
 namespace gs {
 
@@ -43,5 +44,27 @@ static constexpr const char* DT_STRINGMAP = "DT_STRINGMAP";
 static constexpr const char* DT_DATE = "DT_DATE32";
 
 }  // namespace gs
+
+namespace std {
+
+// operator << for EdgeStrategy
+inline ostream& operator<<(ostream& os, const gs::EdgeStrategy& strategy) {
+  switch (strategy) {
+  case gs::EdgeStrategy::kNone:
+    os << "None";
+    break;
+  case gs::EdgeStrategy::kSingle:
+    os << "Single";
+    break;
+  case gs::EdgeStrategy::kMultiple:
+    os << "Multiple";
+    break;
+  default:
+    os << "Unknown";
+    break;
+  }
+  return os;
+}
+}  // namespace std
 
 #endif  // STORAGES_RT_MUTABLE_GRAPH_TYPES_H_

--- a/flex/tests/rt_mutable_graph/modern_graph_string_edge.yaml
+++ b/flex/tests/rt_mutable_graph/modern_graph_string_edge.yaml
@@ -50,9 +50,6 @@ schema:
         - source_vertex: person
           destination_vertex: person
           relation: MANY_TO_MANY
-          x_csr_params:
-            incoming_edge_strategy: Multiple
-            outgoing_edge_strategy: Multiple
       properties:
         - property_id: 0
           property_name: weight
@@ -63,10 +60,7 @@ schema:
       vertex_type_pair_relations:
         - source_vertex: person
           destination_vertex: software
-          relation: ONE_TO_MANY
-          x_csr_params:
-            incoming_edge_strategy: Multiple
-            outgoing_edge_strategy: Single
+          relation: MANY_TO_ONE
       properties:
         - property_id: 0
           property_name: weight

--- a/interactive_engine/compiler/src/test/resources/config/modern/graph.yaml
+++ b/interactive_engine/compiler/src/test/resources/config/modern/graph.yaml
@@ -52,9 +52,6 @@ schema:
   edge_types:
     - type_name: knows
       type_id: 2
-      x_csr_params:
-        incoming_edge_strategy: Multiple
-        outgoing_edge_strategy: Multiple
       vertex_type_pair_relations:
         - source_vertex: person
           destination_vertex: person
@@ -66,13 +63,10 @@ schema:
             primitive_type: DT_DOUBLE
     - type_name: created
       type_id: 3
-      x_csr_params:
-        incoming_edge_strategy: Multiple
-        outgoing_edge_strategy: Single
       vertex_type_pair_relations:
         - source_vertex: person
           destination_vertex: software
-          relation: ONE_TO_MANY
+          relation: MANY_TO_MANY
       properties:
         - property_id: 0
           property_name: weight

--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/external/ExternalStorage.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/external/ExternalStorage.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -56,7 +57,7 @@ public abstract class ExternalStorage {
     public void downloadDataWithMove(String srcPath, String dstPath) throws IOException {
         String tmpPath = dstPath + "." + generateRandomString(6);
         downloadDataSimple(srcPath, tmpPath);
-        Files.move(Path.of(tmpPath), Path.of(dstPath));
+        Files.move(Path.of(tmpPath), Path.of(dstPath), StandardCopyOption.REPLACE_EXISTING);
     }
 
     public void downloadDataWithRetry(String srcPath, String dstPath) throws IOException {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Due to the instability of the network and tunneling tools, a certain store encountered an error while downloading the original file. At this point, the file already exists but only a portion has been downloaded, causing subsequent retry operations to result in a `FileAlreadyExisted` error. This PR addresses the issue by enabling the `REPLACE_EXISTING` option, allowing the overwriting of existing files.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

