### PR TITLE
fix(interactive): Fix python sdk packing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,6 @@ flex/interactive/sdk/python/gs_interactive/api_client.py
 flex/interactive/sdk/python/gs_interactive/api_response.py
 flex/interactive/sdk/python/gs_interactive/configuration.py
 flex/interactive/sdk/python/gs_interactive/exceptions.py
-flex/interactive/sdk/python/gs_interactive/py.typed
 flex/interactive/sdk/python/gs_interactive/rest.py
 !flex/interactive/sdk/python/gs_interactive/client/generated/__init__.py
 

--- a/flex/interactive/sdk/python/.openapi-generator-ignore
+++ b/flex/interactive/sdk/python/.openapi-generator-ignore
@@ -25,7 +25,6 @@
 
 README.md
 setup.py
-gs_interactive/__init__.py
 gs_interactive/client
 requirements.txt
 test-requirements.txt


### PR DESCRIPTION
- `py.typed` is needed, shouldn't be ignored
- `__init__.py` should be generated.