### PR TITLE
chore: Add estimate memory usage command for gsctl

### DIFF
--- a/python/graphscope/gsctl/commands/common.py
+++ b/python/graphscope/gsctl/commands/common.py
@@ -83,18 +83,18 @@ def close():
 
 
 disclaimer = """
-Disclaimer: The `estimate` command serves as a estimator for various kind of GraphScope resources.
+Disclaimer: The `estimate` command serves as an estimator for various kinds of GraphScope resources.
     - GAE memory usage estimator:
         It would do a rough estimation of the total memory usage of the GAE.
-        The actual memory usage may vary vastly due to the complexity of the graph algorithm and the data distribution.
+        The actual memory usage may vary vastly due to the complexity of the graph algorithms and the data distribution.
 
         Here's some assumption when estimating the memory usage:
             1. Assuming the graph is a simple graph, e.g. only has 1 label and at most 1 property for each label.
-            2. Assuming the graph algorithms has a fixed amount of memory consumption, e.g. PageRank, SSSP, CC;
+            2. Assuming the graph algorithm has a fixed amount of memory consumption, e.g. PageRank, SSSP, CC;
                It should not generate a huge amount of intermediate result, like K-Hop, Louvain.
-            3. Assuming the vertex map is global vertex map
+            3. Assuming the vertex map type is global vertex map
 
-        User should take this estimation as a reference and a start point for tuning,
+        Users should take this estimation as a reference and a starting point for tuning,
         and adjust the memory allocation according to the actual situation.
 """
 
@@ -106,8 +106,8 @@ def estimate_gae_memory_usage_for_graph(
     The estimation is based on the following formulas:
     let #V = number of vertices, #E = number of edges,
     assuming load_factor of hashmap is 0.41, sizeof(inner_id) = sizeof(edge_id) = sizeof(vertex_id) = 8 bytes,
-    where vertex_id is the primary key of vertex, default to int64,
-    could be string though, in this case, the memory usage will grow.
+    where vertex_id is the primary key of the vertex, default to int64,
+    it could be string though, in that case, the memory usage will grow.
     Graph:
         1. vertex
             - vertex map: #V * (sizeof(vertex_id) + sizeof(inner_id)) * (1 / load_factor)
@@ -168,7 +168,7 @@ def estimate_gae_memory_usage_for_algorithm(v_num):
 @click.option("-ef", "--e-file-size", type=float, help="Size of edge files in GB")
 @click.option("-p", "--partition", type=int, help="Number of partitions", default=1)
 def estimate(engine, v_num, e_num, v_file_size, e_file_size, partition):
-    """Estimate the memory usage of the graphscope engine"""
+    """Estimate the resources requirement for various kinds of GraphScope components"""
     if engine == "gae":
         if v_num is None or e_num is None or v_file_size is None or e_file_size is None:
             err("Please provide the required parameters.")
@@ -183,7 +183,7 @@ def estimate(engine, v_num, e_num, v_file_size, e_file_size, partition):
             f"The estimated memory usage is {memory_usage:.2f} GB per pod for {partition} pods.\n"
         )
     else:
-        err(f"Estimate usage of engine {engine} is not supported yet.")
+        err(f"Estimating usage of engine {engine} is not supported yet.")
 
 
 if __name__ == "__main__":

--- a/python/graphscope/gsctl/commands/common.py
+++ b/python/graphscope/gsctl/commands/common.py
@@ -83,31 +83,45 @@ def close():
 
 
 disclaimer = """
-Disclaimer: The `estimate` command would do a rough estimation of the total memory usage of the GAE.
-The actual memory usage may vary vastly due to the complexity of the graph algorithm and the data distribution.
+Disclaimer: The `estimate` command serves as a estimator for various kind of GraphScope resources.
+    - GAE memory usage estimator:
+        It would do a rough estimation of the total memory usage of the GAE.
+        The actual memory usage may vary vastly due to the complexity of the graph algorithm and the data distribution.
 
-The estimation is based on the following formulas:
-let #V = number of vertices, #E = number of edges,
-assuming load_factor of hashmap is 0.41, sizeof(inner_id) = sizeof(edge_id) = sizeof(vertex_id) = 8 bytes,
-where vertex_id is the original representation of vertex, it could be string though, in this case, the memory usage will grow.
-Graph:
-    1. vertex
-        - vertex map: #V * (sizeof(vertex_id) + sizeof(inner_id)) * (1 / load_factor)
-        - vertex table: size of vertex files in uncompressed CSV format, unit is GB
-    2. edge
-        - CSR + CSC: 2 * #E * (sizeof(inner_id) + sizeof(edge_id))
-        - offset array: #V * sizeof(size_t)
-        - edge table: size of vertex files in uncompressed CSV format, unit is GB
-    3. additional data structure when graph is partitioned:
-        - outer vertex ID to local ID map:
-        - local ID to outer vertex ID array:
+        Here's some assumption when estimating the memory usage:
+            1. Assuming the graph is a simple graph, e.g. only has 1 label and at most 1 property for each label.
+            2. Assuming the graph algorithms has a fixed amount of memory consumption, e.g. PageRank, SSSP, CC;
+               It should not generate a huge amount of intermediate result, like K-Hop, Louvain.
+            3. Assuming the vertex map is global vertex map
 
-This is the minimum usage of the GAE with 1 partition, the actual memory usage would be larger than this estimation.
-User should enlarge it by a multiple it by some factor (e.g. 2) to simulate the memory usage of the graphscope engine.
+        User should take this estimation as a reference and a start point for tuning,
+        and adjust the memory allocation according to the actual situation.
 """
 
 
-def estimate_gae_memory_usage(v_num, e_num, v_file_size, e_file_size):
+def estimate_gae_memory_usage_for_graph(
+    v_num, e_num, v_file_size, e_file_size, partition
+):
+    """
+    The estimation is based on the following formulas:
+    let #V = number of vertices, #E = number of edges,
+    assuming load_factor of hashmap is 0.41, sizeof(inner_id) = sizeof(edge_id) = sizeof(vertex_id) = 8 bytes,
+    where vertex_id is the primary key of vertex, default to int64,
+    could be string though, in this case, the memory usage will grow.
+    Graph:
+        1. vertex
+            - vertex map: #V * (sizeof(vertex_id) + sizeof(inner_id)) * (1 / load_factor)
+            - vertex table: size of vertex files in uncompressed CSV format, unit is GB
+        2. edge
+            - CSR + CSC: 2 * #E * (sizeof(inner_id) + sizeof(edge_id))
+            - offset array: #V * sizeof(size_t)
+            - edge table: size of vertex files in uncompressed CSV format, unit is GB
+        3. additional data structure when graph is partitioned, assuming 10% of vertices will be outer vertices
+            - outer vertex ID to local ID map: 0.1 * #V * (sizeof(vertex_id) + sizeof(inner_id)) * (1 / load_factor)
+            - local ID to outer vertex ID array:  0.1 * #V * sizeof(size_t)
+
+    This is the minimum usage of the GAE with 1 partition, the actual memory usage would be larger than this estimation.
+    """
     gb = 1024 * 1024 * 1024
     # vertex map
     vertex_map = v_num * (8 + 8) * (1 / 0.41) / gb
@@ -119,32 +133,57 @@ def estimate_gae_memory_usage(v_num, e_num, v_file_size, e_file_size):
     offset_array = v_num * 8 / gb
     # edge table
     edge_table = e_file_size
-    return vertex_map + vertex_table + edge + offset_array + edge_table
+    additional = 0.1 * v_num * (8 + 8) * (1 / 0.41) / gb + 0.1 * v_num * 8 / gb
+    if partition == 1:
+        additional = 0
+    per_partition = (
+        vertex_map
+        + (vertex_table + edge_table + edge + offset_array) / partition
+        + additional
+    )
+    return per_partition
+
+
+def estimate_gae_memory_usage_for_algorithm(v_num):
+    """
+    Simple algorithms like PageRank or CC will have 1 slot for result for each vertex.
+    Formula: #V * sizeof(double)
+    """
+    gb = 1024 * 1024 * 1024
+    usage = v_num * 8 / gb
+    return usage
 
 
 @cli.command()
 @click.option(
-    "-s",
-    "--storage",
+    "-g",
+    "--engine",
     type=click.Choice(["gae"], case_sensitive=False),
-    help="Storage type",
+    help="Engine type",
     required=True,
 )
 @click.option("-v", "--v-num", type=int, help="Number of vertices")
 @click.option("-e", "--e-num", type=int, help="Number of edges")
 @click.option("-vf", "--v-file-size", type=float, help="Size of vertex files in GB")
 @click.option("-ef", "--e-file-size", type=float, help="Size of edge files in GB")
-def estimate(storage, v_num, e_num, v_file_size, e_file_size):
+@click.option("-p", "--partition", type=int, help="Number of partitions", default=1)
+def estimate(engine, v_num, e_num, v_file_size, e_file_size, partition):
     """Estimate the memory usage of the graphscope engine"""
-    if storage == "gae":
+    if engine == "gae":
         if v_num is None or e_num is None or v_file_size is None or e_file_size is None:
             err("Please provide the required parameters.")
             return
-        memory_usage = estimate_gae_memory_usage(v_num, e_num, v_file_size, e_file_size)
+        partition_usage = estimate_gae_memory_usage_for_graph(
+            v_num, e_num, v_file_size, e_file_size, partition
+        )
+        algorithm_usage = estimate_gae_memory_usage_for_algorithm(v_num)
+        memory_usage = partition_usage + algorithm_usage
         info(disclaimer)
-        print(f"The estimated memory usage is {memory_usage:.2f} GB.\n")
+        succ(
+            f"The estimated memory usage is {memory_usage:.2f} GB per pod for {partition} pods.\n"
+        )
     else:
-        err(f"Estimate usage of storage {storage} is not supported yet.")
+        err(f"Estimate usage of engine {engine} is not supported yet.")
 
 
 if __name__ == "__main__":

--- a/python/graphscope/gsctl/commands/common.py
+++ b/python/graphscope/gsctl/commands/common.py
@@ -83,12 +83,12 @@ def close():
 
 
 disclaimer = """
-Disclaimer: The `estimate` command is a roughly estimation of the memory usage of the graphscope engine.
+Disclaimer: The `estimate` command would do a rough estimation of the total memory usage of the GAE.
 The actual memory usage may vary vastly due to the complexity of the graph algorithm and the data distribution.
 
 The estimation is based on the following formulas:
 let #V = number of vertices, #E = number of edges,
-assume load_factor of hashmap is 0.41, sizeof(inner_id) = sizeof(edge_id) = sizeof(vertex_id) = 8 bytes,
+assuming load_factor of hashmap is 0.41, sizeof(inner_id) = sizeof(edge_id) = sizeof(vertex_id) = 8 bytes,
 where vertex_id is the original representation of vertex, it could be string though, in this case, the memory usage will grow.
 Graph:
     1. vertex
@@ -102,7 +102,7 @@ Graph:
         - outer vertex ID to local ID map:
         - local ID to outer vertex ID array:
 
-This is the minimum memory usage of the graphscope engine with 1 partition, the actual memory usage would be larger than this estimation.
+This is the minimum usage of the GAE with 1 partition, the actual memory usage would be larger than this estimation.
 User should enlarge it by a multiple it by some factor (e.g. 2) to simulate the memory usage of the graphscope engine.
 """
 


### PR DESCRIPTION
Example usage:
```bash
❯ PYTHONPATH=`pwd` python3 graphscope/gsctl/gsctl.py estimate -v 222111111 -e 1610000000 -vf 2 -ef 28 -g gae -p 4

Disclaimer: The `estimate` command serves as a estimator for various kind of GraphScope resources.
    - GAE memory usage estimator:
        It would do a rough estimation of the total memory usage of the GAE.
        The actual memory usage may vary vastly due to the complexity of the graph algorithm and the data distribution.

        Here's some assumption when estimating the memory usage:
            1. Assuming the graph is a simple graph, e.g. only has 1 label and at most 1 property for each label.
            2. Assuming the graph algorithms has a fixed amount of memory consumption, e.g. PageRank, SSSP, CC;
               It should not generate a huge amount of intermediate result, like K-Hop, Louvain.
            3. Assuming the vertex map is global vertex map

        User should take this estimation as a reference and a start point for tuning, and adjust the memory allocation according to the actual situation.

[SUCCESS] The estimated memory usage is 30.61 GB per pod for 4 pods.
```