### PR TITLE
fix(python): Fixes `graph.unload()`: makes the warning loudly, and use the new DelData API

### DIFF
--- a/.github/workflows/build-graphscope-wheels-macos.yml
+++ b/.github/workflows/build-graphscope-wheels-macos.yml
@@ -185,7 +185,7 @@ jobs:
       run: |
         . ~/.graphscope_env
         python3 -m pip install libclang
-        git clone --single-branch -b v0.20.3 --depth=1 https://github.com/v6d-io/v6d.git /tmp/v6d
+        git clone --single-branch -b v0.21.3 --depth=1 https://github.com/v6d-io/v6d.git /tmp/v6d
         cd /tmp/v6d
         git submodule update --init
         cmake .  -DCMAKE_INSTALL_PREFIX=/usr/local \

--- a/.github/workflows/gae.yml
+++ b/.github/workflows/gae.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.20.3
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.21.3
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/networkx-forward-algo-nightly.yml
+++ b/.github/workflows/networkx-forward-algo-nightly.yml
@@ -17,7 +17,7 @@ jobs:
       run:
         shell: bash --noprofile --norc -eo pipefail {0}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.20.3
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.21.3
       options:
         --shm-size 4096m
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,7 @@ jobs:
         sudo mkdir /opt/graphscope
         sudo chown -R $(id -u):$(id -g) /opt/graphscope
         python3 -m pip install click 
-        python3 gsctl.py install-deps dev --v6d-version v0.20.3
+        python3 gsctl.py install-deps dev --v6d-version v0.21.3
 
     - name: Setup tmate session
       if: false

--- a/analytical_engine/core/grape_instance.cc
+++ b/analytical_engine/core/grape_instance.cc
@@ -192,11 +192,19 @@ bl::result<void> GrapeInstance::unloadGraph(const rpc::GSParams& params) {
 
       // delete the fragment group first
       if (comm_spec_.worker_id() == 0) {
+#if defined(VINEYARD_VERSION) && VINEYARD_VERSION >= 21003
+        VINEYARD_SUPPRESS(client_->DelData(frag_group_id, false, true, true));
+#else
         VINEYARD_SUPPRESS(client_->DelData(frag_group_id, false, true));
+#endif
       }
       // ensure all fragments get deleted
       MPI_Barrier(comm_spec_.comm());
+#if defined(VINEYARD_VERSION) && VINEYARD_VERSION >= 21003
+      VINEYARD_SUPPRESS(client_->DelData(frag_id, false, true, true));
+#else
       VINEYARD_SUPPRESS(client_->DelData(frag_id, false, true));
+#endif
     }
   }
   VLOG(1) << "Unloading Graph " << graph_name;

--- a/analytical_engine/core/utils/transform_utils.h
+++ b/analytical_engine/core/utils/transform_utils.h
@@ -763,7 +763,8 @@ class TransformUtils<FRAG_T,
     } else if (type->Equals(arrow::float64())) {
       return vertex_property_to_vy_tensor_builder_impl<double>(client, prop_id,
                                                                vertices);
-    } else if (type->Equals(arrow::large_utf8())) {
+    } else if (type->Equals(arrow::utf8()) ||
+               type->Equals(arrow::large_utf8())) {
       return vertex_property_to_vy_tensor_builder_impl<std::string>(
           client, prop_id, vertices);
     } else {

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -10,7 +10,7 @@ endif
 ARCH := $(shell uname -m)
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.20.3
+VINEYARD_VERSION ?= v0.21.3
 # This is the version of builder base image in most cases, except for graphscope-dev
 BUILDER_VERSION ?= $(VINEYARD_VERSION)
 # This is the version of runtime base image

--- a/k8s/actions-runner-controller/manylinux/Makefile
+++ b/k8s/actions-runner-controller/manylinux/Makefile
@@ -12,7 +12,7 @@ TARGETPLATFORM ?= $(shell arch)
 RUNNER_VERSION ?= 2.287.1
 DOCKER_VERSION ?= 20.10.12
 
-VINEYARD_VERSION ?= v0.20.3
+VINEYARD_VERSION ?= v0.21.3
 BUILDER_VERSION ?= $(VINEYARD_VERSION)
 
 # default list of platforms for which multiarch image is built

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -42,7 +42,7 @@ GRAPHSCOPE_HOME ?= /usr/local
 INSTALL_PREFIX ?= /opt/graphscope
 
 VERSION ?= latest
-VINEYARD_VERSION ?= v0.20.3
+VINEYARD_VERSION ?= v0.21.3
 PROFILE ?= release
 CI ?= false
 

--- a/python/graphscope/framework/graph.py
+++ b/python/graphscope/framework/graph.py
@@ -125,10 +125,12 @@ class GraphInterface(metaclass=ABCMeta):
         raise NotImplementedError
 
     def unload(self):
-        warnings.warn(
-            "The Graph.unload() method has been deprecated, please using the `del` operator instead, e.g., `del graph`",
-            DeprecationWarning,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("always", DeprecationWarning)
+            warnings.warn(
+                "The Graph.unload() method has been deprecated, please using the `del` operator instead, i.e., `del graph`",
+                DeprecationWarning,
+            )
 
     def _from_nx_graph(self, g):
         """Create a gs graph from a nx graph.

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -15,7 +15,7 @@ readonly NC="\033[0m" # No Color
 
 readonly GRAPE_BRANCH="master" # libgrape-lite branch
 readonly V6D_VERSION="0.20.3"  # vineyard version
-readonly V6D_BRANCH="v0.20.3" # vineyard branch
+readonly V6D_BRANCH="v0.21.3" # vineyard branch
 
 readonly OUTPUT_ENV_FILE="${HOME}/.graphscope_env"
 IS_IN_WSL=false && [[ ! -z "${IS_WSL}" || ! -z "${WSL_DISTRO_NAME}" ]] && IS_IN_WSL=true


### PR DESCRIPTION
See also: https://github.com/alibaba/GraphScope/pull/3548