### PR TITLE
fix(interactive): append query type in graph_db_ic_handler

### DIFF
--- a/flex/engines/http_server/handler/graph_db_http_handler.cc
+++ b/flex/engines/http_server/handler/graph_db_http_handler.cc
@@ -77,7 +77,7 @@ class graph_db_ic_handler : public seastar::httpd::handler_base {
       std::unique_ptr<seastar::httpd::request> req,
       std::unique_ptr<seastar::httpd::reply> rep) override {
     auto dst_executor = dispatcher_.get_executor_idx();
-
+    req->content.append("\0", 1);
     return executor_refs_[dst_executor]
         .run_graph_db_query(query_param{std::move(req->content)})
         .then_wrapped([rep = std::move(rep)](


### PR DESCRIPTION
Aligned with the interactive handler，append the query type after the request.