### PR TITLE
docs: Update the domain name of GraphScope PlayGround

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -8,7 +8,7 @@
 [![Docs-en](https://shields.io/badge/Docs-English-blue?logo=Read%20The%20Docs)](https://graphscope.io/docs)
 [![Docs-zh](https://shields.io/badge/Docs-%E4%B8%AD%E6%96%87-blue?logo=Read%20The%20Docs)](https://graphscope.io/docs/zh/)
 [![Translation](https://shields.io/badge/README-English-blue)](https://github.com/alibaba/GraphScope)
-[![Playground](https://shields.io/badge/JupyterLab-Try%20GraphScope%20Now!-F37626?logo=jupyter)](https://try.graphscope.app)
+[![Playground](https://shields.io/badge/JupyterLab-Try%20GraphScope%20Now!-F37626?logo=jupyter)](https://try.graphscope.io)
 [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/alibaba/GraphScope)
 
 GraphScope 是阿里巴巴达摩院智能计算实验室研发并开源的一站式图计算平台。依托于阿里海量数据和丰富场景，与达摩院的高水平研究，GraphScope 致力于针对实际生产场景中图计算的挑战，提供一站式高效的解决方案。
@@ -21,7 +21,7 @@ GraphScope 整合了达摩院的多项学术研究成果，其中的核心技术
 
 ## 快速开始
 
-我们提供了一个基于 JupyterLab 的 [Playground](https://try.graphscope.app)，您可以从浏览器中在线试用 GraphScope。
+我们提供了一个基于 JupyterLab 的 [Playground](https://try.graphscope.io)，您可以从浏览器中在线试用 GraphScope。
 
 GraphScope 支持本地运行，或在 [Kubernetes (k8s)](https://kubernetes.io/) 管理的集群上运行。为了快速上手，我们先从本地部署的方式开始。
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![GraphScope CI](https://github.com/alibaba/GraphScope/actions/workflows/local-ci.yml/badge.svg)](https://github.com/alibaba/GraphScope/actions/workflows/local-ci.yml)
 [![Coverage](https://codecov.io/gh/alibaba/GraphScope/branch/main/graph/badge.svg)](https://codecov.io/gh/alibaba/GraphScope)
-[![Playground](https://shields.io/badge/JupyterLab-Try%20GraphScope%20Now!-F37626?logo=jupyter)](https://try.graphscope.app)
+[![Playground](https://shields.io/badge/JupyterLab-Try%20GraphScope%20Now!-F37626?logo=jupyter)](https://try.graphscope.io)
 [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/alibaba/GraphScope)
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/graphscope)](https://artifacthub.io/packages/helm/graphscope/graphscope)
 [![Docs-en](https://shields.io/badge/Docs-English-blue?logo=Read%20The%20Docs)](https://graphscope.io/docs)
@@ -55,7 +55,7 @@ Visit our website at [graphscope.io](https://graphscope.io) to learn more.
 
 ## Getting Started
 
-We provide a [Playground](https://try.graphscope.app) with a managed JupyterLab. [Try GraphScope](https://try.graphscope.app) straight away in your browser!
+We provide a [Playground](https://try.graphscope.io) with a managed JupyterLab. [Try GraphScope](https://try.graphscope.io) straight away in your browser!
 
 GraphScope supports running in standalone mode or on clusters managed by [Kubernetes](https://kubernetes.io/) within containers. For quickly getting started,
 let's begin with the standalone mode.
@@ -310,7 +310,7 @@ g = load_ogbn_mag(sess, "/dataset/ogbn_mag_small/")
 Here, the `g` is loaded in parallel via vineyard and stored in vineyard instances in the cluster managed by the session.
 
 Next, we can conduct graph queries with Gremlin, invoke various graph algorithms, or run graph-based neural network tasks like we did in the standalone mode.
-We do not repeat code here, but a `.ipynb` processing the classification task on k8s is available on the [Playground](https://try.graphscope.app/).
+We do not repeat code here, but a `.ipynb` processing the classification task on k8s is available on the [Playground](https://try.graphscope.io/).
 
 ### Closing the session
 

--- a/charts/graphscope/README.md
+++ b/charts/graphscope/README.md
@@ -184,4 +184,4 @@ $ helm install graphscope ./graphscope --namespace=default
 
 - https://graphscope.io/
 - https://github.com/alibaba/GraphScope
-- https://try.graphscope.app/
+- https://try.graphscope.io/

--- a/docs/python_tutorials.md
+++ b/docs/python_tutorials.md
@@ -5,7 +5,7 @@ how to launch a session, to load graphs, and to run analytical analysis, interac
 network trainings using GAE, GIE and GLE in GraphScope.
 
 The tutorials are organized as jupyter notebooks. Users can try them in any jupyter notebook servers. You could play
-with those tutorials using our well-prepared jupyterlab environment in [GraphScope Playground](https://try.graphscope.app).
+with those tutorials using our well-prepared jupyterlab environment in [GraphScope Playground](https://try.graphscope.io).
 
 All tutorials are listed as follows:
 

--- a/docs/zh/tutorials.rst
+++ b/docs/zh/tutorials.rst
@@ -5,7 +5,7 @@
 使用GraphScope中的GAE、GIE、GLE引擎来完成图分析任务、交互式查询和图神经网络模型的训练。
 
 我们用jupyter notebook来组织这些教程，用户可以在任何一个jupyter notebook服务中尝试执行。我们还提供了已经准备好的Jupyter Lab
-环境 `GraphScope Playground <https://try.graphscope.app>`_ 以便于用户更快地上手GraphScope。
+环境 `GraphScope Playground <https://try.graphscope.io>`_ 以便于用户更快地上手GraphScope。
 
 入门教程包括如下这些内容：
 

--- a/tutorials/zh/10_revisit_classification_on_citation_network_on_k8s.ipynb
+++ b/tutorials/zh/10_revisit_classification_on_citation_network_on_k8s.ipynb
@@ -18,7 +18,7 @@
     "- 执行基于图数据的机器学习任务；\n",
     "- 关闭会话\n",
     "\n",
-    "**除 [GraphScope Jupyter](https://try.graphscope.app) 外，确保运行该教程的环境具备访问操作 [Kubernetes 集群](https://github.com/kubernetes/kubernetes) 的能力**"
+    "**除 [GraphScope Jupyter](https://try.graphscope.io) 外，确保运行该教程的环境具备访问操作 [Kubernetes 集群](https://github.com/kubernetes/kubernetes) 的能力**"
    ]
   },
   {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

Change the GraphScope playground's domain name to "https://try.graphscope.io" 

