### PR TITLE
fix(interactive): Fix CI Bug Caused By PR #3630

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/processor/IrTestOpProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/processor/IrTestOpProcessor.java
@@ -19,7 +19,6 @@ package com.alibaba.graphscope.gremlin.integration.processor;
 import com.alibaba.graphscope.common.client.ExecutionClient;
 import com.alibaba.graphscope.common.client.channel.ChannelFetcher;
 import com.alibaba.graphscope.common.client.type.ExecutionRequest;
-import com.alibaba.graphscope.common.client.type.ExecutionResponseListener;
 import com.alibaba.graphscope.common.config.Configs;
 import com.alibaba.graphscope.common.config.FrontendConfig;
 import com.alibaba.graphscope.common.config.QueryTimeoutConfig;
@@ -147,7 +146,7 @@ public class IrTestOpProcessor extends IrStandardOpProcessor {
                                     GraphPlanner.Summary summary = value.summary;
                                     ResultSchema resultSchema =
                                             new ResultSchema(summary.getLogicalPlan());
-                                    ExecutionResponseListener listener =
+                                    GremlinTestResultProcessor listener =
                                             new GremlinTestResultProcessor(
                                                     configs,
                                                     ctx,
@@ -171,6 +170,8 @@ public class IrTestOpProcessor extends IrStandardOpProcessor {
                                                 listener,
                                                 timeoutConfig);
                                     }
+                                    // request results from remote engine in a blocking way
+                                    listener.request();
                                     break;
                                 default:
                                     throw new IllegalArgumentException(


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
The issue is caused by PR #3630, which changed the result collection from asynchronous to synchronous. After submitting a request to the client, it is necessary to actively call a request to retrieve the result from the buffer. However, the test chain forgot to add this call, leading to the problem. This PR mainly fix the issue.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

