### PR TITLE
fix(analytical): Fix ret type of `getIntData` and `getDoubleData` for arrow fragment java wrapper

### DIFF
--- a/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/ArrowFragment.java
+++ b/analytical_engine/java/grape-jdk/src/main/java/com/alibaba/graphscope/fragment/ArrowFragment.java
@@ -205,12 +205,12 @@ public interface ArrowFragment<OID_T> extends FFIPointer {
             int propertyId);
 
     @FFINameAlias("GetData<uint32_t>")
-    long getIntData(
+    int getIntData(
             @FFITypeAlias(GRAPE_VERTEX + "<uint64_t>") @CXXReference Vertex<Long> vertex,
             int propertyId);
 
     @FFINameAlias("GetData<double>")
-    long getDoubleData(
+    double getDoubleData(
             @FFITypeAlias(GRAPE_VERTEX + "<uint64_t>") @CXXReference Vertex<Long> vertex,
             int propertyId);
 


### PR DESCRIPTION
As titled.

see https://github.com/v6d-io/v6d/blob/ff2aa8f60caec1f20a73b33fd31656f43b9e712f/modules/graph/fragment/arrow_fragment.vineyard-mod#L290