### PR TITLE
fix(k8s): Bump up vineyard to v0.20.3

### DIFF
--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -185,7 +185,7 @@ jobs:
       run: |
         . ~/.graphscope_env
         python3 -m pip install libclang
-        git clone --single-branch -b v0.20.2 --depth=1 https://github.com/v6d-io/v6d.git /tmp/v6d
+        git clone --single-branch -b v0.20.3 --depth=1 https://github.com/v6d-io/v6d.git /tmp/v6d
         cd /tmp/v6d
         git submodule update --init
         cmake .  -DCMAKE_INSTALL_PREFIX=/usr/local \

--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.20.2
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.20.3
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/networkx-forward-algo-nightly.yml
+++ b/.github/workflows/networkx-forward-algo-nightly.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.20.2
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.20.3
       options:
         --shm-size 4096m
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
         sudo mkdir /opt/graphscope
         sudo chown -R $(id -u):$(id -g) /opt/graphscope
         python3 -m pip install click 
-        python3 gsctl.py install-deps dev --v6d-version v0.20.2
+        python3 gsctl.py install-deps dev --v6d-version v0.20.3
 
     - name: Setup tmate session
       if: false

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -10,7 +10,7 @@ endif
 ARCH := $(shell uname -m)
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.20.2
+VINEYARD_VERSION ?= v0.20.3
 # This is the version of builder base image in most cases, except for graphscope-dev
 BUILDER_VERSION ?= $(VINEYARD_VERSION)
 # This is the version of runtime base image

--- a/k8s/actions-runner-controller/manylinux/Makefile
+++ b/k8s/actions-runner-controller/manylinux/Makefile
@@ -12,7 +12,7 @@ TARGETPLATFORM ?= $(shell arch)
 RUNNER_VERSION ?= 2.287.1
 DOCKER_VERSION ?= 20.10.12
 
-VINEYARD_VERSION ?= v0.20.2
+VINEYARD_VERSION ?= v0.20.3
 BUILDER_VERSION ?= $(VINEYARD_VERSION)
 
 # default list of platforms for which multiarch image is built

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -42,7 +42,7 @@ GRAPHSCOPE_HOME ?= /usr/local
 INSTALL_PREFIX ?= /opt/graphscope
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.20.2
+VINEYARD_VERSION ?= v0.20.3
 PROFILE ?= release
 CI ?= false
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -14,8 +14,8 @@ readonly GREEN="\033[0;32m"
 readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
-readonly V6D_VERSION="0.20.2"  # vineyard version
-readonly V6D_BRANCH="v0.20.2" # vineyard branch
+readonly V6D_VERSION="0.20.3"  # vineyard version
+readonly V6D_BRANCH="v0.20.3" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true


### PR DESCRIPTION
## What do these changes do?

The PR is to fix the bug caused by the version mismatch of vineyard in the graphscope-dev image.

As:
https://github.com/alibaba/GraphScope/actions/runs/7771225038/job/21192444777
https://github.com/alibaba/GraphScope/actions/runs/7753022954/job/21144025198

Also, the dev image updated.
https://github.com/alibaba/GraphScope/actions/runs/7773830300

