### PR TITLE
refactor(interactive): Add type and queryStr for `StoredProcedureMeta`

### DIFF
--- a/flex/bin/load_plan_and_gen.sh
+++ b/flex/bin/load_plan_and_gen.sh
@@ -136,6 +136,7 @@ cypher_to_plan() {
   # add extra_key_value_config
   extra_config="name:${procedure_name}"
   extra_config="${extra_config},description:${procedure_description}"
+  extra_config="${extra_config},type:cypher"
 
   cmd="java -cp ${COMPILER_LIB_DIR}/*:${COMPILER_JAR}"
   cmd="${cmd} -Dgraph.schema=${graph_schema_path}"

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/StoredProcedureMeta.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/StoredProcedureMeta.java
@@ -36,6 +36,8 @@ public class StoredProcedureMeta {
     private static final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
 
     private final String name;
+    private final String type;
+    private final String queryStr;
     private final RelDataType returnType;
     private final List<Parameter> parameters;
     private final Mode mode;
@@ -44,12 +46,16 @@ public class StoredProcedureMeta {
 
     protected StoredProcedureMeta(
             String name,
+            String type,
+            String queryStr,
             Mode mode,
             String description,
             String extension,
             RelDataType returnType,
             List<Parameter> parameters) {
         this.name = name;
+        this.type = type;
+        this.queryStr = queryStr;
         this.mode = mode;
         this.description = description;
         this.extension = extension;
@@ -58,9 +64,11 @@ public class StoredProcedureMeta {
     }
 
     public StoredProcedureMeta(
-            Configs configs, RelDataType returnType, List<Parameter> parameters) {
+            Configs configs, String queryStr, RelDataType returnType, List<Parameter> parameters) {
         this(
                 Config.NAME.get(configs),
+                Config.TYPE.get(configs),
+                queryStr,
                 Mode.valueOf(Config.MODE.get(configs)),
                 Config.DESCRIPTION.get(configs),
                 Config.EXTENSION.get(configs),
@@ -86,6 +94,8 @@ public class StoredProcedureMeta {
                 + "name='"
                 + name
                 + '\''
+                + ", queryStr='"
+                + queryStr
                 + ", returnType="
                 + returnType
                 + ", parameters="
@@ -142,8 +152,12 @@ public class StoredProcedureMeta {
             return ImmutableBiMap.of(
                     "name",
                     meta.name,
+                    "type",
+                    meta.type,
                     "description",
                     meta.description,
+                    "queryStr",
+                    meta.queryStr,
                     "mode",
                     meta.mode.name(),
                     "extension",
@@ -177,6 +191,8 @@ public class StoredProcedureMeta {
             Map<String, Object> config = yaml.load(inputStream);
             return new StoredProcedureMeta(
                     (String) config.get("name"),
+                    (String) config.get("type"),
+                    (String) config.get("queryStr"),
                     Mode.valueOf((String) config.get("mode")),
                     (String) config.get("description"),
                     (String) config.get("extension"),
@@ -230,5 +246,7 @@ public class StoredProcedureMeta {
                 com.alibaba.graphscope.common.config.Config.stringConfig("extension", ".so");
         public static final com.alibaba.graphscope.common.config.Config<String> MODE =
                 com.alibaba.graphscope.common.config.Config.stringConfig("mode", "READ");
+        public static final com.alibaba.graphscope.common.config.Config<String> TYPE =
+                com.alibaba.graphscope.common.config.Config.stringConfig("type", "cypher");
     }
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
@@ -292,7 +292,7 @@ public class GraphPlanner {
         Configs extraConfigs = createExtraConfigs(args.length > 4 ? args[4] : null);
         StoredProcedureMeta procedureMeta =
                 new StoredProcedureMeta(
-                        extraConfigs, logicalPlan.getOutputType(), logicalPlan.getDynamicParams());
+                        extraConfigs, query, logicalPlan.getOutputType(), logicalPlan.getDynamicParams());
         StoredProcedureMeta.Serializer.perform(procedureMeta, new FileOutputStream(args[3]));
     }
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
@@ -292,7 +292,10 @@ public class GraphPlanner {
         Configs extraConfigs = createExtraConfigs(args.length > 4 ? args[4] : null);
         StoredProcedureMeta procedureMeta =
                 new StoredProcedureMeta(
-                        extraConfigs, query, logicalPlan.getOutputType(), logicalPlan.getDynamicParams());
+                        extraConfigs,
+                        query,
+                        logicalPlan.getOutputType(),
+                        logicalPlan.getDynamicParams());
         StoredProcedureMeta.Serializer.perform(procedureMeta, new FileOutputStream(args[3]));
     }
 }

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/config/YamlConfigTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/config/YamlConfigTest.java
@@ -41,8 +41,10 @@ public class YamlConfigTest {
         StoredProcedureMeta meta = procedures.getStoredProcedure("ldbc_ic2");
         Assert.assertEquals(
                 "StoredProcedureMeta{name='ldbc_ic2', returnType=RecordType(CHAR(1) name),"
-                        + " parameters=[Parameter{name='personId2', dataType=BIGINT},"
-                        + " Parameter{name='maxDate', dataType=BIGINT}]}",
+                    + " parameters=[Parameter{name='personId2', dataType=BIGINT},"
+                    + " Parameter{name='maxDate', dataType=BIGINT}], option={queryStr='MATCH(n:"
+                    + " PERSON ${personId2}) WHERE n.creationDate < ${maxDate} RETURN n.firstName"
+                    + " AS name LIMIT 10;', type=cypher}}",
                 meta.toString());
     }
 

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/config/YamlConfigTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/config/YamlConfigTest.java
@@ -42,9 +42,9 @@ public class YamlConfigTest {
         Assert.assertEquals(
                 "StoredProcedureMeta{name='ldbc_ic2', returnType=RecordType(CHAR(1) name),"
                     + " parameters=[Parameter{name='personId2', dataType=BIGINT},"
-                    + " Parameter{name='maxDate', dataType=BIGINT}], option={queryStr='MATCH(n:"
-                    + " PERSON ${personId2}) WHERE n.creationDate < ${maxDate} RETURN n.firstName"
-                    + " AS name LIMIT 10;', type=cypher}}",
+                    + " Parameter{name='maxDate', dataType=BIGINT}], option={type=cypher,"
+                    + " queryStr=MATCH(n: PERSON ${personId2}) WHERE n.creationDate < ${maxDate}"
+                    + " RETURN n.firstName AS name LIMIT 10;}}",
                 meta.toString());
     }
 

--- a/interactive_engine/compiler/src/test/resources/config/modern/plugins/ldbc_ic2.yaml
+++ b/interactive_engine/compiler/src/test/resources/config/modern/plugins/ldbc_ic2.yaml
@@ -3,6 +3,7 @@ name: "ldbc_ic2"
 description: "A stored procedures for the ldbc complex interactive workload 2"
 mode: READ  # WRITE, SCHEMA
 type: cypher # cypher/cpp
+queryStr: "MATCH(n: PERSON ${personId2}) WHERE n.creationDate < ${maxDate} RETURN n.firstName AS name LIMIT 10;"
 extension: ".so"
 library: libquery_ic2.so  # To specify the directory to the stored procedure
 params:

--- a/interactive_engine/compiler/src/test/resources/config/modern/plugins/ldbc_ic2.yaml
+++ b/interactive_engine/compiler/src/test/resources/config/modern/plugins/ldbc_ic2.yaml
@@ -2,6 +2,7 @@
 name: "ldbc_ic2"
 description: "A stored procedures for the ldbc complex interactive workload 2"
 mode: READ  # WRITE, SCHEMA
+type: cypher # cypher/cpp
 extension: ".so"
 library: libquery_ic2.so  # To specify the directory to the stored procedure
 params:

--- a/interactive_engine/compiler/src/test/resources/config/modern/plugins/ldbc_ic2.yaml
+++ b/interactive_engine/compiler/src/test/resources/config/modern/plugins/ldbc_ic2.yaml
@@ -2,8 +2,6 @@
 name: "ldbc_ic2"
 description: "A stored procedures for the ldbc complex interactive workload 2"
 mode: READ  # WRITE, SCHEMA
-type: cypher # cypher/cpp
-queryStr: "MATCH(n: PERSON ${personId2}) WHERE n.creationDate < ${maxDate} RETURN n.firstName AS name LIMIT 10;"
 extension: ".so"
 library: libquery_ic2.so  # To specify the directory to the stored procedure
 params:
@@ -14,3 +12,6 @@ params:
 returns:
   - name: "name"
     type: "string"
+option: # consistent with standard cypher procedure meta, use field 'option' to specify additional meta info.
+  type: cypher # cypher/cpp
+  queryStr: "MATCH(n: PERSON ${personId2}) WHERE n.creationDate < ${maxDate} RETURN n.firstName AS name LIMIT 10;"


### PR DESCRIPTION
Add optional field `type: cpp/cypher` and `queryStr: ` for stored procedure's metadata. The queryStr could be cypher query or c++ code.