### PR TITLE
fix: Make gsctl more user friendly

### DIFF
--- a/.github/workflows/flex-interactive.yml
+++ b/.github/workflows/flex-interactive.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Build gsctl Wheel Package
       run: |
         cd ${GITHUB_WORKSPACE}/python
+        python3 setup_flex.py bdist_wheel
         python3 setup_gsctl.py bdist_wheel
 
     - name: Setup tmate session

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
         fi
 
         cd ${GITHUB_WORKSPACE}/python
+        python3 setup_flex.py bdist_wheel
         python3 setup_gsctl.py bdist_wheel
         # move wheels into one folder to upload to PyPI
         mkdir ${GITHUB_WORKSPACE}/upload_pypi

--- a/python/setup_flex.py
+++ b/python/setup_flex.py
@@ -79,7 +79,7 @@ setup(
         "parse": parse_version,
     },
     install_requires=REQUIRES,
-    packages=find_packages(include=["graphscope.flex.rest"]),
+    packages=find_packages(include=["graphscope.flex.rest", "graphscope.flex.rest.*"]),
     include_package_data=True,
     license="Apache 2.0",
     long_description_content_type="text/markdown",


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

- Suppress the warnings executing `gsctl` command.
- Reasonable error reporting when executing `gsctl instance xxxx` command.

![截屏2024-07-05 19 13 37](https://github.com/alibaba/GraphScope/assets/23491543/13919fa8-6776-4169-9216-d9ae04119db8)


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

