### PR TITLE
fix(interactive): Fix c++ procedure gen and codegen

### DIFF
--- a/.github/workflows/hqps-db-ci.yml
+++ b/.github/workflows/hqps-db-ci.yml
@@ -229,6 +229,11 @@ jobs:
           --procedure_name=get_person_name \
           --graph_schema_path=../interactive/examples/modern_graph/graph.yaml
 
+        ./load_plan_and_gen.sh -e=hqps -i=../tests/interactive/sample_app.cc -w=/tmp/codegen \
+          --ir_conf=${GITHUB_WORKSPACE}/flex/tests/hqps/engine_config_test.yaml -o=${PLUGIN_DIR} \
+          --procedure_name=sample_app \
+          --graph_schema_path=../interactive/examples/modern_graph/graph.yaml
+
         ./load_plan_and_gen.sh -e=hqps -i=../interactive/examples/modern_graph/count_vertex_num.cypher -w=/tmp/codegen \
           --ir_conf=${GITHUB_WORKSPACE}/flex/tests/hqps/engine_config_test.yaml  -o=${PLUGIN_DIR} \
           --procedure_name=count_vertex_num \

--- a/.github/workflows/hqps-db-ci.yml
+++ b/.github/workflows/hqps-db-ci.yml
@@ -214,7 +214,7 @@ jobs:
           eval ${cmd} || exit 1
         done
 
-    - name: Test cypher procedure generation and loading
+    - name: Test cypher&cpp procedure generation and loading
       env:
         INTERACTIVE_WORKSPACE: /tmp/interactive_workspace
         PLUGIN_DIR: ${INTERACTIVE_WORKSPACE}/data/modern_graph/plugins

--- a/flex/bin/load_plan_and_gen.sh
+++ b/flex/bin/load_plan_and_gen.sh
@@ -76,6 +76,29 @@ function find_resources(){
   #fi
 }
 
+# Generate a yaml contains the metadata about the c++ procedure
+generate_cpp_yaml() {
+  if [ $# -ne 5 ]; then
+    echo "Usage: generate_cpp_yaml <procedure_name> <procedure_description> <output_so_path> <procedure_query_string> <output_yaml_file>"
+    echo " but receive: "$#
+    exit 1
+  fi
+  procedure_name=$1
+  procedure_description=$2
+  output_so_path=$3
+  procedure_query=$4
+  output_yaml_file=$5
+  template_str="""
+  name: ${procedure_name}
+  description: ${procedure_description}
+  library: ${output_so_path}
+  type: cpp
+  query: "${procedure_query}"
+  """
+  echo "${template_str}" > ${output_yaml_file}
+  info "Generate yaml file to ${output_yaml_file}"
+}
+
 
 cypher_to_plan() {
   if [ $# -ne 8 ]; then
@@ -223,10 +246,14 @@ compile_hqps_so() {
   dst_yaml_path="${output_dir}/${procedure_name}.yaml"
   if [[ $(uname) == "Linux" ]]; then
     output_so_path="${cur_dir}/lib${procedure_name}.so"
+    output_yaml_path="${cur_dir}/${procedure_name}.yaml"
     dst_so_path="${output_dir}/lib${procedure_name}.so"
+    dst_so_name="lib${procedure_name}.so"
   elif [[ $(uname) == "Darwin" ]]; then
     output_so_path="${cur_dir}/lib${procedure_name}.dylib"
+    output_yaml_path="${cur_dir}/${procedure_name}.yaml"
     dst_so_path="${output_dir}/lib${procedure_name}.dylib"
+    dst_so_name="lib${procedure_name}.dylib"
   else
     err "Not support OS."
     exit 1
@@ -242,7 +269,6 @@ compile_hqps_so() {
     info "Generating code from cypher query, procedure name: ${procedure_name}, description: ${procedure_description}"
     # first do .cypher to .pb
     output_pb_path="${cur_dir}/${procedure_name}.pb"
-    output_yaml_path="${cur_dir}/${procedure_name}.yaml"
     cypher_to_plan ${procedure_name} ${input_path} ${output_pb_path} \
       ${output_yaml_path} ${ir_compiler_properties} ${graph_schema_path} \
       ${procedure_name} "${procedure_description}"
@@ -255,7 +281,15 @@ compile_hqps_so() {
     eval ${cmd}
     # then. do .pb to .cc
   elif [[ $last_file_name == *.cc ]]; then
-    cp $input_path ${output_cc_path}
+    # read the input_path into a long string into procedure_query_str
+    procedure_query_str=$(cat ${input_path})
+    # Generate the .yaml file
+    echo "Generating yaml file for ${procedure_name}, description: ${procedure_description}"
+    generate_cpp_yaml ${procedure_name} "${procedure_description}" ${dst_so_name} "${procedure_query_str}" ${output_yaml_path}
+    # copy if path is not equal
+    if [ ${input_path} != ${output_cc_path} ]; then
+      cp $input_path ${output_cc_path}
+    fi
   fi
   info "Start running cmake and make"
   #check output_cc_path exists
@@ -326,12 +360,18 @@ compile_hqps_so() {
     exit 1
   fi
   # copy the generated yaml
-  cp ${output_yaml_path} ${output_dir}
-  if [ ! -f ${dst_yaml_path} ]; then
-    err "Copy failed, ${dst_yaml_path} not exists."
+  if [ ! -z ${output_yaml_path} ]; then
+    cp ${output_yaml_path} ${output_dir}
+    if [ ! -f ${dst_yaml_path} ]; then
+      err "Copy failed, ${dst_yaml_path} not exists."
+      exit 1
+    fi
+    info "Generate yaml file to ${dst_yaml_path}"
+  else
+    err "No yaml file generated."
     exit 1
   fi
-  info "Finish copying, output to ${dst_so_path}"
+  info "Finish compiling and copying, output to ${dst_so_path}"
 }
 
 compile_pegasus_so() {

--- a/flex/bin/load_plan_and_gen.sh
+++ b/flex/bin/load_plan_and_gen.sh
@@ -79,16 +79,16 @@ function find_resources(){
 # Generate a yaml contains the metadata about the c++ procedure
 generate_cpp_yaml() {
   if [ $# -ne 5 ]; then
-    echo "Usage: generate_cpp_yaml <procedure_name> <procedure_description> <output_so_path> <procedure_query_string> <output_yaml_file>"
+    echo "Usage: generate_cpp_yaml <procedure_name> <procedure_description> <output_so_name> <procedure_query_string> <output_yaml_file>"
     echo " but receive: "$#
     exit 1
   fi
-  procedure_name=$1
-  procedure_description=$2
-  output_so_path=$3
-  procedure_query=$4
-  output_yaml_file=$5
-  template_str="""
+  local procedure_name=$1
+  local procedure_description=$2
+  local output_so_name=$3
+  local rocedure_query=$4
+  local output_yaml_file=$5
+  local template_str="""
   name: ${procedure_name}
   description: ${procedure_description}
   library: ${output_so_path}

--- a/flex/engines/http_server/actor/admin_actor.act.cc
+++ b/flex/engines/http_server/actor/admin_actor.act.cc
@@ -428,8 +428,26 @@ seastar::future<admin_query_result> admin_actor::run_get_graph_meta(
   auto meta_res = metadata_store_->GetGraphMeta(query_param.content);
 
   if (meta_res.ok()) {
-    return seastar::make_ready_future<admin_query_result>(
-        gs::Result<seastar::sstring>(std::move(meta_res.value().ToJson())));
+    auto get_all_procedure_res =
+        metadata_store_->GetAllPluginMeta(query_param.content);
+    if (get_all_procedure_res.ok()) {
+      VLOG(10) << "Successfully get all procedures: "
+               << get_all_procedure_res.value().size();
+      auto& all_plugin_metas = get_all_procedure_res.value();
+      for (auto& plugin_meta : all_plugin_metas) {
+        add_runnable_info(plugin_meta);
+      }
+      auto& graph_meta = meta_res.value();
+      graph_meta.plugin_metas = all_plugin_metas;
+      return seastar::make_ready_future<admin_query_result>(
+          gs::Result<seastar::sstring>(std::move(graph_meta.ToJson())));
+    } else {
+      LOG(ERROR) << "Fail to get all procedures: "
+                 << get_all_procedure_res.status().error_message() << " for "
+                 << query_param.content;
+      return seastar::make_ready_future<admin_query_result>(
+          gs::Result<seastar::sstring>(get_all_procedure_res.status()));
+    }
   } else {
     LOG(ERROR) << "Fail to get graph schema: "
                << meta_res.status().error_message();
@@ -917,8 +935,8 @@ seastar::future<admin_query_result> admin_actor::start_service(
   if (!data_dir.ok()) {
     LOG(ERROR) << "Fail to get data directory: "
                << data_dir.status().error_message();
-    if (!prev_lock) {  // If the graph is not locked before, and we fail at some
-                       // steps after locking, we should unlock it.
+    if (!prev_lock) {  // If the graph is not locked before, and we fail at
+                       // some steps after locking, we should unlock it.
       metadata_store_->UnlockGraphIndices(graph_name);
     }
     return seastar::make_ready_future<admin_query_result>(
@@ -946,9 +964,9 @@ seastar::future<admin_query_result> admin_actor::start_service(
       if (!db.Open(schema_value, data_dir_value, thread_num).ok()) {
         LOG(ERROR) << "Fail to load graph from data directory: "
                    << data_dir_value;
-        if (!prev_lock) {  // If the graph is not locked before, and we fail at
-                           // some
-                           // steps after locking, we should unlock it.
+        if (!prev_lock) {  // If the graph is not locked before, and we
+                           // fail at some steps after locking, we should
+                           // unlock it.
           metadata_store_->UnlockGraphIndices(graph_name);
         }
         return seastar::make_ready_future<admin_query_result>(

--- a/flex/engines/http_server/workdir_manipulator.cc
+++ b/flex/engines/http_server/workdir_manipulator.cc
@@ -846,8 +846,6 @@ gs::Result<seastar::sstring> WorkDirManipulator::create_procedure_sanity_check(
     LOG(INFO) << "Cypher procedure, name: " << json["name"].get<std::string>()
               << ", enable: " << json["enable"].get<bool>();
   } else if (type == "CPP" || type == "cpp") {
-    CHECK_JSON_FIELD(json, "params");
-    CHECK_JSON_FIELD(json, "returns");
     LOG(INFO) << "Native procedure, name: " << json["name"].get<std::string>()
               << ", enable: " << json["enable"].get<bool>();
   } else {
@@ -885,7 +883,7 @@ seastar::future<seastar::sstring> WorkDirManipulator::generate_procedure(
   if (type == "cypher" || type == "CYPHER") {
     query_file = temp_codegen_directory + "/" + plugin_id + ".cypher";
   } else if (type == "CPP" || type == "cpp") {
-    query_file = temp_codegen_directory + "/" + plugin_id + ".cpp";
+    query_file = temp_codegen_directory + "/" + plugin_id + ".cc";
   } else {
     return seastar::make_exception_future<seastar::sstring>(
         "Procedure type is not supported: " + type);

--- a/flex/tests/interactive/modern_graph_schema_v0_0.yaml
+++ b/flex/tests/interactive/modern_graph_schema_v0_0.yaml
@@ -5,6 +5,7 @@ stored_procedures:
   enable_lists:
     - libget_person_name.so
     - libcount_vertex_num.so
+    - libsample_app.so
 schema:
   vertex_types:
     - type_id: 0

--- a/flex/tests/interactive/modern_graph_schema_v0_1.yaml
+++ b/flex/tests/interactive/modern_graph_schema_v0_1.yaml
@@ -11,6 +11,10 @@ stored_procedures:
     description: A stored procedure that does something else
     library: /tmp/interactive_workspace/data/modern_graph/plugins/libcount_vertex_num.so
     type: cpp
+  - name: sample_app
+    description: A sample application
+    library: /tmp/interactive_workspace/data/modern_graph/plugins/libsample_app.so
+    type: cpp
 schema:
   vertex_types:
     - type_id: 0

--- a/flex/tests/interactive/sample_app.cc
+++ b/flex/tests/interactive/sample_app.cc
@@ -1,0 +1,50 @@
+#include "flex/engines/hqps_db/core/sync_engine.h"
+#include "flex/utils/app_utils.h"
+
+namespace gs {
+class ExampleQuery : public AppBase {
+ public:
+  using Engine = SyncEngine<gs::MutableCSRInterface>;
+  using label_id_t = typename gs::MutableCSRInterface::label_id_t;
+  using vertex_id_t = typename gs::MutableCSRInterface::vertex_id_t;
+  ExampleQuery(const GraphDBSession& session) : graph(session) {}
+  // Query function for query class
+  results::CollectiveResults Query() const {
+    auto ctx0 = Engine::template ScanVertex<gs::AppendOpt::Persist>(
+        graph, 1, Filter<TruePredicate>());
+
+    auto ctx1 = Engine::Project<PROJ_TO_NEW>(
+        graph, std::move(ctx0),
+        std::tuple{gs::make_mapper_with_variable<INPUT_COL_ID(0)>(
+            gs::PropertySelector<int64_t>("id"))});
+    auto ctx2 = Engine::Limit(std::move(ctx1), 0, 5);
+    auto res = Engine::Sink(graph, ctx2, std::array<int32_t, 1>{0});
+    LOG(INFO) << "res: " << res.DebugString();
+    return res;
+  }
+  // Wrapper query function for query class
+  bool Query(Decoder& decoder, Encoder& encoder) override {
+    // decoding params from decoder, and call real query func
+
+    auto res = Query();
+    // dump results to string
+    std::string res_str = res.SerializeAsString();
+    // encode results to encoder
+    encoder.put_string(res_str);
+    return true;
+  }
+  gs::MutableCSRInterface graph;
+};
+}  // namespace gs
+
+extern "C" {
+void* CreateApp(gs::GraphDBSession& db) {
+  gs::ExampleQuery* app = new gs::ExampleQuery(db);
+  return static_cast<void*>(app);
+}
+
+void DeleteApp(void* app) {
+  gs::ExampleQuery* casted = static_cast<gs::ExampleQuery*>(app);
+  delete casted;
+}
+}

--- a/flex/utils/property/types.cc
+++ b/flex/utils/property/types.cc
@@ -140,58 +140,6 @@ bool PropertyType::IsVarchar() const {
   return type_enum == impl::PropertyTypeImpl::kVarChar;
 }
 
-void to_json(nlohmann::json& j, const PropertyType& p) {
-  if (p == PropertyType::Empty()) {
-    j = "empty";
-  } else if (p == PropertyType::Bool() || p == PropertyType::UInt8() ||
-             p == PropertyType::UInt16() || p == PropertyType::Int32() ||
-             p == PropertyType::UInt32() || p == PropertyType::Float() ||
-             p == PropertyType::Int64() || p == PropertyType::UInt64() ||
-             p == PropertyType::Double()) {
-    j["primitive_type"] = config_parsing::PrimitivePropertyTypeToString(p);
-  } else if (p == PropertyType::Date()) {
-    j["temporal"]["timestamp"] = {};
-  } else if (p == PropertyType::Day()) {
-    j["temporal"]["date32"] = {};
-  } else if (p == PropertyType::String() || p == PropertyType::StringMap()) {
-    j["string"]["long_text"] = {};
-  } else if (p.IsVarchar()) {
-    j["string"]["var_char"]["max_length"] = p.additional_type_info.max_length;
-  } else {
-    LOG(ERROR) << "Unknown property type";
-  }
-}
-
-void from_json(const nlohmann::json& j, PropertyType& p) {
-  if (j.contains("primitive_type")) {
-    p = config_parsing::StringToPrimitivePropertyType(
-        j["primitive_type"].get<std::string>());
-  } else if (j.contains("string")) {
-    if (j["string"].contains("long_text")) {
-      p = PropertyType::String();
-    } else if (j.contains("string") && j["string"].contains("var_char")) {
-      if (j["string"]["var_char"].contains("max_length")) {
-        p = PropertyType::Varchar(
-            j["string"]["var_char"]["max_length"].get<int32_t>());
-      } else {
-        p = PropertyType::Varchar(PropertyType::STRING_DEFAULT_MAX_LENGTH);
-      }
-    } else {
-      throw std::invalid_argument("Unknown string type");
-    }
-  } else if (j.contains("temporal")) {
-    if (j["temporal"].contains("timestamp")) {
-      p = PropertyType::Date();
-    } else if (j["temporal"].contains("date32")) {
-      p = PropertyType::Day();
-    } else {
-      throw std::invalid_argument("Unknown temporal type");
-    }
-  } else {
-    LOG(ERROR) << "Unknown property type";
-  }
-}
-
 /////////////////////////////// Get Type Instance
 //////////////////////////////////
 PropertyType PropertyType::Empty() {

--- a/flex/utils/property/types.h
+++ b/flex/utils/property/types.h
@@ -29,7 +29,6 @@ limitations under the License.
 #include "grape/serialization/out_archive.h"
 
 #include <yaml-cpp/yaml.h>
-#include "nlohmann/json.hpp"
 
 namespace grape {
 
@@ -149,11 +148,6 @@ namespace config_parsing {
 std::string PrimitivePropertyTypeToString(PropertyType type);
 PropertyType StringToPrimitivePropertyType(const std::string& str);
 }  // namespace config_parsing
-
-// With the help of the following functions, we can serialize and deserialize
-// by json.get<PropertyType>() and operator <</operator =;
-void to_json(nlohmann::json& json, const PropertyType& type);
-void from_json(const nlohmann::json& json, PropertyType& type);
 
 // encoded with label_id and vid_t.
 struct GlobalId {

--- a/flex/utils/service_utils.cc
+++ b/flex/utils/service_utils.cc
@@ -17,6 +17,58 @@
 
 namespace gs {
 
+void to_json(nlohmann::json& j, const PropertyType& p) {
+  if (p == PropertyType::Empty()) {
+    j = "empty";
+  } else if (p == PropertyType::Bool() || p == PropertyType::UInt8() ||
+             p == PropertyType::UInt16() || p == PropertyType::Int32() ||
+             p == PropertyType::UInt32() || p == PropertyType::Float() ||
+             p == PropertyType::Int64() || p == PropertyType::UInt64() ||
+             p == PropertyType::Double()) {
+    j["primitive_type"] = config_parsing::PrimitivePropertyTypeToString(p);
+  } else if (p == PropertyType::Date()) {
+    j["temporal"]["timestamp"] = {};
+  } else if (p == PropertyType::Day()) {
+    j["temporal"]["date32"] = {};
+  } else if (p == PropertyType::String() || p == PropertyType::StringMap()) {
+    j["string"]["long_text"] = {};
+  } else if (p.IsVarchar()) {
+    j["string"]["var_char"]["max_length"] = p.additional_type_info.max_length;
+  } else {
+    LOG(ERROR) << "Unknown property type";
+  }
+}
+
+void from_json(const nlohmann::json& j, PropertyType& p) {
+  if (j.contains("primitive_type")) {
+    p = config_parsing::StringToPrimitivePropertyType(
+        j["primitive_type"].get<std::string>());
+  } else if (j.contains("string")) {
+    if (j["string"].contains("long_text")) {
+      p = PropertyType::String();
+    } else if (j.contains("string") && j["string"].contains("var_char")) {
+      if (j["string"]["var_char"].contains("max_length")) {
+        p = PropertyType::Varchar(
+            j["string"]["var_char"]["max_length"].get<int32_t>());
+      } else {
+        p = PropertyType::Varchar(PropertyType::STRING_DEFAULT_MAX_LENGTH);
+      }
+    } else {
+      throw std::invalid_argument("Unknown string type");
+    }
+  } else if (j.contains("temporal")) {
+    if (j["temporal"].contains("timestamp")) {
+      p = PropertyType::Date();
+    } else if (j["temporal"].contains("date32")) {
+      p = PropertyType::Day();
+    } else {
+      throw std::invalid_argument("Unknown temporal type");
+    }
+  } else {
+    LOG(ERROR) << "Unknown property type";
+  }
+}
+
 static unsigned long long lastTotalUser, lastTotalUserLow, lastTotalSys,
     lastTotalIdle;
 

--- a/flex/utils/service_utils.h
+++ b/flex/utils/service_utils.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+#include "flex/utils/property/types.h"
 #include "flex/utils/result.h"
 #include "flex/utils/yaml_utils.h"
 #include "nlohmann/json.hpp"
@@ -45,6 +46,11 @@ inline int64_t GetCurrentTimeStamp() {
              std::chrono::system_clock::now().time_since_epoch())
       .count();
 }
+
+// With the help of the following functions, we can serialize and deserialize
+// by json.get<PropertyType>() and operator <</operator =;
+void to_json(nlohmann::json& json, const PropertyType& type);
+void from_json(const nlohmann::json& json, PropertyType& type);
 
 inline boost::filesystem::path get_current_binary_directory() {
   return boost::filesystem::canonical("/proc/self/exe").parent_path();


### PR DESCRIPTION
- Move the `from_json` and `to_json` method for `PropertyType` to a separate file, avoid including `nlohman_json` header(which will cause issue in cmake installed scenrio).
- Fix the creation of cpp procedure. Generate a yaml contains necessary metadata. Currently the metadata lacks `params` and `returns` info, we will parse from c++ code/ or let user specify later. 

Future work: https://github.com/alibaba/GraphScope/pull/3835