### PR TITLE
fix(interactive): Introduce 'mimalloc' as an alternative memory allocator feature in GIE Backend

### DIFF
--- a/interactive_engine/executor/assembly/groot/Cargo.toml
+++ b/interactive_engine/executor/assembly/groot/Cargo.toml
@@ -18,9 +18,12 @@ runtime = {path = "../../ir/runtime"}
 graph_proxy = {path = "../../ir/graph_proxy", features = ["with_global_query"]}
 log4rs = "1.2"
 tokio = { version = "1.24", features = ["macros", "sync"] }
-tikv-jemallocator = {version = "0.5", default_features=false, features = ["profiling", "disable_initial_exec_tls"] }
+tikv-jemallocator = {version = "0.5", default_features=false, features = ["profiling", "disable_initial_exec_tls"]}
+# from https://github.com/lemonhx/mimalloc-rust
+mimalloc-rust = {version = "0.2.1", optional = true}
 
 [features]
+mimalloc = ["mimalloc-rust"]
 column_filter_push_down = []
 
 [profile.dev]

--- a/interactive_engine/executor/assembly/groot/src/store/graph.rs
+++ b/interactive_engine/executor/assembly/groot/src/store/graph.rs
@@ -21,8 +21,18 @@ use groot_store::db::proto::schema_common::{EdgeKindPb, LabelIdPb, TypeDefPb};
 use crate::store::jna_response::JnaResponse;
 
 pub type GraphHandle = *const c_void;
+
+#[cfg(feature = "mimalloc")]
+use mimalloc_rust::*;
+
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL_MIMALLOC: GlobalMiMalloc = GlobalMiMalloc;
+
+#[cfg(not(feature = "mimalloc"))]
 use tikv_jemallocator::Jemalloc;
 
+#[cfg(not(feature = "mimalloc"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 

--- a/interactive_engine/executor/assembly/v6d/Cargo.toml
+++ b/interactive_engine/executor/assembly/v6d/Cargo.toml
@@ -22,4 +22,9 @@ pegasus_server = { path = "../../engine/pegasus/server" }
 runtime = {path = "../../ir/runtime", features = ["with_v6d"]}
 graph_proxy = {path = "../../ir/graph_proxy", features = ["with_global_query", "with_v6d"]}
 libz-sys= "1.1.9"  # temporary fix for 'could not find native static library "`z`', perhaps an -L flag is missing?' in graphscope-dev:wheel
+# from https://github.com/lemonhx/mimalloc-rust
+mimalloc-rust = {version = "0.2.1", optional = true}
 
+[features]
+default = []
+mimalloc = ["mimalloc-rust"]

--- a/interactive_engine/executor/assembly/v6d/src/bin/gaia_executor.rs
+++ b/interactive_engine/executor/assembly/v6d/src/bin/gaia_executor.rs
@@ -21,12 +21,18 @@ use gaia_runtime::error::{StartServerError, StartServerResult};
 use global_query::{FFIGraphStore, GraphPartitionManager};
 use graph_proxy::{apis::PegasusClusterInfo, create_gs_store, VineyardMultiPartition};
 use log::info;
+#[cfg(feature = "mimalloc")]
+use mimalloc_rust::*;
 use pegasus::api::Sink;
 use pegasus::{wait_servers_ready, Configuration, JobConf, ServerConf};
 use pegasus_network::config::NetworkConfig;
 use pegasus_network::config::ServerAddr;
 use pegasus_server::rpc::{start_rpc_server, RPCServerConfig, ServiceStartListener};
 use runtime::initialize_job_assembly;
+
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL_MIMALLOC: GlobalMiMalloc = GlobalMiMalloc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/interactive_engine/executor/ir/integrated/Cargo.toml
+++ b/interactive_engine/executor/ir/integrated/Cargo.toml
@@ -24,7 +24,10 @@ graph_proxy = {path = "../graph_proxy"}
 graph_store = {path = "../../store/exp_store"}
 dyn_type = {path = "../../common/dyn_type"}
 global_query = {path = "../../store/global_query", optional = true}
+# from https://github.com/lemonhx/mimalloc-rust
+mimalloc-rust = {version = "0.2.1", optional = true}
 
 [features]
 default = []
+mimalloc = ["mimalloc-rust"]
 proto_inplace = ["ir_common/proto_inplace", "pegasus_server/gcip"]

--- a/interactive_engine/executor/ir/integrated/src/bin/start_rpc_server.rs
+++ b/interactive_engine/executor/ir/integrated/src/bin/start_rpc_server.rs
@@ -17,8 +17,13 @@ use std::{path::PathBuf, sync::Arc};
 
 use graph_proxy::{apis::PegasusClusterInfo, create_exp_store, SimplePartition};
 use log::info;
+#[cfg(feature = "mimalloc")]
+use mimalloc_rust::*;
 use runtime::initialize_job_assembly;
 use structopt::StructOpt;
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL_MIMALLOC: GlobalMiMalloc = GlobalMiMalloc;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "EchoServer", about = "example of rpc service")]

--- a/interactive_engine/executor/ir/integrated/src/bin/start_rpc_server_csr.rs
+++ b/interactive_engine/executor/ir/integrated/src/bin/start_rpc_server_csr.rs
@@ -17,8 +17,13 @@ use std::{path::PathBuf, sync::Arc};
 
 use graph_proxy::{apis::PegasusClusterInfo, create_csr_store, SimplePartition};
 use log::info;
+#[cfg(feature = "mimalloc")]
+use mimalloc_rust::*;
 use runtime::initialize_job_assembly;
 use structopt::StructOpt;
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL_MIMALLOC: GlobalMiMalloc = GlobalMiMalloc;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "EchoServer", about = "example of rpc service")]

--- a/interactive_engine/executor/ir/integrated/src/bin/start_rpc_server_k8s.rs
+++ b/interactive_engine/executor/ir/integrated/src/bin/start_rpc_server_k8s.rs
@@ -17,7 +17,12 @@ use std::{env, sync::Arc};
 
 use graph_proxy::{apis::PegasusClusterInfo, create_exp_store, SimplePartition};
 use log::info;
+#[cfg(feature = "mimalloc")]
+use mimalloc_rust::*;
 use runtime::initialize_job_assembly;
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL_MIMALLOC: GlobalMiMalloc = GlobalMiMalloc;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As titled. 
In GIE, if you want to use mimalloc as the default allocator, you can build the backend with `cargo build --features mimalloc`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

