### PR TITLE
fix(interactive): Install `nlohmann/json.hpp` as it is needed by procedure compilation

### DIFF
--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -250,6 +250,8 @@ set(CPACK_DEB_COMPONENT_INSTALL YES)
 
 #install CMakeLists.txt.template to resources/
 install(FILES resources/hqps/CMakeLists.txt.template DESTINATION lib/flex/)
+#install header-only nlohmann-json.hpp to include/
+install(FILES ${CMAKE_SOURCE_DIR}/third_party/nlohmann-json/single_include/nlohmann/json.hpp DESTINATION include/nlohmann)
 
 if(USE_PTHASH)
     install(DIRECTORY ${PROJECT_SOURCE_DIR}/third_party/murmurhash

--- a/flex/engines/http_server/handler/hqps_http_handler.cc
+++ b/flex/engines/http_server/handler/hqps_http_handler.cc
@@ -528,7 +528,7 @@ bool hqps_http_handler::is_running() const { return running_.load(); }
 bool hqps_http_handler::is_actors_running() const {
   return !ic_handler_->is_current_scope_cancelled() &&
          !adhoc_query_handler_->is_current_scope_cancelled() &&
-         proc_handler_->is_current_scope_cancelled();
+         !proc_handler_->is_current_scope_cancelled();
 }
 
 void hqps_http_handler::start() {

--- a/flex/interactive/docker/interactive-runtime.Dockerfile
+++ b/flex/interactive/docker/interactive-runtime.Dockerfile
@@ -32,7 +32,7 @@ cmake . -DCMAKE_INSTALL_PREFIX=/opt/flex -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_
 
 # install flex
 RUN . ${HOME}/.cargo/env  && cd ${HOME}/GraphScope/flex && \
-    git submodule update --init && mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/opt/flex -DBUILD_DOC=OFF && make -j && make install && \
+    git submodule update --init && mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/opt/flex -DBUILD_DOC=OFF -DBUILD_TEST=OFF && make -j && make install && \
     cd ~/GraphScope/interactive_engine/ && mvn clean package -Pexperimental -DskipTests && \
     cd ~/GraphScope/interactive_engine/compiler && cp target/compiler-0.0.1-SNAPSHOT.jar /opt/flex/lib/ && \
     cp target/libs/*.jar /opt/flex/lib/ && \


### PR DESCRIPTION
- Install `nlohmann/json.hpp` to system as it is needed by procedure compilation.
- Skip building tests when building docker image.