### PR TITLE
feat(flex): Configure the memory strategy with memory-level.

### DIFF
--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -15,7 +15,6 @@ option(BUILD_TEST "Whether to build test" ON)
 option(BUILD_DOC "Whether to build doc" ON)
 option(BUILD_ODPS_FRAGMENT_LOADER "Whether to build odps fragment loader" ON)
 option(MONITOR_SESSIONS "Whether monitor sessions" OFF)
-option(ENABLE_HUGEPAGE "Whether to use hugepages when open mmap array in memory" OFF)
 
 #print options
 message(STATUS "Build HighQPS Engine: ${BUILD_HQPS}")
@@ -47,12 +46,6 @@ endif ()
 if (MONITOR_SESSIONS)
     message("Monitor sessions is enabled")
     add_definitions(-DMONITOR_SESSIONS)
-endif ()
-
-
-if (ENABLE_HUGEPAGE)
-    message("Hugepage is enabled")
-    add_definitions(-DHUGEPAGE)
 endif ()
 
 execute_process(COMMAND uname -r OUTPUT_VARIABLE LINUX_KERNEL_VERSION)

--- a/flex/bin/rt_server.cc
+++ b/flex/bin/rt_server.cc
@@ -84,17 +84,12 @@ int main(int argc, char** argv) {
 
   auto schema = gs::Schema::LoadFromYaml(graph_schema_path);
   gs::GraphDBConfig config(schema, data_path, shard_num);
-#ifdef HUGEPAGE
-  config.allocator_strategy = gs::MemoryStrategy::kHugepagePrefered;
-  config.vertex_map_strategy = gs::MemoryStrategy::kHugepagePrefered;
-  config.vertex_table_strategy = gs::MemoryStrategy::kHugepagePrefered;
-  config.topology_strategy = gs::MemoryStrategy::kHugepagePrefered;
-#else
+
   config.allocator_strategy = gs::MemoryStrategy::kMemoryOnly;
   config.vertex_map_strategy = gs::MemoryStrategy::kMemoryOnly;
   config.vertex_table_strategy = gs::MemoryStrategy::kMemoryOnly;
   config.topology_strategy = gs::MemoryStrategy::kMemoryOnly;
-#endif
+
   config.enable_auto_compaction = true;
   config.service_port = http_port;
   db.Open(config);

--- a/flex/bin/rt_server.cc
+++ b/flex/bin/rt_server.cc
@@ -38,8 +38,8 @@ int main(int argc, char** argv) {
                                     "graph schema config file")(
       "data-path,d", bpo::value<std::string>(), "data directory path")(
       "warmup,w", bpo::value<bool>()->default_value(false),
-      "warmup graph data")("memory-only,m",
-                           bpo::value<bool>()->default_value(true));
+      "warmup graph data")("memory-level,m",
+                           bpo::value<int>()->default_value(1));
   google::InitGoogleLogging(argv[0]);
   FLAGS_logtostderr = true;
 
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
 
   bool enable_dpdk = false;
   bool warmup = vm["warmup"].as<bool>();
-  bool memory_only = vm["memory-only"].as<bool>();
+  int memory_level = vm["memory-level"].as<int>();
   uint32_t shard_num = vm["shard-num"].as<uint32_t>();
   uint16_t http_port = vm["http-port"].as<uint16_t>();
 
@@ -84,12 +84,7 @@ int main(int argc, char** argv) {
 
   auto schema = gs::Schema::LoadFromYaml(graph_schema_path);
   gs::GraphDBConfig config(schema, data_path, shard_num);
-
-  config.allocator_strategy = gs::MemoryStrategy::kMemoryOnly;
-  config.vertex_map_strategy = gs::MemoryStrategy::kMemoryOnly;
-  config.vertex_table_strategy = gs::MemoryStrategy::kMemoryOnly;
-  config.topology_strategy = gs::MemoryStrategy::kMemoryOnly;
-
+  config.memory_level = memory_level;
   config.enable_auto_compaction = true;
   config.service_port = http_port;
   db.Open(config);

--- a/flex/engines/graph_db/database/graph_db.h
+++ b/flex/engines/graph_db/database/graph_db.h
@@ -49,10 +49,7 @@ struct GraphDBConfig {
         warmup(false),
         enable_auto_compaction(false),
         service_port(-1),
-        vertex_map_strategy(MemoryStrategy::kMemoryOnly),
-        vertex_table_strategy(MemoryStrategy::kMemoryOnly),
-        topology_strategy(MemoryStrategy::kMemoryOnly),
-        allocator_strategy(MemoryStrategy::kMemoryOnly) {}
+        memory_level(1) {}
 
   Schema schema;
   std::string data_dir;
@@ -60,10 +57,14 @@ struct GraphDBConfig {
   bool warmup;
   bool enable_auto_compaction;
   int service_port;
-  MemoryStrategy vertex_map_strategy;
-  MemoryStrategy vertex_table_strategy;
-  MemoryStrategy topology_strategy;
-  MemoryStrategy allocator_strategy;
+
+  /*
+    0 - sync with disk; 
+    1 - mmap virtual memory; 
+    2 - prefering hugepages; 
+    3 - force hugepages;
+  */
+  int memory_level; 
 };
 
 class GraphDB {

--- a/flex/storages/rt_mutable_graph/dual_csr.h
+++ b/flex/storages/rt_mutable_graph/dual_csr.h
@@ -42,14 +42,12 @@ class DualCsrBase {
                             const std::string& edata_name,
                             const std::string& snapshot_dir,
                             size_t src_vertex_cap, size_t dst_vertex_cap) = 0;
-#ifdef HUGEPAGE
   virtual void OpenWithHugepages(const std::string& oe_name,
                                  const std::string& ie_name,
                                  const std::string& edata_name,
                                  const std::string& snapshot_dir,
                                  size_t src_vertex_cap,
                                  size_t dst_vertex_cap) = 0;
-#endif
   virtual void Dump(const std::string& oe_name, const std::string& ie_name,
                     const std::string& edata_name,
                     const std::string& new_snapshot_dir) = 0;
@@ -120,7 +118,6 @@ class DualCsr : public DualCsrBase {
     out_csr_->open_in_memory(snapshot_dir + "/" + oe_name, src_vertex_cap);
   }
 
-#ifdef HUGEPAGE
   void OpenWithHugepages(const std::string& oe_name, const std::string& ie_name,
                          const std::string& edata_name,
                          const std::string& snapshot_dir, size_t src_vertex_cap,
@@ -128,7 +125,6 @@ class DualCsr : public DualCsrBase {
     in_csr_->open_with_hugepages(snapshot_dir + "/" + ie_name, dst_vertex_cap);
     out_csr_->open_with_hugepages(snapshot_dir + "/" + oe_name, src_vertex_cap);
   }
-#endif
 
   void Dump(const std::string& oe_name, const std::string& ie_name,
             const std::string& edata_name,
@@ -261,14 +257,12 @@ class DualCsr<std::string_view> : public DualCsrBase {
     column_.resize(std::max(column_.size() + (column_.size() + 4) / 5, 4096ul));
   }
 
-#ifdef HUGEPAGE
   void OpenWithHugepages(const std::string& oe_name, const std::string& ie_name,
                          const std::string& edata_name,
                          const std::string& snapshot_dir, size_t src_vertex_cap,
                          size_t dst_vertex_cap) override {
     LOG(FATAL) << "not supported...";
   }
-#endif
 
   void Dump(const std::string& oe_name, const std::string& ie_name,
             const std::string& edata_name,

--- a/flex/storages/rt_mutable_graph/mutable_csr.h
+++ b/flex/storages/rt_mutable_graph/mutable_csr.h
@@ -501,12 +501,10 @@ class MutableCsrBase {
                     const std::string& work_dir) = 0;
 
   virtual void open_in_memory(const std::string& prefix, size_t v_cap = 0) = 0;
-#ifdef HUGEPAGE
   virtual void open_with_hugepages(const std::string& prefix,
                                    size_t v_cap = 0) {
     LOG(FATAL) << "not supported...";
   }
-#endif
 
   virtual void dump(const std::string& name,
                     const std::string& new_spanshot_dir) = 0;
@@ -768,7 +766,6 @@ class MutableCsr : public TypedMutableCsrBase<EDATA_T> {
     }
   }
 
-#ifdef HUGEPAGE
   void open_with_hugepages(const std::string& prefix, size_t v_cap) override {
     mmap_array<int> degree_list;
     degree_list.open(prefix + ".deg", false);
@@ -802,7 +799,6 @@ class MutableCsr : public TypedMutableCsrBase<EDATA_T> {
       delete cap_list;
     }
   }
-#endif
 
   void warmup(int thread_num) const override {
     size_t vnum = adj_lists_.size();
@@ -1282,7 +1278,6 @@ class SingleMutableCsr : public TypedMutableCsrBase<EDATA_T> {
     }
   }
 
-#ifdef HUGEPAGE
   void open_with_hugepages(const std::string& prefix, size_t v_cap) override {
     nbr_list_.open_with_hugepages(prefix + ".snbr", v_cap);
     size_t old_size = nbr_list_.size();
@@ -1293,7 +1288,6 @@ class SingleMutableCsr : public TypedMutableCsrBase<EDATA_T> {
       }
     }
   }
-#endif
 
   void dump(const std::string& name,
             const std::string& new_snapshot_dir) override {
@@ -1640,9 +1634,7 @@ class EmptyCsr : public TypedMutableCsrBase<EDATA_T> {
 
   void open_in_memory(const std::string& prefix, size_t v_cap) override {}
 
-#ifdef HUGEPAGE
   void open_with_hugepages(const std::string& prefix, size_t v_cap) override {}
-#endif
 
   void dump(const std::string& name,
             const std::string& new_spanshot_dir) override {}

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -156,11 +156,9 @@ void MutablePropertyFragment::Open(const std::string& work_dir,
     if (vertex_map_strategy == MemoryStrategy::kMemoryOnly) {
       lf_indexers_[i].open_in_memory(snapshot_dir + "/" +
                                      vertex_map_prefix(v_label_name));
-#ifdef HUGEPAGE
     } else if (vertex_map_strategy == MemoryStrategy::kHugepagePrefered) {
       lf_indexers_[i].open_with_hugepages(snapshot_dir + "/" +
                                           vertex_map_prefix(v_label_name));
-#endif
     } else {
       assert(vertex_map_strategy == MemoryStrategy::kSyncToFile);
       lf_indexers_[i].open(vertex_map_prefix(v_label_name), snapshot_dir,
@@ -173,14 +171,12 @@ void MutablePropertyFragment::Open(const std::string& work_dir,
           schema_.get_vertex_property_names(i),
           schema_.get_vertex_properties(i),
           schema_.get_vertex_storage_strategies(v_label_name));
-#ifdef HUGEPAGE
     } else if (vertex_table_strategy == MemoryStrategy::kHugepagePrefered) {
       vertex_data_[i].open_with_hugepages(
           vertex_table_prefix(v_label_name), snapshot_dir,
           schema_.get_vertex_property_names(i),
           schema_.get_vertex_properties(i),
           schema_.get_vertex_storage_strategies(v_label_name));
-#endif
     } else {
       assert(vertex_table_strategy == MemoryStrategy::kSyncToFile);
       vertex_data_[i].open(vertex_table_prefix(v_label_name), snapshot_dir,
@@ -242,14 +238,12 @@ void MutablePropertyFragment::Open(const std::string& work_dir,
               ie_prefix(src_label, dst_label, edge_label),
               edata_prefix(src_label, dst_label, edge_label), snapshot_dir,
               vertex_capacities[src_label_i], vertex_capacities[dst_label_i]);
-#ifdef HUGEPAGE
         } else if (topology_strategy == MemoryStrategy::kHugepagePrefered) {
           dual_csr_list_[index]->OpenWithHugepages(
               oe_prefix(src_label, dst_label, edge_label),
               ie_prefix(src_label, dst_label, edge_label),
               edata_prefix(src_label, dst_label, edge_label), snapshot_dir,
               vertex_capacities[src_label_i], vertex_capacities[dst_label_i]);
-#endif
         } else {
           assert(topology_strategy == MemoryStrategy::kSyncToFile);
           dual_csr_list_[index]->Open(

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -112,11 +112,7 @@ inline DualCsrBase* create_csr(EdgeStrategy oes, EdgeStrategy ies,
 }
 
 void MutablePropertyFragment::Open(const std::string& work_dir,
-                                   bool memory_only) {
-  Open(work_dir, memory_only ? 1 : 0);
-}
-
-void MutablePropertyFragment::Open(const std::string& work_dir, int memory_level) {
+                                   int memory_level) {
   std::string schema_file = schema_path(work_dir);
   std::string snapshot_dir{};
   bool build_empty_graph = false;
@@ -169,8 +165,8 @@ void MutablePropertyFragment::Open(const std::string& work_dir, int memory_level
           schema_.get_vertex_properties(i),
           schema_.get_vertex_storage_strategies(v_label_name));
     } else if (memory_level == 2) {
-      lf_indexers_[i].open_with_hugepages(snapshot_dir + "/" +
-                                          vertex_map_prefix(v_label_name), false);
+      lf_indexers_[i].open_with_hugepages(
+          snapshot_dir + "/" + vertex_map_prefix(v_label_name), false);
       vertex_data_[i].open_with_hugepages(
           vertex_table_prefix(v_label_name), snapshot_dir,
           schema_.get_vertex_property_names(i),
@@ -178,15 +174,15 @@ void MutablePropertyFragment::Open(const std::string& work_dir, int memory_level
           schema_.get_vertex_storage_strategies(v_label_name), false);
     } else {
       assert(memory_level == 3);
-      lf_indexers_[i].open_with_hugepages(snapshot_dir + "/" +
-                                          vertex_map_prefix(v_label_name), true);
+      lf_indexers_[i].open_with_hugepages(
+          snapshot_dir + "/" + vertex_map_prefix(v_label_name), true);
       vertex_data_[i].open_with_hugepages(
           vertex_table_prefix(v_label_name), snapshot_dir,
           schema_.get_vertex_property_names(i),
           schema_.get_vertex_properties(i),
           schema_.get_vertex_storage_strategies(v_label_name), true);
     }
-    
+
     size_t vertex_capacity =
         schema_.get_max_vnum(v_label_name);  // lf_indexers_[i].capacity();
     if (build_empty_graph) {

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.h
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.h
@@ -48,11 +48,7 @@ class MutablePropertyFragment {
                   vid_t dst_lid, label_t edge_label, timestamp_t ts,
                   const Any& arc, Allocator& alloc);
 
-  void Open(const std::string& work_dir, bool memory_only);
-
-  void Open(const std::string& work_dir, MemoryStrategy vertex_map_strategy,
-            MemoryStrategy vertex_table_strategy,
-            MemoryStrategy topology_strategy);
+  void Open(const std::string& work_dir, int memory_level);
 
   void Compact(uint32_t version);
 

--- a/flex/utils/allocators.h
+++ b/flex/utils/allocators.h
@@ -46,7 +46,6 @@ class ArenaAllocator {
     for (auto ptr : mmap_buffers_) {
       delete ptr;
     }
-    LOG(INFO) << "|ALLOCATOR|" << allocated_batches_ << "|" << allocated_memory_ << "|";
   }
 
   void reserve(size_t cap) {

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -390,7 +390,7 @@ class LFIndexer {
     } else {
       num_elements_.store(0);
     }
-    keys_->open_with_hugepages(name + ".keys");
+    keys_->open_with_hugepages(name + ".keys", true);
     if (hugepage_table) {
       indices_.open_with_hugepages(name + ".indices");
     } else {

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -384,14 +384,18 @@ class LFIndexer {
     keys_->resize(num_elements + (num_elements >> 2));
   }
 
-  void open_with_hugepages(const std::string& name) {
+  void open_with_hugepages(const std::string& name, bool hugepage_table) {
     if (std::filesystem::exists(name + ".meta")) {
       load_meta(name + ".meta");
     } else {
       num_elements_.store(0);
     }
     keys_->open_with_hugepages(name + ".keys");
-    indices_.open_with_hugepages(name + ".indices");
+    if (hugepage_table) {
+      indices_.open_with_hugepages(name + ".indices");
+    } else {
+      indices_.open(name + ".indices", false);
+    }
     indices_size_ = indices_.size();
     size_t num_elements = num_elements_.load();
     keys_->resize(num_elements + (num_elements >> 2));

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -384,7 +384,6 @@ class LFIndexer {
     keys_->resize(num_elements + (num_elements >> 2));
   }
 
-#ifdef HUGEPAGE
   void open_with_hugepages(const std::string& name) {
     if (std::filesystem::exists(name + ".meta")) {
       load_meta(name + ".meta");
@@ -397,7 +396,6 @@ class LFIndexer {
     size_t num_elements = num_elements_.load();
     keys_->resize(num_elements + (num_elements >> 2));
   }
-#endif
 
   void dump(const std::string& name, const std::string& snapshot_dir) {
     keys_->resize(num_elements_.load());

--- a/flex/utils/mmap_array.h
+++ b/flex/utils/mmap_array.h
@@ -169,6 +169,7 @@ class mmap_array {
         if (data_ != MAP_FAILED) {
           FILE* fin = fopen(filename.c_str(), "rb");
           CHECK_EQ(fread(data_, sizeof(T), size_, fin), size_);
+	  fclose(fin);
         } else {
           LOG(ERROR) << "allocating hugepage failed, " << strerror(errno)
                      << ", try with normal pages";

--- a/flex/utils/property/column.cc
+++ b/flex/utils/property/column.cc
@@ -30,7 +30,7 @@ class TypedEmptyColumn : public ColumnBase {
   void open(const std::string& name, const std::string& snapshot_dir,
             const std::string& work_dir) override {}
   void open_in_memory(const std::string& name) override {}
-  void open_with_hugepages(const std::string& name) override {}
+  void open_with_hugepages(const std::string& name, bool force) override {}
   void touch(const std::string& filename) override {}
   void dump(const std::string& filename) override {}
   void copy_to_tmp(const std::string& cur_path,
@@ -69,7 +69,7 @@ class TypedEmptyColumn<std::string_view> : public ColumnBase {
   void open(const std::string& name, const std::string& snapshot_dir,
             const std::string& work_dir) override {}
   void open_in_memory(const std::string& name) override {}
-  void open_with_hugepages(const std::string& name) override {}
+  void open_with_hugepages(const std::string& name, bool force) override {}
   void touch(const std::string& filename) override {}
   void dump(const std::string& filename) override {}
   void copy_to_tmp(const std::string& cur_path,

--- a/flex/utils/property/column.cc
+++ b/flex/utils/property/column.cc
@@ -30,9 +30,7 @@ class TypedEmptyColumn : public ColumnBase {
   void open(const std::string& name, const std::string& snapshot_dir,
             const std::string& work_dir) override {}
   void open_in_memory(const std::string& name) override {}
-#ifdef HUGEPAGE
   void open_with_hugepages(const std::string& name) override {}
-#endif
   void touch(const std::string& filename) override {}
   void dump(const std::string& filename) override {}
   void copy_to_tmp(const std::string& cur_path,
@@ -71,9 +69,7 @@ class TypedEmptyColumn<std::string_view> : public ColumnBase {
   void open(const std::string& name, const std::string& snapshot_dir,
             const std::string& work_dir) override {}
   void open_in_memory(const std::string& name) override {}
-#ifdef HUGEPAGE
   void open_with_hugepages(const std::string& name) override {}
-#endif
   void touch(const std::string& filename) override {}
   void dump(const std::string& filename) override {}
   void copy_to_tmp(const std::string& cur_path,

--- a/flex/utils/property/column.h
+++ b/flex/utils/property/column.h
@@ -523,9 +523,10 @@ void StringMapColumn<INDEX_T>::open_in_memory(const std::string& name) {
 }
 
 template <typename INDEX_T>
-void StringMapColumn<INDEX_T>::open_with_hugepages(const std::string& name, bool force) {
-  index_col_.open_with_hugepages(name);
-  meta_map_->open_with_hugepages(name + ".map_meta");
+void StringMapColumn<INDEX_T>::open_with_hugepages(const std::string& name,
+                                                   bool force) {
+  index_col_.open_with_hugepages(name, force);
+  meta_map_->open_with_hugepages(name + ".map_meta", true);
   meta_map_->reserve(std::numeric_limits<INDEX_T>::max());
 }
 

--- a/flex/utils/property/table.cc
+++ b/flex/utils/property/table.cc
@@ -81,11 +81,11 @@ void Table::open_with_hugepages(
     const std::string& name, const std::string& snapshot_dir,
     const std::vector<std::string>& col_name,
     const std::vector<PropertyType>& property_types,
-    const std::vector<StorageStrategy>& strategies_) {
+    const std::vector<StorageStrategy>& strategies_, bool force) {
   initColumns(col_name, property_types, strategies_);
   for (size_t i = 0; i < columns_.size(); ++i) {
     columns_[i]->open_with_hugepages(snapshot_dir + "/" + name + ".col_" +
-                                     std::to_string(i));
+                                     std::to_string(i), force);
   }
   touched_ = true;
   buildColumnPtrs();

--- a/flex/utils/property/table.cc
+++ b/flex/utils/property/table.cc
@@ -77,7 +77,6 @@ void Table::open_in_memory(const std::string& name,
   buildColumnPtrs();
 }
 
-#ifdef HUGEPAGE
 void Table::open_with_hugepages(
     const std::string& name, const std::string& snapshot_dir,
     const std::vector<std::string>& col_name,
@@ -91,7 +90,6 @@ void Table::open_with_hugepages(
   touched_ = true;
   buildColumnPtrs();
 }
-#endif
 
 void Table::touch(const std::string& name, const std::string& work_dir) {
   if (touched_) {

--- a/flex/utils/property/table.h
+++ b/flex/utils/property/table.h
@@ -52,7 +52,7 @@ class Table {
                            const std::string& snapshot_dir,
                            const std::vector<std::string>& col_name,
                            const std::vector<PropertyType>& property_types,
-                           const std::vector<StorageStrategy>& strategies_);
+                           const std::vector<StorageStrategy>& strategies_, bool force);
 
   void touch(const std::string& name, const std::string& work_dir);
 

--- a/flex/utils/property/table.h
+++ b/flex/utils/property/table.h
@@ -48,13 +48,11 @@ class Table {
                       const std::vector<PropertyType>& property_types,
                       const std::vector<StorageStrategy>& strategies_);
 
-#ifdef HUGEPAGE
   void open_with_hugepages(const std::string& name,
                            const std::string& snapshot_dir,
                            const std::vector<std::string>& col_name,
                            const std::vector<PropertyType>& property_types,
                            const std::vector<StorageStrategy>& strategies_);
-#endif
 
   void touch(const std::string& name, const std::string& work_dir);
 


### PR DESCRIPTION
Passing parameter "--memory-level=n" to rt_server to configure memory allocation strategy.
 - n = 0: memory allocation will be mmap to files in SHARED mode. Suitable for scenarios with severe memory constraints.
 - n = 1: memory allocation will be mmap to files in PRIVATE mode. The modified parts in the storage cannot be swapped to disk; if the modified portions become too large, it may lead to a crash due to insufficient memory.
 - n = 2: the storage of certain data will utilize hugepages, which can enhance the system's throughput. However, the portion using hugepages will be fixed in memory usage, and hugepages require static allocation.
 - n = 3: the storage of all data will endeavor to make use of hugepages as much as possible.