### PR TITLE
fix(interactive): Only allow using of `var_char` and `long_text` on edge property for string type

### DIFF
--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -47,6 +47,7 @@ Note:
 - A single edge type can have multiple `vertex_type_pair_relations`. For instance, a "knows" edge might connect one person to another, symbolizing their friendship. Alternatively, it could associate a person with a skill, indicating their proficiency in that skill.
 - The permissible relations include: `ONE_TO_ONE`, `ONE_TO_MANY`, `MANY_TO_ONE`, and `MANY_TO_MANY`. These relations can be utilized by the optimizer to generate more efficient execution plans.
 - Currently we only support at most one property for each edge triplet.
+- We currently only support var_char as the edge property among all string types.
 - All implementation related configuration are put under `x_csr_params`.
   - `max_vertex_num` limit the number of vertices of this type:
     - The limit number is used to `mmap` memory, so it only takes virtual memory before vertices are actually inserted.

--- a/docs/flex/interactive/data_model.md
+++ b/docs/flex/interactive/data_model.md
@@ -47,7 +47,7 @@ Note:
 - A single edge type can have multiple `vertex_type_pair_relations`. For instance, a "knows" edge might connect one person to another, symbolizing their friendship. Alternatively, it could associate a person with a skill, indicating their proficiency in that skill.
 - The permissible relations include: `ONE_TO_ONE`, `ONE_TO_MANY`, `MANY_TO_ONE`, and `MANY_TO_MANY`. These relations can be utilized by the optimizer to generate more efficient execution plans.
 - Currently we only support at most one property for each edge triplet.
-- We currently only support var_char as the edge property among all string types.
+- We currently only support `var_char` and `long_text` as the edge property among all string types.
 - All implementation related configuration are put under `x_csr_params`.
   - `max_vertex_num` limit the number of vertices of this type:
     - The limit number is used to `mmap` memory, so it only takes virtual memory before vertices are actually inserted.

--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -152,9 +152,12 @@ endif ()
 
 find_package(opentelemetry-cpp CONFIG)
 if (OPENTELEMETRY_CPP_FOUND)
+    message(STATUS "opentelemetry-cpp found")
     find_package(Protobuf REQUIRED)
     find_package(CURL REQUIRED)
     add_definitions(-DHAVE_OPENTELEMETRY_CPP)
+else()
+    message(STATUS "opentelemetry-cpp not found, build without opentelemetry-cpp")
 endif ()
 
 # Find Doxygen

--- a/flex/otel/CMakeLists.txt
+++ b/flex/otel/CMakeLists.txt
@@ -1,13 +1,12 @@
 # OpenTelemetry
-find_package(opentelemetry-cpp CONFIG)
 if (OPENTELEMETRY_CPP_FOUND)
     find_package(Protobuf REQUIRED)
     find_package(CURL REQUIRED)
+
+    include_directories("${OPENTELEMETRY_CPP_INCLUDE_DIRS}")
+
+    add_library(otel "otel.cc")
+    target_link_libraries(otel ${OPENTELEMETRY_CPP_LIBRARIES})
+
+    install_without_export_flex_target(otel)
 endif ()
-
-include_directories("${OPENTELEMETRY_CPP_INCLUDE_DIRS}")
-
-add_library(otel "otel.cc")
-target_link_libraries(otel ${OPENTELEMETRY_CPP_LIBRARIES})
-
-install_without_export_flex_target(otel)

--- a/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.cc
@@ -326,7 +326,10 @@ void AbstractArrowFragmentLoader::AddEdgesRecordBatch(
       addEdgesRecordBatchImpl<float>(src_label_i, dst_label_i, edge_label_i,
                                      filenames, supplier_creator);
     }
-  } else if (property_types[0].type_enum == impl::PropertyTypeImpl::kVarChar) {
+  } else if (property_types[0].type_enum == impl::PropertyTypeImpl::kVarChar ||
+             property_types[0].type_enum == impl::PropertyTypeImpl::kString) {
+    // Both varchar and string are treated as string. For String, we use the
+    // default max length defined in PropertyType::STRING_DEFAULT_MAX_LENGTH
     if (filenames.empty()) {
       basic_fragment_loader_.AddNoPropEdgeBatch<std::string_view>(
           src_label_i, dst_label_i, edge_label_i);

--- a/flex/storages/rt_mutable_graph/loader/basic_fragment_loader.h
+++ b/flex/storages/rt_mutable_graph/loader/basic_fragment_loader.h
@@ -125,8 +125,13 @@ class BasicFragmentLoader {
     if constexpr (std::is_same_v<EDATA_T, std::string_view>) {
       const auto& prop = schema_.get_edge_properties(src_label_id, dst_label_id,
                                                      edge_label_id);
-      dual_csr_list_[index] = new DualCsr<std::string_view>(
-          oe_strategy, ie_strategy, prop[0].additional_type_info.max_length);
+
+      size_t max_length = PropertyType::STRING_DEFAULT_MAX_LENGTH;
+      if (prop[0].IsVarchar()) {
+        max_length = prop[0].additional_type_info.max_length;
+      }
+      dual_csr_list_[index] =
+          new DualCsr<std::string_view>(oe_strategy, ie_strategy, max_length);
     } else {
       bool oe_mutable = schema_.outgoing_edge_mutable(
           src_label_name, dst_label_name, edge_label_name);
@@ -167,8 +172,12 @@ class BasicFragmentLoader {
     if constexpr (std::is_same_v<EDATA_T, std::string_view>) {
       const auto& prop = schema_.get_edge_properties(src_label_id, dst_label_id,
                                                      edge_label_id);
-      auto dual_csr = new DualCsr<std::string_view>(
-          oe_strategy, ie_strategy, prop[0].additional_type_info.max_length);
+      size_t max_length = PropertyType::STRING_DEFAULT_MAX_LENGTH;
+      if (prop[0].IsVarchar()) {
+        max_length = prop[0].additional_type_info.max_length;
+      }
+      auto dual_csr =
+          new DualCsr<std::string_view>(oe_strategy, ie_strategy, max_length);
       dual_csr_list_[index] = dual_csr;
       ie_[index] = dual_csr_list_[index]->GetInCsr();
       oe_[index] = dual_csr_list_[index]->GetOutCsr();

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -616,6 +616,20 @@ static Status parse_edge_properties(YAML::Node node,
                     "type of edge-" + label_name + " prop-" +
                         std::to_string(i - 1) + " is not specified...");
     }
+    // For edge properties, we have some constrains on the property type. We
+    // currently only support var_char. long_text string are not supported.
+    if (prop_type == PropertyType::String() ||
+        prop_type == PropertyType::StringMap()) {
+      LOG(ERROR) << "Please use varchar as the type of edge-" << label_name
+                 << " prop-" << i - 1
+                 << ", if you want to use string property.";
+      return Status(StatusCode::InvalidSchema,
+                    "Please use varchar as the type of edge-" + label_name +
+                        " prop-" + std::to_string(i - 1) +
+                        ", if you want to "
+                        "use string property.");
+    }
+
     if (!get_scalar(node[i], "property_name", prop_name_str)) {
       LOG(ERROR) << "name of edge-" << label_name << " prop-" << i - 1
                  << " is not specified...";

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -618,11 +618,11 @@ static Status parse_edge_properties(YAML::Node node,
     }
     // For edge properties, we have some constrains on the property type. We
     // currently only support var_char. long_text string are not supported.
-    if (prop_type == PropertyType::String() ||
-        prop_type == PropertyType::StringMap()) {
+    if (prop_type == PropertyType::StringMap()) {
       LOG(ERROR) << "Please use varchar as the type of edge-" << label_name
                  << " prop-" << i - 1
-                 << ", if you want to use string property.";
+                 << ", if you want to use string property: " << prop_type
+                 << ", prop_type.enum" << prop_type.type_enum;
       return Status(StatusCode::InvalidSchema,
                     "Please use varchar as the type of edge-" + label_name +
                         " prop-" + std::to_string(i - 1) +


### PR DESCRIPTION
As titled.