### PR TITLE
feat(interactive): Add profile to build compiler fat-jar

### DIFF
--- a/interactive_engine/compiler/pom.xml
+++ b/interactive_engine/compiler/pom.xml
@@ -147,6 +147,9 @@
     <profiles>
         <profile>
             <id>procedure-generator</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
             <build>
                 <resources>
                     <resource>

--- a/interactive_engine/compiler/pom.xml
+++ b/interactive_engine/compiler/pom.xml
@@ -144,6 +144,56 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>procedure-generator</id>
+            <build>
+                <resources>
+                    <resource>
+                        <directory>${project.basedir}/../executor/ir/target/release</directory>
+                        <includes>
+                            <include>libir_core.so</include>
+                        </includes>
+                    </resource>
+                </resources>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>${maven.shade.version}</version>
+                        <configuration>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <!-- put your configurations here -->
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
+                                    <finalName>${project.artifactId}-${project.version}-shade</finalName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <extensions>
             <extension>


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
This pr add a profile in compiler's pom.xml.
This pom.xml can generate a fat-jar and package libircore.so within the jar when the procedure-generator profile is specified.

To generate a compiler's fat-jar, run
`mvn clean package -DskipTests -Drevision=0.0.1-SNAPSHOT -Pexperimental,procedure-generator`
in directory GraphScope/interactive_engine

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/alibaba/GraphScope/issues/3573

