### PR TITLE
refactor(interactive): Rename two temporal types, Date and Day to TimeStamp and Date

### DIFF
--- a/flex/codegen/src/graph_types.h
+++ b/flex/codegen/src/graph_types.h
@@ -113,6 +113,8 @@ static std::string single_common_data_type_pb_2_str(
     return "std::vector<int32_t>";
   case common::DataType::DATE32:
     return "Date";
+  case common::DataType::TIMESTAMP:
+    return "TimeStamp";
     // TODO: support time32 and timestamp
   default:
     throw std::runtime_error(
@@ -196,6 +198,8 @@ static std::string data_type_2_string(const codegen::DataType& data_type) {
     return LENGTH_KEY_T;
   case codegen::DataType::kEdgeId:
     return EDGE_ID_T;
+  case codegen::DataType::kTimeStamp:
+    return "TimeStamp";
   case codegen::DataType::kDate:
     return "Date";
   case codegen::DataType::kLabelId:

--- a/flex/engines/graph_db/database/transaction_utils.h
+++ b/flex/engines/graph_db/database/transaction_utils.h
@@ -32,9 +32,9 @@ inline void serialize_field(grape::InArchive& arc, const Any& prop) {
     arc << prop.value.i;
   } else if (prop.type == PropertyType::UInt32()) {
     arc << prop.value.ui;
-  } else if (prop.type == PropertyType::Date()) {
+  } else if (prop.type == PropertyType::TimeStamp()) {
     arc << prop.value.d.milli_second;
-  } else if (prop.type == PropertyType::Day()) {
+  } else if (prop.type == PropertyType::Date()) {
     arc << prop.value.day.to_u32();
   } else if (prop.type == PropertyType::String()) {
     arc << prop.value.s;
@@ -59,11 +59,11 @@ inline void deserialize_field(grape::OutArchive& arc, Any& prop) {
     arc >> prop.value.i;
   } else if (prop.type == PropertyType::UInt32()) {
     arc >> prop.value.ui;
-  } else if (prop.type == PropertyType::Date()) {
+  } else if (prop.type == PropertyType::TimeStamp()) {
     int64_t date_val;
     arc >> date_val;
     prop.value.d.milli_second = date_val;
-  } else if (prop.type == PropertyType::Day()) {
+  } else if (prop.type == PropertyType::Date()) {
     uint32_t val;
     arc >> val;
     prop.value.day.from_u32(val);

--- a/flex/engines/hqps_db/core/null_record.h
+++ b/flex/engines/hqps_db/core/null_record.h
@@ -52,6 +52,15 @@ struct NullRecordCreator<TimeStamp> {
 };
 
 template <>
+struct NullRecordCreator<Date> {
+  static inline Date GetNull() {
+    Date date;
+    date.from_u32(std::numeric_limits<int32_t>::max());
+    return date;
+  }
+};
+
+template <>
 struct NullRecordCreator<Any> {
   static inline Any GetNull() { return Any(); }
 };

--- a/flex/engines/hqps_db/core/null_record.h
+++ b/flex/engines/hqps_db/core/null_record.h
@@ -45,9 +45,9 @@ struct NullRecordCreator<std::string_view> {
 };
 
 template <>
-struct NullRecordCreator<Date> {
-  static inline Date GetNull() {
-    return Date(std::numeric_limits<int64_t>::max());
+struct NullRecordCreator<TimeStamp> {
+  static inline TimeStamp GetNull() {
+    return TimeStamp(std::numeric_limits<int64_t>::max());
   }
 };
 

--- a/flex/engines/hqps_db/core/operator/sink.h
+++ b/flex/engines/hqps_db/core/operator/sink.h
@@ -146,8 +146,8 @@ void template_set_value(common::Value* value, T v) {
 }
 
 template <typename T, typename std::enable_if<
-                          (std::is_same_v<T, gs::Date>)>::type* = nullptr>
-void template_set_value(common::Value* value, gs::Date v) {
+                          (std::is_same_v<T, gs::TimeStamp>)>::type* = nullptr>
+void template_set_value(common::Value* value, gs::TimeStamp v) {
   value->set_i64(v.milli_second);
 }
 
@@ -210,7 +210,7 @@ void set_any_to_element(const Any& any, results::Element* element) {
     element->mutable_object()->set_f64(any.value.db);
   } else if (any.type == PropertyType::Float()) {
     element->mutable_object()->set_f64(any.value.f);
-  } else if (any.type == PropertyType::Date()) {
+  } else if (any.type == PropertyType::TimeStamp()) {
     element->mutable_object()->set_i64(any.value.d.milli_second);
   } else if (any.type == PropertyType::String()) {
     element->mutable_object()->mutable_str()->assign(any.value.s.data(),
@@ -258,7 +258,7 @@ void set_any_to_common_value(const Any& any, common::Value* value) {
     value->set_f64(any.value.db);
   } else if (any.type == PropertyType::Float()) {
     value->set_f64(any.value.f);
-  } else if (any.type == PropertyType::Date()) {
+  } else if (any.type == PropertyType::TimeStamp()) {
     value->set_i64(any.value.d.milli_second);
   } else if (any.type == PropertyType::String()) {
     value->mutable_str()->assign(any.value.s.data(), any.value.s.size());
@@ -292,7 +292,7 @@ void set_edge_property(results::Edge* edge, const std::string& prop_name,
 }
 // set date
 void set_edge_property(results::Edge* edge, const std::string& prop_name,
-                       const std::tuple<gs::Date>& value) {
+                       const std::tuple<gs::TimeStamp>& value) {
   auto prop = edge->add_properties();
   prop->mutable_value()->set_i64(std::get<0>(value).milli_second);
   prop->mutable_key()->set_name(prop_name);

--- a/flex/engines/hqps_db/core/operator/sink.h
+++ b/flex/engines/hqps_db/core/operator/sink.h
@@ -151,6 +151,12 @@ void template_set_value(common::Value* value, gs::TimeStamp v) {
   value->set_i64(v.milli_second);
 }
 
+template <typename T, typename std::enable_if<
+                          (std::is_same_v<T, gs::Date>)>::type* = nullptr>
+void template_set_value(common::Value* value, gs::Date v) {
+  value->set_i64(v.to_timestamp());
+}
+
 template <size_t Is = 0, typename... T>
 void template_set_tuple_value_impl(results::Collection* collection,
                                    const std::tuple<T...>& t) {

--- a/flex/engines/hqps_db/core/params.h
+++ b/flex/engines/hqps_db/core/params.h
@@ -385,11 +385,11 @@ enum Interval {
 template <Interval interval>
 struct DateTimeExtractor;
 
-// Extract Year, month, day, hour, minute, second from Date
+// Extract Year, month, day, hour, minute, second from TimeStamp
 
 template <>
 struct DateTimeExtractor<Interval::YEAR> {
-  static int32_t extract(const Date& date) {
+  static int32_t extract(const TimeStamp& date) {
     auto micro_second = date.milli_second / 1000;
     struct tm tm;
     gmtime_r((time_t*) (&micro_second), &tm);
@@ -399,7 +399,7 @@ struct DateTimeExtractor<Interval::YEAR> {
 
 template <>
 struct DateTimeExtractor<Interval::MONTH> {
-  static int32_t extract(const Date& date) {
+  static int32_t extract(const TimeStamp& date) {
     auto micro_second = date.milli_second / 1000;
     struct tm tm;
     gmtime_r((time_t*) (&micro_second), &tm);
@@ -409,7 +409,7 @@ struct DateTimeExtractor<Interval::MONTH> {
 
 template <>
 struct DateTimeExtractor<Interval::DAY> {
-  static int32_t extract(const Date& date) {
+  static int32_t extract(const TimeStamp& date) {
     auto micro_second = date.milli_second / 1000;
     struct tm tm;
     gmtime_r((time_t*) (&micro_second), &tm);
@@ -419,7 +419,7 @@ struct DateTimeExtractor<Interval::DAY> {
 
 template <>
 struct DateTimeExtractor<Interval::HOUR> {
-  static int32_t extract(const Date& date) {
+  static int32_t extract(const TimeStamp& date) {
     auto micro_second = date.milli_second / 1000;
     struct tm tm;
     gmtime_r((time_t*) (&micro_second), &tm);
@@ -429,7 +429,7 @@ struct DateTimeExtractor<Interval::HOUR> {
 
 template <>
 struct DateTimeExtractor<Interval::MINUTE> {
-  static int32_t extract(const Date& date) {
+  static int32_t extract(const TimeStamp& date) {
     auto micro_second = date.milli_second / 1000;
     struct tm tm;
     gmtime_r((time_t*) (&micro_second), &tm);
@@ -439,7 +439,7 @@ struct DateTimeExtractor<Interval::MINUTE> {
 
 template <>
 struct DateTimeExtractor<Interval::SECOND> {
-  static int32_t extract(const Date& date) {
+  static int32_t extract(const TimeStamp& date) {
     auto micro_second = date.milli_second / 1000;
     struct tm tm;
     gmtime_r((time_t*) (&micro_second), &tm);

--- a/flex/engines/hqps_db/core/params.h
+++ b/flex/engines/hqps_db/core/params.h
@@ -395,6 +395,8 @@ struct DateTimeExtractor<Interval::YEAR> {
     gmtime_r((time_t*) (&micro_second), &tm);
     return tm.tm_year + 1900;
   }
+
+  static int32_t extract(const Date& date) { return date.year(); }
 };
 
 template <>
@@ -405,6 +407,8 @@ struct DateTimeExtractor<Interval::MONTH> {
     gmtime_r((time_t*) (&micro_second), &tm);
     return tm.tm_mon + 1;
   }
+
+  static int32_t extract(const Date& date) { return date.month(); }
 };
 
 template <>
@@ -415,6 +419,8 @@ struct DateTimeExtractor<Interval::DAY> {
     gmtime_r((time_t*) (&micro_second), &tm);
     return tm.tm_mday;
   }
+
+  static int32_t extract(const Date& date) { return date.day(); }
 };
 
 template <>

--- a/flex/engines/hqps_db/core/utils/hqps_utils.h
+++ b/flex/engines/hqps_db/core/utils/hqps_utils.h
@@ -780,8 +780,8 @@ struct to_string_impl<Dist> {
 };
 
 template <>
-struct to_string_impl<Date> {
-  static inline std::string to_string(const Date& empty) {
+struct to_string_impl<TimeStamp> {
+  static inline std::string to_string(const TimeStamp& empty) {
     return std::to_string(empty.milli_second);
   }
 };

--- a/flex/engines/hqps_db/database/mutable_csr_interface.h
+++ b/flex/engines/hqps_db/database/mutable_csr_interface.h
@@ -881,8 +881,8 @@ class MutableCSRInterface {
       return std::make_shared<TypedRefColumn<uint64_t>>(
           *std::dynamic_pointer_cast<TypedColumn<uint64_t>>(column));
     } else if (type == PropertyType::kDate) {
-      return std::make_shared<TypedRefColumn<Date>>(
-          *std::dynamic_pointer_cast<TypedColumn<Date>>(column));
+      return std::make_shared<TypedRefColumn<TimeStamp>>(
+          *std::dynamic_pointer_cast<TypedColumn<TimeStamp>>(column));
     } else if (type == PropertyType::kString) {
       return std::make_shared<TypedRefColumn<std::string_view>>(
           *std::dynamic_pointer_cast<TypedColumn<std::string_view>>(column));

--- a/flex/engines/hqps_db/database/mutable_csr_interface.h
+++ b/flex/engines/hqps_db/database/mutable_csr_interface.h
@@ -880,7 +880,7 @@ class MutableCSRInterface {
     } else if (type == PropertyType::kUInt64) {
       return std::make_shared<TypedRefColumn<uint64_t>>(
           *std::dynamic_pointer_cast<TypedColumn<uint64_t>>(column));
-    } else if (type == PropertyType::kDate) {
+    } else if (type == PropertyType::kTimeStamp) {
       return std::make_shared<TypedRefColumn<TimeStamp>>(
           *std::dynamic_pointer_cast<TypedColumn<TimeStamp>>(column));
     } else if (type == PropertyType::kString) {
@@ -889,6 +889,9 @@ class MutableCSRInterface {
     } else if (type == PropertyType::kFloat) {
       return std::make_shared<TypedRefColumn<float>>(
           *std::dynamic_pointer_cast<TypedColumn<float>>(column));
+    } else if (type == PropertyType::kDate) {
+      return std::make_shared<TypedRefColumn<Date>>(
+          *std::dynamic_pointer_cast<TypedColumn<Date>>(column));
     } else {
       LOG(FATAL) << "unexpected type to create column, "
                  << static_cast<int>(type.type_enum);

--- a/flex/storages/rt_mutable_graph/csr/mutable_csr.cc
+++ b/flex/storages/rt_mutable_graph/csr/mutable_csr.cc
@@ -32,8 +32,8 @@ template class MutableCsr<int32_t>;
 template class SingleMutableCsr<uint32_t>;
 template class MutableCsr<uint32_t>;
 
-template class SingleMutableCsr<Date>;
-template class MutableCsr<Date>;
+template class SingleMutableCsr<TimeStamp>;
+template class MutableCsr<TimeStamp>;
 
 template class SingleMutableCsr<int64_t>;
 template class MutableCsr<int64_t>;

--- a/flex/storages/rt_mutable_graph/csr/nbr.h
+++ b/flex/storages/rt_mutable_graph/csr/nbr.h
@@ -50,7 +50,7 @@ struct ImmutableNbr {
 };
 
 template <>
-struct __attribute__((packed)) ImmutableNbr<Date> {
+struct __attribute__((packed)) ImmutableNbr<TimeStamp> {
   ImmutableNbr() = default;
   ImmutableNbr(const ImmutableNbr& rhs)
       : neighbor(rhs.neighbor), data(rhs.data) {}
@@ -62,16 +62,16 @@ struct __attribute__((packed)) ImmutableNbr<Date> {
     return *this;
   }
 
-  const Date& get_data() const { return data; }
+  const TimeStamp& get_data() const { return data; }
   vid_t get_neighbor() const { return neighbor; }
 
-  void set_data(const Date& val) { data = val; }
+  void set_data(const TimeStamp& val) { data = val; }
   void set_neighbor(vid_t neighbor) { this->neighbor = neighbor; }
 
   bool exists() const { return neighbor != std::numeric_limits<vid_t>::max(); }
 
   vid_t neighbor;
-  Date data;
+  TimeStamp data;
 };
 
 template <>

--- a/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.cc
@@ -82,10 +82,10 @@ void set_vertex_properties(gs::ColumnBase* col,
     set_single_vertex_column<float>(col, array, vids);
   } else if (col_type == PropertyType::kStringMap) {
     set_vertex_column_from_string_array(col, array, vids);
-  } else if (col_type == PropertyType::kDate) {
+  } else if (col_type == PropertyType::kTimeStamp) {
     set_vertex_column_from_timestamp_array(col, array, vids);
-  } else if (col_type == PropertyType::kDay) {
-    set_vertex_column_from_timestamp_array_to_day(col, array, vids);
+  } else if (col_type == PropertyType::kDate) {
+    set_vertex_column_from_timestamp_array_to_date(col, array, vids);
   } else if (col_type.type_enum == impl::PropertyTypeImpl::kVarChar) {
     set_vertex_column_from_string_array(col, array, vids);
   } else {
@@ -104,8 +104,9 @@ void set_vertex_column_from_timestamp_array(
       auto casted =
           std::static_pointer_cast<arrow::TimestampArray>(array->chunk(j));
       for (auto k = 0; k < casted->length(); ++k) {
-        col->set_any(vids[cur_ind++],
-                     std::move(AnyConverter<Date>::to_any(casted->Value(k))));
+        col->set_any(
+            vids[cur_ind++],
+            std::move(AnyConverter<TimeStamp>::to_any(casted->Value(k))));
       }
     }
   } else {
@@ -114,7 +115,7 @@ void set_vertex_column_from_timestamp_array(
   }
 }
 
-void set_vertex_column_from_timestamp_array_to_day(
+void set_vertex_column_from_timestamp_array_to_date(
     gs::ColumnBase* col, std::shared_ptr<arrow::ChunkedArray> array,
     const std::vector<vid_t>& vids) {
   auto type = array->type();
@@ -126,7 +127,7 @@ void set_vertex_column_from_timestamp_array_to_day(
           std::static_pointer_cast<arrow::TimestampArray>(array->chunk(j));
       for (auto k = 0; k < casted->length(); ++k) {
         col->set_any(vids[cur_ind++],
-                     std::move(AnyConverter<Day>::to_any(casted->Value(k))));
+                     std::move(AnyConverter<Date>::to_any(casted->Value(k))));
       }
     }
   } else {
@@ -247,13 +248,13 @@ void AbstractArrowFragmentLoader::AddEdgesRecordBatch(
       addEdgesRecordBatchImpl<bool>(src_label_i, dst_label_i, edge_label_i,
                                     filenames, supplier_creator);
     }
-  } else if (property_types[0] == PropertyType::kDate) {
+  } else if (property_types[0] == PropertyType::kTimeStamp) {
     if (filenames.empty()) {
-      basic_fragment_loader_.AddNoPropEdgeBatch<Date>(src_label_i, dst_label_i,
-                                                      edge_label_i);
+      basic_fragment_loader_.AddNoPropEdgeBatch<TimeStamp>(
+          src_label_i, dst_label_i, edge_label_i);
     } else {
-      addEdgesRecordBatchImpl<Date>(src_label_i, dst_label_i, edge_label_i,
-                                    filenames, supplier_creator);
+      addEdgesRecordBatchImpl<TimeStamp>(src_label_i, dst_label_i, edge_label_i,
+                                         filenames, supplier_creator);
     }
   } else if (property_types[0] == PropertyType::kInt32) {
     if (filenames.empty()) {

--- a/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.h
+++ b/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.h
@@ -69,7 +69,7 @@ void set_vertex_column_from_timestamp_array(
     gs::ColumnBase* col, std::shared_ptr<arrow::ChunkedArray> array,
     const std::vector<vid_t>& vids);
 
-void set_vertex_column_from_timestamp_array_to_day(
+void set_vertex_column_from_timestamp_array_to_date(
     gs::ColumnBase* col, std::shared_ptr<arrow::ChunkedArray> array,
     const std::vector<vid_t>& vids);
 

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -88,7 +88,7 @@ inline DualCsrBase* create_csr(EdgeStrategy oes, EdgeStrategy ies,
     } else if (properties[0] == PropertyType::kUInt32) {
       return new DualCsr<uint32_t>(oes, ies, oe_mutable, ie_mutable);
     } else if (properties[0] == PropertyType::kDate) {
-      return new DualCsr<Date>(oes, ies, oe_mutable, ie_mutable);
+      return new DualCsr<TimeStamp>(oes, ies, oe_mutable, ie_mutable);
     } else if (properties[0] == PropertyType::kInt64) {
       return new DualCsr<int64_t>(oes, ies, oe_mutable, ie_mutable);
     } else if (properties[0] == PropertyType::kUInt64) {

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -442,8 +442,8 @@ std::string PropertyTypeToString(PropertyType type) {
     return DT_BOOL;
   } else if (type == PropertyType::kDate) {
     return DT_DATE;
-  } else if (type == PropertyType::kDay) {
-    return DT_DAY;
+  } else if (type == PropertyType::kTimeStamp) {
+    return DT_TIMESTAMP;
   } else if (type == PropertyType::kString) {
     return DT_STRING;
   } else if (type == PropertyType::kStringMap) {
@@ -470,10 +470,10 @@ PropertyType StringToPropertyType(const std::string& str) {
     return PropertyType::kUInt32;
   } else if (str == "bool" || str == "BOOL" || str == DT_BOOL) {
     return PropertyType::kBool;
+  } else if (str == "TimeStamp" || str == DT_TIMESTAMP) {
+    return PropertyType::kTimeStamp;
   } else if (str == "Date" || str == DT_DATE) {
     return PropertyType::kDate;
-  } else if (str == "Day" || str == DT_DAY) {
-    return PropertyType::kDay;
   } else if (str == "String" || str == "STRING" || str == DT_STRING) {
     // DT_STRING is a alias for VARCHAR(STRING_DEFAULT_MAX_LENGTH);
     return PropertyType::Varchar(PropertyType::STRING_DEFAULT_MAX_LENGTH);
@@ -545,10 +545,10 @@ static bool parse_property_type(YAML::Node node, PropertyType& type) {
     return true;
   } else if (node["date"]) {
     auto format = node["date"].as<std::string>();
-    prop_type_str = DT_DATE;
+    prop_type_str = DT_TIMESTAMP;
   } else if (node["day"]) {
     auto format = node["day"].as<std::string>();
-    prop_type_str = DT_DAY;
+    prop_type_str = DT_DATE;
   } else {
     return false;
   }

--- a/flex/storages/rt_mutable_graph/types.h
+++ b/flex/storages/rt_mutable_graph/types.h
@@ -42,7 +42,7 @@ static constexpr const char* DT_DOUBLE = "DT_DOUBLE";
 static constexpr const char* DT_STRING = "DT_STRING";
 static constexpr const char* DT_STRINGMAP = "DT_STRINGMAP";
 static constexpr const char* DT_DATE = "DT_DATE32";
-static constexpr const char* DT_DAY = "DT_DAY32";
+static constexpr const char* DT_TIMESTAMP = "TIMESTAMP";
 
 }  // namespace gs
 

--- a/flex/tests/hqps/match_query.h
+++ b/flex/tests/hqps/match_query.h
@@ -835,7 +835,7 @@ struct MatchQuery13Expr0 {
   using result_t = bool;
   MatchQuery13Expr0() {}
 
-  inline auto operator()(Date var0) const {
+  inline auto operator()(TimeStamp var0) const {
     return gs::DateTimeExtractor<Interval::MONTH>::extract(var0) == 7;
   }
 
@@ -847,7 +847,7 @@ struct MatchQuery13Expr1 {
   using result_t = int64_t;
   MatchQuery13Expr1() {}
 
-  inline auto operator()(Date var1) const {
+  inline auto operator()(TimeStamp var1) const {
     return gs::DateTimeExtractor<Interval::MONTH>::extract(var1);
   }
 
@@ -868,16 +868,16 @@ class MatchQuery13 : public AppBase {
     auto ctx1 = Engine::Project<PROJ_TO_NEW>(
         graph, std::move(ctx0),
         std::tuple{gs::make_mapper_with_variable<INPUT_COL_ID(0)>(
-            gs::PropertySelector<Date>("birthday"))});
+            gs::PropertySelector<TimeStamp>("birthday"))});
     auto expr0 = gs::make_filter(MatchQuery13Expr0(),
-                                 gs::PropertySelector<Date>("None"));
+                                 gs::PropertySelector<TimeStamp>("None"));
     auto ctx2 = Engine::template Select<INPUT_COL_ID(0)>(graph, std::move(ctx1),
                                                          std::move(expr0));
 
     auto ctx3 = Engine::Project<PROJ_TO_NEW>(
         graph, std::move(ctx2),
         std::tuple{gs::make_mapper_with_expr<0>(
-            MatchQuery13Expr1(), gs::PropertySelector<Date>("None"))});
+            MatchQuery13Expr1(), gs::PropertySelector<TimeStamp>("None"))});
     return Engine::Sink(graph, ctx3, std::array<int32_t, 1>{2});
   }
   // Wrapper query function for query class

--- a/flex/utils/arrow_utils.cc
+++ b/flex/utils/arrow_utils.cc
@@ -30,9 +30,9 @@ std::shared_ptr<arrow::DataType> PropertyTypeToArrowType(PropertyType type) {
     return arrow::float64();
   } else if (type == PropertyType::Float()) {
     return arrow::float32();
-  } else if (type == PropertyType::Date()) {
+  } else if (type == PropertyType::TimeStamp()) {
     return arrow::timestamp(arrow::TimeUnit::MILLI);
-  } else if (type == PropertyType::Day()) {
+  } else if (type == PropertyType::Date()) {
     return arrow::timestamp(arrow::TimeUnit::MILLI);
   } else if (type == PropertyType::String()) {
     return arrow::large_utf8();

--- a/flex/utils/arrow_utils.h
+++ b/flex/utils/arrow_utils.h
@@ -179,7 +179,8 @@ class LDBCLongDateParser : public arrow::TimestampParser {
   const char* format() const override { return "LongDateFormat"; }
 };
 
-// convert c++ type to arrow type. support other types likes emptyType, Date
+// convert c++ type to arrow type. support other types likes emptyType,
+// TimeStamp
 template <typename T>
 struct TypeConverter;
 
@@ -273,7 +274,7 @@ struct TypeConverter<std::string_view> {
 };
 
 template <>
-struct TypeConverter<Date> {
+struct TypeConverter<TimeStamp> {
   static PropertyType property_type() { return PropertyType::kDate; }
   using ArrowType = arrow::TimestampType;
   using ArrowArrayType = arrow::TimestampArray;
@@ -283,8 +284,8 @@ struct TypeConverter<Date> {
 };
 
 template <>
-struct TypeConverter<Day> {
-  static PropertyType property_type() { return PropertyType::kDay; }
+struct TypeConverter<Date> {
+  static PropertyType property_type() { return PropertyType::kDate; }
   using ArrowType = arrow::TimestampType;
   using ArrowArrayType = arrow::TimestampArray;
   static std::shared_ptr<arrow::DataType> ArrowTypeValue() {

--- a/flex/utils/property/column.cc
+++ b/flex/utils/property/column.cc
@@ -102,8 +102,8 @@ using IntEmptyColumn = TypedEmptyColumn<int32_t>;
 using UIntEmptyColumn = TypedEmptyColumn<uint32_t>;
 using LongEmptyColumn = TypedEmptyColumn<int64_t>;
 using ULongEmptyColumn = TypedEmptyColumn<uint64_t>;
+using TimeStampEmptyColumn = TypedEmptyColumn<TimeStamp>;
 using DateEmptyColumn = TypedEmptyColumn<Date>;
-using DayEmptyColumn = TypedEmptyColumn<Day>;
 using BoolEmptyColumn = TypedEmptyColumn<bool>;
 using FloatEmptyColumn = TypedEmptyColumn<float>;
 using DoubleEmptyColumn = TypedEmptyColumn<double>;
@@ -128,8 +128,8 @@ std::shared_ptr<ColumnBase> CreateColumn(PropertyType type,
       return std::make_shared<FloatEmptyColumn>();
     } else if (type == PropertyType::kDate) {
       return std::make_shared<DateEmptyColumn>();
-    } else if (type == PropertyType::kDay) {
-      return std::make_shared<DayEmptyColumn>();
+    } else if (type == PropertyType::kTimeStamp) {
+      return std::make_shared<TimeStampEmptyColumn>();
     } else if (type == PropertyType::kStringMap) {
       return std::make_shared<StringEmptyColumn>();
     } else if (type.type_enum == impl::PropertyTypeImpl::kVarChar) {
@@ -157,8 +157,8 @@ std::shared_ptr<ColumnBase> CreateColumn(PropertyType type,
       return std::make_shared<FloatColumn>(strategy);
     } else if (type == PropertyType::kDate) {
       return std::make_shared<DateColumn>(strategy);
-    } else if (type == PropertyType::kDay) {
-      return std::make_shared<DayColumn>(strategy);
+    } else if (type == PropertyType::kTimeStamp) {
+      return std::make_shared<TimeStampColumn>(strategy);
     } else if (type == PropertyType::kStringMap) {
       return std::make_shared<StringMapColumn<uint8_t>>(strategy);
     } else if (type == PropertyType::kString) {

--- a/flex/utils/property/column.h
+++ b/flex/utils/property/column.h
@@ -227,7 +227,7 @@ using UIntColumn = TypedColumn<uint32_t>;
 using LongColumn = TypedColumn<int64_t>;
 using ULongColumn = TypedColumn<uint64_t>;
 using DateColumn = TypedColumn<Date>;
-using DayColumn = TypedColumn<Day>;
+using TimeStampColumn = TypedColumn<TimeStamp>;
 using DoubleColumn = TypedColumn<double>;
 using FloatColumn = TypedColumn<float>;
 

--- a/flex/utils/property/types.cc
+++ b/flex/utils/property/types.cc
@@ -42,8 +42,8 @@ const PropertyType PropertyType::kDouble =
     PropertyType(impl::PropertyTypeImpl::kDouble);
 const PropertyType PropertyType::kDate =
     PropertyType(impl::PropertyTypeImpl::kDate);
-const PropertyType PropertyType::kDay =
-    PropertyType(impl::PropertyTypeImpl::kDay);
+const PropertyType PropertyType::kTimeStamp =
+    PropertyType(impl::PropertyTypeImpl::kTimeStamp);
 const PropertyType PropertyType::kString =
     PropertyType(impl::PropertyTypeImpl::kString);
 const PropertyType PropertyType::kStringMap =
@@ -108,11 +108,11 @@ PropertyType PropertyType::UInt64() {
 PropertyType PropertyType::Double() {
   return PropertyType(impl::PropertyTypeImpl::kDouble);
 }
+PropertyType PropertyType::TimeStamp() {
+  return PropertyType(impl::PropertyTypeImpl::kTimeStamp);
+}
 PropertyType PropertyType::Date() {
   return PropertyType(impl::PropertyTypeImpl::kDate);
-}
-PropertyType PropertyType::Day() {
-  return PropertyType(impl::PropertyTypeImpl::kDay);
 }
 PropertyType PropertyType::String() {
   return PropertyType(impl::PropertyTypeImpl::kString);
@@ -170,9 +170,9 @@ grape::InArchive& operator<<(grape::InArchive& in_archive, const Any& value) {
     in_archive << value.type << value.value.ul;
   } else if (value.type == PropertyType::Double()) {
     in_archive << value.type << value.value.db;
-  } else if (value.type == PropertyType::Date()) {
+  } else if (value.type == PropertyType::TimeStamp()) {
     in_archive << value.type << value.value.d.milli_second;
-  } else if (value.type == PropertyType::Day()) {
+  } else if (value.type == PropertyType::Date()) {
     in_archive << value.type << value.value.day.to_u32();
   } else if (value.type == PropertyType::String()) {
     in_archive << value.type << value.value.s;
@@ -208,11 +208,11 @@ grape::OutArchive& operator>>(grape::OutArchive& out_archive, Any& value) {
     out_archive >> value.value.ul;
   } else if (value.type == PropertyType::Double()) {
     out_archive >> value.value.db;
+  } else if (value.type == PropertyType::TimeStamp()) {
+    int64_t ts;
+    out_archive >> ts;
+    value.value.d.milli_second = ts;
   } else if (value.type == PropertyType::Date()) {
-    int64_t date_val;
-    out_archive >> date_val;
-    value.value.d.milli_second = date_val;
-  } else if (value.type == PropertyType::Day()) {
     uint32_t val;
     out_archive >> val;
     value.value.day.from_u32(val);
@@ -291,28 +291,27 @@ GlobalId::vid_t GlobalId::vid() const {
 
 std::string GlobalId::to_string() const { return std::to_string(global_id); }
 
-Date::Date(int64_t x) : milli_second(x) {}
+TimeStamp::TimeStamp(int64_t x) : milli_second(x) {}
 
-std::string Date::to_string() const { return std::to_string(milli_second); }
+std::string TimeStamp::to_string() const { return std::to_string(milli_second); }
 
-Day::Day(int64_t ts) { from_timestamp(ts); }
+Date::Date(int64_t ts) { from_timestamp(ts); }
 
-std::string Day::to_string() const {
+std::string Date::to_string() const {
   return std::to_string(static_cast<int>(year())) + "-" +
          std::to_string(static_cast<int>(month())) + "-" +
          std::to_string(static_cast<int>(day()));
 }
 
-uint32_t Day::to_u32() const { return value.integer; }
+uint32_t Date::to_u32() const { return value.integer; }
 
-void Day::from_u32(uint32_t val) { value.integer = val; }
+void Date::from_u32(uint32_t val) { value.integer = val; }
 
-int Day::year() const { return value.internal.year; }
+int Date::year() const { return value.internal.year; }
 
-int Day::month() const { return value.internal.month; }
+int Date::month() const { return value.internal.month; }
 
-int Day::day() const { return value.internal.day; }
+int Date::day() const { return value.internal.day; }
 
-int Day::hour() const { return value.internal.hour; }
 
 }  // namespace gs


### PR DESCRIPTION
Currently Interactive support two temporal data types,
- Date
- Day

However, the naming of these two types doesn't really match its implementation. The struct `Date` actually stores a timestamp(in million second), the struct `Day` actually stores a Date(Year, Month and Day).


- This PR **will also change the** the data type usage in graph schema. 
- This PR may affect the previously written stored procedures, where `set_day` and `set_date` maybe used. Should be changed to `set_date` and `set_timestamp`.