### PR TITLE
feat(interactive): Implement the `get_graph_statistics` for AdminService

### DIFF
--- a/docs/flex/interactive/development/restful_api.md
+++ b/docs/flex/interactive/development/restful_api.md
@@ -12,6 +12,7 @@ The table below provides an overview of the available APIs:
 | API name        | Method and URL                                 | Explanation                                                        |
 |-----------------|------------------------------------------------|--------------------------------------------------------------------|
 | ListGraphs      | GET /v1/graph                                  | Get all graphs in current interactive service, the schema for each graph is returned. |
+| GetGraphStatistics | GET /v1/graph/{graph}/statistics            | Get the statistics for the specified graph.|
 | GetGraphSchema  | GET /v1/graph/{graph}/schema                   | Get the schema for the specified graph.                            |
 | CreateGraph     | POST /v1/graph                                 | Create an empty graph with the specified schema.                   |
 | DeleteGraph     | DELETE /v1/graph/{graph}                       | Delete the specified graph.                                        |
@@ -178,6 +179,64 @@ curl -X GET -H "Content-Type: application/json" "http://{INTERACTIVE_ENDPOINT}/v
 #### Status Codes
 - `200 OK`: Request successful.
 - `500 Internal Error`: Server internal Error.
+
+### GetGraphStatistics API (GraphManagement Category)
+
+#### Description
+
+This API retrieves the statistical data(enumerating the count of vertices and edges corresponding to each label) for the actively running graph.
+If at the time of the request, no graph is in service, the service will respond with a NOT FOUND status.
+
+#### HTTP Request
+- **Method**: GET
+- **Endpoint**: `/v1/graph/{graph_id}/statistics`
+- **Content-type**: `application/json`
+
+#### Curl Command Example
+```bash
+curl -X GET -H "Content-Type: application/json" "http://{INTERACTIVE_ENDPOINT}/v1/graph/{graph_id}/statistics"
+```
+
+#### Expected Response
+- **Format**: `application/json`
+- **Body**:
+```json
+{
+    "edge_type_statistics": [
+        {
+            "type_id": 0,
+            "type_name": "knows",
+            "vertex_type_pair_statistics": [
+                {
+                    "count": 5,
+                    "destination_vertex": "person",
+                    "source_vertex": "person"
+                }
+            ]
+        }
+    ],
+    "total_edge_count": 5,
+    "total_vertex_count": 6,
+    "vertex_type_statistics": [
+        {
+            "count": 4,
+            "type_id": 0,
+            "type_name": "person"
+        },
+        {
+            "count": 2,
+            "type_id": 1,
+            "type_name": "software"
+        }
+    ]
+}
+```
+
+#### Status Codes
+- `200 OK`: Request successful.
+- `500 Internal Error`: Server internal Error.
+- `404 Not Found`: No graph is serving or the queried graph is not the running graph.
+
 
 ### CreateGraph (GraphManagement Category)
 

--- a/flex/engines/http_server/actor/admin_actor.act.h
+++ b/flex/engines/http_server/actor/admin_actor.act.h
@@ -70,6 +70,8 @@ class ANNOTATION(actor:impl) admin_actor : public hiactor::actor {
 
   seastar::future<admin_query_result> ANNOTATION(actor:method) cancel_job(query_param&& param);
 
+  seastar::future<admin_query_result> ANNOTATION(actor:method) run_get_graph_statistic(query_param&& param);
+
   // DECLARE_RUN_QUERIES;
   /// Declare `do_work` func here, no need to implement.
   ACTOR_DO_WORK()

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/GraphInterface.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/GraphInterface.java
@@ -32,6 +32,8 @@ public interface GraphInterface {
 
     Result<GetGraphSchemaResponse> getGraphSchema(String graphId);
 
+    Result<GetGraphStatisticsResponse> getGraphStatistics(String graphId);
+
     Result<GetGraphResponse> getGraphMeta(String graphId);
 
     Result<List<GetGraphResponse>> getAllGraphs();

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
@@ -203,6 +203,18 @@ public class DefaultSession implements Session {
     }
 
     @Override
+    public Result<GetGraphStatisticsResponse> getGraphStatistics(String graphId) {
+        try {
+            ApiResponse<GetGraphStatisticsResponse> response =
+                    graphApi.getGraphStatisticWithHttpInfo(graphId);
+            return Result.fromResponse(response);
+        } catch (ApiException e) {
+            e.printStackTrace();
+            return Result.fromException(e);
+        }
+    }
+
+    @Override
     public Result<GetGraphResponse> getGraphMeta(String graphId) {
         try {
             ApiResponse<GetGraphResponse> response = graphApi.getGraphWithHttpInfo(graphId);

--- a/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
+++ b/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
@@ -483,6 +483,14 @@ public class DriverTest {
 
     @Test
     @Order(11)
+    public void test9GetGraphStatistics() {
+        Result<GetGraphStatisticsResponse> resp = session.getGraphStatistics(graphId);
+        assertOk(resp);
+        logger.info("graph statistics: " + resp.getValue());
+    }
+
+    @Test
+    @Order(12)
     public void test9CallCppProcedure1() {
         QueryRequest request = new QueryRequest();
         request.setQueryName(cppProcedureId1);
@@ -500,7 +508,7 @@ public class DriverTest {
     }
 
     @Test
-    @Order(12)
+    @Order(13)
     public void test9CallCppProcedure1Current() {
         QueryRequest request = new QueryRequest();
         request.setQueryName(cppProcedureId1);
@@ -518,7 +526,7 @@ public class DriverTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     public void test9CallCppProcedure2() {
         byte[] bytes = new byte[4 + 1];
         Encoder encoder = new Encoder(bytes);
@@ -529,7 +537,7 @@ public class DriverTest {
     }
 
     @Test
-    @Order(14)
+    @Order(15)
     public void test10CallCypherProcedureViaNeo4j() {
         String query = "CALL " + cypherProcedureId + "() YIELD *;";
         org.neo4j.driver.Result result = neo4jSession.run(query);

--- a/flex/interactive/sdk/python/interactive_sdk/client/session.py
+++ b/flex/interactive/sdk/python/interactive_sdk/client/session.py
@@ -57,6 +57,7 @@ from interactive_sdk.openapi.models.get_graph_response import GetGraphResponse
 from interactive_sdk.openapi.models.get_graph_schema_response import (
     GetGraphSchemaResponse,
 )
+from interactive_sdk.openapi.models.get_graph_statistics_response import GetGraphStatisticsResponse
 from interactive_sdk.openapi.models.get_procedure_response import GetProcedureResponse
 from interactive_sdk.openapi.models.job_response import JobResponse
 from interactive_sdk.openapi.models.job_status import JobStatus
@@ -176,6 +177,14 @@ class GraphInterface(metaclass=ABCMeta):
             StrictStr, Field(description="The id of graph to get")
         ],
     ) -> Result[GetGraphResponse]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_graph_statistics(
+        graph_id: Annotated[
+            StrictStr, Field(description="The id of graph to get")
+        ],
+    ) -> Result[GetGraphStatisticsResponse]:
         raise NotImplementedError
 
     @abstractmethod
@@ -434,6 +443,16 @@ class DefaultSession(Session):
     ) -> Result[GetGraphResponse]:
         try:
             response = self._graph_api.get_graph_with_http_info(graph_id)
+            return Result.from_response(response)
+        except Exception as e:
+            return Result.from_exception(e)
+    
+    def get_graph_statistics(
+        self,
+        graph_id: Annotated[StrictStr, Field(description="The id of graph to get")],
+    ) -> Result[GetGraphStatisticsResponse]:
+        try:
+            response = self._graph_api.get_graph_statistic_with_http_info(graph_id)
             return Result.from_response(response)
         except Exception as e:
             return Result.from_exception(e)

--- a/flex/interactive/sdk/python/test/test_driver.py
+++ b/flex/interactive/sdk/python/test/test_driver.py
@@ -100,6 +100,7 @@ class TestDriver(unittest.TestCase):
         self.createCypherProcedure()
         self.createCppProcedure()
         self.restart()
+        self.getStatistics()
         self.callProcedure()
         self.callProcedureWithHttp()
         self.callProcedureWithHttpCurrent()
@@ -259,6 +260,11 @@ class TestDriver(unittest.TestCase):
         print("restart: ", resp.get_value())
         # wait 5 seconds
         time.sleep(5)
+
+    def getStatistics(self):
+        resp = self._sess.get_graph_statistics(self._graph_id)
+        assert resp.is_ok()
+        print("get graph statistics: ", resp.get_value())
 
     def callProcedure(self):
         with self._driver.getNeo4jSession() as session:

--- a/flex/openapi/openapi_interactive.yaml
+++ b/flex/openapi/openapi_interactive.yaml
@@ -170,6 +170,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetGraphSchemaResponse'
+  /v1/graph/{graph_id}/statistics:
+    get:
+      tags:
+        - AdminService/GraphManagement
+      description: Get the statics info of a graph, including number of vertices for each label, number of edges for each label.
+      operationId: get_graph_statistic
+      parameters:
+        - name: graph_id
+          in : path
+          required: true
+          schema:
+            type: string
+          description: The id of graph to get statistics
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetGraphStatisticsResponse'
+        '500':
+          description: Server Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIResponse'
+              example: "Internal error"
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIResponse'
+              example: "Graph not running or graph not exists"
+        '503':
+          description: Service Unavailable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIResponse'
+              example: "Service unavailable, try again later"
 
   /v1/graph/{graph_id}/dataloading:
     post:
@@ -1291,6 +1332,61 @@ components:
       x-body-name: api_response
       type: string
       example: "Response string"
+    VertexStatistics:
+      x-body-name: vertex_statistics
+      type: object
+      properties:
+        type_id:
+          type: integer
+        type_name:
+          type: string
+        count:
+          type: integer
+    VertexTypePairStatistics:
+      type: object
+      x-body-name: vertex_type_pair_statistics
+      required:
+        - source_vertex
+        - destination_vertex
+        - count
+      properties:
+        source_vertex: 
+          type: string
+        destination_vertex:
+          type: string
+        count:
+          type: integer
+    EdgeStatistics:
+      x-body-name: edge_statistics
+      type: object
+      properties:
+        type_id:
+          type: integer
+        type_name:
+          type: string
+        vertex_type_pair_statistics:
+          type: array
+          items:
+            $ref: '#/components/schemas/VertexTypePairStatistics'
+    GetGraphStatisticsResponse:
+      x-body-name: graph_statistics_response
+      type: object
+      required:
+        - total_vertex_count
+        - total_edge_count
+      properties:
+        total_vertex_count:
+          type: integer
+        total_edge_count:
+          type: integer
+        vertex_type_statistics:
+          type: array
+          items: 
+            $ref: '#/components/schemas/VertexStatistics'
+        edge_type_statistics:
+          type: array
+          items:
+            $ref: '#/components/schemas/EdgeStatistics'
     GetGraphResponse:
       x-body-name: get_graph_response
       type: object

--- a/flex/storages/metadata/graph_meta_store.h
+++ b/flex/storages/metadata/graph_meta_store.h
@@ -223,6 +223,28 @@ struct UpdateJobMetaRequest {
   static UpdateJobMetaRequest NewFinished(int rc);
 };
 
+struct GraphStatistics {
+  // type_id, type_name, count
+  using vertex_type_statistic = std::tuple<int32_t, std::string, int32_t>;
+  // src_vertex_type_name, dst_vertex_type_name, count
+  using vertex_type_pair_statistic =
+      std::tuple<std::string, std::string, int32_t>;
+  // edge_type_id, edge_type_name, Vec<vertex_type_pair_statistics>
+  using edge_type_statistic =
+      std::tuple<int32_t, std::string, std::vector<vertex_type_pair_statistic>>;
+
+  GraphStatistics() : total_vertex_count(0), total_edge_count(0) {}
+
+  uint64_t total_vertex_count;
+  uint64_t total_edge_count;
+  std::vector<vertex_type_statistic> vertex_type_statistics;
+  std::vector<edge_type_statistic> edge_type_statistics;
+
+  std::string ToJson() const;
+  static Result<GraphStatistics> FromJson(const std::string& json_str);
+  static Result<GraphStatistics> FromJson(const nlohmann::json& json);
+};
+
 /*
  * The metadata store is responsible for storing metadata of the graph, plugins
  * and other information.


### PR DESCRIPTION
`curl -X GET http://localhost:7777/v1/graph/{graph_id}/statistics` retrieves the graph's stats: total vertex and edge counts, plus label counts for each vertex and edge.

Currently, this API will only returns the statistics of the graph if it is running. inquire about a non-running graph will yield an error.