### PR TITLE
refactor(interactive): add plugin into graph meta

### DIFF
--- a/flex/engines/http_server/workdir_manipulator.cc
+++ b/flex/engines/http_server/workdir_manipulator.cc
@@ -365,7 +365,7 @@ WorkDirManipulator::GetProcedureByGraphAndProcedureName(
         "Fail to load graph schema: " + schema_file + ", error: " + e.what()));
   }
   // get yaml file in plugin directory.
-  auto plugin_dir = get_graph_plugin_dir(graph_id);
+  auto plugin_dir = GetGraphPluginDir(graph_id);
   if (!std::filesystem::exists(plugin_dir)) {
     return gs::Result<seastar::sstring>(gs::Status(
         gs::StatusCode::NotExists,
@@ -398,7 +398,7 @@ seastar::future<seastar::sstring> WorkDirManipulator::CreateProcedure(
                                                         graph_name);
   }
   // check procedure exits
-  auto plugin_dir = get_graph_plugin_dir(graph_name);
+  auto plugin_dir = GetGraphPluginDir(graph_name);
   if (!std::filesystem::exists(plugin_dir)) {
     try {
       std::filesystem::create_directory(plugin_dir);
@@ -436,7 +436,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::DeleteProcedure(
         gs::StatusCode::NotExists, "Graph not exists: " + graph_name));
   }
   // remove the plugin file and dynamic lib
-  auto plugin_dir = get_graph_plugin_dir(graph_name);
+  auto plugin_dir = GetGraphPluginDir(graph_name);
   if (!std::filesystem::exists(plugin_dir)) {
     return gs::Result<seastar::sstring>(gs::Status(
         gs::StatusCode::NotExists,
@@ -475,7 +475,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::UpdateProcedure(
     const std::string& graph_name, const std::string& procedure_name,
     const std::string& parameters) {
   // check procedure exits.
-  auto plugin_dir = get_graph_plugin_dir(graph_name);
+  auto plugin_dir = GetGraphPluginDir(graph_name);
   if (!std::filesystem::exists(plugin_dir)) {
     return gs::Result<seastar::sstring>(gs::Status(
         gs::StatusCode::NotExists,
@@ -558,7 +558,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::GetProcedureLibPath(
         gs::StatusCode::NotExists, "Graph not exists: " + graph_name));
   }
   // get the plugin dir and append procedure_name
-  auto plugin_dir = get_graph_plugin_dir(graph_name);
+  auto plugin_dir = GetGraphPluginDir(graph_name);
   if (!std::filesystem::exists(plugin_dir)) {
     return gs::Result<seastar::sstring>(gs::Status(
         gs::StatusCode::NotExists,
@@ -660,7 +660,7 @@ std::string WorkDirManipulator::get_graph_indices_file(
          GRAPH_INDICES_FILE_NAME;
 }
 
-std::string WorkDirManipulator::get_graph_plugin_dir(
+std::string WorkDirManipulator::GetGraphPluginDir(
     const std::string& graph_name) {
   return get_graph_dir(graph_name) + "/" + GRAPH_PLUGIN_DIR_NAME;
 }
@@ -882,7 +882,7 @@ seastar::future<seastar::sstring> WorkDirManipulator::generate_procedure(
     return seastar::make_exception_future<seastar::sstring>(
         std::runtime_error("Graph not exists: " + graph_id));
   }
-  auto output_dir = get_graph_plugin_dir(graph_id);
+  auto output_dir = GetGraphPluginDir(graph_id);
   if (!std::filesystem::exists(output_dir)) {
     std::filesystem::create_directory(output_dir);
   }
@@ -940,7 +940,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::get_all_procedure_yamls(
     const std::string& graph_name,
     const std::vector<std::string>& procedure_names) {
   YAML::Node yaml_list;
-  auto plugin_dir = get_graph_plugin_dir(graph_name);
+  auto plugin_dir = GetGraphPluginDir(graph_name);
   // iterate all .yamls in plugin_dir
   if (std::filesystem::exists(plugin_dir)) {
     for (const auto& entry : std::filesystem::directory_iterator(plugin_dir)) {
@@ -990,7 +990,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::get_all_procedure_yamls(
 gs::Result<seastar::sstring> WorkDirManipulator::get_all_procedure_yamls(
     const std::string& graph_name) {
   YAML::Node yaml_list;
-  auto plugin_dir = get_graph_plugin_dir(graph_name);
+  auto plugin_dir = GetGraphPluginDir(graph_name);
   // iterate all .yamls in plugin_dir
   if (std::filesystem::exists(plugin_dir)) {
     for (const auto& entry : std::filesystem::directory_iterator(plugin_dir)) {
@@ -1025,7 +1025,7 @@ gs::Result<seastar::sstring> WorkDirManipulator::get_all_procedure_yamls(
 gs::Result<seastar::sstring> WorkDirManipulator::get_procedure_yaml(
     const std::string& graph_name, const std::string& procedure_name) {
   auto procedure_yaml_file =
-      get_graph_plugin_dir(graph_name) + "/" + procedure_name + ".yaml";
+      GetGraphPluginDir(graph_name) + "/" + procedure_name + ".yaml";
   if (!std::filesystem::exists(procedure_yaml_file)) {
     LOG(ERROR) << "Procedure yaml file not exists: " << procedure_yaml_file;
     return gs::Result<seastar::sstring>(

--- a/flex/engines/http_server/workdir_manipulator.h
+++ b/flex/engines/http_server/workdir_manipulator.h
@@ -199,14 +199,6 @@ class WorkDirManipulator {
   static gs::Result<std::string> dump_graph_schema(
       const YAML::Node& yaml_config, const std::string& graph_name);
 
-  static gs::Result<bool> dump_graph_schema_v0_0(
-      YAML::Node yaml_config, const std::string& graph_id,
-      const std::vector<gs::PluginMeta>& plugin_metas);
-
-  static gs::Result<bool> dump_graph_schema_v0_1(
-      YAML::Node yaml_config, const std::string& graph_id,
-      const std::vector<gs::PluginMeta>& plugin_metas);
-
   // Generate the procedure, return the generated yaml config.
   static seastar::future<seastar::sstring> generate_procedure(
       const std::string& graph_id, const std::string& plugin_id,

--- a/flex/engines/http_server/workdir_manipulator.h
+++ b/flex/engines/http_server/workdir_manipulator.h
@@ -155,6 +155,8 @@ class WorkDirManipulator {
 
   static std::string GetGraphIndicesDir(const std::string& graph_name);
 
+  static std::string GetGraphPluginDir(const std::string& graph_name);
+
   static std::string GetLogDir();
 
   static std::string GetCompilerLogFile();
@@ -188,8 +190,6 @@ class WorkDirManipulator {
 
   static std::string get_graph_lock_file(const std::string& graph_name);
 
-  static std::string get_graph_plugin_dir(const std::string& graph_name);
-
   static std::string get_graph_dir(const std::string& graph_name);
 
   static bool is_graph_exist(const std::string& graph_name);
@@ -198,6 +198,14 @@ class WorkDirManipulator {
 
   static gs::Result<std::string> dump_graph_schema(
       const YAML::Node& yaml_config, const std::string& graph_name);
+
+  static gs::Result<bool> dump_graph_schema_v0_0(
+      YAML::Node yaml_config, const std::string& graph_id,
+      const std::vector<gs::PluginMeta>& plugin_metas);
+
+  static gs::Result<bool> dump_graph_schema_v0_1(
+      YAML::Node yaml_config, const std::string& graph_id,
+      const std::vector<gs::PluginMeta>& plugin_metas);
 
   // Generate the procedure, return the generated yaml config.
   static seastar::future<seastar::sstring> generate_procedure(

--- a/flex/storages/metadata/graph_meta_store.cc
+++ b/flex/storages/metadata/graph_meta_store.cc
@@ -69,6 +69,11 @@ std::string GraphMeta::ToJson() const {
     json["data_import_config"] = nlohmann::json::parse(data_import_config);
   }
   json["schema"] = nlohmann::json::parse(schema);
+  json["stored_procedures"] = nlohmann::json::array();
+  for (auto& plugin_meta : plugin_metas) {
+    json["stored_procedures"].push_back(
+        nlohmann::json::parse(plugin_meta.ToJson()));
+  }
   return json.dump();
 }
 
@@ -97,6 +102,11 @@ GraphMeta GraphMeta::FromJson(const nlohmann::json& json) {
   }
   if (json.contains("data_import_config")) {
     meta.data_import_config = json["data_import_config"].dump();
+  }
+  if (json.contains("stored_procedures")) {
+    for (auto& plugin : json["stored_procedures"]) {
+      meta.plugin_metas.push_back(PluginMeta::FromJson(plugin));
+    }
   }
   return meta;
 }
@@ -132,6 +142,12 @@ PluginMeta PluginMeta::FromJson(const nlohmann::json& json) {
   }
   if (json.contains("library")) {
     meta.library = json["library"].get<std::string>();
+  }
+  if (json.contains("query")) {
+    meta.query = json["query"].get<std::string>();
+  }
+  if (json.contains("type")) {
+    meta.type = json["type"].get<std::string>();
   }
   if (json.contains("option")) {
     meta.setOptionFromJsonString(json["option"].dump());
@@ -178,6 +194,9 @@ std::string PluginMeta::ToJson() const {
   json["update_time"] = update_time;
   json["enable"] = enable;
   json["runnable"] = runnable;
+  json["library"] = library;
+  json["query"] = query;
+  json["type"] = type;
   return json.dump();
 }
 
@@ -394,6 +413,8 @@ std::string CreatePluginMetaRequest::ToString() const {
   for (auto& opt : option) {
     json["option"][opt.first] = opt.second;
   }
+  json["query"] = query;
+  json["type"] = type;
   json["enable"] = enable;
   return json.dump();
 }
@@ -457,6 +478,12 @@ CreatePluginMetaRequest CreatePluginMetaRequest::FromJson(
       request.option[opt.key()] = opt.value().get<std::string>();
     }
   }
+  if (j.contains("query")) {
+    request.query = j["query"].get<std::string>();
+  }
+  if (j.contains("type")) {
+    request.type = j["type"].get<std::string>();
+  }
   if (j.contains("enable")) {
     request.enable = j["enable"].get<bool>();
   }
@@ -486,31 +513,30 @@ UpdatePluginMetaRequest UpdatePluginMetaRequest::FromJson(
       request.update_time = GetCurrentTimeStamp();
     }
     if (j.contains("params")) {
-      request.params.emplace();
+      request.params = std::vector<Parameter>();
       for (auto& param : j["params"]) {
         Parameter p;
         p.name = param["name"].get<std::string>();
         p.type = config_parsing::StringToPropertyType(
             param["type"].get<std::string>());
 
-        request.params->emplace_back(p);
+        request.params->emplace_back(std::move(p));
       }
     }
     if (j.contains("returns")) {
-      request.returns.emplace();
+      request.returns = std::vector<Parameter>();
       for (auto& ret : j["returns"]) {
         Parameter p;
         p.name = ret["name"].get<std::string>();
         p.type = config_parsing::StringToPropertyType(
             ret["type"].get<std::string>());
-        request.returns->emplace_back(p);
+        request.returns->emplace_back(std::move(p));
       }
     }
     if (j.contains("library")) {
       request.library = j["library"].get<std::string>();
     }
     if (j.contains("option")) {
-      request.option.emplace();
       for (auto& opt : j["option"].items()) {
         request.option->insert({opt.key(), opt.value()});
       }
@@ -581,7 +607,7 @@ std::string UpdatePluginMetaRequest::ToString() const {
       nlohmann::json param_json;
       param_json["name"] = param.name;
       param_json["type"] = config_parsing::PropertyTypeToString(param.type);
-      json["params"].push_back(param_json);
+      json["params"].emplace_back(std::move(param_json));
     }
   }
 
@@ -591,7 +617,7 @@ std::string UpdatePluginMetaRequest::ToString() const {
       nlohmann::json ret_json;
       ret_json["name"] = ret.name;
       ret_json["type"] = config_parsing::PropertyTypeToString(ret.type);
-      json["returns"].push_back(ret_json);
+      json["returns"].emplace_back(std::move(ret_json));
     }
   }
   if (library.has_value()) {

--- a/flex/storages/metadata/graph_meta_store.cc
+++ b/flex/storages/metadata/graph_meta_store.cc
@@ -537,6 +537,7 @@ UpdatePluginMetaRequest UpdatePluginMetaRequest::FromJson(
       request.library = j["library"].get<std::string>();
     }
     if (j.contains("option")) {
+      request.option = std::unordered_map<std::string, std::string>();
       for (auto& opt : j["option"].items()) {
         request.option->insert({opt.key(), opt.value()});
       }

--- a/flex/storages/metadata/graph_meta_store.h
+++ b/flex/storages/metadata/graph_meta_store.h
@@ -54,6 +54,7 @@ enum class JobStatus {
 JobStatus parseFromString(const std::string& status_string);
 
 ////////////////// MetaData ///////////////////////
+struct PluginMeta;
 struct GraphMeta {
   GraphId id;
   std::string name;
@@ -63,6 +64,8 @@ struct GraphMeta {
   uint64_t data_update_time;
   std::string data_import_config;
   std::string schema;
+
+  std::vector<PluginMeta> plugin_metas;
 
   std::string ToJson() const;
   static GraphMeta FromJson(const std::string& json_str);
@@ -79,6 +82,8 @@ struct PluginMeta {
   std::string library;
   std::unordered_map<std::string, std::string>
       option;  // other optional configuration
+  std::string query;
+  std::string type;
 
   bool enable;    // whether the plugin is enabled.
   bool runnable;  // whether the plugin is runnable.
@@ -143,6 +148,8 @@ struct CreatePluginMetaRequest {
   std::vector<Parameter> returns;
   std::string library;
   std::unordered_map<std::string, std::string> option;
+  std::string query;
+  std::string type;
   bool enable;  // default true
 
   CreatePluginMetaRequest();


### PR DESCRIPTION
- Return the meta of plugins when retrieving a graph's metadata.
- AdminService can create graph from schema with no `type_id` and `property_id` specified.
- Add `query` and `type` field for stored procedure's meta.