### PR TITLE
refactor(interactive): Return the correct http code

### DIFF
--- a/docs/flex/interactive/development/admin_service.md
+++ b/docs/flex/interactive/development/admin_service.md
@@ -1086,3 +1086,29 @@ The Compiler service could be started as a subprocess of the AdminService. This 
 
 ```bash
 ./bin/interactive_server -c ${ENGINE_CONFIG} -w ${WORKSPACE} --enable-admin-service true --start-compiler true
+```
+
+
+## Http error code
+
+Internally we use [`StatusCode`](https://github.com/alibaba/GraphScope/blob/main/flex/utils/result.h) to record the runtime errors.
+The mapping between statusCode and http code is shown in the following table.
+
+| Code                                | HTTP Code   |
+| ----------------------------------- | ----------- |
+| gs::StatusCode::OK                  | 200         |
+| gs::StatusCode::InValidArgument     | 400         |
+| gs::StatusCode::UnsupportedOperator | 400         |
+| gs::StatusCode::AlreadyExists       | 409         |
+| gs::StatusCode::NotExists           | 404         |
+| gs::StatusCode::CodegenError        | 500         |
+| gs::StatusCode::UninitializedStatus | 500         |
+| gs::StatusCode::InvalidSchema       | 400         |
+| gs::StatusCode::PermissionError     | 403         |
+| gs::StatusCode::IllegalOperation    | 400         |
+| gs::StatusCode::InternalError       | 500         |
+| gs::StatusCode::InvalidImportFile   | 400         |
+| gs::StatusCode::IOError             | 500         |
+| gs::StatusCode::NotFound            | 404         |
+| gs::StatusCode::QueryFailed         | 500         |
+| default                             | 500         |

--- a/flex/engines/http_server/actor/admin_actor.act.h
+++ b/flex/engines/http_server/actor/admin_actor.act.h
@@ -31,33 +31,33 @@ class ANNOTATION(actor:impl) admin_actor : public hiactor::actor {
   admin_actor(hiactor::actor_base* exec_ctx, const hiactor::byte_t* addr);
   ~admin_actor() override;
 
-  seastar::future<query_result> ANNOTATION(actor:method) run_create_graph(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) run_create_graph(query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) run_get_graph_schema(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) run_get_graph_schema(query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) run_list_graphs(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) run_list_graphs(query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) run_delete_graph(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) run_delete_graph(query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) run_graph_loading(graph_management_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) run_graph_loading(graph_management_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) start_service(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) start_service(query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) stop_service(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) stop_service(query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) service_status(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) service_status(query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) get_procedure_by_procedure_name(procedure_query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) get_procedure_by_procedure_name(procedure_query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) get_procedures_by_graph_name(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) get_procedures_by_graph_name(query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) create_procedure(create_procedure_query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) create_procedure(create_procedure_query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) delete_procedure(procedure_query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) delete_procedure(procedure_query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) update_procedure(update_procedure_query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) update_procedure(update_procedure_query_param&& param);
 
-  seastar::future<query_result> ANNOTATION(actor:method) node_status(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) node_status(query_param&& param);
 
   // DECLARE_RUN_QUERIES;
   /// Declare `do_work` func here, no need to implement.

--- a/flex/engines/http_server/handler/admin_http_handler.cc
+++ b/flex/engines/http_server/handler/admin_http_handler.cc
@@ -59,46 +59,31 @@ class admin_http_graph_handler_impl : public seastar::httpd::handler_base {
       if (path.find("dataloading") != seastar::sstring::npos) {
         LOG(INFO) << "Route to loading graph";
         if (!req->param.exists("graph_name")) {
-          return seastar::make_exception_future<
-              std::unique_ptr<seastar::httpd::reply>>(
-              std::runtime_error("graph_name not exists"));
+          return new_bad_request_reply(std::move(rep),
+                                       "expect field 'graph_name' in request");
         } else {
           auto graph_name = req->param.at("graph_name");
           LOG(INFO) << "Graph name: " << graph_name;
           auto pair = std::make_pair(graph_name, std::move(req->content));
           return admin_actor_refs_[dst_executor]
               .run_graph_loading(graph_management_param{std::move(pair)})
-              .then_wrapped([rep = std::move(rep)](
-                                seastar::future<query_result>&& fut) mutable {
-                if (__builtin_expect(fut.failed(), false)) {
-                  return seastar::make_exception_future<
-                      std::unique_ptr<seastar::httpd::reply>>(
-                      fut.get_exception());
-                }
-                auto result = fut.get0();
-                rep->write_body("application/json", std::move(result.content));
-                rep->done();
-                return seastar::make_ready_future<
-                    std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
-              });
+              .then_wrapped(
+                  [rep = std::move(rep)](
+                      seastar::future<admin_query_result>&& fut) mutable {
+                    return return_reply_with_result(std::move(rep),
+                                                    std::move(fut));
+                  });
         }
       } else {
         LOG(INFO) << "Route to creating graph";
         return admin_actor_refs_[dst_executor]
             .run_create_graph(query_param{std::move(req->content)})
-            .then_wrapped([rep = std::move(rep)](
-                              seastar::future<query_result>&& fut) mutable {
-              if (__builtin_expect(fut.failed(), false)) {
-                return seastar::make_exception_future<
-                    std::unique_ptr<seastar::httpd::reply>>(
-                    fut.get_exception());
-              }
-              auto result = fut.get0();
-              rep->write_body("application/json", std::move(result.content));
-              rep->done();
-              return seastar::make_ready_future<
-                  std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
-            });
+            .then_wrapped(
+                [rep = std::move(rep)](
+                    seastar::future<admin_query_result>&& fut) mutable {
+                  return return_reply_with_result(std::move(rep),
+                                                  std::move(fut));
+                });
       }
     } else if (method == "GET") {
       if (req->param.exists("graph_name") &&
@@ -106,35 +91,21 @@ class admin_http_graph_handler_impl : public seastar::httpd::handler_base {
         auto graph_name = req->param.at("graph_name");
         return admin_actor_refs_[dst_executor]
             .run_get_graph_schema(query_param{std::move(graph_name)})
-            .then_wrapped([rep = std::move(rep)](
-                              seastar::future<query_result>&& fut) mutable {
-              if (__builtin_expect(fut.failed(), false)) {
-                return seastar::make_exception_future<
-                    std::unique_ptr<seastar::httpd::reply>>(
-                    fut.get_exception());
-              }
-              auto result = fut.get0();
-              rep->write_body("application/json", std::move(result.content));
-              rep->done();
-              return seastar::make_ready_future<
-                  std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
-            });
+            .then_wrapped(
+                [rep = std::move(rep)](
+                    seastar::future<admin_query_result>&& fut) mutable {
+                  return return_reply_with_result(std::move(rep),
+                                                  std::move(fut));
+                });
       } else {
         return admin_actor_refs_[dst_executor]
             .run_list_graphs(query_param{std::move(req->content)})
-            .then_wrapped([rep = std::move(rep)](
-                              seastar::future<query_result>&& fut) mutable {
-              if (__builtin_expect(fut.failed(), false)) {
-                return seastar::make_exception_future<
-                    std::unique_ptr<seastar::httpd::reply>>(
-                    fut.get_exception());
-              }
-              auto result = fut.get0();
-              rep->write_body("application/json", std::move(result.content));
-              rep->done();
-              return seastar::make_ready_future<
-                  std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
-            });
+            .then_wrapped(
+                [rep = std::move(rep)](
+                    seastar::future<admin_query_result>&& fut) mutable {
+                  return return_reply_with_result(std::move(rep),
+                                                  std::move(fut));
+                });
       }
     } else if (method == "DELETE") {
       if (!req->param.exists("graph_name")) {
@@ -146,16 +117,8 @@ class admin_http_graph_handler_impl : public seastar::httpd::handler_base {
       return admin_actor_refs_[dst_executor]
           .run_delete_graph(query_param{std::move(graph_name)})
           .then_wrapped([rep = std::move(rep)](
-                            seastar::future<query_result>&& fut) mutable {
-            if (__builtin_expect(fut.failed(), false)) {
-              return seastar::make_exception_future<
-                  std::unique_ptr<seastar::httpd::reply>>(fut.get_exception());
-            }
-            auto result = fut.get0();
-            rep->write_body("application/json", std::move(result.content));
-            rep->done();
-            return seastar::make_ready_future<
-                std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
+                            seastar::future<admin_query_result>&& fut) mutable {
+            return return_reply_with_result(std::move(rep), std::move(fut));
           });
     } else {
       return seastar::make_exception_future<
@@ -220,37 +183,23 @@ class admin_http_procedure_handler_impl : public seastar::httpd::handler_base {
         return admin_actor_refs_[dst_executor]
             .get_procedure_by_procedure_name(
                 procedure_query_param{std::move(pair)})
-            .then_wrapped([rep = std::move(rep)](
-                              seastar::future<query_result>&& fut) mutable {
-              if (__builtin_expect(fut.failed(), false)) {
-                return seastar::make_exception_future<
-                    std::unique_ptr<seastar::httpd::reply>>(
-                    fut.get_exception());
-              }
-              auto result = fut.get0();
-              rep->write_body("application/json", std::move(result.content));
-              rep->done();
-              return seastar::make_ready_future<
-                  std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
-            });
+            .then_wrapped(
+                [rep = std::move(rep)](
+                    seastar::future<admin_query_result>&& fut) mutable {
+                  return return_reply_with_result(std::move(rep),
+                                                  std::move(fut));
+                });
       } else {
         // get all procedures.
         LOG(INFO) << "Get all procedures for: " << graph_name;
         return admin_actor_refs_[dst_executor]
             .get_procedures_by_graph_name(query_param{std::move(graph_name)})
-            .then_wrapped([rep = std::move(rep)](
-                              seastar::future<query_result>&& fut) mutable {
-              if (__builtin_expect(fut.failed(), false)) {
-                return seastar::make_exception_future<
-                    std::unique_ptr<seastar::httpd::reply>>(
-                    fut.get_exception());
-              }
-              auto result = fut.get0();
-              rep->write_body("application/json", std::move(result.content));
-              rep->done();
-              return seastar::make_ready_future<
-                  std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
-            });
+            .then_wrapped(
+                [rep = std::move(rep)](
+                    seastar::future<admin_query_result>&& fut) mutable {
+                  return return_reply_with_result(std::move(rep),
+                                                  std::move(fut));
+                });
       }
     } else if (req->_method == "POST") {
       if (!req->param.exists("graph_name")) {
@@ -267,16 +216,8 @@ class admin_http_procedure_handler_impl : public seastar::httpd::handler_base {
           .create_procedure(create_procedure_query_param{
               std::make_pair(graph_name, std::move(req->content))})
           .then_wrapped([rep = std::move(rep)](
-                            seastar::future<query_result>&& fut) mutable {
-            if (__builtin_expect(fut.failed(), false)) {
-              return seastar::make_exception_future<
-                  std::unique_ptr<seastar::httpd::reply>>(fut.get_exception());
-            }
-            auto result = fut.get0();
-            rep->write_body("application/json", std::move(result.content));
-            rep->done();
-            return seastar::make_ready_future<
-                std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
+                            seastar::future<admin_query_result>&& fut) mutable {
+            return return_reply_with_result(std::move(rep), std::move(fut));
           });
     } else if (req->_method == "DELETE") {
       // delete must give graph_name and procedure_name
@@ -299,16 +240,8 @@ class admin_http_procedure_handler_impl : public seastar::httpd::handler_base {
           .delete_procedure(
               procedure_query_param{std::make_pair(graph_name, procedure_name)})
           .then_wrapped([rep = std::move(rep)](
-                            seastar::future<query_result>&& fut) mutable {
-            if (__builtin_expect(fut.failed(), false)) {
-              return seastar::make_exception_future<
-                  std::unique_ptr<seastar::httpd::reply>>(fut.get_exception());
-            }
-            auto result = fut.get0();
-            rep->write_body("application/json", std::move(result.content));
-            rep->done();
-            return seastar::make_ready_future<
-                std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
+                            seastar::future<admin_query_result>&& fut) mutable {
+            return return_reply_with_result(std::move(rep), std::move(fut));
           });
     } else if (req->_method == "PUT") {
       if (!req->param.exists("graph_name") ||
@@ -330,16 +263,8 @@ class admin_http_procedure_handler_impl : public seastar::httpd::handler_base {
           .update_procedure(update_procedure_query_param{
               std::make_tuple(graph_name, procedure_name, req->content)})
           .then_wrapped([rep = std::move(rep)](
-                            seastar::future<query_result>&& fut) mutable {
-            if (__builtin_expect(fut.failed(), false)) {
-              return seastar::make_exception_future<
-                  std::unique_ptr<seastar::httpd::reply>>(fut.get_exception());
-            }
-            auto result = fut.get0();
-            rep->write_body("application/json", std::move(result.content));
-            rep->done();
-            return seastar::make_ready_future<
-                std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
+                            seastar::future<admin_query_result>&& fut) mutable {
+            return return_reply_with_result(std::move(rep), std::move(fut));
           });
     } else {
       return seastar::make_exception_future<
@@ -395,19 +320,12 @@ class admin_http_service_handler_impl : public seastar::httpd::handler_base {
       if (action == "start" || action == "restart") {
         return admin_actor_refs_[dst_executor]
             .start_service(query_param{std::move(req->content)})
-            .then_wrapped([rep = std::move(rep)](
-                              seastar::future<query_result>&& fut) mutable {
-              if (__builtin_expect(fut.failed(), false)) {
-                return seastar::make_exception_future<
-                    std::unique_ptr<seastar::httpd::reply>>(
-                    fut.get_exception());
-              }
-              auto result = fut.get0();
-              rep->write_body("application/json", std::move(result.content));
-              rep->done();
-              return seastar::make_ready_future<
-                  std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
-            });
+            .then_wrapped(
+                [rep = std::move(rep)](
+                    seastar::future<admin_query_result>&& fut) mutable {
+                  return return_reply_with_result(std::move(rep),
+                                                  std::move(fut));
+                });
       } else if (action == "stop") {
         return admin_actor_refs_[dst_executor]
             .stop_service(query_param{std::move(req->content)})
@@ -435,17 +353,8 @@ class admin_http_service_handler_impl : public seastar::httpd::handler_base {
       return admin_actor_refs_[dst_executor]
           .service_status(query_param{std::move(req->content)})
           .then_wrapped([rep = std::move(rep)](
-                            seastar::future<query_result>&& fut) mutable {
-            if (__builtin_expect(fut.failed(), false)) {
-              return seastar::make_exception_future<
-                  std::unique_ptr<seastar::httpd::reply>>(fut.get_exception());
-            }
-            auto result = fut.get0();
-            LOG(INFO) << "Service status: " << result.content;
-            rep->write_body("application/json", std::move(result.content));
-            rep->done();
-            return seastar::make_ready_future<
-                std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
+                            seastar::future<admin_query_result>&& fut) mutable {
+            return return_reply_with_result(std::move(rep), std::move(fut));
           });
     }
   }
@@ -485,17 +394,8 @@ class admin_http_node_handler_impl : public seastar::httpd::handler_base {
       return admin_actor_refs_[dst_executor]
           .node_status(query_param{std::move(req->content)})
           .then_wrapped([rep = std::move(rep)](
-                            seastar::future<query_result>&& fut) mutable {
-            if (__builtin_expect(fut.failed(), false)) {
-              return seastar::make_exception_future<
-                  std::unique_ptr<seastar::httpd::reply>>(fut.get_exception());
-            }
-            auto result = fut.get0();
-            LOG(INFO) << "Node status: " << result.content;
-            rep->write_body("application/json", std::move(result.content));
-            rep->done();
-            return seastar::make_ready_future<
-                std::unique_ptr<seastar::httpd::reply>>(std::move(rep));
+                            seastar::future<admin_query_result>&& fut) mutable {
+            return return_reply_with_result(std::move(rep), std::move(fut));
           });
     } else {
       return seastar::make_exception_future<

--- a/flex/engines/http_server/handler/admin_http_handler.h
+++ b/flex/engines/http_server/handler/admin_http_handler.h
@@ -19,6 +19,7 @@
 #include <boost/property_tree/json_parser.hpp>
 #include <seastar/http/httpd.hh>
 #include <string>
+#include "flex/engines/http_server/handler/http_utils.h"
 #include "flex/engines/http_server/types.h"
 #include "flex/utils/service_utils.h"
 

--- a/flex/engines/http_server/handler/http_utils.cc
+++ b/flex/engines/http_server/handler/http_utils.cc
@@ -1,0 +1,105 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flex/engines/http_server/handler/http_utils.h"
+
+namespace server {
+
+seastar::future<std::unique_ptr<seastar::httpd::reply>> new_bad_request_reply(
+    std::unique_ptr<seastar::httpd::reply> rep, const std::string& msg) {
+  rep->set_status(seastar::httpd::reply::status_type::bad_request);
+  rep->write_body("application/json", seastar::sstring(msg));
+  rep->done();
+  return seastar::make_ready_future<std::unique_ptr<seastar::httpd::reply>>(
+      std::move(rep));
+}
+
+seastar::httpd::reply::status_type status_code_to_http_code(
+    gs::StatusCode code) {
+  switch (code) {
+  case gs::StatusCode::OK:
+    return seastar::httpd::reply::status_type::ok;
+  case gs::StatusCode::InValidArgument:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::UnsupportedOperator:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::AlreadyExists:
+    return seastar::httpd::reply::status_type::conflict;
+  case gs::StatusCode::NotExists:
+    return seastar::httpd::reply::status_type::not_found;
+  case gs::StatusCode::CodegenError:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  case gs::StatusCode::UninitializedStatus:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  case gs::StatusCode::InvalidSchema:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::PermissionError:
+    return seastar::httpd::reply::status_type::forbidden;
+  case gs::StatusCode::IllegalOperation:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::InternalError:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  case gs::StatusCode::InvalidImportFile:
+    return seastar::httpd::reply::status_type::bad_request;
+  case gs::StatusCode::IOError:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  case gs::StatusCode::NotFound:
+    return seastar::httpd::reply::status_type::not_found;
+  case gs::StatusCode::QueryFailed:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  default:
+    return seastar::httpd::reply::status_type::internal_server_error;
+  }
+}
+
+seastar::future<std::unique_ptr<seastar::httpd::reply>>
+catch_exception_and_return_reply(std::unique_ptr<seastar::httpd::reply> rep,
+                                 std::exception_ptr ex) {
+  try {
+    std::rethrow_exception(ex);
+  } catch (std::exception& e) {
+    LOG(ERROR) << "Exception: " << e.what();
+    seastar::sstring what = e.what();
+    rep->write_body("application/json", std::move(what));
+    rep->set_status(seastar::httpd::reply::status_type::bad_request);
+    rep->done();
+    return seastar::make_ready_future<std::unique_ptr<seastar::httpd::reply>>(
+        std::move(rep));
+  }
+}
+
+seastar::future<std::unique_ptr<seastar::httpd::reply>>
+return_reply_with_result(std::unique_ptr<seastar::httpd::reply> rep,
+                         seastar::future<admin_query_result>&& fut) {
+  if (__builtin_expect(fut.failed(), false)) {
+    return catch_exception_and_return_reply(std::move(rep),
+                                            fut.get_exception());
+  }
+  auto&& result = fut.get0();
+  auto status_code =
+      status_code_to_http_code(result.content.status().error_code());
+  rep->set_status(status_code);
+  if (status_code == seastar::httpd::reply::status_type::ok) {
+    rep->write_body("application/json", std::move(result.content.value()));
+  } else {
+    rep->write_body("application/json",
+                    seastar::sstring(result.content.status().error_message()));
+  }
+  rep->done();
+  return seastar::make_ready_future<std::unique_ptr<seastar::httpd::reply>>(
+      std::move(rep));
+}
+
+}  // namespace server

--- a/flex/engines/http_server/handler/http_utils.h
+++ b/flex/engines/http_server/handler/http_utils.h
@@ -1,0 +1,40 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "flex/engines/http_server/types.h"
+#include "flex/utils/result.h"
+#include "seastar/http/reply.hh"
+
+#ifndef ENGINES_HTTP_SERVER_HANDLER_HTTP_UTILS_H_
+#define ENGINES_HTTP_SERVER_HANDLER_HTTP_UTILS_H_
+
+namespace server {
+
+seastar::future<std::unique_ptr<seastar::httpd::reply>> new_bad_request_reply(
+    std::unique_ptr<seastar::httpd::reply> rep, const std::string& msg);
+
+seastar::httpd::reply::status_type status_code_to_http_code(
+    gs::StatusCode code);
+
+seastar::future<std::unique_ptr<seastar::httpd::reply>>
+catch_exception_and_return_reply(std::unique_ptr<seastar::httpd::reply> rep,
+                                 std::exception_ptr ex);
+
+seastar::future<std::unique_ptr<seastar::httpd::reply>>
+return_reply_with_result(std::unique_ptr<seastar::httpd::reply> rep,
+                         seastar::future<admin_query_result>&& fut);
+
+}  // namespace server
+
+#endif  // ENGINES_HTTP_SERVER_HANDLER_HTTP_UTILS_H_


### PR DESCRIPTION
- Internally use `Result<>` to store the runtime error, and map the error to http code at `admin_http_handler`.
- Extract commonly used code into utils function `http_utils.h`.