### PR TITLE
fix(interactive): Fix the Invalid cross-device link error occurring with copy_file_range in the Docker environment.

### DIFF
--- a/flex/storages/rt_mutable_graph/file_names.h
+++ b/flex/storages/rt_mutable_graph/file_names.h
@@ -98,6 +98,11 @@ inline void copy_file(const std::string& src, const std::string& dst) {
       LOG(ERROR) << "Failed to set read/write permission for file: " << dst
                  << " " << errorCode.message() << std::endl;
     }
+
+    // For a newly created file, you may need to close and then reopen it,
+    // otherwise you may encounter a copy_file_range "Invalid cross-device link"
+    // error, one possible cause of the error could be that the
+    // file's metadata has not yet been flushed to the file system.
     close(dst_fd);
     dst_fd = open(dst.c_str(), O_WRONLY);
   }

--- a/flex/storages/rt_mutable_graph/file_names.h
+++ b/flex/storages/rt_mutable_graph/file_names.h
@@ -98,6 +98,8 @@ inline void copy_file(const std::string& src, const std::string& dst) {
       LOG(ERROR) << "Failed to set read/write permission for file: " << dst
                  << " " << errorCode.message() << std::endl;
     }
+    close(dst_fd);
+    dst_fd = open(dst.c_str(), O_WRONLY);
   }
   ssize_t ret;
   do {


### PR DESCRIPTION
Fix [#3447](Fixeshttps://github.com/alibaba/GraphScope/issues/3447)

