### PR TITLE
fix(interactive): Fix Bugs in Operator Precedence of `not` operator

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/runtime/proto/RexToProtoConverter.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/runtime/proto/RexToProtoConverter.java
@@ -293,8 +293,19 @@ public class RexToProtoConverter extends RexVisitorImpl<OuterExpression.Expressi
     }
 
     private boolean needBrace(SqlOperator operator, RexNode operand) {
-        return operand instanceof RexCall
-                && ((RexCall) operand).getOperator().getLeftPrec() <= operator.getLeftPrec();
+        switch (operator.getKind()) {
+            case NOT:
+                // the operator precedence of `not` in sql is low, which is the same as `and` or
+                // `or`.
+                // However, the `not` operator is implemented by `!` in c++ or in rust, which
+                // precedence is high,
+                // To solve the inconsistency, we always add brace for operand of `not` operator.
+                return true;
+            default:
+                return operand instanceof RexCall
+                        && ((RexCall) operand).getOperator().getLeftPrec()
+                                <= operator.getLeftPrec();
+        }
     }
 
     @Override

--- a/interactive_engine/compiler/src/test/resources/proto/name_not_containing_expr.json
+++ b/interactive_engine/compiler/src/test/resources/proto/name_not_containing_expr.json
@@ -1,0 +1,38 @@
+{
+  "operators": [{
+    "logical": "NOT",
+    "nodeType": {
+      "dataType": "BOOLEAN"
+    }
+  }, {
+    "brace": "LEFT_BRACE"
+  }, {
+    "var": {
+      "property": {
+        "key": {
+          "name": "name"
+        }
+      },
+      "nodeType": {
+        "dataType": "STRING"
+      }
+    },
+    "nodeType": {
+      "dataType": "STRING"
+    }
+  }, {
+    "logical": "REGEX",
+    "nodeType": {
+      "dataType": "BOOLEAN"
+    }
+  }, {
+    "const": {
+      "str": ".*mar.*"
+    },
+    "nodeType": {
+      "dataType": "STRING"
+    }
+  }, {
+    "brace": "RIGHT_BRACE"
+  }]
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
The operator precedence of `not` in sql is low, which is the same as `and` or `or`. However, the `not` operator is implemented by `!` in c++ or in rust, which precedence is high. To solve the inconsistency, we always add brace for operand of `not` operator.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

