### PR TITLE
fix(interactive): Fix the incorrect casting from int into string when converting from `YAML` to `JSON`

### DIFF
--- a/flex/engines/http_server/workdir_manipulator.cc
+++ b/flex/engines/http_server/workdir_manipulator.cc
@@ -113,7 +113,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::GetGraphSchemaString(
         "Graph schema file is expected, but not exists: " + schema_file));
   }
   // read schema file and output to string
-  auto schema_str_res = gs::get_string_from_yaml(schema_file);
+  auto schema_str_res = gs::get_json_string_from_yaml(schema_file);
   if (!schema_str_res.ok()) {
     return gs::Result<seastar::sstring>(
         gs::Status(gs::StatusCode::NotExists,
@@ -197,7 +197,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::ListGraphs() {
       }
     }
   }
-  auto json_str = gs::get_string_from_yaml(yaml_list);
+  auto json_str = gs::get_json_string_from_yaml(yaml_list);
   if (!json_str.ok()) {
     return gs::Result<seastar::sstring>(gs::Status(
         gs::StatusCode::InternalError,
@@ -1090,7 +1090,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::get_all_procedure_yamls(
     }
   }
   // dump to json
-  auto res = gs::get_string_from_yaml(yaml_list);
+  auto res = gs::get_json_string_from_yaml(yaml_list);
   if (!res.ok()) {
     return gs::Result<seastar::sstring>(
         gs::Status(gs::StatusCode::InternalError,
@@ -1126,7 +1126,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::get_all_procedure_yamls(
     }
   }
   // dump to json
-  auto res = gs::get_string_from_yaml(yaml_list);
+  auto res = gs::get_json_string_from_yaml(yaml_list);
   if (!res.ok()) {
     return gs::Result<seastar::sstring>(
         gs::Status(gs::StatusCode::InternalError,

--- a/flex/tests/hqps/admin_http_test.cc
+++ b/flex/tests/hqps/admin_http_test.cc
@@ -304,7 +304,8 @@ void run_procedure_test(httplib::Client& client, httplib::Client& query_client,
     CHECK(res->status == 200) << "delete procedure failed: " << res->body;
   }
   //-----6. call procedure on deleted procedure------------------------------
-  // Should return fail.
+  // Should return success, since the procedure will be deleted when restart
+  // the service.
   if (procedures.size() > 0) {
     auto proc_name = get_file_name_from_path(procedures[0]);
     auto call_proc_payload =
@@ -427,7 +428,7 @@ int main(int argc, char** argv) {
                      procedure_paths);
   LOG(INFO) << "run procedure tests done";
   run_get_node_status(cli);
-  test_delete_graph(cli,graph_name);
+  test_delete_graph(cli, graph_name);
   LOG(INFO) << "test delete graph done";
   return 0;
 }

--- a/flex/utils/yaml_utils.cc
+++ b/flex/utils/yaml_utils.cc
@@ -15,6 +15,8 @@
  */
 
 #include "flex/utils/yaml_utils.h"
+#include <fstream>
+#include "nlohmann/json.hpp"
 namespace gs {
 std::vector<std::string> get_yaml_files(const std::string& plugin_dir) {
   std::filesystem::path dir_path = plugin_dir;
@@ -29,31 +31,118 @@ std::vector<std::string> get_yaml_files(const std::string& plugin_dir) {
   return res_yaml_files;
 }
 
-Result<std::string> get_string_from_yaml(const std::string& file_path) {
+nlohmann::json convert_yaml_node_to_json(const YAML::Node& node) {
+  nlohmann::json json;
+  try {
+    switch (node.Type()) {
+    case YAML::NodeType::Null: {
+      json = nullptr;
+      break;
+    }
+    case YAML::NodeType::Scalar: {
+      try {
+        json = node.as<int>();
+      } catch (const YAML::BadConversion& e) {
+        try {
+          json = node.as<double>();
+        } catch (const YAML::BadConversion& e) {
+          try {
+            json = node.as<bool>();
+          } catch (const YAML::BadConversion& e) {
+            json = node.as<std::string>();
+          }
+        }
+      }
+      break;
+    }
+    case YAML::NodeType::Sequence: {
+      for (const auto& item : node) {
+        json.push_back(convert_yaml_node_to_json(item));
+      }
+      break;
+    }
+    case YAML::NodeType::Map:
+      for (const auto& pair : node) {
+        json[pair.first.as<std::string>()] =
+            convert_yaml_node_to_json(pair.second);
+      }
+      break;
+    default:
+      throw std::runtime_error("Unsupported YAML node type" +
+                               std::to_string(node.Type()));
+      break;
+    }
+  } catch (const YAML::BadConversion& e) {
+    throw Status{StatusCode::IOError, e.what()};
+  }
+  return json;
+}
+
+Result<std::string> get_json_string_from_yaml(const std::string& file_path) {
   try {
     YAML::Node config = YAML::LoadFile(file_path);
-    // output config to string
-    return get_string_from_yaml(config);
+    // output config to json string
+    return get_json_string_from_yaml(config);
   } catch (const YAML::BadFile& e) {
-    return Result<std::string>(Status{StatusCode::IOError, e.what()});
-  } catch (const YAML::ParserException& e) {
-    return Result<std::string>(Status{StatusCode::IOError, e.what()});
-  } catch (const YAML::BadConversion& e) {
     return Result<std::string>(Status{StatusCode::IOError, e.what()});
   }
 }
 
-Result<std::string> get_string_from_yaml(const YAML::Node& node) {
+Result<std::string> get_json_string_from_yaml(const YAML::Node& node) {
   try {
-    // output config to string
-    YAML::Emitter emitter;
-    emitter << YAML::DoubleQuoted << YAML::Flow << YAML::BeginSeq << node;
-    std::string json(emitter.c_str() + 1);
-    return Result<std::string>(Status{StatusCode::OK, "Success"}, json);
+    if (node.IsNull()) {
+      return Result<std::string>(Status{StatusCode::OK, "{}"});
+    }
+    nlohmann::json json = convert_yaml_node_to_json(node);
+    return json.dump(2);  // 2 indents
+  } catch (const YAML::BadConversion& e) {
+    return Result<std::string>(Status{StatusCode::IOError, e.what()});
+  } catch (const std::runtime_error& e) {
+    return Result<std::string>(Status{StatusCode::IOError, e.what()});
   } catch (...) {
-    return Result<std::string>(
-        Status{StatusCode::IOError, "Failed to convert yaml to json"});
+    return Result<std::string>(Status{StatusCode::IOError, "Unknown error"});
   }
+}
+
+Status write_yaml_node_to_yaml_string(const YAML::Node& node,
+                                      YAML::Emitter& emitter) {
+  if (node.IsNull()) {
+    emitter << YAML::Null;
+    return Status::OK();
+  }
+  try {
+    switch (node.Type()) {
+    case YAML::NodeType::Scalar: {
+      emitter << node.as<std::string>();
+      break;
+    }
+    case YAML::NodeType::Sequence: {
+      emitter << YAML::BeginSeq;
+      for (const auto& item : node) {
+        write_yaml_node_to_yaml_string(item, emitter);
+      }
+      emitter << YAML::EndSeq;
+      break;
+    }
+    case YAML::NodeType::Map: {
+      emitter << YAML::BeginMap;
+      for (const auto& pair : node) {
+        emitter << YAML::Key << pair.first.as<std::string>();
+        emitter << YAML::Value;
+        write_yaml_node_to_yaml_string(pair.second, emitter);
+      }
+      emitter << YAML::EndMap;
+      break;
+    }
+    default:
+      throw std::runtime_error("Unsupported YAML node type" +
+                               std::to_string(node.Type()));
+      break;
+    }
+  } catch (const YAML::BadConversion& e) {
+    return Status{StatusCode::IOError, e.what()};
+  }
+  return Status::OK();
 }
 
 }  // namespace gs

--- a/flex/utils/yaml_utils.h
+++ b/flex/utils/yaml_utils.h
@@ -28,9 +28,12 @@ namespace gs {
 
 std::vector<std::string> get_yaml_files(const std::string& plugin_dir);
 
-Result<std::string> get_string_from_yaml(const std::string& file_path);
+Result<std::string> get_json_string_from_yaml(const std::string& file_path);
 
-Result<std::string> get_string_from_yaml(const YAML::Node& yaml_node);
+Result<std::string> get_json_string_from_yaml(const YAML::Node& yaml_node);
+
+Status write_yaml_node_to_yaml_string(const YAML::Node& node,
+                                      YAML::Emitter& emitter);
 
 namespace config_parsing {
 template <typename T>


### PR DESCRIPTION
`YAML::Emitter` will convert a `int` value to `string`, which is not desired.

We Implement a converter which convert a yaml to json.