### PR TITLE
refactor(interactive): Support `elementId` Operator to Get Node Identifier in Cypher

### DIFF
--- a/docs/interactive_engine/neo4j/supported_cypher.md
+++ b/docs/interactive_engine/neo4j/supported_cypher.md
@@ -107,6 +107,7 @@ Note that some Aggregator operators, such as `max()`, we listed here are impleme
 | ListLiteral | Fold expressions into a single list | [] | [] | <input type="checkbox" disabled checked /> |   |
 | MapLiteral | Fold expressions with keys into a single map | {} | {} | <input type="checkbox" disabled checked /> |   |
 | Labels | Get label name of a vertex type | labels() | labels() | <input type="checkbox" disabled checked /> |   |
+| elementId | Get a vertex or an edge identifier, unique by an object type and a database | elementId() | elementId() | <input type="checkbox" disabled checked /> |   |
 | Type | Get label name of an edge type | type() | type() | <input type="checkbox" disabled checked /> |   |
 | Extract | Get interval value from a temporal type | \<temporal\>.\<interval\> | \<temporal\>.\<interval\> | <input type="checkbox" disabled checked /> |   |
 

--- a/docs/interactive_engine/tinkerpop/supported_gremlin_steps.md
+++ b/docs/interactive_engine/tinkerpop/supported_gremlin_steps.md
@@ -770,6 +770,7 @@ aggregate | AVG | calculate the average value of the elements | unsupported | AV
 aggregate | COLLECT | fold the elements into a list | unsupported | COLLECT(_.age)
 aggregate | HEAD(COLLECT()) | find the first value of the elements | unsupported | HEAD(COLLECT(_.age))
 other | LABELS | get the labels of the specified tag which is a vertex | @a.~label | LABELS(a)
+other | elementId | get a vertex or an edge identifier, unique by an object type and a database | @a.~id | elementId(a)
 other | TYPE | get the type of the specified tag which is an edge | @a.~label |TYPE(a)
 other | LENGTH | get the length of the specified tag which is a path | @a.~len | LENGTH(a)
 

--- a/interactive_engine/compiler/src/main/antlr4/ExprGS.g4
+++ b/interactive_engine/compiler/src/main/antlr4/ExprGS.g4
@@ -128,13 +128,15 @@ FOLD : ( 'F' | 'f' ) ( 'O' | 'o' ) ( 'L' | 'l' ) ( 'D' | 'd' );
 MEAN : ( 'M' | 'm' ) ( 'E' | 'e' ) ( 'A' | 'a' ) ( 'N' | 'n' );
 
 oC_ScalarFunctionInvocation
-    :  ( LENGTH | POWER | LABELS | TYPE | HEAD | DURATION ) SP? '(' SP? ( oC_Expression SP? ( ',' SP? oC_Expression SP? )* )? ')' ;
+    :  ( LENGTH | POWER | LABELS | ELEMENTID | TYPE | HEAD | DURATION ) SP? '(' SP? ( oC_Expression SP? ( ',' SP? oC_Expression SP? )* )? ')' ;
 
 LENGTH : ( 'L' | 'l' ) ( 'E' | 'e' ) ( 'N' | 'n' ) ( 'G' | 'g' ) ( 'T' | 't' ) ( 'H' | 'h' );
 
 POWER : ( 'P' | 'p' ) ( 'O' | 'o' ) ( 'W' | 'w' ) ( 'E' | 'e' ) ( 'R' | 'r' );
 
 LABELS : ( 'L' | 'l' ) ( 'A' | 'a' ) ( 'B' | 'b' ) ( 'E' | 'e' ) ( 'L' | 'l' ) ( 'S' | 's' );
+
+ELEMENTID: ( 'E' | 'e' ) ( 'L' | 'l' ) ( 'E' | 'e' ) ( 'M' | 'm' ) ( 'E' | 'e' ) ( 'N' | 'n' ) ( 'T' | 't' ) ( 'I' | 'i' ) ( 'D' | 'd' );
 
 TYPE : ( 'T' | 't' ) ( 'Y' | 'y' ) ( 'P' | 'p' ) ( 'E' | 'e' );
 
@@ -361,6 +363,7 @@ oC_SymbolicName
 
 oC_ReservedWord
             : LABELS
+            | ELEMENTID
             | TYPE
             | LENGTH
             | POWER

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/antlr4/visitor/ExpressionVisitor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/antlr4/visitor/ExpressionVisitor.java
@@ -427,6 +427,13 @@ public class ExpressionVisitor extends CypherGSBaseVisitor<ExprVisitorResult> {
                         "'type' can only be applied on edge type");
                 return new ExprVisitorResult(
                         builder.variable(exprCtx.get(0).getText(), GraphProperty.LABEL_KEY));
+            case "ELEMENTID":
+                RexNode idVar = builder.variable(exprCtx.get(0).getText());
+                Preconditions.checkArgument(
+                        idVar.getType() instanceof GraphSchemaType,
+                        "'elementId' can only be applied on vertex or edge type");
+                return new ExprVisitorResult(
+                        builder.variable(exprCtx.get(0).getText(), GraphProperty.ID_KEY));
             case "LENGTH":
                 Preconditions.checkArgument(
                         !exprCtx.isEmpty(), "LENGTH function should have one argument");

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4x/visitor/ExtExpressionVisitor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4x/visitor/ExtExpressionVisitor.java
@@ -420,6 +420,13 @@ public class ExtExpressionVisitor extends GremlinGSBaseVisitor<ExprVisitorResult
                         "'type' can only be applied on edge type");
                 return new ExprVisitorResult(
                         builder.variable(exprCtx.get(0).getText(), GraphProperty.LABEL_KEY));
+            case "ELEMENTID":
+                RexNode idVar = builder.variable(exprCtx.get(0).getText());
+                Preconditions.checkArgument(
+                        idVar.getType() instanceof GraphSchemaType,
+                        "'elementId' can only be applied on vertex or edge type");
+                return new ExprVisitorResult(
+                        builder.variable(exprCtx.get(0).getText(), GraphProperty.ID_KEY));
             case "LENGTH":
                 Preconditions.checkArgument(
                         !exprCtx.isEmpty(), "LENGTH function should have one argument");

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/cypher/antlr4/WhereTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/cypher/antlr4/WhereTest.java
@@ -273,4 +273,15 @@ public class WhereTest {
         }
         Assert.fail("should have thrown exceptions for property 'name' is not a date type");
     }
+
+    @Test
+    public void where_11_test() {
+        // the condition is fused into source and identified as primary key filtering
+        RelNode where = Utils.eval("Match (a:person) Where elementId(a) = 2 Return a").build();
+        Assert.assertEquals(
+                "GraphLogicalProject(a=[a], isAppend=[false])\n"
+                        + "  GraphLogicalSource(tableConfig=[{isAll=false, tables=[person]}],"
+                        + " alias=[a], opt=[VERTEX], uniqueKeyFilters=[=(_.~id, 2)])",
+                where.explain().trim());
+    }
 }

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4x/GraphBuilderTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4x/GraphBuilderTest.java
@@ -1511,4 +1511,15 @@ public class GraphBuilderTest {
                         + " person]}], alias=[_], opt=[VERTEX])",
                 after.explain().trim());
     }
+
+    @Test
+    public void g_V_as_a_select_expr_id_a_test() {
+        // the condition is fused into source and identified as primary key filtering
+        RelNode node = eval("g.V().as('a').where(expr(elementId(a) = 2))");
+        Assert.assertEquals(
+                "GraphLogicalProject(a=[a], isAppend=[false])\n"
+                    + "  GraphLogicalSource(tableConfig=[{isAll=true, tables=[software, person]}],"
+                    + " alias=[a], opt=[VERTEX], uniqueKeyFilters=[=(_.~id, 2)])",
+                node.explain().trim());
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. Support `elementId` operator in cypher, used to obtain the inner id specific to graph storage; 
2. Support obtaining inner id through `elementId` in Gremlin expression syntax sugar;

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

