### PR TITLE
fix(interactive): Support using string as primary key

### DIFF
--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -30,7 +30,7 @@ Within the `graph.yaml` file, vertices are delineated under the `vertex_types` s
 
 Note:
 - In the current version, only one single primary key can be specified, but we plan to support multiple primary keys in the future. 
-- The data type of primary key column must be one of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64`,`DT_UNSIGNED_INT64`, or string types `var_char`, `fixed_char`, `long_text`.
+- The data type of primary key column must be one of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64`,`DT_UNSIGNED_INT64`, or string types `var_char`,`long_text`(`fixed_char` is currently not supported).
 
 Edges are defined within the `edge_types` section, characterized by the mandatory fields: `type_name`, `vertex_type_pair_relations`, and `properties`. The type_name and properties fields function similarly to those in vertices. However, the vertex_type_pair_relations field is exclusive to edges, specifying the permissible source and destination vertex types, as well as the relationship detailing how many source and destination vertices can be linked by this edge. Here's an illustrative example:
 ```yaml

--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -30,7 +30,7 @@ Within the `graph.yaml` file, vertices are delineated under the `vertex_types` s
 
 Note:
 - In the current version, only one single primary key can be specified, but we plan to support multiple primary keys in the future. 
-- The data type of primary key column must be one of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64` or `DT_UNSIGNED_INT64`.
+- The data type of primary key column must be one of `DT_SIGNED_INT32`, `DT_UNSIGNED_INT32`, `DT_SIGNED_INT64`,`DT_UNSIGNED_INT64`, or string types `var_char`, `fixed_char`, `long_text`.
 
 Edges are defined within the `edge_types` section, characterized by the mandatory fields: `type_name`, `vertex_type_pair_relations`, and `properties`. The type_name and properties fields function similarly to those in vertices. However, the vertex_type_pair_relations field is exclusive to edges, specifying the permissible source and destination vertex types, as well as the relationship detailing how many source and destination vertices can be linked by this edge. Here's an illustrative example:
 ```yaml

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -701,12 +701,14 @@ static Status parse_vertex_schema(YAML::Node node, Schema& schema) {
         property_types[primary_key_inds[i]] != PropertyType::kString &&
         property_types[primary_key_inds[i]] != PropertyType::kUInt64 &&
         property_types[primary_key_inds[i]] != PropertyType::kInt32 &&
-        property_types[primary_key_inds[i]] != PropertyType::kUInt32) {
+        property_types[primary_key_inds[i]] != PropertyType::kUInt32 &&
+        !property_types[primary_key_inds[i]].IsVarchar()) {
       LOG(ERROR) << "Primary key " << primary_key_name
-                 << " should be int64 or string";
-      return Status(
-          StatusCode::InvalidSchema,
-          "Primary key " + primary_key_name + " should be int64 or string");
+                 << " should be int64/int32/uint64/uint32 or string/varchar";
+      return Status(StatusCode::InvalidSchema,
+                    "Primary key " + primary_key_name +
+                        " should be int64/int32/uint64/"
+                        "uint32 or string/varchar");
     }
     primary_keys.emplace_back(property_types[primary_key_inds[i]],
                               property_names[primary_key_inds[i]],

--- a/flex/utils/id_indexer.h
+++ b/flex/utils/id_indexer.h
@@ -239,6 +239,13 @@ class LFIndexer {
     } else if (type.type_enum == impl::PropertyTypeImpl::kVarChar) {
       keys_ = new StringColumn(StorageStrategy::kMem,
                                type.additional_type_info.max_length);
+    } else if (type.type_enum == impl::PropertyTypeImpl::kString) {
+      LOG(WARNING) << "String type is a deprecated type, use varchar instead.";
+      LOG(WARNING) << "Use default max length"
+                   << PropertyType::STRING_DEFAULT_MAX_LENGTH
+                   << " for varchar type.";
+      keys_ = new StringColumn(StorageStrategy::kMem,
+                               PropertyType::STRING_DEFAULT_MAX_LENGTH);
     } else {
       LOG(FATAL) << "Not support type [" << type << "] as pk type ..";
     }


### PR DESCRIPTION
For three string types: `long_text`, `var_char` and `fixed_char`, we currently support `long_text`, `var_char` and primary key for vertex. `fixed_char` hasn't been supported yet.

