### PR TITLE
refactor(interactive): Refine Interactive SDK `call_proc` API design

### DIFF
--- a/flex/engines/graph_db/database/graph_db_session.h
+++ b/flex/engines/graph_db/database/graph_db_session.h
@@ -47,6 +47,7 @@ class GraphDBSession {
   static constexpr int32_t MAX_RETRY = 3;
   static constexpr int32_t MAX_PLUGIN_NUM = 256;  // 2^(sizeof(uint8_t)*8)
 #ifdef BUILD_HQPS
+  static constexpr const char* kCppEncoder = "\x00";
   static constexpr const char* kCypherJson = "\x01";
   static constexpr const char* kCypherInternalAdhoc = "\x02";
   static constexpr const char* kCypherInternalProcedure = "\x03";

--- a/flex/engines/http_server/handler/hqps_http_handler.cc
+++ b/flex/engines/http_server/handler/hqps_http_handler.cc
@@ -45,8 +45,7 @@ class optional_param_matcher : public matcher {
    */
   explicit optional_param_matcher(const sstring& name) : _name(name) {}
 
-  virtual size_t match(const sstring& url, size_t ind,
-                       parameters& param) override {
+  size_t match(const sstring& url, size_t ind, parameters& param) override {
     size_t last = find_end_param(url, ind);
     if (last == url.size()) {
       // Means we didn't find the parameter, but we still return true,

--- a/flex/engines/http_server/handler/hqps_http_handler.cc
+++ b/flex/engines/http_server/handler/hqps_http_handler.cc
@@ -536,7 +536,6 @@ hqps_adhoc_query_handler::handle(const seastar::sstring& path,
 hqps_http_handler::hqps_http_handler(uint16_t http_port, int32_t shard_num)
     : http_port_(http_port) {
   ic_handlers_.resize(shard_num);
-  proc_handlers_.resize(shard_num);
   adhoc_query_handlers_.resize(shard_num);
 }
 
@@ -595,10 +594,6 @@ seastar::future<> hqps_http_handler::stop_query_actors() {
             ->cancel_current_scope();
       })
       .then([this] {
-        return proc_handlers_[hiactor::local_shard_id()]
-            ->cancel_current_scope();
-      })
-      .then([this] {
         LOG(INFO) << "Cancelled proc scope";
         actors_running_.store(false);
         return seastar::make_ready_future<>();
@@ -608,7 +603,6 @@ seastar::future<> hqps_http_handler::stop_query_actors() {
 void hqps_http_handler::start_query_actors() {
   ic_handlers_[hiactor::local_shard_id()]->create_actors();
   adhoc_query_handlers_[hiactor::local_shard_id()]->create_actors();
-  proc_handlers_[hiactor::local_shard_id()]->create_actors();
   actors_running_.store(true);
 }
 
@@ -617,19 +611,13 @@ seastar::future<> hqps_http_handler::set_routes() {
     auto ic_handler =
         new hqps_ic_handler(ic_query_group_id, max_group_id, group_inc_step,
                             shard_query_concurrency);
-    auto proc_handler =
-        new hqps_ic_handler(ic_query_group_id, max_group_id, group_inc_step,
-                            shard_query_concurrency);
     auto adhoc_query_handler = new hqps_adhoc_query_handler(
         ic_adhoc_group_id, codegen_group_id, max_group_id, group_inc_step,
         shard_adhoc_concurrency);
 
-    r.add(seastar::httpd::operation_type::POST,
-          seastar::httpd::url("/v1/query"), ic_handler);
-
-    auto rule_proc = new seastar::httpd::match_rule(proc_handler);
+    auto rule_proc = new seastar::httpd::match_rule(ic_handler);
     rule_proc->add_str("/v1/graph")
-        .add_matcher(new seastar::httpd::param_matcher("graph_id"))
+        .add_matcher(new seastar::httpd::optional_param_matcher("graph_id"))
         .add_str("/query");
 
     r.add(rule_proc, seastar::httpd::operation_type::POST);
@@ -638,7 +626,6 @@ seastar::future<> hqps_http_handler::set_routes() {
           seastar::httpd::url("/interactive/adhoc_query"), adhoc_query_handler);
 
     ic_handlers_[hiactor::local_shard_id()] = ic_handler;
-    proc_handlers_[hiactor::local_shard_id()] = proc_handler;
     adhoc_query_handlers_[hiactor::local_shard_id()] = adhoc_query_handler;
 
     return seastar::make_ready_future<>();

--- a/flex/engines/http_server/handler/hqps_http_handler.cc
+++ b/flex/engines/http_server/handler/hqps_http_handler.cc
@@ -27,6 +27,50 @@
 #include "flex/engines/http_server/types.h"
 #include "flex/otel/otel.h"
 
+#include <seastar/core/when_all.hh>
+
+namespace seastar {
+namespace httpd {
+// The seastar::httpd::param_matcher will fail to match if param is not
+// specified.
+class optional_param_matcher : public matcher {
+ public:
+  /**
+   * Constructor
+   * @param name the name of the parameter, will be used as the key
+   * in the parameters object
+   * @param entire_path when set to true, the matched parameters will
+   * include all the remaining url until the end of it.
+   * when set to false the match will terminate at the next slash
+   */
+  explicit optional_param_matcher(const sstring& name) : _name(name) {}
+
+  virtual size_t match(const sstring& url, size_t ind,
+                       parameters& param) override {
+    size_t last = find_end_param(url, ind);
+    if (last == url.size()) {
+      // Means we didn't find the parameter, but we still return true,
+      // and set the value to empty string.
+      param.set(_name, "");
+      return ind;
+    }
+    param.set(_name, url.substr(ind, last - ind));
+    return last;
+  }
+
+ private:
+  size_t find_end_param(const sstring& url, size_t ind) {
+    size_t pos = url.find('/', ind + 1);
+    if (pos == sstring::npos) {
+      return url.length();
+    }
+    return pos;
+  }
+  sstring _name;
+};
+}  // namespace httpd
+}  // namespace seastar
+
 namespace server {
 
 hqps_ic_handler::hqps_ic_handler(uint32_t init_group_id, uint32_t max_group_id,
@@ -124,39 +168,39 @@ seastar::future<std::unique_ptr<seastar::httpd::reply>> hqps_ic_handler::handle(
     std::unique_ptr<seastar::httpd::reply> rep) {
   auto dst_executor = executor_idx_;
   executor_idx_ = (executor_idx_ + 1) % shard_concurrency_;
-  if (req->content.size() <= 0) {
-    // At least one input format byte is needed
+  // TODO(zhanglei): choose read or write based on the request, after the
+  // read/write info is supported in physical plan
+  auto request_format = req->get_header(INTERACTIVE_REQUEST_FORMAT);
+  if (request_format.empty()) {
+    // If no format specfied, we use default format: proto
+    request_format = PROTOCOL_FORMAT;
+  }
+  if (request_format == JSON_FORMAT) {
+    req->content.append(gs::GraphDBSession::kCypherJson, 1);
+  } else if (request_format == PROTOCOL_FORMAT) {
+    req->content.append(gs::GraphDBSession::kCypherInternalProcedure, 1);
+  } else if (request_format == ENCODER_FORMAT) {
+    req->content.append(gs::GraphDBSession::kCppEncoder, 1);
+  } else {
+    LOG(ERROR) << "Unsupported request format: " << request_format;
     rep->set_status(seastar::httpd::reply::status_type::internal_server_error);
-    rep->write_body("bin", seastar::sstring("Empty request!"));
+    rep->write_body("bin", seastar::sstring("Unsupported request format!"));
     rep->done();
     return seastar::make_ready_future<std::unique_ptr<seastar::httpd::reply>>(
         std::move(rep));
   }
-  uint8_t input_format =
-      req->content.back();  // see graph_db_session.h#parse_query_type
-  // TODO(zhanglei): choose read or write based on the request, after the
-  // read/write info is supported in physical plan
-  if (req->param.exists("graph_id")) {
+  if (path != "/v1/graph/current/query" && req->param.exists("graph_id")) {
+    // TODO(zhanglei): get from graph_db.
     if (!is_running_graph(req->param["graph_id"])) {
       rep->set_status(
           seastar::httpd::reply::status_type::internal_server_error);
-      rep->write_body("bin", seastar::sstring("Failed to get running graph!"));
+      rep->write_body("bin",
+                      seastar::sstring("The querying query is not running:" +
+                                       req->param["graph_id"]));
       rep->done();
       return seastar::make_ready_future<std::unique_ptr<seastar::httpd::reply>>(
           std::move(rep));
     }
-  } else {
-    req->content.append(gs::GraphDBSession::kCypherInternalProcedure, 1);
-    // This handler with accept two kinds of queries, /v1/graph/{graph_id}/query
-    // and /v1/query/ The former one will have a graph_id in the request, and
-    // the latter one will not. For the first one, the input format is the last
-    // byte of the request content, and is added at client side; For the second
-    // one, the request is send from compiler, and currently compiler will not
-    // add extra bytes to the request content. So we need to add the input
-    // format here. Finally, we should REMOVE this adhoc appended byte, i.e. the
-    // input format byte should be added at compiler side
-    // TODO(zhanglei): remove this adhoc appended byte, add the byte at compiler
-    // side. Or maybe we should refine the protocol.
   }
 #ifdef HAVE_OPENTELEMETRY_CPP
   auto tracer = otel::get_tracer("hqps_procedure_query_handler");
@@ -173,31 +217,30 @@ seastar::future<std::unique_ptr<seastar::httpd::reply>> hqps_ic_handler::handle(
 
   return executor_refs_[dst_executor]
       .run_graph_db_query(query_param{std::move(req->content)})
-      .then([input_format
+      .then([request_format
 #ifdef HAVE_OPENTELEMETRY_CPP
              ,
              this, outer_span = outer_span
 #endif  // HAVE_OPENTELEMETRY_CPP
   ](auto&& output) {
-        if (output.content.size() < 4) {
-          LOG(ERROR) << "Invalid output size: " << output.content.size();
-#ifdef HAVE_OPENTELEMETRY_CPP
-          outer_span->SetStatus(opentelemetry::trace::StatusCode::kError,
-                                "Invalid output size");
-          outer_span->End();
-          std::map<std::string, std::string> labels = {{"status", "fail"}};
-          total_counter_->Add(1, labels);
-#endif  // HAVE_OPENTELEMETRY_CPP
-          return seastar::make_ready_future<query_param>(std::move(output));
-        }
-        if (input_format == static_cast<uint8_t>(
-                                gs::GraphDBSession::InputFormat::kCppEncoder)) {
+        if (request_format == ENCODER_FORMAT) {
           return seastar::make_ready_future<query_param>(
               std::move(output.content));
         } else {
           // For cypher input format, the results are written with
           // output.put_string(), which will add extra 4 bytes. So we need to
           // remove the first 4 bytes here.
+          if (output.content.size() < 4) {
+            LOG(ERROR) << "Invalid output size: " << output.content.size();
+#ifdef HAVE_OPENTELEMETRY_CPP
+            outer_span->SetStatus(opentelemetry::trace::StatusCode::kError,
+                                  "Invalid output size");
+            outer_span->End();
+            std::map<std::string, std::string> labels = {{"status", "fail"}};
+            total_counter_->Add(1, labels);
+#endif  // HAVE_OPENTELEMETRY_CPP
+            return seastar::make_ready_future<query_param>(std::move(output));
+          }
           return seastar::make_ready_future<query_param>(
               std::move(output.content.substr(4)));
         }
@@ -491,27 +534,8 @@ hqps_adhoc_query_handler::handle(const seastar::sstring& path,
       });
 }
 
-seastar::future<std::unique_ptr<seastar::httpd::reply>>
-hqps_exit_handler::handle(const seastar::sstring& path,
-                          std::unique_ptr<seastar::httpd::request> req,
-                          std::unique_ptr<seastar::httpd::reply> rep) {
-  HQPSService::get().set_exit_state();
-  rep->write_body("bin", seastar::sstring{"HQPS service is exiting ..."});
-  return seastar::make_ready_future<std::unique_ptr<seastar::httpd::reply>>(
-      std::move(rep));
-}
-
 hqps_http_handler::hqps_http_handler(uint16_t http_port)
-    : http_port_(http_port) {
-  ic_handler_ = new hqps_ic_handler(ic_query_group_id, max_group_id,
-                                    group_inc_step, shard_query_concurrency);
-  proc_handler_ = new hqps_ic_handler(proc_query_group_id, max_group_id,
-                                      group_inc_step, shard_query_concurrency);
-  adhoc_query_handler_ = new hqps_adhoc_query_handler(
-      ic_adhoc_group_id, codegen_group_id, max_group_id, group_inc_step,
-      shard_adhoc_concurrency);
-  exit_handler_ = new hqps_exit_handler();
-}
+    : http_port_(http_port) {}
 
 hqps_http_handler::~hqps_http_handler() {
   if (is_running()) {
@@ -526,9 +550,7 @@ uint16_t hqps_http_handler::get_port() const { return http_port_; }
 bool hqps_http_handler::is_running() const { return running_.load(); }
 
 bool hqps_http_handler::is_actors_running() const {
-  return !ic_handler_->is_current_scope_cancelled() &&
-         !adhoc_query_handler_->is_current_scope_cancelled() &&
-         !proc_handler_->is_current_scope_cancelled();
+  return actors_running_.load();
 }
 
 void hqps_http_handler::start() {
@@ -562,43 +584,48 @@ void hqps_http_handler::stop() {
 
 seastar::future<> hqps_http_handler::stop_query_actors() {
   // First cancel the scope.
-  return ic_handler_->cancel_current_scope()
+  return ic_handlers_[hiactor::local_shard_id()]
+      ->cancel_current_scope()
       .then([this] {
-        LOG(INFO) << "Cancel ic scope";
-        return adhoc_query_handler_->cancel_current_scope();
+        LOG(INFO) << "Cancelled ic scope";
+        return adhoc_query_handlers_[hiactor::local_shard_id()]
+            ->cancel_current_scope();
       })
       .then([this] {
-        LOG(INFO) << "Cancel adhoc scope";
-        return proc_handler_->cancel_current_scope();
-      })
-      .then([] {
-        LOG(INFO) << "Cancel proc scope";
+        LOG(INFO) << "Cancelled proc scope";
+        actors_running_.store(false);
         return seastar::make_ready_future<>();
       });
 }
 
 void hqps_http_handler::start_query_actors() {
-  ic_handler_->create_actors();
-  adhoc_query_handler_->create_actors();
-  proc_handler_->create_actors();
-  LOG(INFO) << "Restart all actors";
+  ic_handlers_[hiactor::local_shard_id()]->create_actors();
+  adhoc_query_handlers_[hiactor::local_shard_id()]->create_actors();
+  actors_running_.store(true);
 }
 
 seastar::future<> hqps_http_handler::set_routes() {
   return server_.set_routes([this](seastar::httpd::routes& r) {
+    auto ic_handler =
+        new hqps_ic_handler(ic_query_group_id, max_group_id, group_inc_step,
+                            shard_query_concurrency);
+    auto adhoc_query_handler = new hqps_adhoc_query_handler(
+        ic_adhoc_group_id, codegen_group_id, max_group_id, group_inc_step,
+        shard_adhoc_concurrency);
+
+    auto rule_proc = new seastar::httpd::match_rule(ic_handler);
+    rule_proc->add_str("/v1/graph")
+        .add_matcher(new seastar::httpd::optional_param_matcher("graph_id"))
+        .add_str("/query");
+    // Get All procedures
+    r.add(rule_proc, seastar::httpd::operation_type::POST);
+
     r.add(seastar::httpd::operation_type::POST,
-          seastar::httpd::url("/v1/query"), ic_handler_);
-    {
-      auto rule_proc = new seastar::httpd::match_rule(proc_handler_);
-      rule_proc->add_str("/v1/graph").add_param("graph_id").add_str("/query");
-      // Get All procedures
-      r.add(rule_proc, seastar::httpd::operation_type::POST);
-    }
-    r.add(seastar::httpd::operation_type::POST,
-          seastar::httpd::url("/interactive/adhoc_query"),
-          adhoc_query_handler_);
-    r.add(seastar::httpd::operation_type::POST,
-          seastar::httpd::url("/interactive/exit"), exit_handler_);
+          seastar::httpd::url("/interactive/adhoc_query"), adhoc_query_handler);
+
+    ic_handlers_.emplace_back(ic_handler);
+    adhoc_query_handlers_.emplace_back(adhoc_query_handler);
+
     return seastar::make_ready_future<>();
   });
 }

--- a/flex/engines/http_server/handler/hqps_http_handler.cc
+++ b/flex/engines/http_server/handler/hqps_http_handler.cc
@@ -161,7 +161,7 @@ bool hqps_ic_handler::is_running_graph(const seastar::sstring& graph_id) const {
   return running_graph_res.value() == graph_id_str;
 }
 
-// Handles both /v1/graph/{graph_id}/query and /v1/query/
+// Handles both /v1/graph/{graph_id}/query and /v1/graph/current/query/
 seastar::future<std::unique_ptr<seastar::httpd::reply>> hqps_ic_handler::handle(
     const seastar::sstring& path, std::unique_ptr<seastar::httpd::request> req,
     std::unique_ptr<seastar::httpd::reply> rep) {

--- a/flex/engines/http_server/handler/hqps_http_handler.h
+++ b/flex/engines/http_server/handler/hqps_http_handler.h
@@ -132,7 +132,6 @@ class hqps_http_handler {
   std::atomic<bool> running_{false}, actors_running_{false};
 
   std::vector<hqps_ic_handler*> ic_handlers_;
-  std::vector<hqps_ic_handler*> proc_handlers_;
   std::vector<hqps_adhoc_query_handler*> adhoc_query_handlers_;
 };
 

--- a/flex/engines/http_server/handler/hqps_http_handler.h
+++ b/flex/engines/http_server/handler/hqps_http_handler.h
@@ -107,7 +107,7 @@ class hqps_adhoc_query_handler : public seastar::httpd::handler_base {
 
 class hqps_http_handler {
  public:
-  hqps_http_handler(uint16_t http_port);
+  hqps_http_handler(uint16_t http_port, int32_t shard_num);
   ~hqps_http_handler();
 
   void start();
@@ -132,6 +132,7 @@ class hqps_http_handler {
   std::atomic<bool> running_{false}, actors_running_{false};
 
   std::vector<hqps_ic_handler*> ic_handlers_;
+  std::vector<hqps_ic_handler*> proc_handlers_;
   std::vector<hqps_adhoc_query_handler*> adhoc_query_handlers_;
 };
 

--- a/flex/engines/http_server/handler/hqps_http_handler.h
+++ b/flex/engines/http_server/handler/hqps_http_handler.h
@@ -31,6 +31,12 @@ namespace server {
 
 class hqps_ic_handler : public seastar::httpd::handler_base {
  public:
+  // extra headers
+  static constexpr const char* INTERACTIVE_REQUEST_FORMAT =
+      "X-Interactive-Request-Format";
+  static constexpr const char* PROTOCOL_FORMAT = "proto";
+  static constexpr const char* JSON_FORMAT = "json";
+  static constexpr const char* ENCODER_FORMAT = "encoder";
   hqps_ic_handler(uint32_t init_group_id, uint32_t max_group_id,
                   uint32_t group_inc_step, uint32_t shard_concurrency);
   ~hqps_ic_handler() override;
@@ -99,14 +105,6 @@ class hqps_adhoc_query_handler : public seastar::httpd::handler_base {
 #endif
 };
 
-class hqps_exit_handler : public seastar::httpd::handler_base {
- public:
-  seastar::future<std::unique_ptr<seastar::httpd::reply>> handle(
-      const seastar::sstring& path,
-      std::unique_ptr<seastar::httpd::request> req,
-      std::unique_ptr<seastar::httpd::reply> rep) override;
-};
-
 class hqps_http_handler {
  public:
   hqps_http_handler(uint16_t http_port);
@@ -131,11 +129,10 @@ class hqps_http_handler {
  private:
   const uint16_t http_port_;
   seastar::httpd::http_server_control server_;
-  std::atomic<bool> running_{false};
+  std::atomic<bool> running_{false}, actors_running_{false};
 
-  hqps_ic_handler *ic_handler_, *proc_handler_;
-  hqps_adhoc_query_handler* adhoc_query_handler_;
-  hqps_exit_handler* exit_handler_;
+  std::vector<hqps_ic_handler*> ic_handlers_;
+  std::vector<hqps_adhoc_query_handler*> adhoc_query_handlers_;
 };
 
 }  // namespace server

--- a/flex/engines/http_server/service/hqps_service.cc
+++ b/flex/engines/http_server/service/hqps_service.cc
@@ -64,7 +64,8 @@ void HQPSService::init(const ServiceConfig& config) {
   actor_sys_ = std::make_unique<actor_system>(
       config.shard_num, config.dpdk_mode, config.enable_thread_resource_pool,
       config.external_thread_num, [this]() { set_exit_state(); });
-  query_hdl_ = std::make_unique<hqps_http_handler>(config.query_port);
+  query_hdl_ =
+      std::make_unique<hqps_http_handler>(config.query_port, config.shard_num);
   if (config.start_admin_service) {
     admin_hdl_ = std::make_unique<admin_http_handler>(config.admin_port);
   }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/ProcedureInterface.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/ProcedureInterface.java
@@ -43,6 +43,6 @@ public interface ProcedureInterface {
     Result<IrResult.CollectiveResults> callProcedure(QueryRequest request);
 
     Result<byte[]> callProcedureRaw(String graphId, byte[] request);
-    
+
     Result<byte[]> callProcedureRaw(byte[] request);
 }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/ProcedureInterface.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/ProcedureInterface.java
@@ -40,5 +40,9 @@ public interface ProcedureInterface {
 
     Result<IrResult.CollectiveResults> callProcedure(String graphId, QueryRequest request);
 
+    Result<IrResult.CollectiveResults> callProcedure(QueryRequest request);
+
     Result<byte[]> callProcedureRaw(String graphId, byte[] request);
+    
+    Result<byte[]> callProcedureRaw(byte[] request);
 }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
@@ -43,6 +43,9 @@ public class DefaultSession implements Session {
 
     private static final int DEFAULT_READ_TIMEOUT = 30000;
     private static final int DEFAULT_WRITE_TIMEOUT = 30000;
+    private static String JSON_FORMAT_STRING = "json";
+    private static String PROTO_FORMAT_STRING = "proto";
+    private static String ENCODER_FORMAT_STRING = "encoder";
 
     private final ApiClient client, queryClient;
 
@@ -331,7 +334,7 @@ public class DefaultSession implements Session {
             // flex/engines/graph_db/graph_db_session.h
             // Here we add byte of value 1 to denote the input format is in JSON format.
             byte[] encodedStr = encodeString(request.toJson(), 1);
-            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName, encodedStr);
+            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName,JSON_FORMAT_STRING, encodedStr);
             if (response.getStatusCode() != 200) {
                 return Result.fromException(
                         new ApiException(response.getStatusCode(), "Failed to call procedure"));
@@ -358,7 +361,7 @@ public class DefaultSession implements Session {
             byte[] encodedStr = new byte[request.length + 1];
             System.arraycopy(request, 0, encodedStr, 0, request.length);
             encodedStr[request.length] = 0;
-            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName, encodedStr);
+            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName, ENCODER_FORMAT_STRING, encodedStr);
             if (response.getStatusCode() != 200) {
                 return Result.fromException(
                         new ApiException(response.getStatusCode(), "Failed to call procedure"));

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
@@ -319,13 +319,6 @@ public class DefaultSession implements Session {
         }
     }
 
-    private byte[] encodeString(String jsonStr, int lastByte) {
-        byte[] bytes = new byte[jsonStr.length() + 1];
-        System.arraycopy(jsonStr.getBytes(), 0, bytes, 0, jsonStr.length());
-        bytes[jsonStr.length()] = (byte) lastByte;
-        return bytes;
-    }
-
     @Override
     public Result<IrResult.CollectiveResults> callProcedure(
             String graphName, QueryRequest request) {
@@ -333,8 +326,30 @@ public class DefaultSession implements Session {
             // Interactive currently support four type of inputformat, see
             // flex/engines/graph_db/graph_db_session.h
             // Here we add byte of value 1 to denote the input format is in JSON format.
-            byte[] encodedStr = encodeString(request.toJson(), 1);
-            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName,JSON_FORMAT_STRING, encodedStr);
+            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName,JSON_FORMAT_STRING, request.toJson().getBytes());
+            if (response.getStatusCode() != 200) {
+                return Result.fromException(
+                        new ApiException(response.getStatusCode(), "Failed to call procedure"));
+            }
+            IrResult.CollectiveResults results =
+                    IrResult.CollectiveResults.parseFrom(response.getData());
+            return new Result<>(results);
+        } catch (ApiException e) {
+            e.printStackTrace();
+            return Result.fromException(e);
+        } catch (InvalidProtocolBufferException e) {
+            e.printStackTrace();
+            return Result.error(e.getMessage());
+        }
+    }
+
+    @Override
+    public Result<IrResult.CollectiveResults> callProcedure(QueryRequest request) {
+        try {
+            // Interactive currently support four type of inputformat, see
+            // flex/engines/graph_db/graph_db_session.h
+            // Here we add byte of value 1 to denote the input format is in JSON format.
+            ApiResponse<byte[]> response = queryApi.procCallCurrentWithHttpInfo(JSON_FORMAT_STRING, request.toJson().getBytes());
             if (response.getStatusCode() != 200) {
                 return Result.fromException(
                         new ApiException(response.getStatusCode(), "Failed to call procedure"));
@@ -358,10 +373,26 @@ public class DefaultSession implements Session {
             // flex/engines/graph_db/graph_db_session.h
             // Here we add byte of value 0 to denote the input format is in raw encoder/decoder
             // format.
-            byte[] encodedStr = new byte[request.length + 1];
-            System.arraycopy(request, 0, encodedStr, 0, request.length);
-            encodedStr[request.length] = 0;
-            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName, ENCODER_FORMAT_STRING, encodedStr);
+            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName, ENCODER_FORMAT_STRING, request);
+            if (response.getStatusCode() != 200) {
+                return Result.fromException(
+                        new ApiException(response.getStatusCode(), "Failed to call procedure"));
+            }
+            return new Result<byte[]>(response.getData());
+        } catch (ApiException e) {
+            e.printStackTrace();
+            return Result.fromException(e);
+        }
+    }
+
+    @Override
+    public Result<byte[]> callProcedureRaw(byte[] request) {
+        try {
+            // Interactive currently support four type of inputformat, see
+            // flex/engines/graph_db/graph_db_session.h
+            // Here we add byte of value 0 to denote the input format is in raw encoder/decoder
+            // format.
+            ApiResponse<byte[]> response = queryApi.procCallCurrentWithHttpInfo(ENCODER_FORMAT_STRING, request);
             if (response.getStatusCode() != 200) {
                 return Result.fromException(
                         new ApiException(response.getStatusCode(), "Failed to call procedure"));

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
@@ -326,7 +326,9 @@ public class DefaultSession implements Session {
             // Interactive currently support four type of inputformat, see
             // flex/engines/graph_db/graph_db_session.h
             // Here we add byte of value 1 to denote the input format is in JSON format.
-            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName,JSON_FORMAT_STRING, request.toJson().getBytes());
+            ApiResponse<byte[]> response =
+                    queryApi.procCallWithHttpInfo(
+                            graphName, JSON_FORMAT_STRING, request.toJson().getBytes());
             if (response.getStatusCode() != 200) {
                 return Result.fromException(
                         new ApiException(response.getStatusCode(), "Failed to call procedure"));
@@ -349,7 +351,9 @@ public class DefaultSession implements Session {
             // Interactive currently support four type of inputformat, see
             // flex/engines/graph_db/graph_db_session.h
             // Here we add byte of value 1 to denote the input format is in JSON format.
-            ApiResponse<byte[]> response = queryApi.procCallCurrentWithHttpInfo(JSON_FORMAT_STRING, request.toJson().getBytes());
+            ApiResponse<byte[]> response =
+                    queryApi.procCallCurrentWithHttpInfo(
+                            JSON_FORMAT_STRING, request.toJson().getBytes());
             if (response.getStatusCode() != 200) {
                 return Result.fromException(
                         new ApiException(response.getStatusCode(), "Failed to call procedure"));
@@ -373,7 +377,8 @@ public class DefaultSession implements Session {
             // flex/engines/graph_db/graph_db_session.h
             // Here we add byte of value 0 to denote the input format is in raw encoder/decoder
             // format.
-            ApiResponse<byte[]> response = queryApi.procCallWithHttpInfo(graphName, ENCODER_FORMAT_STRING, request);
+            ApiResponse<byte[]> response =
+                    queryApi.procCallWithHttpInfo(graphName, ENCODER_FORMAT_STRING, request);
             if (response.getStatusCode() != 200) {
                 return Result.fromException(
                         new ApiException(response.getStatusCode(), "Failed to call procedure"));
@@ -392,7 +397,8 @@ public class DefaultSession implements Session {
             // flex/engines/graph_db/graph_db_session.h
             // Here we add byte of value 0 to denote the input format is in raw encoder/decoder
             // format.
-            ApiResponse<byte[]> response = queryApi.procCallCurrentWithHttpInfo(ENCODER_FORMAT_STRING, request);
+            ApiResponse<byte[]> response =
+                    queryApi.procCallCurrentWithHttpInfo(ENCODER_FORMAT_STRING, request);
             if (response.getStatusCode() != 200) {
                 return Result.fromException(
                         new ApiException(response.getStatusCode(), "Failed to call procedure"));

--- a/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
+++ b/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
@@ -501,6 +501,24 @@ public class DriverTest {
 
     @Test
     @Order(12)
+    public void test9CallCppProcedure1Current() {
+        QueryRequest request = new QueryRequest();
+        request.setQueryName(cppProcedureId1);
+        request.addArgumentsItem(
+                new TypedValue()
+                        .value(1)
+                        .type(
+                                new GSDataType(
+                                        new PrimitiveType()
+                                                .primitiveType(
+                                                        PrimitiveType.PrimitiveTypeEnum
+                                                                .SIGNED_INT32))));
+        Result<IrResult.CollectiveResults> resp = session.callProcedure(request);
+        assertOk(resp);
+    }
+
+    @Test
+    @Order(13)
     public void test9CallCppProcedure2() {
         byte[] bytes = new byte[4 + 1];
         Encoder encoder = new Encoder(bytes);
@@ -511,7 +529,7 @@ public class DriverTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     public void test10CallCypherProcedureViaNeo4j() {
         String query = "CALL " + cypherProcedureId + "() YIELD *;";
         org.neo4j.driver.Result result = neo4jSession.run(query);

--- a/flex/interactive/sdk/python/interactive_sdk/client/session.py
+++ b/flex/interactive/sdk/python/interactive_sdk/client/session.py
@@ -237,7 +237,7 @@ class ProcedureInterface(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def call_procedure(
+    def call_procedure_current(
         self, params: QueryRequest
     ) -> Result[CollectiveResults]:
         raise NotImplementedError
@@ -247,7 +247,7 @@ class ProcedureInterface(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def call_procedure_raw(self, params: str) -> Result[str]:
+    def call_procedure_current_raw(self, params: str) -> Result[str]:
         raise NotImplementedError
 
 class QueryServiceInterface:
@@ -531,7 +531,9 @@ class DefaultSession(Session):
             # Interactive currently support four type of inputformat, see flex/engines/graph_db/graph_db_session.h
             # Here we add byte of value 1 to denote the input format is in json format
             response = self._query_api.proc_call_with_http_info(
-                graph_id, self.JSON_FORMAT, params.to_json()
+                graph_id = graph_id, 
+                x_interactive_request_format = self.JSON_FORMAT,
+                body=params.to_json()
             )
             result = CollectiveResults()
             if response.status_code == 200:
@@ -542,15 +544,15 @@ class DefaultSession(Session):
         except Exception as e:
             return Result.from_exception(e)
 
-    def call_procedure(
+    def call_procedure_current(
         self, params: QueryRequest
     ) -> Result[CollectiveResults]:
         try:
             # Interactive currently support four type of inputformat, see flex/engines/graph_db/graph_db_session.h
             # Here we add byte of value 1 to denote the input format is in json format
             response = self._query_api.proc_call_current_with_http_info(
-                self.JSON_FORMAT,
-                params.to_json()
+                x_interactive_request_format = self.JSON_FORMAT,
+                body = params.to_json()
             )
             result = CollectiveResults()
             if response.status_code == 200:
@@ -566,18 +568,21 @@ class DefaultSession(Session):
             # Interactive currently support four type of inputformat, see flex/engines/graph_db/graph_db_session.h
             # Here we add byte of value 1 to denote the input format is in encoder/decoder format
             response = self._query_api.proc_call_with_http_info(
-                graph_id, self.ENCODER_FORMAT, params
+                graph_id = graph_id, 
+                x_interactive_request_format = self.ENCODER_FORMAT, 
+                body = params
             )
             return Result.from_response(response)
         except Exception as e:
             return Result.from_exception(e)
         
-    def call_procedure_raw(self, params: str) -> Result[str]:
+    def call_procedure_current_raw(self, params: str) -> Result[str]:
         try:
             # Interactive currently support four type of inputformat, see flex/engines/graph_db/graph_db_session.h
             # Here we add byte of value 1 to denote the input format is in encoder/decoder format
             response = self._query_api.proc_call_current_with_http_info(
-                self.ENCODER_FORMAT, params
+                x_interactive_request_format = self.ENCODER_FORMAT, 
+                body = params
             )
             return Result.from_response(response)
         except Exception as e:

--- a/flex/interactive/sdk/python/interactive_sdk/client/session.py
+++ b/flex/interactive/sdk/python/interactive_sdk/client/session.py
@@ -235,11 +235,20 @@ class ProcedureInterface(metaclass=ABCMeta):
         self, graph_id: StrictStr, params: QueryRequest
     ) -> Result[CollectiveResults]:
         raise NotImplementedError
-    
+
+    @abstractmethod
+    def call_procedure(
+        self, params: QueryRequest
+    ) -> Result[CollectiveResults]:
+        raise NotImplementedError
+
     @abstractmethod
     def call_procedure_raw(self, graph_id: StrictStr, params: str) -> Result[str]:
         raise NotImplementedError
 
+    @abstractmethod
+    def call_procedure_raw(self, params: str) -> Result[str]:
+        raise NotImplementedError
 
 class QueryServiceInterface:
     @abstractmethod
@@ -291,6 +300,9 @@ class Session(
 
 
 class DefaultSession(Session):
+    PROTOCOL_FORMAT = "proto"
+    JSON_FORMAT = "json"
+    ENCODER_FORMAT = "encoder"
     def __init__(self, uri: str):
         self._client = ApiClient(Configuration(host=uri))
 
@@ -518,9 +530,27 @@ class DefaultSession(Session):
         try:
             # Interactive currently support four type of inputformat, see flex/engines/graph_db/graph_db_session.h
             # Here we add byte of value 1 to denote the input format is in json format
-            params_str = params.to_json() + chr(1)
             response = self._query_api.proc_call_with_http_info(
-                graph_id, params_str
+                graph_id, self.JSON_FORMAT, params.to_json()
+            )
+            result = CollectiveResults()
+            if response.status_code == 200:
+                result.ParseFromString(response.data)
+                return Result.ok(result)
+            else:
+                return Result(Status.from_response(response), result)
+        except Exception as e:
+            return Result.from_exception(e)
+
+    def call_procedure(
+        self, params: QueryRequest
+    ) -> Result[CollectiveResults]:
+        try:
+            # Interactive currently support four type of inputformat, see flex/engines/graph_db/graph_db_session.h
+            # Here we add byte of value 1 to denote the input format is in json format
+            response = self._query_api.proc_call_current_with_http_info(
+                self.JSON_FORMAT,
+                params.to_json()
             )
             result = CollectiveResults()
             if response.status_code == 200:
@@ -535,9 +565,19 @@ class DefaultSession(Session):
         try:
             # Interactive currently support four type of inputformat, see flex/engines/graph_db/graph_db_session.h
             # Here we add byte of value 1 to denote the input format is in encoder/decoder format
-            params = params + chr(0)
             response = self._query_api.proc_call_with_http_info(
-                graph_id, params
+                graph_id, self.ENCODER_FORMAT, params
+            )
+            return Result.from_response(response)
+        except Exception as e:
+            return Result.from_exception(e)
+        
+    def call_procedure_raw(self, params: str) -> Result[str]:
+        try:
+            # Interactive currently support four type of inputformat, see flex/engines/graph_db/graph_db_session.h
+            # Here we add byte of value 1 to denote the input format is in encoder/decoder format
+            response = self._query_api.proc_call_current_with_http_info(
+                self.ENCODER_FORMAT, params
             )
             return Result.from_response(response)
         except Exception as e:

--- a/flex/interactive/sdk/python/test/test_driver.py
+++ b/flex/interactive/sdk/python/test/test_driver.py
@@ -280,6 +280,21 @@ class TestDriver(unittest.TestCase):
         assert resp.is_ok()
         print("call procedure result: ", resp.get_value())
 
+    def callProcedureWithHttpCurrent(self):
+        req = QueryRequest(
+            query_name=self._cpp_proc_name,
+            arguments=[
+                TypedValue(
+                    type=GSDataType(
+                        PrimitiveType(primitive_type="DT_SIGNED_INT32")
+                    ),
+                    value = 1
+                )
+            ]
+        )
+        resp = self._sess.call_procedure(req)
+        assert resp.is_ok()
+        print("call procedure result: ", resp.get_value())
 
 if __name__ == "__main__":
     unittest.main()

--- a/flex/interactive/sdk/python/test/test_driver.py
+++ b/flex/interactive/sdk/python/test/test_driver.py
@@ -94,7 +94,7 @@ class TestDriver(unittest.TestCase):
         self.createGraph()
         self.bulkLoading()
         self.waitJobFinish()
-        self.test_list_graph()
+        self.list_graph()
         self.runCypherQuery()
         self.runGremlinQuery()
         self.createCypherProcedure()
@@ -102,6 +102,7 @@ class TestDriver(unittest.TestCase):
         self.restart()
         self.callProcedure()
         self.callProcedureWithHttp()
+        self.callProcedureWithHttpCurrent()
 
     def createGraph(self):
         create_graph = CreateGraphRequest(name="test_graph", description="test graph")
@@ -197,7 +198,7 @@ class TestDriver(unittest.TestCase):
                 time.sleep(1)
         print("job finished")
 
-    def test_list_graph(self):
+    def list_graph(self):
         resp = self._sess.list_graphs()
         assert resp.is_ok()
         print("list graph: ", resp.get_value())
@@ -276,7 +277,7 @@ class TestDriver(unittest.TestCase):
                 )
             ]
         )
-        resp = self._sess.call_procedure(self._graph_id, req)
+        resp = self._sess.call_procedure(graph_id = self._graph_id, params = req)
         assert resp.is_ok()
         print("call procedure result: ", resp.get_value())
 
@@ -292,7 +293,7 @@ class TestDriver(unittest.TestCase):
                 )
             ]
         )
-        resp = self._sess.call_procedure(req)
+        resp = self._sess.call_procedure_current(params = req)
         assert resp.is_ok()
         print("call procedure result: ", resp.get_value())
 

--- a/flex/openapi/openapi_interactive.yaml
+++ b/flex/openapi/openapi_interactive.yaml
@@ -901,10 +901,41 @@ paths:
       parameters:
         - name: graph_id
           in : path
-          required: false # Can be empty
+          required: true
           schema:
             type: string
-        - name: request_format
+        - name: X-Interactive-Request-Format
+          in: header
+          required: true
+          schema:
+            type: string
+            enum: [proto, encoder, json]
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: byte
+      responses:
+        '200':
+          description: Successfully runned. Empty if failed?
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: byte
+        '500':
+          description: Server internal error
+  /v1/graph/current/query:
+    post:
+      tags:
+        - QueryService
+      summary: run queries on the running graph
+      operationId: proc_call_current
+      description: |
+        Submit a query to the running graph.
+      parameters:
+        - name: X-Interactive-Request-Format
           in: header
           required: true
           schema:

--- a/flex/openapi/openapi_interactive.yaml
+++ b/flex/openapi/openapi_interactive.yaml
@@ -926,7 +926,7 @@ paths:
                 format: byte
         '500':
           description: Server internal error
-  /v1/query:
+  /v1/graph/current/query:
     post:
       tags:
         - QueryService

--- a/flex/openapi/openapi_interactive.yaml
+++ b/flex/openapi/openapi_interactive.yaml
@@ -926,7 +926,7 @@ paths:
                 format: byte
         '500':
           description: Server internal error
-  /v1/graph/current/query:
+  /v1/query:
     post:
       tags:
         - QueryService

--- a/flex/openapi/openapi_interactive.yaml
+++ b/flex/openapi/openapi_interactive.yaml
@@ -901,9 +901,15 @@ paths:
       parameters:
         - name: graph_id
           in : path
+          required: false # Can be empty
+          schema:
+            type: string
+        - name: request_format
+          in: header
           required: true
           schema:
             type: string
+            enum: [proto, encoder, json]
       requestBody:
         content:
           text/plain:

--- a/flex/tests/hqps/admin_http_test.cc
+++ b/flex/tests/hqps/admin_http_test.cc
@@ -132,8 +132,8 @@ void run_builtin_graph_test(
     for (auto& proc_id : plugin_ids) {
       procedure::Query query;
       query.mutable_query_name()->set_name(proc_id);
-      auto res = query_client.Post("/v1/query", query.SerializeAsString(),
-                                   "text/plain");
+      auto res = query_client.Post("/v1/graph/current/query",
+                                   query.SerializeAsString(), "text/plain");
       CHECK(res->status != 200);
       LOG(INFO) << "call procedure response: " << res->body;
       // find failed in res->body
@@ -160,8 +160,8 @@ void run_builtin_graph_test(
     for (auto& plugin_id : plugin_ids) {
       procedure::Query query;
       query.mutable_query_name()->set_name(plugin_id);
-      auto res = query_client.Post("/v1/query", query.SerializeAsString(),
-                                   "text/plain");
+      auto res = query_client.Post("/v1/graph/current/query",
+                                   query.SerializeAsString(), "text/plain");
       CHECK(res->status == 200)
           << "call procedure should success: " << res->body
           << ", for query: " << query.DebugString();
@@ -298,8 +298,8 @@ void run_procedure_test(httplib::Client& client, httplib::Client& query_client,
       auto query_str = pair.second;
       procedure::Query query;
       query.mutable_query_name()->set_name(query_name);
-      auto res = query_client.Post("/v1/query", query.SerializeAsString(),
-                                   "text/plain");
+      auto res = query_client.Post("/v1/graph/current/query",
+                                   query.SerializeAsString(), "text/plain");
       CHECK(res->status != 200)
           << "call previous procedure on current graph should fail: "
           << res->body;
@@ -309,7 +309,8 @@ void run_procedure_test(httplib::Client& client, httplib::Client& query_client,
   //----4. call procedures-----------------------------------------------
   for (auto& proc_id : plugin_ids) {
     auto call_proc_payload = generate_call_procedure_payload(graph_id, proc_id);
-    res = query_client.Post("/v1/query", call_proc_payload, "text/plain");
+    res = query_client.Post("/v1/graph/current/query", call_proc_payload,
+                            "text/plain");
     CHECK(res->status == 200) << "call procedure failed: " << res->body
                               << ", for query: " << call_proc_payload;
   }
@@ -325,7 +326,8 @@ void run_procedure_test(httplib::Client& client, httplib::Client& query_client,
   if (procedures.size() > 0) {
     auto call_proc_payload =
         generate_call_procedure_payload(graph_id, plugin_ids[0]);
-    res = query_client.Post("/v1/query", call_proc_payload, "text/plain");
+    res = query_client.Post("/v1/graph/current/query", call_proc_payload,
+                            "text/plain");
     CHECK(res->status == 200) << "call procedure failed: " << res->body
                               << ", for query: " << call_proc_payload;
   }

--- a/flex/tests/hqps/engine_config_test.yaml
+++ b/flex/tests/hqps/engine_config_test.yaml
@@ -5,12 +5,12 @@ directories:
     logs: logs
     conf: conf
 log_level: INFO
-default_graph: ldbc
+default_graph: modern_graph
 compute_engine:
   type: hiactor
   workers:
     - localhost:10000
-  thread_num_per_worker: 1
+  thread_num_per_worker: 12
   store:
     type: cpp-mcsr
   metadata_store:

--- a/flex/tests/hqps/engine_config_test.yaml
+++ b/flex/tests/hqps/engine_config_test.yaml
@@ -5,12 +5,12 @@ directories:
     logs: logs
     conf: conf
 log_level: INFO
-default_graph: modern_graph
+default_graph: ldbc
 compute_engine:
   type: hiactor
   workers:
     - localhost:10000
-  thread_num_per_worker: 12
+  thread_num_per_worker: 1
   store:
     type: cpp-mcsr
   metadata_store:

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/HttpExecutionClient.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/client/HttpExecutionClient.java
@@ -55,8 +55,10 @@ import java.util.concurrent.TimeUnit;
 public class HttpExecutionClient extends ExecutionClient<URI> {
     private static final Logger logger = LoggerFactory.getLogger(HttpExecutionClient.class);
     private static final String CONTENT_TYPE = "Content-Type";
+    private static final String INTERACTIVE_REQUEST_FORMAT = "X-Interactive-Request-Format";
     private static final String TEXT_PLAIN = "text/plain;charset=UTF-8";
-    private static final String INTERACTIVE_QUERY_PATH = "/v1/query";
+    private static final String PROTOCOL_FORMAT = "proto";
+    private static final String INTERACTIVE_QUERY_PATH = "/v1/graph/current/query";
     private static final String INTERACTIVE_ADHOC_QUERY_PATH = "/interactive/adhoc_query";
     private final HttpClient httpClient;
 
@@ -96,6 +98,7 @@ public class HttpExecutionClient extends ExecutionClient<URI> {
                         HttpRequest.newBuilder()
                                 .uri(uri)
                                 .headers(CONTENT_TYPE, TEXT_PLAIN)
+                                .headers(INTERACTIVE_REQUEST_FORMAT, PROTOCOL_FORMAT)
                                 .POST(
                                         HttpRequest.BodyPublishers.ofByteArray(
                                                 (byte[])


### PR DESCRIPTION
- Introduce customized header `X-Interactive-Request-Format` with value `[proto, encoder, json]` to distinguish between different format. 
- There will be no byte appending on SDK side. The format byte will be append in `hqps_ic_handler`.
- Support calling procedure without specifying the graph id, by submitting queries to the running graph with url`/v1/graph/current/query` .
- Remove `hqps_exit_handler` since not used.
- Create handlers for each shard.