### PR TITLE
feat(interactive): Track the start_time of `hqps_service` and return in `get_service_status`

### DIFF
--- a/flex/engines/http_server/actor/admin_actor.act.cc
+++ b/flex/engines/http_server/actor/admin_actor.act.cc
@@ -1012,6 +1012,7 @@ seastar::future<admin_query_result> admin_actor::start_service(
                                                   "Fail to start compiler")));
     }
     LOG(INFO) << "Successfully started service with graph: " << graph_name;
+    hqps_service.reset_start_time();
     return seastar::make_ready_future<admin_query_result>(
         gs::Result<seastar::sstring>("Successfully start service"));
   });
@@ -1083,6 +1084,7 @@ seastar::future<admin_query_result> admin_actor::service_status(
     } else {
       res["graph"] = {};
     }
+    res["start_time"] = hqps_service.get_start_time();
   } else {
     LOG(INFO) << "Query service has not been inited!";
     res["status"] = "Query service has not been inited!";

--- a/flex/engines/http_server/service/hqps_service.cc
+++ b/flex/engines/http_server/service/hqps_service.cc
@@ -100,6 +100,7 @@ void HQPSService::init(const ServiceConfig& config) {
   if (config.start_compiler) {
     start_compiler_subprocess();
   }
+  start_time_.store(gs::GetCurrentTimeStamp());
 }
 
 HQPSService::~HQPSService() {
@@ -129,6 +130,14 @@ uint16_t HQPSService::get_query_port() const {
     return query_hdl_->get_port();
   }
   return 0;
+}
+
+uint64_t HQPSService::get_start_time() const {
+  return start_time_.load(std::memory_order_relaxed);
+}
+
+void HQPSService::reset_start_time() {
+  start_time_.store(gs::GetCurrentTimeStamp());
 }
 
 std::shared_ptr<gs::IGraphMetaStore> HQPSService::get_metadata_store() const {

--- a/flex/engines/http_server/service/hqps_service.h
+++ b/flex/engines/http_server/service/hqps_service.h
@@ -83,6 +83,10 @@ class HQPSService {
 
   uint16_t get_query_port() const;
 
+  uint64_t get_start_time() const;
+
+  void reset_start_time();
+
   std::shared_ptr<gs::IGraphMetaStore> get_metadata_store() const;
 
   gs::Result<seastar::sstring> service_status();
@@ -122,6 +126,7 @@ class HQPSService {
   std::unique_ptr<hqps_http_handler> query_hdl_;
   std::atomic<bool> running_{false};
   std::atomic<bool> initialized_{false};
+  std::atomic<uint64_t> start_time_{0};
   std::mutex mtx_;
 
   ServiceConfig service_config_;

--- a/flex/openapi/openapi_interactive.yaml
+++ b/flex/openapi/openapi_interactive.yaml
@@ -1607,6 +1607,9 @@ components:
         gremlin_port:
           type: integer
           format: int32
+        start_time:
+          type: integer
+          format: int32
     JobResponse:
       type: object
       x-body-name: job_response

--- a/flex/tests/hqps/engine_config_test.yaml
+++ b/flex/tests/hqps/engine_config_test.yaml
@@ -5,7 +5,7 @@ directories:
     logs: logs
     conf: conf
 log_level: INFO
-default_graph: ldbc
+default_graph: modern_graph
 compute_engine:
   type: hiactor
   workers:

--- a/flex/tests/hqps/engine_config_test.yaml
+++ b/flex/tests/hqps/engine_config_test.yaml
@@ -5,7 +5,7 @@ directories:
     logs: logs
     conf: conf
 log_level: INFO
-default_graph: modern_graph
+default_graph: ldbc
 compute_engine:
   type: hiactor
   workers:


### PR DESCRIPTION
The start_time is returns in timestamp, and will be refreshed when service got started.