### PR TITLE
fix(interactive): Support identical plugin names for distinct plugins across graphs.

### DIFF
--- a/flex/storages/metadata/default_graph_meta_store.cc
+++ b/flex/storages/metadata/default_graph_meta_store.cc
@@ -103,19 +103,17 @@ Result<bool> DefaultGraphMetaStore::UpdateGraphMeta(
 
 Result<PluginId> DefaultGraphMetaStore::CreatePluginMeta(
     const CreatePluginMetaRequest& request) {
-  PluginId plugin_id;
   if (request.id.has_value()) {
     auto real_meta_key =
         generate_real_plugin_meta_key(request.bound_graph, request.id.value());
-    ASSIGN_AND_RETURN_IF_RESULT_NOT_OK(
-        plugin_id, base_store_->CreateMeta(PLUGIN_META, real_meta_key,
-                                           request.ToString()));
+    RETURN_IF_NOT_OK(base_store_->CreateMeta(PLUGIN_META, real_meta_key,
+                                             request.ToString()));
+    return Result<PluginId>(request.id.value());
   } else {
     LOG(ERROR) << "Can not create plugin meta without id";
     return Result<PluginId>(Status(StatusCode::InValidArgument,
                                    "Can not create plugin meta without id"));
   }
-  return Result<PluginId>(plugin_id);
 }
 
 Result<PluginMeta> DefaultGraphMetaStore::GetPluginMeta(

--- a/flex/storages/metadata/default_graph_meta_store.cc
+++ b/flex/storages/metadata/default_graph_meta_store.cc
@@ -112,7 +112,7 @@ Result<PluginId> DefaultGraphMetaStore::CreatePluginMeta(
                                            request.ToString()));
   } else {
     LOG(ERROR) << "Can not create plugin meta without id";
-    return Result<PluginId>(Status(StatusCode::InvalidArgument,
+    return Result<PluginId>(Status(StatusCode::InValidArgument,
                                    "Can not create plugin meta without id"));
   }
   return Result<PluginId>(plugin_id);

--- a/flex/storages/metadata/default_graph_meta_store.h
+++ b/flex/storages/metadata/default_graph_meta_store.h
@@ -105,6 +105,9 @@ class DefaultGraphMetaStore : public IGraphMetaStore {
 
  private:
   Result<bool> clear_locks();
+  // We assume the graph_id
+  std::string generate_real_plugin_meta_key(const GraphId& graph_id,
+                                            const PluginId& plugin_id);
 
   std::unique_ptr<IMetaStore> base_store_;
 };


### PR DESCRIPTION
Support identical plugin names for distinct plugins across graphs.
Currently plugin_name is deemed to be unique globally.

Fix #3841 