### PR TITLE
fix(interactive): Remove dummy code

### DIFF
--- a/flex/utils/yaml_utils.cc
+++ b/flex/utils/yaml_utils.cc
@@ -16,6 +16,7 @@
 
 #include "flex/utils/yaml_utils.h"
 #include <fstream>
+#include "nlohmann/json.hpp"
 
 namespace gs {
 std::vector<std::string> get_yaml_files(const std::string& plugin_dir) {
@@ -114,27 +115,6 @@ Result<std::string> get_yaml_string_from_yaml_node(const YAML::Node& node) {
     return std::string(emitter.c_str());
   } catch (const YAML::BadConversion& e) {
     return Result<std::string>(Status{StatusCode::IOError, e.what()});
-  }
-}
-
-Result<nlohmann::json> read_json_from_file(const std::string& file_path) {
-  if (!std::filesystem::exists(file_path)) {
-    return Result<nlohmann::json>(
-        Status{StatusCode::IOError, "File not exists: " + file_path});
-  }
-  // read string from file_path, and parse into json
-  std::ifstream file(file_path, std::ios::in);
-  if (!file.is_open()) {
-    return Result<nlohmann::json>(
-        Status{StatusCode::IOError, "Failed to open file: " + file_path});
-  }
-  std::string json_str((std::istreambuf_iterator<char>(file)),
-                       std::istreambuf_iterator<char>());
-  file.close();
-  try {
-    return nlohmann::json::parse(json_str);
-  } catch (const nlohmann::json::parse_error& e) {
-    return Result<nlohmann::json>(Status{StatusCode::InternalError, e.what()});
   }
 }
 

--- a/flex/utils/yaml_utils.h
+++ b/flex/utils/yaml_utils.h
@@ -23,7 +23,6 @@
 #include "flex/utils/result.h"
 
 #include "glog/logging.h"
-#include "nlohmann/json.hpp"
 
 namespace gs {
 
@@ -32,8 +31,6 @@ std::vector<std::string> get_yaml_files(const std::string& plugin_dir);
 Result<std::string> get_json_string_from_yaml(const std::string& file_path);
 
 Result<std::string> get_json_string_from_yaml(const YAML::Node& yaml_node);
-
-Result<nlohmann::json> read_json_from_file(const std::string& file_path);
 
 Status write_yaml_node_to_yaml_string(const YAML::Node& node,
                                       YAML::Emitter& emitter);


### PR DESCRIPTION
Remove a redundant function and shift the inclusion of `nlohmann/json.hpp` header from the .h file to the .cc file. This will resolve a runtime code generation error that occurs after installing flex interactive system-wide.