### PR TITLE
fix(interactive): Support `long_text` as primary key

### DIFF
--- a/.github/workflows/interactive.yml
+++ b/.github/workflows/interactive.yml
@@ -452,6 +452,16 @@ jobs:
       run: |
         git clone -b master --single-branch --depth=1 https://github.com/GraphScope/gstest.git ${GS_TEST_DIR}
 
+    - name: Test String primary key on modern graph
+      env:
+        FLEX_DATA_DIR: ${{ github.workspace }}/flex/interactive/examples/modern_graph/
+      run: |
+        rm -rf /tmp/csr-data-dir/
+        cd ${GITHUB_WORKSPACE}/flex/build/
+        SCHEMA_FILE=../tests/rt_mutable_graph/modern_graph_string_pk.yaml 
+        BULK_LOAD_FILE=../interactive/examples/modern_graph/bulk_load.yaml
+        GLOG_v=10 ./bin/bulk_loader  -g ${SCHEMA_FILE} -l ${BULK_LOAD_FILE} -d /tmp/csr-data-dir/
+
     - name: Test String edge property on modern graph
       env:
         FLEX_DATA_DIR: ${{ github.workspace }}/flex/interactive/examples/modern_graph/

--- a/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.cc
@@ -101,9 +101,9 @@ void set_properties_column(gs::ColumnBase* col,
     set_column_from_timestamp_array_to_day(col, array, offset);
   } else if (col_type == PropertyType::kStringMap) {
     set_column_from_string_array(col, array, offset);
-  } else if (col_type == PropertyType::kStringView) {
-    set_column_from_string_array(col, array, offset);
   } else if (col_type.type_enum == impl::PropertyTypeImpl::kVarChar) {
+    set_column_from_string_array(col, array, offset);
+  } else if (col_type == PropertyType::kStringView) {
     set_column_from_string_array(col, array, offset);
   } else {
     LOG(FATAL) << "Not support type: " << type->ToString();

--- a/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.cc
+++ b/flex/storages/rt_mutable_graph/loader/abstract_arrow_fragment_loader.cc
@@ -95,12 +95,14 @@ void set_properties_column(gs::ColumnBase* col,
     set_column<double>(col, array, offset);
   } else if (col_type == PropertyType::kFloat) {
     set_column<float>(col, array, offset);
-  } else if (col_type == PropertyType::kStringMap) {
-    set_column_from_string_array(col, array, offset);
   } else if (col_type == PropertyType::kDate) {
     set_column_from_timestamp_array(col, array, offset);
   } else if (col_type == PropertyType::kDay) {
     set_column_from_timestamp_array_to_day(col, array, offset);
+  } else if (col_type == PropertyType::kStringMap) {
+    set_column_from_string_array(col, array, offset);
+  } else if (col_type == PropertyType::kStringView) {
+    set_column_from_string_array(col, array, offset);
   } else if (col_type.type_enum == impl::PropertyTypeImpl::kVarChar) {
     set_column_from_string_array(col, array, offset);
   } else {
@@ -216,9 +218,13 @@ void AbstractArrowFragmentLoader::AddVerticesRecordBatch(
     addVertexRecordBatchImpl<uint32_t>(v_label_id, v_files, supplier_creator);
   } else if (type == PropertyType::kUInt64) {
     addVertexRecordBatchImpl<uint64_t>(v_label_id, v_files, supplier_creator);
-  } else if (type.type_enum == impl::PropertyTypeImpl::kVarChar) {
+  } else if (type.type_enum == impl::PropertyTypeImpl::kVarChar ||
+             type.type_enum == impl::PropertyTypeImpl::kStringView) {
     addVertexRecordBatchImpl<std::string_view>(v_label_id, v_files,
                                                supplier_creator);
+  } else {
+    LOG(FATAL) << "Unsupported primary key type for vertex, type: " << type
+               << ", label: " << v_label_name;
   }
   VLOG(10) << "Finish init vertices for label " << v_label_name;
 }

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -102,7 +102,8 @@ inline DualCsrBase* create_csr(EdgeStrategy oes, EdgeStrategy ies,
       return new DualCsr<std::string_view>(
           oes, ies, properties[0].additional_type_info.max_length);
     } else if (properties[0] == PropertyType::kStringView) {
-      return new DualCsr<std::string_view>(oes, ies, 256);
+      return new DualCsr<std::string_view>(
+          oes, ies, gs::PropertyType::STRING_DEFAULT_MAX_LENGTH);
     }
   } else {
     // TODO: fix me, storage strategy not set

--- a/flex/tests/rt_mutable_graph/modern_graph_string_pk.yaml
+++ b/flex/tests/rt_mutable_graph/modern_graph_string_pk.yaml
@@ -1,0 +1,71 @@
+name: modern_graph # then must have a modern dir under ${data} directory
+store_type: mutable_csr  # v6d, groot, gart
+schema:
+  vertex_types:
+    - type_id: 0
+      type_name: person
+      x_csr_params:
+        max_vertex_num: 100
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            string:
+              long_text: ""
+        - property_id: 1
+          property_name: name
+          property_type:
+            varchar:
+              max_length: 64
+        - property_id: 2
+          property_name: age
+          property_type:
+            primitive_type: DT_SIGNED_INT32
+      primary_keys:
+        - id
+    - type_id: 1
+      type_name: software
+      x_csr_params:
+        max_vertex_num: 100
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            varchar:
+              max_length: 64
+        - property_id: 1
+          property_name: name
+          property_type:
+            varchar:
+              max_length: 64
+        - property_id: 2
+          property_name: lang
+          property_type:
+            varchar:
+              max_length: 64
+      primary_keys:
+        - id
+  edge_types:
+    - type_id: 0
+      type_name: knows
+      vertex_type_pair_relations:
+        - source_vertex: person
+          destination_vertex: person
+          relation: MANY_TO_MANY
+      properties:
+        - property_id: 0
+          property_name: weight
+          property_type:
+            primitive_type: DT_DOUBLE
+    - type_id: 1
+      type_name: created
+      vertex_type_pair_relations:
+        - source_vertex: person
+          destination_vertex: software
+          relation: MANY_TO_MANY
+      properties:
+        - property_id: 0
+          property_name: weight
+          property_type:
+            varchar:
+              max_length: 64

--- a/flex/utils/property/column.cc
+++ b/flex/utils/property/column.cc
@@ -132,6 +132,9 @@ std::shared_ptr<ColumnBase> CreateColumn(PropertyType type,
       return std::make_shared<DayEmptyColumn>();
     } else if (type == PropertyType::kStringMap) {
       return std::make_shared<StringEmptyColumn>();
+    } else if (type == PropertyType::kStringView) {
+      return std::make_shared<StringEmptyColumn>(
+          gs::PropertyType::STRING_DEFAULT_MAX_LENGTH);
     } else if (type.type_enum == impl::PropertyTypeImpl::kVarChar) {
       return std::make_shared<StringEmptyColumn>(
           type.additional_type_info.max_length);

--- a/flex/utils/pt_indexer.h
+++ b/flex/utils/pt_indexer.h
@@ -184,8 +184,8 @@ class PTIndexer {
       keys_ = new StringColumn(StorageStrategy::kMem,
                                type.additional_type_info.max_length);
     } else if (type == PropertyType::kStringView) {
-      keys_ = new StringViewColumn(StorageStrategy::kMem,
-                                   gs::PropertyType::STRING_DEFAULT_MAX_LENGTH);
+      keys_ = new StringColumn(StorageStrategy::kMem,
+                               gs::PropertyType::STRING_DEFAULT_MAX_LENGTH);
     } else {
       LOG(FATAL) << "Not support type [" << type << "] as pk type ..";
     }

--- a/flex/utils/pt_indexer.h
+++ b/flex/utils/pt_indexer.h
@@ -183,6 +183,9 @@ class PTIndexer {
     } else if (type.type_enum == impl::PropertyTypeImpl::kVarChar) {
       keys_ = new StringColumn(StorageStrategy::kMem,
                                type.additional_type_info.max_length);
+    } else if (type == PropertyType::kStringView) {
+      keys_ = new StringViewColumn(StorageStrategy::kMem,
+                                   gs::PropertyType::STRING_DEFAULT_MAX_LENGTH);
     } else {
       LOG(FATAL) << "Not support type [" << type << "] as pk type ..";
     }


### PR DESCRIPTION
Before, we only supported `var_char` as the primary key, but `long_text` makes no difference when used as a primary key in Interactive.