### PR TITLE
refactor(interactive): Support customizing ports when deploy interactive in local mode and connect via SDK

### DIFF
--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
@@ -32,36 +32,96 @@ import java.util.logging.Logger;
 public class Driver {
     private static final Logger logger = Logger.getLogger(Driver.class.getName());
 
-    private final String host;
-    private final int port;
+    private final String adminUri;
+    private final String storedProcUri;
+    private String cypherUri;
+    private String gremlinUri;
+    private String host;
+    private int port;
     private Session defaultSession;
 
-    public static Driver connect(String host, int port) {
-        return new Driver(host + ":" + port);
+    /**
+     * Connect to the interactive service with the environment variables
+     *  INTERACTIVE_ADMIN_ENDPOINT, INTERACTIVE_STORED_PROC_ENDPOINT, INTERACTIVE_CYPHER_ENDPOINT, INTERACTIVE_GREMLIN_ENDPOINT
+     * @return The driver object.
+     */
+    public static Driver connect() {
+        String adminUri = System.getenv("INTERACTIVE_ADMIN_ENDPOINT");
+        if (adminUri == null){
+            throw new IllegalArgumentException("INTERACTIVE_ADMIN_ENDPOINT is not set");
+        }
+        String storedProcUri = System.getenv("INTERACTIVE_STORED_PROC_ENDPOINT");
+        if (storedProcUri == null){
+            throw new IllegalArgumentException("INTERACTIVE_STORED_PROC_ENDPOINT is not set");
+        }
+        String cypherUri = System.getenv("INTERACTIVE_CYPHER_ENDPOINT");
+        if (cypherUri == null){
+           logger.warning("INTERACTIVE_CYPHER_ENDPOINT is not set, will try to parse endpoint from service_status");
+        }
+        String gremlinUri = System.getenv("INTERACTIVE_GREMLIN_ENDPOINT");
+        if (gremlinUri == null){
+            logger.warning("INTERACTIVE_GREMLIN_ENDPOINT is not set, will try to parse endpoint from service_status");
+        }
+        return connect(adminUri, storedProcUri, cypherUri, gremlinUri);
     }
 
+    /**
+     * Connect to the interactive service by specifying the URIs of the admin, stored procedure, cypher, and gremlin services.
+     * @param adminUri The URI of the admin service.
+     * @param storedProcUri The URI of the stored procedure service.
+     * @param cypherUri The URI of the cypher service.
+     * @param gremlinUri The URI of the gremlin service.
+     * @return The driver object.
+     */
+    public static Driver connect(String adminUri, String storedProcUri, String cypherUri, String gremlinUri) {
+        return new Driver(adminUri, storedProcUri, cypherUri, gremlinUri);
+    }
+
+    /**
+     * Should only be used internally. Users should use method connect() or connect(admin_uri,storedProcUri,cypherUri,gremlinUri)
+     * which require the URIs of all services, or need all uris exported to the environment variables.
+     * Connect to the interactive service by only specifying the admin service's uri.
+     * @param uri The URI of the admin service.
+     * @return The driver object.
+     */
     public static Driver connect(String uri) {
         return new Driver(uri);
     }
 
     private Driver(String uri) {
+        this.adminUri = uri;
+        this.storedProcUri = null;
+        this.cypherUri = null;
+        this.gremlinUri = null;
         // Parse uri
-        String[] parts = uri.split(":");
-        if (parts.length != 2) {
-            throw new IllegalArgumentException("Invalid uri: " + uri);
-        }
-        String host = parts[0];
-        this.port = Integer.parseInt(parts[1]);
-        if (host.startsWith("http://")) {
-            this.host = host.substring(7);
-        } else {
-            this.host = host;
-        }
+        initHostPort();
+        this.defaultSession = null;
     }
 
-    private Driver(String host, int port) {
-        this.host = host;
-        this.port = port;
+    private Driver(String adminUri, String storedProcUri, String cypherUri, String gremlinUri) {
+        this.adminUri = adminUri;
+        this.storedProcUri = storedProcUri;
+        this.cypherUri = cypherUri;
+        this.gremlinUri = gremlinUri;
+        // Parse uri
+        if (!storedProcUri.startsWith("http")){
+            throw new IllegalArgumentException("Invalid uri: " + storedProcUri);
+        }
+        initHostPort();
+        this.defaultSession = null;
+    }
+
+    private Driver(String adminUri, String storedProcUri) {
+        this.adminUri = adminUri;
+        this.storedProcUri = storedProcUri;
+        this.cypherUri = null;
+        this.gremlinUri = null;
+        // Parse uri
+        if (!storedProcUri.startsWith("http")){
+            throw new IllegalArgumentException("Invalid uri: " + storedProcUri);
+        }
+        initHostPort();
+        this.defaultSession = null;
     }
 
     /**
@@ -70,7 +130,12 @@ public class Driver {
      * @return
      */
     public Session session() {
-        return DefaultSession.newInstance(this.host, this.port);
+        if (storedProcUri == null) {
+            return DefaultSession.newInstance(adminUri);
+        }
+        else {
+            return DefaultSession.newInstance(adminUri, storedProcUri);
+        }
     }
 
     public Session getDefaultSession() {
@@ -101,11 +166,15 @@ public class Driver {
     }
 
     public String getNeo4jEndpoint() {
+        if (cypherUri != null) {
+            return cypherUri;
+        }
         Pair<String, Integer> endpoint = getNeo4jEndpointImpl();
         if (endpoint == null) {
             return null;
         }
-        return "bolt://" + endpoint.getLeft() + ":" + endpoint.getRight();
+        cypherUri =  "bolt://" + endpoint.getLeft() + ":" + endpoint.getRight();
+        return cypherUri;
     }
 
     /**
@@ -118,7 +187,7 @@ public class Driver {
     }
 
     public Client getGremlinClient() {
-        Pair<String, Integer> endpoint = getGremlinEndpointImpl();
+        Pair<String, Integer> endpoint = getGremlinEndpoint();
         Cluster cluster =
                 Cluster.build()
                         .addContactPoint(endpoint.getLeft())
@@ -161,6 +230,17 @@ public class Driver {
 
     // TODO(zhanglei): return null if gremlin is not enabled
     private Pair<String, Integer> getGremlinEndpointImpl() {
+        if (gremlinUri != null) {
+            //parse host and port from ws://host:port/gremlin
+            String[] parts = gremlinUri.split(":");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("Invalid uri: " + gremlinUri);
+            }
+            String host = parts[1].substring(2);
+            String portStr = parts[2].split("/")[0];
+            Integer port = Integer.parseInt(portStr);
+            return Pair.of(host, port);
+        }
         Session gsSession = getDefaultSession();
         Result<ServiceStatus> serviceStatus = gsSession.getServiceStatus();
         if (!serviceStatus.isOk()) {
@@ -172,5 +252,17 @@ public class Driver {
             // Currently, we assume the host is the same as the gs server
             return Pair.of(host, gremlinPort);
         }
+    }
+
+    private void initHostPort() {
+        if (!adminUri.startsWith("http")){
+            throw new IllegalArgumentException("Invalid uri: " + adminUri);
+        }
+        String[] parts = adminUri.split(":");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Invalid uri: " + adminUri);
+        }
+        this.host = parts[0].substring(7);
+        this.port = Integer.parseInt(parts[1]);
     }
 }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
@@ -263,10 +263,10 @@ public class Driver {
             throw new IllegalArgumentException("Invalid uri: " + adminUri);
         }
         String[] parts = adminUri.split(":");
-        if (parts.length != 2) {
+        if (parts.length != 3) {
             throw new IllegalArgumentException("Invalid uri: " + adminUri);
         }
-        this.host = parts[0].substring(7);
-        this.port = Integer.parseInt(parts[1]);
+        host = parts[1].substring(2);
+        port = Integer.parseInt(parts[2]);
     }
 }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
@@ -47,20 +47,24 @@ public class Driver {
      */
     public static Driver connect() {
         String adminUri = System.getenv("INTERACTIVE_ADMIN_ENDPOINT");
-        if (adminUri == null){
+        if (adminUri == null) {
             throw new IllegalArgumentException("INTERACTIVE_ADMIN_ENDPOINT is not set");
         }
         String storedProcUri = System.getenv("INTERACTIVE_STORED_PROC_ENDPOINT");
-        if (storedProcUri == null){
+        if (storedProcUri == null) {
             throw new IllegalArgumentException("INTERACTIVE_STORED_PROC_ENDPOINT is not set");
         }
         String cypherUri = System.getenv("INTERACTIVE_CYPHER_ENDPOINT");
-        if (cypherUri == null){
-           logger.warning("INTERACTIVE_CYPHER_ENDPOINT is not set, will try to parse endpoint from service_status");
+        if (cypherUri == null) {
+            logger.warning(
+                    "INTERACTIVE_CYPHER_ENDPOINT is not set, will try to parse endpoint from"
+                            + " service_status");
         }
         String gremlinUri = System.getenv("INTERACTIVE_GREMLIN_ENDPOINT");
-        if (gremlinUri == null){
-            logger.warning("INTERACTIVE_GREMLIN_ENDPOINT is not set, will try to parse endpoint from service_status");
+        if (gremlinUri == null) {
+            logger.warning(
+                    "INTERACTIVE_GREMLIN_ENDPOINT is not set, will try to parse endpoint from"
+                            + " service_status");
         }
         return connect(adminUri, storedProcUri, cypherUri, gremlinUri);
     }
@@ -73,7 +77,8 @@ public class Driver {
      * @param gremlinUri The URI of the gremlin service.
      * @return The driver object.
      */
-    public static Driver connect(String adminUri, String storedProcUri, String cypherUri, String gremlinUri) {
+    public static Driver connect(
+            String adminUri, String storedProcUri, String cypherUri, String gremlinUri) {
         return new Driver(adminUri, storedProcUri, cypherUri, gremlinUri);
     }
 
@@ -104,7 +109,7 @@ public class Driver {
         this.cypherUri = cypherUri;
         this.gremlinUri = gremlinUri;
         // Parse uri
-        if (!storedProcUri.startsWith("http")){
+        if (!storedProcUri.startsWith("http")) {
             throw new IllegalArgumentException("Invalid uri: " + storedProcUri);
         }
         initHostPort();
@@ -117,7 +122,7 @@ public class Driver {
         this.cypherUri = null;
         this.gremlinUri = null;
         // Parse uri
-        if (!storedProcUri.startsWith("http")){
+        if (!storedProcUri.startsWith("http")) {
             throw new IllegalArgumentException("Invalid uri: " + storedProcUri);
         }
         initHostPort();
@@ -132,8 +137,7 @@ public class Driver {
     public Session session() {
         if (storedProcUri == null) {
             return DefaultSession.newInstance(adminUri);
-        }
-        else {
+        } else {
             return DefaultSession.newInstance(adminUri, storedProcUri);
         }
     }
@@ -173,7 +177,7 @@ public class Driver {
         if (endpoint == null) {
             return null;
         }
-        cypherUri =  "bolt://" + endpoint.getLeft() + ":" + endpoint.getRight();
+        cypherUri = "bolt://" + endpoint.getLeft() + ":" + endpoint.getRight();
         return cypherUri;
     }
 
@@ -231,7 +235,7 @@ public class Driver {
     // TODO(zhanglei): return null if gremlin is not enabled
     private Pair<String, Integer> getGremlinEndpointImpl() {
         if (gremlinUri != null) {
-            //parse host and port from ws://host:port/gremlin
+            // parse host and port from ws://host:port/gremlin
             String[] parts = gremlinUri.split(":");
             if (parts.length != 3) {
                 throw new IllegalArgumentException("Invalid uri: " + gremlinUri);
@@ -255,7 +259,7 @@ public class Driver {
     }
 
     private void initHostPort() {
-        if (!adminUri.startsWith("http")){
+        if (!adminUri.startsWith("http")) {
             throw new IllegalArgumentException("Invalid uri: " + adminUri);
         }
         String[] parts = adminUri.split(":");

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
@@ -52,7 +52,9 @@ public class Driver {
         }
         String storedProcUri = System.getenv("INTERACTIVE_STORED_PROC_ENDPOINT");
         if (storedProcUri == null) {
-            throw new IllegalArgumentException("INTERACTIVE_STORED_PROC_ENDPOINT is not set");
+            logger.warning(
+                    "INTERACTIVE_STORED_PROC_ENDPOINT is not set, will try to parse endpoint from"
+                            + " service_status");
         }
         String cypherUri = System.getenv("INTERACTIVE_CYPHER_ENDPOINT");
         if (cypherUri == null) {
@@ -109,20 +111,7 @@ public class Driver {
         this.cypherUri = cypherUri;
         this.gremlinUri = gremlinUri;
         // Parse uri
-        if (!storedProcUri.startsWith("http")) {
-            throw new IllegalArgumentException("Invalid uri: " + storedProcUri);
-        }
-        initHostPort();
-        this.defaultSession = null;
-    }
-
-    private Driver(String adminUri, String storedProcUri) {
-        this.adminUri = adminUri;
-        this.storedProcUri = storedProcUri;
-        this.cypherUri = null;
-        this.gremlinUri = null;
-        // Parse uri
-        if (!storedProcUri.startsWith("http")) {
+        if (storedProcUri != null && !storedProcUri.startsWith("http")) {
             throw new IllegalArgumentException("Invalid uri: " + storedProcUri);
         }
         initHostPort();

--- a/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
+++ b/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.graphscope.interactive.client;
 
+import com.alibaba.graphscope.gaia.proto.IrResult;
 import com.alibaba.graphscope.interactive.client.common.Result;
 import com.alibaba.graphscope.interactive.models.*;
 
@@ -27,6 +28,10 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -328,237 +333,237 @@ public class DriverTest {
         waitJobFinished(jobId);
     }
 
-    // @Test
-    // @Order(3)
-    // public void test1BulkLoadingUploading() {
-    //     SchemaMapping schemaMapping = new SchemaMapping();
-    //     {
-    //         SchemaMappingLoadingConfig loadingConfig = new SchemaMappingLoadingConfig();
-    //         loadingConfig.setImportOption(SchemaMappingLoadingConfig.ImportOptionEnum.INIT);
-    //         loadingConfig.setFormat(new SchemaMappingLoadingConfigFormat().type("csv"));
-    //         schemaMapping.setLoadingConfig(loadingConfig);
-    //     }
-    //     {
-    //         // get env var FLEX_DATA_DIR
-    //         if (System.getenv("FLEX_DATA_DIR") == null) {
-    //             logger.info("FLEX_DATA_DIR is not set");
-    //             return;
-    //         }
-    //         // The file will be uploaded to the server
-    //         String personPath = "@" + System.getenv("FLEX_DATA_DIR") + "/person.csv";
-    //         String knowsPath = "@" + System.getenv("FLEX_DATA_DIR") + "/person_knows_person.csv";
-    //         {
-    //             VertexMapping vertexMapping = new VertexMapping();
-    //             vertexMapping.setTypeName("person");
-    //             vertexMapping.addInputsItem(personPath);
-    //             schemaMapping.addVertexMappingsItem(vertexMapping);
-    //         }
-    //         {
-    //             EdgeMapping edgeMapping = new EdgeMapping();
-    //             edgeMapping.setTypeTriplet(
-    //                     new EdgeMappingTypeTriplet()
-    //                             .edge("knows")
-    //                             .sourceVertex("person")
-    //                             .destinationVertex("person"));
-    //             edgeMapping.addInputsItem(knowsPath);
-    //             schemaMapping.addEdgeMappingsItem(edgeMapping);
-    //         }
-    //     }
-    //     Result<JobResponse> rep = session.bulkLoading(graphId, schemaMapping);
-    //     assertOk(rep);
-    //     jobId = rep.getValue().getJobId();
-    //     logger.info("job id: " + jobId);
-    //     waitJobFinished(jobId);
-    // }
+    @Test
+    @Order(3)
+    public void test1BulkLoadingUploading() {
+        SchemaMapping schemaMapping = new SchemaMapping();
+        {
+            SchemaMappingLoadingConfig loadingConfig = new SchemaMappingLoadingConfig();
+            loadingConfig.setImportOption(SchemaMappingLoadingConfig.ImportOptionEnum.INIT);
+            loadingConfig.setFormat(new SchemaMappingLoadingConfigFormat().type("csv"));
+            schemaMapping.setLoadingConfig(loadingConfig);
+        }
+        {
+            // get env var FLEX_DATA_DIR
+            if (System.getenv("FLEX_DATA_DIR") == null) {
+                logger.info("FLEX_DATA_DIR is not set");
+                return;
+            }
+            // The file will be uploaded to the server
+            String personPath = "@" + System.getenv("FLEX_DATA_DIR") + "/person.csv";
+            String knowsPath = "@" + System.getenv("FLEX_DATA_DIR") + "/person_knows_person.csv";
+            {
+                VertexMapping vertexMapping = new VertexMapping();
+                vertexMapping.setTypeName("person");
+                vertexMapping.addInputsItem(personPath);
+                schemaMapping.addVertexMappingsItem(vertexMapping);
+            }
+            {
+                EdgeMapping edgeMapping = new EdgeMapping();
+                edgeMapping.setTypeTriplet(
+                        new EdgeMappingTypeTriplet()
+                                .edge("knows")
+                                .sourceVertex("person")
+                                .destinationVertex("person"));
+                edgeMapping.addInputsItem(knowsPath);
+                schemaMapping.addEdgeMappingsItem(edgeMapping);
+            }
+        }
+        Result<JobResponse> rep = session.bulkLoading(graphId, schemaMapping);
+        assertOk(rep);
+        jobId = rep.getValue().getJobId();
+        logger.info("job id: " + jobId);
+        waitJobFinished(jobId);
+    }
 
-    // @Test
-    // @Order(4)
-    // public void test3StartService() {
-    //     Result<String> startServiceResponse =
-    //             session.startService(new StartServiceRequest().graphId(graphId));
-    //     if (startServiceResponse.isOk()) {
-    //         try {
-    //             Thread.sleep(5000);
-    //         } catch (InterruptedException e) {
-    //             e.printStackTrace();
-    //         }
-    //         System.out.println("start service success");
-    //     } else {
-    //         throw new RuntimeException(
-    //                 "start service failed: " + startServiceResponse.getStatusMessage());
-    //     }
-    // }
+    @Test
+    @Order(4)
+    public void test3StartService() {
+        Result<String> startServiceResponse =
+                session.startService(new StartServiceRequest().graphId(graphId));
+        if (startServiceResponse.isOk()) {
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            System.out.println("start service success");
+        } else {
+            throw new RuntimeException(
+                    "start service failed: " + startServiceResponse.getStatusMessage());
+        }
+    }
 
-    // @Test
-    // @Order(5)
-    // public void test4CypherAdhocQuery() {
-    //     String query = "MATCH(a) return COUNT(a);";
-    //     org.neo4j.driver.Result result = neo4jSession.run(query);
-    //     logger.info("result: " + result.toString());
-    // }
+    @Test
+    @Order(5)
+    public void test4CypherAdhocQuery() {
+        String query = "MATCH(a) return COUNT(a);";
+        org.neo4j.driver.Result result = neo4jSession.run(query);
+        logger.info("result: " + result.toString());
+    }
 
-    // @Test
-    // @Order(6)
-    // public void test5GremlinAdhoQuery() throws Exception {
-    //     String query = "g.V().count();";
-    //     List<org.apache.tinkerpop.gremlin.driver.Result> results =
-    //             gremlinClient.submit(query).all().get();
-    //     logger.info("result: " + results.toString());
-    // }
+    @Test
+    @Order(6)
+    public void test5GremlinAdhoQuery() throws Exception {
+        String query = "g.V().count();";
+        List<org.apache.tinkerpop.gremlin.driver.Result> results =
+                gremlinClient.submit(query).all().get();
+        logger.info("result: " + results.toString());
+    }
 
-    // @Test
-    // @Order(7)
-    // public void test6CreateCypherProcedure() {
-    //     CreateProcedureRequest procedure = new CreateProcedureRequest();
-    //     procedure.setName("cypherProcedure");
-    //     procedure.setDescription("a simple test procedure");
-    //     procedure.setQuery("MATCH(p:person) RETURN COUNT(p);");
-    //     procedure.setType(CreateProcedureRequest.TypeEnum.CYPHER);
-    //     Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
-    //     assertOk(resp);
-    //     cypherProcedureId = "cypherProcedure";
-    // }
+    @Test
+    @Order(7)
+    public void test6CreateCypherProcedure() {
+        CreateProcedureRequest procedure = new CreateProcedureRequest();
+        procedure.setName("cypherProcedure");
+        procedure.setDescription("a simple test procedure");
+        procedure.setQuery("MATCH(p:person) RETURN COUNT(p);");
+        procedure.setType(CreateProcedureRequest.TypeEnum.CYPHER);
+        Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
+        assertOk(resp);
+        cypherProcedureId = "cypherProcedure";
+    }
 
-    // @Test
-    // @Order(8)
-    // public void test7CreateCppProcedure1() {
-    //     CreateProcedureRequest procedure = new CreateProcedureRequest();
-    //     procedure.setName("cppProcedure1");
-    //     procedure.setDescription("a simple test procedure");
-    //     // sampleAppFilePath is under the resources folder,with name sample_app.cc
-    //     String sampleAppFilePath = "sample_app.cc";
-    //     String sampleAppContent = "";
-    //     try {
-    //         sampleAppContent =
-    //                 new String(
-    //                         Files.readAllBytes(
-    //                                 Paths.get(
-    //                                         Thread.currentThread()
-    //                                                 .getContextClassLoader()
-    //                                                 .getResource(sampleAppFilePath)
-    //                                                 .toURI())));
-    //     } catch (IOException | URISyntaxException e) {
-    //         e.printStackTrace();
-    //     }
-    //     if (sampleAppContent.isEmpty()) {
-    //         throw new RuntimeException("sample app content is empty");
-    //     }
-    //     logger.info("sample app content: " + sampleAppContent);
-    //     procedure.setQuery(sampleAppContent);
-    //     procedure.setType(CreateProcedureRequest.TypeEnum.CPP);
-    //     Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
-    //     assertOk(resp);
-    //     cppProcedureId1 = "cppProcedure1";
-    // }
+    @Test
+    @Order(8)
+    public void test7CreateCppProcedure1() {
+        CreateProcedureRequest procedure = new CreateProcedureRequest();
+        procedure.setName("cppProcedure1");
+        procedure.setDescription("a simple test procedure");
+        // sampleAppFilePath is under the resources folder,with name sample_app.cc
+        String sampleAppFilePath = "sample_app.cc";
+        String sampleAppContent = "";
+        try {
+            sampleAppContent =
+                    new String(
+                            Files.readAllBytes(
+                                    Paths.get(
+                                            Thread.currentThread()
+                                                    .getContextClassLoader()
+                                                    .getResource(sampleAppFilePath)
+                                                    .toURI())));
+        } catch (IOException | URISyntaxException e) {
+            e.printStackTrace();
+        }
+        if (sampleAppContent.isEmpty()) {
+            throw new RuntimeException("sample app content is empty");
+        }
+        logger.info("sample app content: " + sampleAppContent);
+        procedure.setQuery(sampleAppContent);
+        procedure.setType(CreateProcedureRequest.TypeEnum.CPP);
+        Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
+        assertOk(resp);
+        cppProcedureId1 = "cppProcedure1";
+    }
 
-    // @Test
-    // @Order(9)
-    // public void test7CreateCppProcedure2() {
-    //     CreateProcedureRequest procedure = new CreateProcedureRequest();
-    //     procedure.setName("cppProcedure2");
-    //     procedure.setDescription("a simple test procedure");
-    //     // sampleAppFilePath is under the resources folder,with name sample_app.cc
-    //     String sampleAppFilePath = "read_app_example.cc";
-    //     String sampleAppContent = "";
-    //     try {
-    //         sampleAppContent =
-    //                 new String(
-    //                         Files.readAllBytes(
-    //                                 Paths.get(
-    //                                         Thread.currentThread()
-    //                                                 .getContextClassLoader()
-    //                                                 .getResource(sampleAppFilePath)
-    //                                                 .toURI())));
-    //     } catch (IOException | URISyntaxException e) {
-    //         e.printStackTrace();
-    //     }
-    //     if (sampleAppContent.isEmpty()) {
-    //         throw new RuntimeException("read_app_example content is empty");
-    //     }
-    //     logger.info("read_app_example content: " + sampleAppContent);
-    //     procedure.setQuery(sampleAppContent);
-    //     procedure.setType(CreateProcedureRequest.TypeEnum.CPP);
-    //     Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
-    //     assertOk(resp);
-    //     cppProcedureId2 = "cppProcedure2";
-    // }
+    @Test
+    @Order(9)
+    public void test7CreateCppProcedure2() {
+        CreateProcedureRequest procedure = new CreateProcedureRequest();
+        procedure.setName("cppProcedure2");
+        procedure.setDescription("a simple test procedure");
+        // sampleAppFilePath is under the resources folder,with name sample_app.cc
+        String sampleAppFilePath = "read_app_example.cc";
+        String sampleAppContent = "";
+        try {
+            sampleAppContent =
+                    new String(
+                            Files.readAllBytes(
+                                    Paths.get(
+                                            Thread.currentThread()
+                                                    .getContextClassLoader()
+                                                    .getResource(sampleAppFilePath)
+                                                    .toURI())));
+        } catch (IOException | URISyntaxException e) {
+            e.printStackTrace();
+        }
+        if (sampleAppContent.isEmpty()) {
+            throw new RuntimeException("read_app_example content is empty");
+        }
+        logger.info("read_app_example content: " + sampleAppContent);
+        procedure.setQuery(sampleAppContent);
+        procedure.setType(CreateProcedureRequest.TypeEnum.CPP);
+        Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
+        assertOk(resp);
+        cppProcedureId2 = "cppProcedure2";
+    }
 
-    // @Test
-    // @Order(10)
-    // public void test8Restart() {
-    //     Result<String> resp = session.startService(new StartServiceRequest().graphId(graphId));
-    //     assertOk(resp);
-    //     // Sleep 10 seconds to wait for the service to restart
-    //     try {
-    //         Thread.sleep(10000);
-    //     } catch (InterruptedException e) {
-    //         e.printStackTrace();
-    //     }
-    //     logger.info("service restarted: " + resp.getValue());
-    // }
+    @Test
+    @Order(10)
+    public void test8Restart() {
+        Result<String> resp = session.startService(new StartServiceRequest().graphId(graphId));
+        assertOk(resp);
+        // Sleep 10 seconds to wait for the service to restart
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info("service restarted: " + resp.getValue());
+    }
 
-    // @Test
-    // @Order(11)
-    // public void test9GetGraphStatistics() {
-    //     Result<GetGraphStatisticsResponse> resp = session.getGraphStatistics(graphId);
-    //     assertOk(resp);
-    //     logger.info("graph statistics: " + resp.getValue());
-    // }
+    @Test
+    @Order(11)
+    public void test9GetGraphStatistics() {
+        Result<GetGraphStatisticsResponse> resp = session.getGraphStatistics(graphId);
+        assertOk(resp);
+        logger.info("graph statistics: " + resp.getValue());
+    }
 
-    // @Test
-    // @Order(12)
-    // public void test9CallCppProcedure1() {
-    //     QueryRequest request = new QueryRequest();
-    //     request.setQueryName(cppProcedureId1);
-    //     request.addArgumentsItem(
-    //             new TypedValue()
-    //                     .value(1)
-    //                     .type(
-    //                             new GSDataType(
-    //                                     new PrimitiveType()
-    //                                             .primitiveType(
-    //                                                     PrimitiveType.PrimitiveTypeEnum
-    //                                                             .SIGNED_INT32))));
-    //     Result<IrResult.CollectiveResults> resp = session.callProcedure(graphId, request);
-    //     assertOk(resp);
-    // }
+    @Test
+    @Order(12)
+    public void test9CallCppProcedure1() {
+        QueryRequest request = new QueryRequest();
+        request.setQueryName(cppProcedureId1);
+        request.addArgumentsItem(
+                new TypedValue()
+                        .value(1)
+                        .type(
+                                new GSDataType(
+                                        new PrimitiveType()
+                                                .primitiveType(
+                                                        PrimitiveType.PrimitiveTypeEnum
+                                                                .SIGNED_INT32))));
+        Result<IrResult.CollectiveResults> resp = session.callProcedure(graphId, request);
+        assertOk(resp);
+    }
 
-    // @Test
-    // @Order(13)
-    // public void test9CallCppProcedure1Current() {
-    //     QueryRequest request = new QueryRequest();
-    //     request.setQueryName(cppProcedureId1);
-    //     request.addArgumentsItem(
-    //             new TypedValue()
-    //                     .value(1)
-    //                     .type(
-    //                             new GSDataType(
-    //                                     new PrimitiveType()
-    //                                             .primitiveType(
-    //                                                     PrimitiveType.PrimitiveTypeEnum
-    //                                                             .SIGNED_INT32))));
-    //     Result<IrResult.CollectiveResults> resp = session.callProcedure(request);
-    //     assertOk(resp);
-    // }
+    @Test
+    @Order(13)
+    public void test9CallCppProcedure1Current() {
+        QueryRequest request = new QueryRequest();
+        request.setQueryName(cppProcedureId1);
+        request.addArgumentsItem(
+                new TypedValue()
+                        .value(1)
+                        .type(
+                                new GSDataType(
+                                        new PrimitiveType()
+                                                .primitiveType(
+                                                        PrimitiveType.PrimitiveTypeEnum
+                                                                .SIGNED_INT32))));
+        Result<IrResult.CollectiveResults> resp = session.callProcedure(request);
+        assertOk(resp);
+    }
 
-    // @Test
-    // @Order(14)
-    // public void test9CallCppProcedure2() {
-    //     byte[] bytes = new byte[4 + 1];
-    //     Encoder encoder = new Encoder(bytes);
-    //     encoder.put_int(1);
-    //     encoder.put_byte((byte) 1); // Assume the procedure index is 1
-    //     Result<byte[]> resp = session.callProcedureRaw(graphId, bytes);
-    //     assertOk(resp);
-    // }
+    @Test
+    @Order(14)
+    public void test9CallCppProcedure2() {
+        byte[] bytes = new byte[4 + 1];
+        Encoder encoder = new Encoder(bytes);
+        encoder.put_int(1);
+        encoder.put_byte((byte) 1); // Assume the procedure index is 1
+        Result<byte[]> resp = session.callProcedureRaw(graphId, bytes);
+        assertOk(resp);
+    }
 
-    // @Test
-    // @Order(15)
-    // public void test10CallCypherProcedureViaNeo4j() {
-    //     String query = "CALL " + cypherProcedureId + "() YIELD *;";
-    //     org.neo4j.driver.Result result = neo4jSession.run(query);
-    //     logger.info("result: " + result.toString());
-    // }
+    @Test
+    @Order(15)
+    public void test10CallCypherProcedureViaNeo4j() {
+        String query = "CALL " + cypherProcedureId + "() YIELD *;";
+        org.neo4j.driver.Result result = neo4jSession.run(query);
+        logger.info("result: " + result.toString());
+    }
 
     @Test
     @Order(16)

--- a/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
+++ b/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
@@ -15,7 +15,6 @@
  */
 package com.alibaba.graphscope.interactive.client;
 
-import com.alibaba.graphscope.gaia.proto.IrResult;
 import com.alibaba.graphscope.interactive.client.common.Result;
 import com.alibaba.graphscope.interactive.models.*;
 
@@ -28,10 +27,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -198,7 +193,8 @@ public class DriverTest {
 
     @BeforeAll
     public static void beforeClass() {
-        String interactiveEndpoint = System.getProperty("interactive.endpoint", "localhost:7777");
+        String interactiveEndpoint =
+                System.getProperty("interactive.endpoint", "http://localhost:7777");
         driver = Driver.connect(interactiveEndpoint);
         session = driver.session();
         String neo4jEndpoint = driver.getNeo4jEndpoint();
@@ -332,236 +328,245 @@ public class DriverTest {
         waitJobFinished(jobId);
     }
 
-    @Test
-    @Order(3)
-    public void test1BulkLoadingUploading() {
-        SchemaMapping schemaMapping = new SchemaMapping();
-        {
-            SchemaMappingLoadingConfig loadingConfig = new SchemaMappingLoadingConfig();
-            loadingConfig.setImportOption(SchemaMappingLoadingConfig.ImportOptionEnum.INIT);
-            loadingConfig.setFormat(new SchemaMappingLoadingConfigFormat().type("csv"));
-            schemaMapping.setLoadingConfig(loadingConfig);
-        }
-        {
-            // get env var FLEX_DATA_DIR
-            if (System.getenv("FLEX_DATA_DIR") == null) {
-                logger.info("FLEX_DATA_DIR is not set");
-                return;
-            }
-            // The file will be uploaded to the server
-            String personPath = "@" + System.getenv("FLEX_DATA_DIR") + "/person.csv";
-            String knowsPath = "@" + System.getenv("FLEX_DATA_DIR") + "/person_knows_person.csv";
-            {
-                VertexMapping vertexMapping = new VertexMapping();
-                vertexMapping.setTypeName("person");
-                vertexMapping.addInputsItem(personPath);
-                schemaMapping.addVertexMappingsItem(vertexMapping);
-            }
-            {
-                EdgeMapping edgeMapping = new EdgeMapping();
-                edgeMapping.setTypeTriplet(
-                        new EdgeMappingTypeTriplet()
-                                .edge("knows")
-                                .sourceVertex("person")
-                                .destinationVertex("person"));
-                edgeMapping.addInputsItem(knowsPath);
-                schemaMapping.addEdgeMappingsItem(edgeMapping);
-            }
-        }
-        Result<JobResponse> rep = session.bulkLoading(graphId, schemaMapping);
-        assertOk(rep);
-        jobId = rep.getValue().getJobId();
-        logger.info("job id: " + jobId);
-        waitJobFinished(jobId);
-    }
+    // @Test
+    // @Order(3)
+    // public void test1BulkLoadingUploading() {
+    //     SchemaMapping schemaMapping = new SchemaMapping();
+    //     {
+    //         SchemaMappingLoadingConfig loadingConfig = new SchemaMappingLoadingConfig();
+    //         loadingConfig.setImportOption(SchemaMappingLoadingConfig.ImportOptionEnum.INIT);
+    //         loadingConfig.setFormat(new SchemaMappingLoadingConfigFormat().type("csv"));
+    //         schemaMapping.setLoadingConfig(loadingConfig);
+    //     }
+    //     {
+    //         // get env var FLEX_DATA_DIR
+    //         if (System.getenv("FLEX_DATA_DIR") == null) {
+    //             logger.info("FLEX_DATA_DIR is not set");
+    //             return;
+    //         }
+    //         // The file will be uploaded to the server
+    //         String personPath = "@" + System.getenv("FLEX_DATA_DIR") + "/person.csv";
+    //         String knowsPath = "@" + System.getenv("FLEX_DATA_DIR") + "/person_knows_person.csv";
+    //         {
+    //             VertexMapping vertexMapping = new VertexMapping();
+    //             vertexMapping.setTypeName("person");
+    //             vertexMapping.addInputsItem(personPath);
+    //             schemaMapping.addVertexMappingsItem(vertexMapping);
+    //         }
+    //         {
+    //             EdgeMapping edgeMapping = new EdgeMapping();
+    //             edgeMapping.setTypeTriplet(
+    //                     new EdgeMappingTypeTriplet()
+    //                             .edge("knows")
+    //                             .sourceVertex("person")
+    //                             .destinationVertex("person"));
+    //             edgeMapping.addInputsItem(knowsPath);
+    //             schemaMapping.addEdgeMappingsItem(edgeMapping);
+    //         }
+    //     }
+    //     Result<JobResponse> rep = session.bulkLoading(graphId, schemaMapping);
+    //     assertOk(rep);
+    //     jobId = rep.getValue().getJobId();
+    //     logger.info("job id: " + jobId);
+    //     waitJobFinished(jobId);
+    // }
+
+    // @Test
+    // @Order(4)
+    // public void test3StartService() {
+    //     Result<String> startServiceResponse =
+    //             session.startService(new StartServiceRequest().graphId(graphId));
+    //     if (startServiceResponse.isOk()) {
+    //         try {
+    //             Thread.sleep(5000);
+    //         } catch (InterruptedException e) {
+    //             e.printStackTrace();
+    //         }
+    //         System.out.println("start service success");
+    //     } else {
+    //         throw new RuntimeException(
+    //                 "start service failed: " + startServiceResponse.getStatusMessage());
+    //     }
+    // }
+
+    // @Test
+    // @Order(5)
+    // public void test4CypherAdhocQuery() {
+    //     String query = "MATCH(a) return COUNT(a);";
+    //     org.neo4j.driver.Result result = neo4jSession.run(query);
+    //     logger.info("result: " + result.toString());
+    // }
+
+    // @Test
+    // @Order(6)
+    // public void test5GremlinAdhoQuery() throws Exception {
+    //     String query = "g.V().count();";
+    //     List<org.apache.tinkerpop.gremlin.driver.Result> results =
+    //             gremlinClient.submit(query).all().get();
+    //     logger.info("result: " + results.toString());
+    // }
+
+    // @Test
+    // @Order(7)
+    // public void test6CreateCypherProcedure() {
+    //     CreateProcedureRequest procedure = new CreateProcedureRequest();
+    //     procedure.setName("cypherProcedure");
+    //     procedure.setDescription("a simple test procedure");
+    //     procedure.setQuery("MATCH(p:person) RETURN COUNT(p);");
+    //     procedure.setType(CreateProcedureRequest.TypeEnum.CYPHER);
+    //     Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
+    //     assertOk(resp);
+    //     cypherProcedureId = "cypherProcedure";
+    // }
+
+    // @Test
+    // @Order(8)
+    // public void test7CreateCppProcedure1() {
+    //     CreateProcedureRequest procedure = new CreateProcedureRequest();
+    //     procedure.setName("cppProcedure1");
+    //     procedure.setDescription("a simple test procedure");
+    //     // sampleAppFilePath is under the resources folder,with name sample_app.cc
+    //     String sampleAppFilePath = "sample_app.cc";
+    //     String sampleAppContent = "";
+    //     try {
+    //         sampleAppContent =
+    //                 new String(
+    //                         Files.readAllBytes(
+    //                                 Paths.get(
+    //                                         Thread.currentThread()
+    //                                                 .getContextClassLoader()
+    //                                                 .getResource(sampleAppFilePath)
+    //                                                 .toURI())));
+    //     } catch (IOException | URISyntaxException e) {
+    //         e.printStackTrace();
+    //     }
+    //     if (sampleAppContent.isEmpty()) {
+    //         throw new RuntimeException("sample app content is empty");
+    //     }
+    //     logger.info("sample app content: " + sampleAppContent);
+    //     procedure.setQuery(sampleAppContent);
+    //     procedure.setType(CreateProcedureRequest.TypeEnum.CPP);
+    //     Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
+    //     assertOk(resp);
+    //     cppProcedureId1 = "cppProcedure1";
+    // }
+
+    // @Test
+    // @Order(9)
+    // public void test7CreateCppProcedure2() {
+    //     CreateProcedureRequest procedure = new CreateProcedureRequest();
+    //     procedure.setName("cppProcedure2");
+    //     procedure.setDescription("a simple test procedure");
+    //     // sampleAppFilePath is under the resources folder,with name sample_app.cc
+    //     String sampleAppFilePath = "read_app_example.cc";
+    //     String sampleAppContent = "";
+    //     try {
+    //         sampleAppContent =
+    //                 new String(
+    //                         Files.readAllBytes(
+    //                                 Paths.get(
+    //                                         Thread.currentThread()
+    //                                                 .getContextClassLoader()
+    //                                                 .getResource(sampleAppFilePath)
+    //                                                 .toURI())));
+    //     } catch (IOException | URISyntaxException e) {
+    //         e.printStackTrace();
+    //     }
+    //     if (sampleAppContent.isEmpty()) {
+    //         throw new RuntimeException("read_app_example content is empty");
+    //     }
+    //     logger.info("read_app_example content: " + sampleAppContent);
+    //     procedure.setQuery(sampleAppContent);
+    //     procedure.setType(CreateProcedureRequest.TypeEnum.CPP);
+    //     Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
+    //     assertOk(resp);
+    //     cppProcedureId2 = "cppProcedure2";
+    // }
+
+    // @Test
+    // @Order(10)
+    // public void test8Restart() {
+    //     Result<String> resp = session.startService(new StartServiceRequest().graphId(graphId));
+    //     assertOk(resp);
+    //     // Sleep 10 seconds to wait for the service to restart
+    //     try {
+    //         Thread.sleep(10000);
+    //     } catch (InterruptedException e) {
+    //         e.printStackTrace();
+    //     }
+    //     logger.info("service restarted: " + resp.getValue());
+    // }
+
+    // @Test
+    // @Order(11)
+    // public void test9GetGraphStatistics() {
+    //     Result<GetGraphStatisticsResponse> resp = session.getGraphStatistics(graphId);
+    //     assertOk(resp);
+    //     logger.info("graph statistics: " + resp.getValue());
+    // }
+
+    // @Test
+    // @Order(12)
+    // public void test9CallCppProcedure1() {
+    //     QueryRequest request = new QueryRequest();
+    //     request.setQueryName(cppProcedureId1);
+    //     request.addArgumentsItem(
+    //             new TypedValue()
+    //                     .value(1)
+    //                     .type(
+    //                             new GSDataType(
+    //                                     new PrimitiveType()
+    //                                             .primitiveType(
+    //                                                     PrimitiveType.PrimitiveTypeEnum
+    //                                                             .SIGNED_INT32))));
+    //     Result<IrResult.CollectiveResults> resp = session.callProcedure(graphId, request);
+    //     assertOk(resp);
+    // }
+
+    // @Test
+    // @Order(13)
+    // public void test9CallCppProcedure1Current() {
+    //     QueryRequest request = new QueryRequest();
+    //     request.setQueryName(cppProcedureId1);
+    //     request.addArgumentsItem(
+    //             new TypedValue()
+    //                     .value(1)
+    //                     .type(
+    //                             new GSDataType(
+    //                                     new PrimitiveType()
+    //                                             .primitiveType(
+    //                                                     PrimitiveType.PrimitiveTypeEnum
+    //                                                             .SIGNED_INT32))));
+    //     Result<IrResult.CollectiveResults> resp = session.callProcedure(request);
+    //     assertOk(resp);
+    // }
+
+    // @Test
+    // @Order(14)
+    // public void test9CallCppProcedure2() {
+    //     byte[] bytes = new byte[4 + 1];
+    //     Encoder encoder = new Encoder(bytes);
+    //     encoder.put_int(1);
+    //     encoder.put_byte((byte) 1); // Assume the procedure index is 1
+    //     Result<byte[]> resp = session.callProcedureRaw(graphId, bytes);
+    //     assertOk(resp);
+    // }
+
+    // @Test
+    // @Order(15)
+    // public void test10CallCypherProcedureViaNeo4j() {
+    //     String query = "CALL " + cypherProcedureId + "() YIELD *;";
+    //     org.neo4j.driver.Result result = neo4jSession.run(query);
+    //     logger.info("result: " + result.toString());
+    // }
 
     @Test
-    @Order(4)
-    public void test3StartService() {
-        Result<String> startServiceResponse =
-                session.startService(new StartServiceRequest().graphId(graphId));
-        if (startServiceResponse.isOk()) {
-            try {
-                Thread.sleep(5000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-            System.out.println("start service success");
-        } else {
-            throw new RuntimeException(
-                    "start service failed: " + startServiceResponse.getStatusMessage());
-        }
-    }
-
-    @Test
-    @Order(5)
-    public void test4CypherAdhocQuery() {
-        String query = "MATCH(a) return COUNT(a);";
-        org.neo4j.driver.Result result = neo4jSession.run(query);
-        logger.info("result: " + result.toString());
-    }
-
-    @Test
-    @Order(6)
-    public void test5GremlinAdhoQuery() throws Exception {
-        String query = "g.V().count();";
-        List<org.apache.tinkerpop.gremlin.driver.Result> results =
-                gremlinClient.submit(query).all().get();
-        logger.info("result: " + results.toString());
-    }
-
-    @Test
-    @Order(7)
-    public void test6CreateCypherProcedure() {
-        CreateProcedureRequest procedure = new CreateProcedureRequest();
-        procedure.setName("cypherProcedure");
-        procedure.setDescription("a simple test procedure");
-        procedure.setQuery("MATCH(p:person) RETURN COUNT(p);");
-        procedure.setType(CreateProcedureRequest.TypeEnum.CYPHER);
-        Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
-        assertOk(resp);
-        cypherProcedureId = "cypherProcedure";
-    }
-
-    @Test
-    @Order(8)
-    public void test7CreateCppProcedure1() {
-        CreateProcedureRequest procedure = new CreateProcedureRequest();
-        procedure.setName("cppProcedure1");
-        procedure.setDescription("a simple test procedure");
-        // sampleAppFilePath is under the resources folder,with name sample_app.cc
-        String sampleAppFilePath = "sample_app.cc";
-        String sampleAppContent = "";
-        try {
-            sampleAppContent =
-                    new String(
-                            Files.readAllBytes(
-                                    Paths.get(
-                                            Thread.currentThread()
-                                                    .getContextClassLoader()
-                                                    .getResource(sampleAppFilePath)
-                                                    .toURI())));
-        } catch (IOException | URISyntaxException e) {
-            e.printStackTrace();
-        }
-        if (sampleAppContent.isEmpty()) {
-            throw new RuntimeException("sample app content is empty");
-        }
-        logger.info("sample app content: " + sampleAppContent);
-        procedure.setQuery(sampleAppContent);
-        procedure.setType(CreateProcedureRequest.TypeEnum.CPP);
-        Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
-        assertOk(resp);
-        cppProcedureId1 = "cppProcedure1";
-    }
-
-    @Test
-    @Order(9)
-    public void test7CreateCppProcedure2() {
-        CreateProcedureRequest procedure = new CreateProcedureRequest();
-        procedure.setName("cppProcedure2");
-        procedure.setDescription("a simple test procedure");
-        // sampleAppFilePath is under the resources folder,with name sample_app.cc
-        String sampleAppFilePath = "read_app_example.cc";
-        String sampleAppContent = "";
-        try {
-            sampleAppContent =
-                    new String(
-                            Files.readAllBytes(
-                                    Paths.get(
-                                            Thread.currentThread()
-                                                    .getContextClassLoader()
-                                                    .getResource(sampleAppFilePath)
-                                                    .toURI())));
-        } catch (IOException | URISyntaxException e) {
-            e.printStackTrace();
-        }
-        if (sampleAppContent.isEmpty()) {
-            throw new RuntimeException("read_app_example content is empty");
-        }
-        logger.info("read_app_example content: " + sampleAppContent);
-        procedure.setQuery(sampleAppContent);
-        procedure.setType(CreateProcedureRequest.TypeEnum.CPP);
-        Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
-        assertOk(resp);
-        cppProcedureId2 = "cppProcedure2";
-    }
-
-    @Test
-    @Order(10)
-    public void test8Restart() {
-        Result<String> resp = session.startService(new StartServiceRequest().graphId(graphId));
-        assertOk(resp);
-        // Sleep 10 seconds to wait for the service to restart
-        try {
-            Thread.sleep(10000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        logger.info("service restarted: " + resp.getValue());
-    }
-
-    @Test
-    @Order(11)
-    public void test9GetGraphStatistics() {
-        Result<GetGraphStatisticsResponse> resp = session.getGraphStatistics(graphId);
-        assertOk(resp);
-        logger.info("graph statistics: " + resp.getValue());
-    }
-
-    @Test
-    @Order(12)
-    public void test9CallCppProcedure1() {
-        QueryRequest request = new QueryRequest();
-        request.setQueryName(cppProcedureId1);
-        request.addArgumentsItem(
-                new TypedValue()
-                        .value(1)
-                        .type(
-                                new GSDataType(
-                                        new PrimitiveType()
-                                                .primitiveType(
-                                                        PrimitiveType.PrimitiveTypeEnum
-                                                                .SIGNED_INT32))));
-        Result<IrResult.CollectiveResults> resp = session.callProcedure(graphId, request);
-        assertOk(resp);
-    }
-
-    @Test
-    @Order(13)
-    public void test9CallCppProcedure1Current() {
-        QueryRequest request = new QueryRequest();
-        request.setQueryName(cppProcedureId1);
-        request.addArgumentsItem(
-                new TypedValue()
-                        .value(1)
-                        .type(
-                                new GSDataType(
-                                        new PrimitiveType()
-                                                .primitiveType(
-                                                        PrimitiveType.PrimitiveTypeEnum
-                                                                .SIGNED_INT32))));
-        Result<IrResult.CollectiveResults> resp = session.callProcedure(request);
-        assertOk(resp);
-    }
-
-    @Test
-    @Order(14)
-    public void test9CallCppProcedure2() {
-        byte[] bytes = new byte[4 + 1];
-        Encoder encoder = new Encoder(bytes);
-        encoder.put_int(1);
-        encoder.put_byte((byte) 1); // Assume the procedure index is 1
-        Result<byte[]> resp = session.callProcedureRaw(graphId, bytes);
-        assertOk(resp);
-    }
-
-    @Test
-    @Order(15)
-    public void test10CallCypherProcedureViaNeo4j() {
-        String query = "CALL " + cypherProcedureId + "() YIELD *;";
-        org.neo4j.driver.Result result = neo4jSession.run(query);
-        logger.info("result: " + result.toString());
+    @Order(16)
+    public void test11CreateDriver() {
+        // Create a new driver with all endpoints specified.
+        // Assume the environment variables are set
+        Driver driver = Driver.connect();
+        Session session = driver.session();
     }
 
     @AfterAll

--- a/flex/interactive/sdk/python/gs_interactive/client/driver.py
+++ b/flex/interactive/sdk/python/gs_interactive/client/driver.py
@@ -68,7 +68,8 @@ class Driver:
         self._admin_endpoint = os.environ.get("INTERACTIVE_ADMIN_ENDPOINT")
         assert self._admin_endpoint is not None, "INTERACTIVE_ADMIN_ENDPOINT is not set"
         self._stored_proc_endpoint = os.environ.get("INTERACTIVE_STORED_PROC_ENDPOINT")
-        assert self._stored_proc_endpoint is not None, "INTERACTIVE_STORED_PROC_ENDPOINT is not set"
+        if self._stored_proc_endpoint is None:
+            print("INTERACTIVE_STORED_PROC_ENDPOINT is not set, will try to get it from service status endpoint")
         self._cypher_endpoint = os.environ.get("INTERACTIVE_CYPHER_ENDPOINT")
         if self._cypher_endpoint is None:
             print("INTERACTIVE_CYPHER_ENDPOINT is not set, will try to get it from service status endpoint")

--- a/flex/interactive/sdk/python/gs_interactive/client/driver.py
+++ b/flex/interactive/sdk/python/gs_interactive/client/driver.py
@@ -36,6 +36,10 @@ class Driver:
     def __init__(self):
         """
         Construct a new driver from the endpoints declared in environment variables.
+        INTERACTIVE_ADMIN_ENDPOINT: http://host:port
+        INTERACTIVE_STORED_PROC_ENDPOINT: http://host:port
+        INTERACTIVE_CYPHER_ENDPOINT: neo4j://host:port or bolt://host:port
+        INTERACTIVE_GREMLIN_ENDPOINT: ws://host:port/gremlin
         """
         self._admin_endpoint = os.environ.get("INTERACTIVE_ADMIN_ENDPOINT")
         assert self._admin_endpoint is not None, "INTERACTIVE_ADMIN_ENDPOINT is not set"
@@ -48,6 +52,7 @@ class Driver:
         if self._gremlin_endpoint is None:
             print("INTERACTIVE_GREMLIN_ENDPOINT is not set, will try to get it from service status endpoint")
         self._session = None
+        self.init_host_and_port()
 
     def __init__(self, admin_endpoint: str, stored_proc_endpoint : str, cypher_endpoint : str, gremlin_endpoint : str):
         """
@@ -58,6 +63,7 @@ class Driver:
         self._cypher_endpoint = cypher_endpoint
         self._gremlin_endpoint = gremlin_endpoint
         self._session = None
+        self.init_host_and_port()
 
     def __init__(self, admin_endpoint: str):
         """
@@ -68,6 +74,13 @@ class Driver:
         """
         # split uri into host and port
         self._admin_endpoint = admin_endpoint
+        self._stored_proc_endpoint = None
+        self._cypher_endpoint = None
+        self._gremlin_endpoint = None
+        self._session = None
+        self.init_host_and_port()
+
+    def init_host_and_port(self):
         # prepend http:// to self._admin_endpoint
         if not self._admin_endpoint.startswith("http://"):
             raise ValueError("Invalid uri, expected format is http://host:port")
@@ -77,7 +90,6 @@ class Driver:
             raise ValueError("Invalid uri, expected format is host:port")
         self._host = splitted[0]
         self._port = int(splitted[1])
-        self._session = None
 
     def session(self) -> Session:
         if self._stored_proc_endpoint is None:

--- a/flex/interactive/sdk/python/test/test_driver.py
+++ b/flex/interactive/sdk/python/test/test_driver.py
@@ -109,6 +109,7 @@ class TestDriver(unittest.TestCase):
         self.callProcedure()
         self.callProcedureWithHttp()
         self.callProcedureWithHttpCurrent()
+        self.createDriver()
 
     def createGraph(self):
         create_graph = CreateGraphRequest(name="test_graph", description="test graph")
@@ -399,6 +400,11 @@ class TestDriver(unittest.TestCase):
         resp = self._sess.call_procedure_current(params = req)
         assert resp.is_ok()
         print("call procedure result: ", resp.get_value())
+    
+    def createDriver(self):
+        driver = Driver()
+        sess = driver.getDefaultSession()
+        print("create driver: ", sess)     
 
 if __name__ == "__main__":
     unittest.main()

--- a/flex/tests/hqps/hqps_sdk_test.sh
+++ b/flex/tests/hqps/hqps_sdk_test.sh
@@ -19,6 +19,8 @@ SERVER_BIN=${FLEX_HOME}/build/bin/interactive_server
 GIE_HOME=${FLEX_HOME}/../interactive_engine/
 ADMIN_PORT=7777
 QUERY_PORT=10000
+CYPHER_PORT=7687
+GREMLIN_PORT=8182
 
 # 
 if [ ! $# -eq 3 ]; then
@@ -112,6 +114,10 @@ run_python_sdk_test(){
 
 kill_service
 start_engine_service
+export INTERACTIVE_ADMIN_ENDPOINT=http://localhost:${ADMIN_PORT}
+export INTERACTIVE_STORED_PROC_ENDPOINT=http://localhost:${QUERY_PORT}
+export INTERACTIVE_CYPHER_ENDPOINT=neo4j://localhost:${CYPHER_PORT}
+export INTERACTIVE_GREMLIN_ENDPOINT=ws://localhost:${GREMLIN_PORT}/gremlin
 if [ ${SDK_TYPE} == "java" ]; then
   run_java_sdk_test
 elif [ ${SDK_TYPE} == "python" ]; then

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -104,6 +104,8 @@ graphscope-darwin-py3:
 
 graphscope-manylinux2014-py3-nodocker:
 	# TODO(siyuan) Remove after newer wheel image are released
+	sudo sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
 	sudo yum install java-11-openjdk-devel -y && \
 	sudo yum remove java-1.8.0-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-headless -y && \
 	cd $(WORKING_DIR)/../.. && \

--- a/python/graphscope/gsctl/commands/dev.py
+++ b/python/graphscope/gsctl/commands/dev.py
@@ -198,13 +198,14 @@ def interactive(app, graphscope_repo):
 )
 def deploy(
     type,
-    coordinator_port,
-    cypher_port,
-    storedproc_port,
-    gremlin_port,
     container_name,
     image_registry,
     image_tag,
+    coordinator_port = 8081,
+    admin_port = 7778,
+    storedproc_port = 10001,
+    cypher_port = 7688,
+    gremlin_port = 8183,
 ):  # noqa: F811
     """Deploy Flex Interactive instance"""
     cmd = []
@@ -220,12 +221,14 @@ def deploy(
             "-p",
             f"{coordinator_port}:8080",
             "-p",
-            f"{cypher_port}:7687",
+            f"{admin_port}:7777",
             "-p",
             f"{storedproc_port}:10000",
+            "-p",
+            f"{cypher_port}:7687",
+            "-p",
+            f"{gremlin_port}:8182",
         ]
-        if gremlin_port != -1:
-            cmd.extend(["-p", f"{gremlin_port}:8182"])
         image = f"{image_registry}/{type}:{image_tag}"
         cmd.extend([image, "--enable-coordinator"])
     click.secho("Run command: {0}".format(" ".join(cmd)))
@@ -238,18 +241,25 @@ def deploy(
 Coordinator is listening on {coordinator_port} port, you can connect to coordinator by:
     gsctl connect --coordinator-endpoint http://127.0.0.1:{coordinator_port}
 
-Cypher service is listening on {cypher_port} port, you can connect to cypher service with:
-    neo4j://127.0.0.1:{cypher_port}
+Interactive service is ready, you can connect to the interactive service with interactive sdk:
+Interactive Admin service is listening at 
+    http://127.0.0.1{admin_port}, 
+You can connect to admin service with Interactive SDK, with following environment variables declared.
 
-Stored procedure service is listening on {storedproc_port} port , you can connect to stored procedure service with:
-    http://127.0.0.1:{storedproc_port}
+############################################################################################
+    export INTERACTIVE_ADMIN_ENDPOINT=http://127.0.0.1:{admin_port}
+    export INTERACTIVE_STORED_PROC_ENDPOINT=http://127.0.0.1:{storedproc_port}
+    export INTERACTIVE_CYPHER_ENDPOINT=neo4j://127.0.0.1:{cypher_port}
+    export INTERACTIVE_GREMLIN_ENDPOINT=ws://127.0.0.1:{gremlin_port}/gremlin
+############################################################################################
+
+See https://graphscope.io/docs/latest/flex/interactive/development/java/java_sdk and 
+https://graphscope.io/docs/latest/flex/interactive/development/python/python_sdk for more details 
+about the usage of Interactive SDK.
+
+Apart from interactive sdk, you can also use neo4j native tools(like cypher-shell) to connect to cypher endpoint, 
+and gremlin console to connect to gremlin endpoint.
         """
-        if gremlin_port != -1:
-            message += f"""
-Gremlin service is listening on {gremlin_port} port, you can connect to gremlin service with:
-    ws://127.0.0.1:{gremlin_port}/gremlin
-
-            """
         click.secho(message, bold=False)
     else:
         click.secho("[FAILED] ", nl=False, fg="red", bold=True)

--- a/python/graphscope/gsctl/commands/dev.py
+++ b/python/graphscope/gsctl/commands/dev.py
@@ -242,8 +242,8 @@ Coordinator is listening on {coordinator_port} port, you can connect to coordina
     gsctl connect --coordinator-endpoint http://127.0.0.1:{coordinator_port}
 
 Interactive service is ready, you can connect to the interactive service with interactive sdk:
-Interactive Admin service is listening at 
-    http://127.0.0.1{admin_port}, 
+Interactive Admin service is listening at
+    http://127.0.0.1{admin_port},
 You can connect to admin service with Interactive SDK, with following environment variables declared.
 
 ############################################################################################
@@ -253,11 +253,11 @@ You can connect to admin service with Interactive SDK, with following environmen
     export INTERACTIVE_GREMLIN_ENDPOINT=ws://127.0.0.1:{gremlin_port}/gremlin
 ############################################################################################
 
-See https://graphscope.io/docs/latest/flex/interactive/development/java/java_sdk and 
-https://graphscope.io/docs/latest/flex/interactive/development/python/python_sdk for more details 
+See https://graphscope.io/docs/latest/flex/interactive/development/java/java_sdk and
+https://graphscope.io/docs/latest/flex/interactive/development/python/python_sdk for more details
 about the usage of Interactive SDK.
 
-Apart from interactive sdk, you can also use neo4j native tools(like cypher-shell) to connect to cypher endpoint, 
+Apart from interactive sdk, you can also use neo4j native tools(like cypher-shell) to connect to cypher endpoint,
 and gremlin console to connect to gremlin endpoint.
         """
         click.secho(message, bold=False)

--- a/python/graphscope/gsctl/commands/dev.py
+++ b/python/graphscope/gsctl/commands/dev.py
@@ -201,11 +201,11 @@ def deploy(
     container_name,
     image_registry,
     image_tag,
-    coordinator_port = 8081,
-    admin_port = 7778,
-    storedproc_port = 10001,
-    cypher_port = 7688,
-    gremlin_port = 8183,
+    coordinator_port=8081,
+    admin_port=7778,
+    storedproc_port=10001,
+    cypher_port=7688,
+    gremlin_port=8183,
 ):  # noqa: F811
     """Deploy Flex Interactive instance"""
     cmd = []


### PR DESCRIPTION
Interactive service exposes many ports, including `admin_port`, `query_port(stored_proc_port)`, `cypher_port` and `gremlin_port`. In previous SDK implementation, we create a driver by only providing the `admin_endpoint`, hoping for get all other ports via `GET /v1/service/status`, However, this only works if the SDK runs inside the service's container. In cases like k8s deployment, the internal port will be mapped to a large port number which is chosen by the cluster.

In this PR, we let user to declare the endpoints to environment variables, and connect via SDK.
```bash
export INTERACTIVE_ADMIN_ENDPOINT: http://host:port
export INTERACTIVE_STORED_PROC_ENDPOINT: http://host:port
export INTERACTIVE_CYPHER_ENDPOINT: neo4j://host:port or bolt://host:port
export INTERACTIVE_GREMLIN_ENDPOINT: ws://host:port/gremlin
```

For example, with python sdk, user can connect to the Interactive service after all environment variable is exported.
```python
from gs_interactive.client.driver import Driver
driver = Driver()
with driver.session() as sess:
   #....
```


The documentaion will be added after the interactive documentation is refactored with `gsctl`