### PR TITLE
fix(interactive): Fixed bug that wasted disk space

### DIFF
--- a/flex/engines/http_server/service/hqps_service.cc
+++ b/flex/engines/http_server/service/hqps_service.cc
@@ -293,7 +293,8 @@ bool HQPSService::stop_compiler_subprocess() {
   if (compiler_process_.running()) {
     LOG(INFO) << "Terminate previous compiler process with pid: "
               << compiler_process_.id();
-    compiler_process_.terminate();
+    auto pid = compiler_process_.id();
+    ::kill(pid, SIGINT);
   }
   return true;
 }


### PR DESCRIPTION
## What do these changes do?
The interactive service generates n cache files named neo4j-xxx in the /tmp/ directory during execution, each with a size of at least **0.5GB**. These files do not get deleted when the process ends. Here, n represents the number of times the interactive server has been started or restarted.

This issue was due to the previously used termination method for the compiler process, which utilized the **terminate()** function. Since terminate() does not facilitate a normal exit, it led to the compiler's inability to clean up the cache files it created. 

Transitioning to sending the **SIGINT signal** ensures that the compiler exits gracefully and performs the necessary cache cleanup.