### PR TITLE
fix(interactive): Fixed bug that wasted disk space

### DIFF
--- a/flex/engines/http_server/service/hqps_service.cc
+++ b/flex/engines/http_server/service/hqps_service.cc
@@ -293,7 +293,31 @@ bool HQPSService::stop_compiler_subprocess() {
   if (compiler_process_.running()) {
     LOG(INFO) << "Terminate previous compiler process with pid: "
               << compiler_process_.id();
-    compiler_process_.terminate();
+    auto pid = compiler_process_.id();
+    ::kill(pid, SIGINT);
+    int32_t sleep_time = 0;
+    int32_t max_sleep_time = 10;
+    int32_t sleep_interval = 2;
+    bool sub_process_exited = false;
+    // sleep for a maximum 10 seconds to wait for the compiler process to stop
+    while (sleep_time < max_sleep_time) {
+      std::this_thread::sleep_for(std::chrono::seconds(sleep_interval));
+      // check if the compiler process is still running
+      if (compiler_process_.running() == false) {
+        sub_process_exited = true;
+        break;
+      }
+      sleep_time += sleep_interval;
+    }
+    // if the compiler process is still running, force to kill it with SIGKILL
+    if (sub_process_exited == false) {
+      LOG(ERROR) << "Fail to stop compiler process! Force to kill it!";
+      ::kill(pid, SIGKILL);
+      std::this_thread::sleep_for(std::chrono::seconds(sleep_interval));
+    } else {
+      LOG(INFO) << "Compiler process stopped successfully in " << sleep_time
+                << " seconds.";
+    }
   }
   return true;
 }


### PR DESCRIPTION
## What do these changes do?
The interactive service generates n cache files named neo4j-xxx in the /tmp/ directory during execution, each with a size of at least **0.5GB**. These files do not get deleted when the process ends. Here, n represents the number of times the interactive server has been started or restarted.

This issue was due to the previously used termination method for the compiler process, which utilized the **terminate()** function. Since terminate() does not facilitate a normal exit, it led to the compiler's inability to clean up the cache files it created.

Transitioning to sending the **SIGINT signal** ensures that the compiler exits gracefully and performs the necessary cache cleanup. And sleep for up to 10 seconds to wait for the compiler process to stop