### PR TITLE
fix(interactive): Fix bugs of Groot Bulk Load When Retrying to Download Source Files

### DIFF
--- a/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/external/ExternalStorage.java
+++ b/interactive_engine/groot-module/src/main/java/com/alibaba/graphscope/groot/store/external/ExternalStorage.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -56,7 +57,7 @@ public abstract class ExternalStorage {
     public void downloadDataWithMove(String srcPath, String dstPath) throws IOException {
         String tmpPath = dstPath + "." + generateRandomString(6);
         downloadDataSimple(srcPath, tmpPath);
-        Files.move(Path.of(tmpPath), Path.of(dstPath));
+        Files.move(Path.of(tmpPath), Path.of(dstPath), StandardCopyOption.REPLACE_EXISTING);
     }
 
     public void downloadDataWithRetry(String srcPath, String dstPath) throws IOException {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Due to the instability of the network and tunneling tools, a certain store encountered an error while downloading the original file. At this point, the file already exists but only a portion has been downloaded, causing subsequent retry operations to result in a `FileAlreadyExisted` error. This PR addresses the issue by enabling the `REPLACE_EXISTING` option, allowing the overwriting of existing files.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

