### PR TITLE
feat(interactive): Adapt to new data type definition

### DIFF
--- a/.github/workflows/flex.yml
+++ b/.github/workflows/flex.yml
@@ -156,6 +156,16 @@ jobs:
         GLOG_v=10 ./bin/bulk_loader  -g ${SCHEMA_FILE} -l ${BULK_LOAD_FILE} -d /tmp/csr-data-dir/
         GLOG_v=10 ./tests/rt_mutable_graph/string_edge_property_test ${SCHEMA_FILE} /tmp/csr-data-dir/
 
+    - name: Test schema parsing and loading on modern graph
+      env:
+        FLEX_DATA_DIR: ${{ github.workspace }}/flex/interactive/examples/modern_graph/
+      run: |
+        rm -rf /tmp/csr-data-dir/
+        cd ${GITHUB_WORKSPACE}/flex/build/
+        SCHEMA_FILE=../tests/rt_mutable_graph/modern_graph_unified_schema.yaml
+        BULK_LOAD_FILE=../interactive/examples/modern_graph/bulk_load.yaml
+        GLOG_v=10 ./bin/bulk_loader  -g ${SCHEMA_FILE} -l ${BULK_LOAD_FILE} -d /tmp/csr-data-dir/
+
     - name: Test build empty graph
       run: |
         rm -rf /tmp/csr-data-dir/

--- a/docs/flex/interactive/custom_graph_data.md
+++ b/docs/flex/interactive/custom_graph_data.md
@@ -56,10 +56,12 @@ schema:
             primitive_type: DT_SIGNED_INT32
         - property_name: tagline
           property_type:
-            primitive_type: DT_STRING
+            string:
+              long_text:
         - property_name: title
           property_type:
-            primitive_type: DT_STRING
+            string:
+              long_text:
       primary_keys:
         - id
     - type_name: Person
@@ -72,7 +74,8 @@ schema:
             primitive_type: DT_SIGNED_INT32
         - property_name: name
           property_type:
-            primitive_type: DT_STRING
+            string:
+              long_text:
       primary_keys:
         - id
   edge_types:
@@ -120,8 +123,6 @@ Supported primitive data types for properties include:
 - DT_BOOL
 - DT_FLOAT
 - DT_DOUBLE
-- DT_STRING
-- DT_DATE32
 
 For a comprehensive list of supported types, please refer to the [data model](./data_model) page.
 

--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -21,7 +21,8 @@ Within the `graph.yaml` file, vertices are delineated under the `vertex_types` s
         primitive_type: DT_SIGNED_INT64
     - property_name: name
       property_type:
-        primitive_type: DT_STRING
+        string:
+          long_text:
   primary_keys: # these must also be listed in the properties
     - id  
 ```
@@ -66,20 +67,79 @@ Entity data pertains to the properties associated with vertices and edges. In Gr
 - DT_BOOL
 - DT_FLOAT
 - DT_DOUBLE
-- DT_STRING
-- DT_DATE32
 
-In the `graph.yaml`, a primitive type, such as `DT_STRING`, can be written as:
+In the `graph.yaml`, a primitive type, such as `DT_DOUBLE`, can be written as:
 ```yaml
 property_type:
-  primitive_type: DT_STRING
+  primitive_type: DT_DOUBLE
 ```
+
+### String Types
+
+
+We categorize string type into three subtypes:
+- `long_text`: A string type with no length limitation, allowing for unlimited text content.
+- `char`: A string type with a fixed length. The field defines an attribute fixed_length, which specifies the desired length of the string. The string will be restricted to the specified length.
+- `var_char`: A string type with variable length, bounded by a maximum length. The field defines an attribute max_length, which sets the maximum length of the string. The string will be limited to the specified maximum length.
+
+These three string type can be written in yaml as:
+
+```yaml
+string:
+  long_text: # string with unlimited length
+  char:  # string with fixed length
+    fixed_length: <uint32>
+  var_char:  # string with variable length, bounded by max_length
+    max_length: <uint32>
+```
+
+Users can choose the appropriate string type based on their requirements. The long_text type is suitable for handling text with unlimited length. The char type is useful for scenarios that require fixed-length strings. The var_char type is ideal for situations where the string length needs to be restricted and a maximum length is specified.
+
+Note: fixed-length char is currently not supported.
+
+
+### Temporal types
+
+Temporal types can be defined in the following ways:
+
+```yaml
+temporal:
+  date:
+    # optional value: DF_YYYY_MM_DD, means ISO fomat: 2019-01-01
+    date_format: <string> 
+  time:
+    # optional value: TF_HH_MM_SS_SSS, means ISO format: 00:00:00.000
+    time_format: <string>
+    # optional value: TZF_UTC, TZF_OFFSET
+    time_zone_format: <string>
+  date_time:
+    # optional value: DTF_YYYY_MM_DD_HH_MM_SS_SSS,
+    # means ISO format: 2019-01-01 00:00:00.000
+    date_time_format: <string>
+    time_zone_format: <string> # optional value: TZF_UTC, TZF_OFFSET
+  date32: # int32 days since 1970-01-01
+  time32: # int32 milliseconds past midnight
+  timestamp:  # int64 milliseconds since 1970-01-01 00:00:00.000000
+```
+
+Here is an explanation of each temporal type:
+- `date`: Denotes a date value. Optionally, the field date_format can be specified to define the format of the date. The date_format attribute could take a value like DF_YYYY_MM_DD, indicating the ISO format: "2019-01-01".
+- `time`: Represents a time value. Optionally, the field time_format can be used to specify the format of the time. The time_format attribute could take a value like TF_HH_MM_SS_SSS, indicating the ISO format: "00:00:00.000". The time_zone_format attribute can also be included to define the format of the time zone, with optional values of TZF_UTC or TZF_OFFSET.
+- `date_time`: Signifies a combination of date and time. The field date_time_format is optional and can be used to specify the format of the date and time. For example, a date_time_format value of DTF_YYYY_MM_DD_HH_MM_SS_SSS would indicate the ISO format: "2019-01-01 00:00:00.000". The time_zone_format attribute can additionally be specified to define the format of the time zone, with optional values of TZF_UTC or TZF_OFFSET.
+- `date32`: Represents the date as an integer, with the value being the number of days since January 1, 1970.
+- `time32`: Represents the time as an integer, representing the number of milliseconds past midnight.
+- `timestamp`: Denotes a timestamp as an integer, representing the number of milliseconds since January 1, 1970 at 00:00:00.000.
+
+This YAML structure allows users to select the appropriate data type and format for handling temporal data, such as dates, times, and timestamps. The optional attributes provide flexibility to define the desired format or timezone representation.
+
+Note: 
+- Currently we only support `date` and `timestamp`. The other types will be supported in the near future.
 
 ### Array Types
 
 Array types are currently not supported, but are planned to be supported in the near future.
 Once supported, albeit requiring that every element within the array adheres to one of the previously mentioned primitive types. 
-It's crucial that all elements within a single array share the same type. In `graph.yaml`, user can describe designating a property as an array of the `DT_STRING` type as:
+It's crucial that all elements within a single array share the same type. In `graph.yaml`, user can describe designating a property as an array of the `DT_UNSIGNED_INT64` type as:
 
 ```yaml
 property_type:

--- a/docs/flex/interactive/development/admin_service.md
+++ b/docs/flex/interactive/development/admin_service.md
@@ -74,14 +74,18 @@ curl -X GET -H "Content-Type: application/json" "http://[host]/v1/graph"
               "property_id": "1",
               "property_name": "name",
               "property_type": {
-                "primitive_type": "DT_STRING"
+                "string":{
+                  "long_text": {}
+                }
               }
             },
             {
               "property_id": "2",
               "property_name": "age",
               "property_type": {
-                "primitive_type": "DT_SIGNED_INT32"
+                "string":{
+                  "long_text": {}
+                }
               }
             }
           ],
@@ -104,14 +108,18 @@ curl -X GET -H "Content-Type: application/json" "http://[host]/v1/graph"
               "property_id": "1",
               "property_name": "name",
               "property_type": {
-                "primitive_type": "DT_STRING"
+                "string":{
+                  "long_text": {}
+                }
               }
             },
             {
               "property_id": "2",
               "property_name": "lang",
               "property_type": {
-                "primitive_type": "DT_STRING"
+                "string":{
+                  "long_text": {}
+                }
               }
             }
           ],
@@ -202,14 +210,18 @@ This API create a new graph according to the specified schema in request body.
                         "property_id": 1,
                         "property_name": "name",
                         "property_type": {
-                            "primitive_type": "DT_STRING"
+                            "string":{
+                              "long_text": {}
+                            }
                         }
                     },
                     {
                         "property_id": 2,
                         "property_name": "age",
                         "property_type": {
-                            "primitive_type": "DT_SIGNED_INT32"
+                            "string":{
+                              "long_text": {}
+                            }
                         }
                     }
                 ],
@@ -232,14 +244,18 @@ This API create a new graph according to the specified schema in request body.
                         "property_id": 1,
                         "property_name": "name",
                         "property_type": {
-                            "primitive_type": "DT_STRING"
+                            "string":{
+                              "long_text": {}
+                            }
                         }
                     },
                     {
                         "property_id": 2,
                         "property_name": "lang",
                         "property_type": {
-                            "primitive_type": "DT_STRING"
+                            "string":{
+                              "long_text": {}
+                            }
                         }
                     }
                 ],
@@ -380,14 +396,18 @@ curl -X GET  -H "Content-Type: application/json" "http://[host]/v1/graph/{graph_
                   "property_id": 1,
                   "property_name": "name",
                   "property_type": {
-                      "primitive_type": "DT_STRING"
+                      "string":{
+                          "long_text": {}
+                      }
                   }
               },
               {
                   "property_id": 2,
                   "property_name": "age",
                   "property_type": {
-                      "primitive_type": "DT_SIGNED_INT32"
+                      "string":{
+                          "long_text": {}
+                      }
                   }
               }
           ],
@@ -410,14 +430,18 @@ curl -X GET  -H "Content-Type: application/json" "http://[host]/v1/graph/{graph_
                   "property_id": 1,
                   "property_name": "name",
                   "property_type": {
-                      "primitive_type": "DT_STRING"
+                      "string":{
+                          "long_text": {}
+                      }
                   }
               },
               {
                   "property_id": 2,
                   "property_name": "lang",
                   "property_type": {
-                      "primitive_type": "DT_STRING"
+                      "string":{
+                          "long_text": {}
+                      }
                   }
               }
           ],

--- a/flex/storages/metadata/graph_meta_store.cc
+++ b/flex/storages/metadata/graph_meta_store.cc
@@ -53,7 +53,7 @@ UpdateGraphMetaRequest::UpdateGraphMetaRequest(
 std::string Parameter::ToJson() const {
   nlohmann::json json;
   json["name"] = name;
-  json["type"] = config_parsing::PropertyTypeToString(type);
+  json["type"] = type;  // calls to_json implicitly
   return json.dump();
 }
 
@@ -177,14 +177,14 @@ std::string PluginMeta::ToJson() const {
   for (auto& param : params) {
     nlohmann::json p;
     p["name"] = param.name;
-    p["type"] = config_parsing::PropertyTypeToString(param.type);
+    p["type"] = param.type;
     json["params"].push_back(p);
   }
   json["returns"] = nlohmann::json::array();
   for (auto& ret : returns) {
     nlohmann::json r;
     r["name"] = ret.name;
-    r["type"] = config_parsing::PropertyTypeToString(ret.type);
+    r["type"] = ret.type;
     json["returns"].push_back(r);
   }
   for (auto& opt : option) {
@@ -210,8 +210,7 @@ void PluginMeta::setParamsFromJsonString(const std::string& json_str) {
     for (auto& param : j) {
       Parameter p;
       p.name = param["name"].get<std::string>();
-      p.type = config_parsing::StringToPropertyType(
-          param["type"].get<std::string>());
+      p.type = param["type"].get<PropertyType>();
       params.push_back(p);
     }
   } else {
@@ -224,8 +223,7 @@ void PluginMeta::setReturnsFromJsonString(const std::string& json_str) {
   for (auto& ret : j) {
     Parameter p;
     p.name = ret["name"].get<std::string>();
-    p.type =
-        config_parsing::StringToPropertyType(ret["type"].get<std::string>());
+    p.type = ret["type"].get<PropertyType>();
     returns.push_back(p);
   }
 }
@@ -359,7 +357,7 @@ std::string CreatePluginMetaRequest::paramsString() const {
   for (auto& param : params) {
     nlohmann::json param_json;
     param_json["name"] = param.name;
-    param_json["type"] = config_parsing::PropertyTypeToString(param.type);
+    param_json["type"] = param.type;
     json.push_back(param_json);
   }
   return json.dump();
@@ -370,7 +368,7 @@ std::string CreatePluginMetaRequest::returnsString() const {
   for (auto& ret : returns) {
     nlohmann::json ret_json;
     ret_json["name"] = ret.name;
-    ret_json["type"] = config_parsing::PropertyTypeToString(ret.type);
+    ret_json["type"] = ret.type;
     json.push_back(ret_json);
   }
   return json.dump();
@@ -397,14 +395,14 @@ std::string CreatePluginMetaRequest::ToString() const {
   for (auto& param : params) {
     nlohmann::json param_json;
     param_json["name"] = param.name;
-    param_json["type"] = config_parsing::PropertyTypeToString(param.type);
+    param_json["type"] = param.type;
     json["params"].push_back(param_json);
   }
   json["returns"] = nlohmann::json::array();
   for (auto& ret : returns) {
     nlohmann::json ret_json;
     ret_json["name"] = ret.name;
-    ret_json["type"] = config_parsing::PropertyTypeToString(ret.type);
+    ret_json["type"] = ret.type;
     json["returns"].push_back(ret_json);
   }
 
@@ -456,8 +454,7 @@ CreatePluginMetaRequest CreatePluginMetaRequest::FromJson(
     for (auto& param : j["params"]) {
       Parameter p;
       p.name = param["name"].get<std::string>();
-      p.type = config_parsing::StringToPropertyType(
-          param["type"].get<std::string>());
+      p.type = param["type"].get<PropertyType>();
       request.params.push_back(p);
     }
   }
@@ -465,8 +462,7 @@ CreatePluginMetaRequest CreatePluginMetaRequest::FromJson(
     for (auto& ret : j["returns"]) {
       Parameter p;
       p.name = ret["name"].get<std::string>();
-      p.type =
-          config_parsing::StringToPropertyType(ret["type"].get<std::string>());
+      p.type = ret["type"].get<PropertyType>();
       request.returns.push_back(p);
     }
   }
@@ -517,8 +513,7 @@ UpdatePluginMetaRequest UpdatePluginMetaRequest::FromJson(
       for (auto& param : j["params"]) {
         Parameter p;
         p.name = param["name"].get<std::string>();
-        p.type = config_parsing::StringToPropertyType(
-            param["type"].get<std::string>());
+        p.type = param["type"].get<PropertyType>();
 
         request.params->emplace_back(std::move(p));
       }
@@ -528,8 +523,7 @@ UpdatePluginMetaRequest UpdatePluginMetaRequest::FromJson(
       for (auto& ret : j["returns"]) {
         Parameter p;
         p.name = ret["name"].get<std::string>();
-        p.type = config_parsing::StringToPropertyType(
-            ret["type"].get<std::string>());
+        p.type = ret["type"].get<PropertyType>();
         request.returns->emplace_back(std::move(p));
       }
     }
@@ -557,7 +551,7 @@ std::string UpdatePluginMetaRequest::paramsString() const {
     for (auto& param : params.value()) {
       nlohmann::json param_json;
       param_json["name"] = param.name;
-      param_json["type"] = config_parsing::PropertyTypeToString(param.type);
+      param_json["type"] = param.type;
       json.push_back(param_json);
     }
   }
@@ -570,7 +564,7 @@ std::string UpdatePluginMetaRequest::returnsString() const {
     for (auto& ret : returns.value()) {
       nlohmann::json ret_json;
       ret_json["name"] = ret.name;
-      ret_json["type"] = config_parsing::PropertyTypeToString(ret.type);
+      ret_json["type"] = ret.type;
       json.push_back(ret_json);
     }
   }
@@ -607,7 +601,7 @@ std::string UpdatePluginMetaRequest::ToString() const {
     for (auto& param : params.value()) {
       nlohmann::json param_json;
       param_json["name"] = param.name;
-      param_json["type"] = config_parsing::PropertyTypeToString(param.type);
+      param_json["type"] = param.type;
       json["params"].emplace_back(std::move(param_json));
     }
   }
@@ -617,7 +611,7 @@ std::string UpdatePluginMetaRequest::ToString() const {
     for (auto& ret : returns.value()) {
       nlohmann::json ret_json;
       ret_json["name"] = ret.name;
-      ret_json["type"] = config_parsing::PropertyTypeToString(ret.type);
+      ret_json["type"] = ret.type;
       json["returns"].emplace_back(std::move(ret_json));
     }
   }

--- a/flex/storages/rt_mutable_graph/README.md
+++ b/flex/storages/rt_mutable_graph/README.md
@@ -44,7 +44,8 @@ schema:
         - property_id: 1
           property_name: name
           property_type:
-            primitive_type: DT_STRING
+            string:
+              long_text:
         - property_id: 2
           property_name: age
           property_type:
@@ -62,11 +63,13 @@ schema:
         - property_id: 1
           property_name: name
           property_type:
-            primitive_type: DT_STRING
+            string:
+              long_text:
         - property_id: 2
           property_name: lang
           property_type:
-            primitive_type: DT_STRING
+            string:
+              long_text:
       primary_keys:
         - id
   edge_types:

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -433,66 +433,6 @@ bool Schema::Equals(const Schema& other) const {
 
 namespace config_parsing {
 
-std::string PropertyTypeToString(PropertyType type) {
-  if (type == PropertyType::kInt32) {
-    return DT_SIGNED_INT32;
-  } else if (type == PropertyType::kUInt32) {
-    return DT_UNSIGNED_INT32;
-  } else if (type == PropertyType::kBool) {
-    return DT_BOOL;
-  } else if (type == PropertyType::kDate) {
-    return DT_DATE;
-  } else if (type == PropertyType::kDay) {
-    return DT_DAY;
-  } else if (type == PropertyType::kString) {
-    return DT_STRING;
-  } else if (type == PropertyType::kStringMap) {
-    return DT_STRINGMAP;
-  } else if (type == PropertyType::kEmpty) {
-    return "Empty";
-  } else if (type == PropertyType::kInt64) {
-    return DT_SIGNED_INT64;
-  } else if (type == PropertyType::kUInt64) {
-    return DT_UNSIGNED_INT64;
-  } else if (type == PropertyType::kFloat) {
-    return DT_FLOAT;
-  } else if (type == PropertyType::kDouble) {
-    return DT_DOUBLE;
-  } else {
-    return "Empty";
-  }
-}
-
-PropertyType StringToPropertyType(const std::string& str) {
-  if (str == "int32" || str == "INT" || str == DT_SIGNED_INT32) {
-    return PropertyType::kInt32;
-  } else if (str == "uint32" || str == DT_UNSIGNED_INT32) {
-    return PropertyType::kUInt32;
-  } else if (str == "bool" || str == "BOOL" || str == DT_BOOL) {
-    return PropertyType::kBool;
-  } else if (str == "Date" || str == DT_DATE) {
-    return PropertyType::kDate;
-  } else if (str == "Day" || str == DT_DAY) {
-    return PropertyType::kDay;
-  } else if (str == "String" || str == "STRING" || str == DT_STRING) {
-    // DT_STRING is a alias for VARCHAR(STRING_DEFAULT_MAX_LENGTH);
-    return PropertyType::Varchar(PropertyType::STRING_DEFAULT_MAX_LENGTH);
-  } else if (str == DT_STRINGMAP) {
-    return PropertyType::kStringMap;
-  } else if (str == "Empty") {
-    return PropertyType::kEmpty;
-  } else if (str == "int64" || str == "LONG" || str == DT_SIGNED_INT64) {
-    return PropertyType::kInt64;
-  } else if (str == "uint64" || str == DT_UNSIGNED_INT64) {
-    return PropertyType::kUInt64;
-  } else if (str == "float" || str == "FLOAT" || str == DT_FLOAT) {
-    return PropertyType::kFloat;
-  } else if (str == "double" || str == "DOUBLE" || str == DT_DOUBLE) {
-    return PropertyType::kDouble;
-  } else {
-    return PropertyType::kEmpty;
-  }
-}
 void RelationToEdgeStrategy(const std::string& rel_str,
                             EdgeStrategy& ie_strategy,
                             EdgeStrategy& oe_strategy) {
@@ -529,31 +469,13 @@ StorageStrategy StringToStorageStrategy(const std::string& str) {
 }
 
 static bool parse_property_type(YAML::Node node, PropertyType& type) {
-  std::string prop_type_str{};
-  if (node["primitive_type"]) {
-    if (!get_scalar(node, "primitive_type", prop_type_str)) {
-      return false;
-    }
-  } else if (node["varchar"]) {
-    auto varchar_node = node["varchar"];
-    int length{};
-    if (!varchar_node["max_length"] ||
-        !get_scalar(varchar_node, "max_length", length)) {
-      return false;
-    }
-    type = PropertyType::Varchar(length);
+  try {
+    type = node.as<gs::PropertyType>();
     return true;
-  } else if (node["date"]) {
-    auto format = node["date"].as<std::string>();
-    prop_type_str = DT_DATE;
-  } else if (node["day"]) {
-    auto format = node["day"].as<std::string>();
-    prop_type_str = DT_DAY;
-  } else {
+  } catch (const YAML::BadConversion& e) {
+    LOG(ERROR) << "Failed to parse property type: " << e.what();
     return false;
   }
-  type = StringToPropertyType(prop_type_str);
-  return true;
 }
 static bool parse_vertex_properties(YAML::Node node,
                                     const std::string& label_name,

--- a/flex/storages/rt_mutable_graph/schema.h
+++ b/flex/storages/rt_mutable_graph/schema.h
@@ -20,15 +20,11 @@
 #include "flex/storages/rt_mutable_graph/types.h"
 #include "flex/utils/id_indexer.h"
 #include "flex/utils/property/table.h"
+#include "flex/utils/property/types.h"
 #include "flex/utils/result.h"
 #include "flex/utils/yaml_utils.h"
 
 namespace gs {
-
-namespace config_parsing {
-std::string PropertyTypeToString(PropertyType type);
-PropertyType StringToPropertyType(const std::string& str);
-}  // namespace config_parsing
 
 class Schema {
  public:

--- a/flex/storages/rt_mutable_graph/types.h
+++ b/flex/storages/rt_mutable_graph/types.h
@@ -31,19 +31,6 @@ using timestamp_t = uint32_t;
 using vid_t = uint32_t;
 using label_t = uint8_t;
 
-// primitive types
-static constexpr const char* DT_SIGNED_INT32 = "DT_SIGNED_INT32";
-static constexpr const char* DT_UNSIGNED_INT32 = "DT_UNSIGNED_INT32";
-static constexpr const char* DT_SIGNED_INT64 = "DT_SIGNED_INT64";
-static constexpr const char* DT_UNSIGNED_INT64 = "DT_UNSIGNED_INT64";
-static constexpr const char* DT_BOOL = "DT_BOOL";
-static constexpr const char* DT_FLOAT = "DT_FLOAT";
-static constexpr const char* DT_DOUBLE = "DT_DOUBLE";
-static constexpr const char* DT_STRING = "DT_STRING";
-static constexpr const char* DT_STRINGMAP = "DT_STRINGMAP";
-static constexpr const char* DT_DATE = "DT_DATE32";
-static constexpr const char* DT_DAY = "DT_DAY32";
-
 }  // namespace gs
 
 namespace std {

--- a/flex/tests/rt_mutable_graph/modern_graph_unified_schema.yaml
+++ b/flex/tests/rt_mutable_graph/modern_graph_unified_schema.yaml
@@ -1,0 +1,75 @@
+name: modern_graph # then must have a modern dir under ${data} directory
+store_type: mutable_csr  # v6d, groot, gart
+schema:
+  vertex_types:
+    - type_id: 0
+      type_name: person
+      x_csr_params:
+        max_vertex_num: 100
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+        - property_id: 1
+          property_name: name
+          property_type:
+            string:
+              var_char:
+                max_length: 64
+        - property_id: 2
+          property_name: age
+          property_type:
+            primitive_type: DT_SIGNED_INT32
+      primary_keys:
+        - id
+    - type_id: 1
+      type_name: software
+      x_csr_params:
+        max_vertex_num: 100
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            string:
+              var_char:
+                max_length: 64
+        - property_id: 1
+          property_name: name
+          property_type:
+            string:
+              var_char:
+                max_length: 64
+        - property_id: 2
+          property_name: lang
+          property_type:
+            string:
+              var_char:
+                max_length: 64
+      primary_keys:
+        - id
+  edge_types:
+    - type_id: 0
+      type_name: knows
+      vertex_type_pair_relations:
+        - source_vertex: person
+          destination_vertex: person
+          relation: MANY_TO_MANY
+      properties:
+        - property_id: 0
+          property_name: weight
+          property_type:
+            primitive_type: DT_DOUBLE
+    - type_id: 1
+      type_name: created
+      vertex_type_pair_relations:
+        - source_vertex: person
+          destination_vertex: software
+          relation: MANY_TO_MANY
+      properties:
+        - property_id: 0
+          property_name: weight
+          property_type:
+            string:
+              var_char:
+                max_length: 64


### PR DESCRIPTION
Support parsing the data type from the new unified type definition.

```yaml
GS_DATA_TYPE:  # choose one
  # optional value: DT_SIGNED_INT32, DT_UNSIGNED_INT32, DT_SIGNED_INT64
  #                 DT_UNSIGNED_INT64, DT_BOOL, DT_FLOAT, DT_DOUBLE
  primitive_type:
  string:  # choose one
    long_text: # string with unlimited length
    var_char:  # string with variable length, bounded by max_length
      max_length: <uint32>
  temporal: # choose one
    date32:
    timestamp:
```

Also compatible with previous schema files.