### PR TITLE
fix(interactive): Fix Bug of Duplicated Plan Id Generation After Failover

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/RpcExecutionClient.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/RpcExecutionClient.java
@@ -64,7 +64,7 @@ public class RpcExecutionClient extends ExecutionClient<RpcChannel> {
                         .build();
         PegasusClient.JobConfig jobConfig =
                 PegasusClient.JobConfig.newBuilder()
-                        .setJobId(request.getRequestId())
+                        .setJobId(request.getRequestId().longValue())
                         .setJobName(request.getRequestName())
                         .setWorkers(PegasusConfig.PEGASUS_WORKER_NUM.get(graphConfig))
                         .setBatchSize(PegasusConfig.PEGASUS_BATCH_SIZE.get(graphConfig))

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/type/ExecutionRequest.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/type/ExecutionRequest.java
@@ -19,17 +19,19 @@ package com.alibaba.graphscope.common.client.type;
 import com.alibaba.graphscope.common.ir.runtime.PhysicalPlan;
 import com.alibaba.graphscope.common.ir.tools.LogicalPlan;
 
+import java.math.BigInteger;
+
 /**
  * request to submit to remote engine service
  */
 public class ExecutionRequest {
-    private final long requestId;
+    private final BigInteger requestId;
     private final String requestName;
     private final LogicalPlan requestLogical;
     private final PhysicalPlan requestPhysical;
 
     public ExecutionRequest(
-            long requestId,
+            BigInteger requestId,
             String requestName,
             LogicalPlan requestLogical,
             PhysicalPlan requestPhysical) {
@@ -39,7 +41,7 @@ public class ExecutionRequest {
         this.requestPhysical = requestPhysical;
     }
 
-    public long getRequestId() {
+    public BigInteger getRequestId() {
         return requestId;
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/QueryIdGenerator.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/QueryIdGenerator.java
@@ -17,25 +17,43 @@
 package com.alibaba.graphscope.common.ir.tools;
 
 import com.alibaba.graphscope.common.config.Configs;
-import com.alibaba.graphscope.common.config.FrontendConfig;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.math.BigInteger;
+import java.security.SecureRandom;
 
 public class QueryIdGenerator {
     private final Configs configs;
-    private final AtomicLong idGenerator;
+    private final SecureRandom idGenerator;
 
     public QueryIdGenerator(Configs configs) {
         this.configs = configs;
-        this.idGenerator = new AtomicLong(FrontendConfig.FRONTEND_SERVER_ID.get(configs));
+        this.idGenerator = new SecureRandom();
     }
 
-    public long generateId() {
-        long delta = FrontendConfig.FRONTEND_SERVER_NUM.get(configs);
-        return idGenerator.getAndAdd(delta);
+    /**
+     * The function is to assign a unique job id for the query, which needs to ensure uniqueness in time and space.
+     * Specifically, for queries a and b, the following two cases are required to not produce duplicate plan ids:
+     *  1. When query a and b are sent to the same frontend but at different times;
+     *  2. When query a and b are sent to different frontends, regardless if the timestamps are the same or not;
+     *
+     * This requires us to implement the functionality of UUID. The default Java {@link java.util.UUID} is composed of 128 bits,
+     * with the first 64 bits determined by timestamp and the latter 64 bits composed of MAC address plus other items.
+     * However, our job id is made up of 64 bits, and converting 128 bits into 64 bits might compromise the uniqueness of the id;
+     *
+     * Therefore, we adopt another method similar to random number generation. We use Java’s built-in {@link java.security.SecureRandom},
+     * which can directly generate a random 64-bit id through {@link SecureRandom#nextLong()}. SecureRandom is a method of pseudo-random generation,
+     * that is, deterministic generation of a random sequence with a random seed determined by a combination of timestamp + machine physical properties,
+     * which basically meets our needs for plan id.
+     *
+     * @return Here, we use {@link BigInteger} to store the returned 64-bit UUID, which will be further converted to uint64 when being sent to the Pegasus engine.
+     */
+    public BigInteger generateId() {
+        byte[] bytes = new byte[8];
+        idGenerator.nextBytes(bytes);
+        return new BigInteger(1, bytes);
     }
 
-    public String generateName(long uniqueId) {
+    public String generateName(BigInteger uniqueId) {
         return "ir_plan_" + uniqueId;
     }
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/executor/GraphQueryExecutor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/executor/GraphQueryExecutor.java
@@ -44,6 +44,7 @@ import org.neo4j.values.virtual.MapValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -114,7 +115,7 @@ public class GraphQueryExecutor extends FabricExecutor {
             Preconditions.checkArgument(
                     cacheValue != null,
                     "value should have been loaded automatically in query cache");
-            long jobId = idGenerator.generateId();
+            BigInteger jobId = idGenerator.generateId();
             String jobName = idGenerator.generateName(jobId);
             GraphPlanner.Summary planSummary =
                     new GraphPlanner.Summary(

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/processor/IrTestOpProcessor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/processor/IrTestOpProcessor.java
@@ -53,6 +53,7 @@ import org.apache.tinkerpop.gremlin.util.function.ThrowingConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 
@@ -119,7 +120,7 @@ public class IrTestOpProcessor extends IrStandardOpProcessor {
                                             ? true
                                             : false;
                             String script = getScript(byteCode, removeQuoteInExpr);
-                            long queryId = idGenerator.generateId();
+                            BigInteger queryId = idGenerator.generateId();
                             String queryName = idGenerator.generateName(queryId);
                             IrMeta irMeta = metaQueryCallback.beforeExec();
                             QueryStatusCallback statusCallback =

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/QueryLogger.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/QueryLogger.java
@@ -19,14 +19,16 @@ package com.alibaba.graphscope.gremlin.plugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigInteger;
+
 public class QueryLogger {
     private static final Logger defaultLogger = LoggerFactory.getLogger(QueryLogger.class);
     private static Logger metricLogger = LoggerFactory.getLogger("MetricLog");
 
     private final String query;
-    private final long queryId;
+    private final BigInteger queryId;
 
-    public QueryLogger(String query, long queryId) {
+    public QueryLogger(String query, BigInteger queryId) {
         this.query = query;
         this.queryId = queryId;
     }
@@ -60,7 +62,7 @@ public class QueryLogger {
         return query;
     }
 
-    public long getQueryId() {
+    public BigInteger getQueryId() {
         return queryId;
     }
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/LifeCycleSupplier.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/LifeCycleSupplier.java
@@ -33,6 +33,7 @@ import com.google.common.base.Preconditions;
 import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
 import org.apache.tinkerpop.gremlin.server.Context;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -41,7 +42,7 @@ public class LifeCycleSupplier implements Supplier<GremlinExecutor.LifeCycle> {
     private final QueryCache queryCache;
     private final ExecutionClient client;
     private final Context ctx;
-    private final long queryId;
+    private final BigInteger queryId;
     private final String queryName;
     private final IrMeta meta;
     private final QueryStatusCallback statusCallback;
@@ -52,7 +53,7 @@ public class LifeCycleSupplier implements Supplier<GremlinExecutor.LifeCycle> {
             Context ctx,
             QueryCache queryCache,
             ExecutionClient client,
-            long queryId,
+            BigInteger queryId,
             String queryName,
             IrMeta meta,
             QueryStatusCallback statusCallback,


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
Re-implement `QueryIdGenerator` strategy to avoid duplicated plan id generation after failover. The new implemented function is to assign a unique job id for the query, which needs to ensure uniqueness in time and space. 

Specifically, for queries a and b, the following two cases are required not to produce duplicated plan ids:
1. When query a and b are sent to the same frontend but at different times;
2. When query a and b are sent to different frontends, regardless if the timestamps are the same or not;

This requires us to implement the functionality of `UUID`. The default Java `UUID` is composed of 128 bits, with the first 64 bits determined by timestamp and the latter 64 bits composed of MAC address plus other items. However, our job id is made up of 64 bits, and converting 128 bits into 64 bits might compromise the uniqueness of the id;

Therefore, we adopt another method similar to random number generation. We use Java’s built-in `SecureRandom`, which can directly generate a random 64-bit id through `SecureRandom#nextLong()`. `SecureRandom` is a method of pseudo-random generation, that is, deterministic generation of a random sequence with a random seed determined by a combination of timestamp + machine physical properties, which basically meets our needs for plan id.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #3702 

