### PR TITLE
fix(python): Enable the BUILD_VINEYARD_GRAPH_WITH_GAR compile option in gsctl

### DIFF
--- a/python/graphscope/gsctl/scripts/lib/install_vineyard.sh
+++ b/python/graphscope/gsctl/scripts/lib/install_vineyard.sh
@@ -42,7 +42,7 @@ install_vineyard() {
         -DBUILD_VINEYARD_TESTS=OFF \
         -DBUILD_SHARED_LIBS=ON \
         -DBUILD_VINEYARD_PYTHON_BINDINGS=ON  \
-        -DBUILD_VINEYARD_GRAPH_WITH_GAR=OFF
+        -DBUILD_VINEYARD_GRAPH_WITH_GAR=ON
   make -j"${jobs}"
   make install
   strip "${V6D_PREFIX}"/bin/vineyard* "${V6D_PREFIX}"/lib/libvineyard*


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Enable the BUILD_VINEYARD_GRAPH_WITH_GAR compile option in gsctl

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

