### PR TITLE
fix(interactive): Add meta data information of IMDB dataset

### DIFF
--- a/interactive_engine/compiler/src/main/resources/statistics/imdb_statistics.json
+++ b/interactive_engine/compiler/src/main/resources/statistics/imdb_statistics.json
@@ -1,0 +1,313 @@
+{
+    "total_vertex_count": 50486838,
+    "total_edge_count": 162121663,
+    "vertex_type_statistics": [
+        {
+            "type_id": 0,
+            "type_name": "AKA_NAME",
+            "count": 901343
+        },
+        {
+            "type_id": 1,
+            "type_name": "AKA_TITLE",
+            "count": 361472
+        },
+        {
+            "type_id": 2,
+            "type_name": "TITLE",
+            "count": 2528312
+        },
+        {
+            "type_id": 3,
+            "type_name": "CHAR_NAME",
+            "count": 3140339
+        },
+        {
+            "type_id": 4,
+            "type_name": "COMP_CAST_TYPE",
+            "count": 4
+        },
+        {
+            "type_id": 5,
+            "type_name": "COMPANY_NAME",
+            "count": 234997
+        },
+        {
+            "type_id": 6,
+            "type_name": "COMPANY_TYPE",
+            "count": 4
+        },
+        {
+            "type_id": 7,
+            "type_name": "INFO_TYPE",
+            "count": 113
+        },
+        {
+            "type_id": 8,
+            "type_name": "KEYWORD",
+            "count": 134170
+        },
+        {
+            "type_id": 9,
+            "type_name": "KIND_TYPE",
+            "count": 7
+        },
+        {
+            "type_id": 10,
+            "type_name": "LINK_TYPE",
+            "count": 18
+        },
+        {
+            "type_id": 11,
+            "type_name": "NAME",
+            "count": 4167491
+        },
+        {
+            "type_id": 12,
+            "type_name": "ROLE_TYPE",
+            "count": 12
+        },
+        {
+            "type_id": 13,
+            "type_name": "CAST_INFO",
+            "count": 36244344
+        },
+        {
+            "type_id": 14,
+            "type_name": "COMPLETE_CAST",
+            "count": 135086
+        },
+        {
+            "type_id": 15,
+            "type_name": "MOVIE_COMPANIES",
+            "count": 2609129
+        },
+        {
+            "type_id": 16,
+            "type_name": "MOVIE_LINK",
+            "count": 29997
+        }
+    ],
+    "edge_type_statistics": [
+        {
+            "type_id": 0,
+            "type_name": "ALSO_KNOWN_AS_NAME",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "AKA_NAME",
+                    "destination_vertex": "NAME",
+                    "count": 901343
+                }
+            ]
+        },
+        {
+            "type_id": 1,
+            "type_name": "ALSO_KNOWN_AS_TITLE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "AKA_TITLE",
+                    "destination_vertex": "TITLE",
+                    "count": 361472
+                }
+            ]
+        },
+        {
+            "type_id": 2,
+            "type_name": "KIND_TYPE_TITLE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "KIND_TYPE",
+                    "destination_vertex": "TITLE",
+                    "count": 2528312
+                }
+            ]
+        },
+        {
+            "type_id": 3,
+            "type_name": "MOVIE_INFO",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "TITLE",
+                    "destination_vertex": "INFO_TYPE",
+                    "count": 14835720
+                }
+            ]
+        },
+        {
+            "type_id": 5,
+            "type_name": "PERSON_INFO",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "NAME",
+                    "destination_vertex": "INFO_TYPE",
+                    "count": 2963664
+                }
+            ]
+        },
+        {
+            "type_id": 6,
+            "type_name": "MOVIE_KEYWORD",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "TITLE",
+                    "destination_vertex": "KEYWORD",
+                    "count": 4523930
+                }
+            ]
+        },
+        {
+            "type_id": 7,
+            "type_name": "CAST_INFO_NAME",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "CAST_INFO",
+                    "destination_vertex": "NAME",
+                    "count": 36244344
+                }
+            ]
+        },
+        {
+            "type_id": 8,
+            "type_name": "CAST_INFO_TITLE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "CAST_INFO",
+                    "destination_vertex": "TITLE",
+                    "count": 36244344
+                }
+            ]
+        },
+        {
+            "type_id": 9,
+            "type_name": "CAST_INFO_CHAR",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "CAST_INFO",
+                    "destination_vertex": "CHAR_NAME",
+                    "count": 17571519
+                }
+            ]
+        },
+        {
+            "type_id": 10,
+            "type_name": "CAST_INFO_ROLE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "CAST_INFO",
+                    "destination_vertex": "ROLE_TYPE",
+                    "count": 36244344
+                }
+            ]
+        },
+        {
+            "type_id": 11,
+            "type_name": "COMPLETE_CAST_TITLE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "COMPLETE_CAST",
+                    "destination_vertex": "TITLE",
+                    "count": 135086
+                }
+            ]
+        },
+        {
+            "type_id": 12,
+            "type_name": "COMPLETE_CAST_SUBJECT",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "COMPLETE_CAST",
+                    "destination_vertex": "COMP_CAST_TYPE",
+                    "count": 135086
+                }
+            ]
+        },
+        {
+            "type_id": 13,
+            "type_name": "COMPLETE_CAST_STATUS",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "COMPLETE_CAST",
+                    "destination_vertex": "COMP_CAST_TYPE",
+                    "count": 135086
+                }
+            ]
+        },
+        {
+            "type_id": 14,
+            "type_name": "MOVIE_COMPANIES_TITLE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "MOVIE_COMPANIES",
+                    "destination_vertex": "TITLE",
+                    "count": 2609129
+                }
+            ]
+        },
+        {
+            "type_id": 15,
+            "type_name": "MOVIE_COMPANIES_COMPANY_NAME",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "MOVIE_COMPANIES",
+                    "destination_vertex": "COMPANY_NAME",
+                    "count": 2609129
+                }
+            ]
+        },
+        {
+            "type_id": 16,
+            "type_name": "MOVIE_COMPANIES_TYPE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "MOVIE_COMPANIES",
+                    "destination_vertex": "COMPANY_TYPE",
+                    "count": 2609129
+                }
+            ]
+        },
+        {
+            "type_id": 18,
+            "type_name": "MOVIE_LINK_TITLE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "MOVIE_LINK",
+                    "destination_vertex": "TITLE",
+                    "count": 29997
+                }
+            ]
+        },
+        {
+            "type_id": 17,
+            "type_name": "MOVIE_LINK_LINKED_TITLE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "MOVIE_LINK",
+                    "destination_vertex": "TITLE",
+                    "count": 29997
+                }
+            ]
+        },
+        {
+            "type_id": 19,
+            "type_name": "MOVIE_LINK_LINKED_TYPE",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "MOVIE_LINK",
+                    "destination_vertex": "LINK_TYPE",
+                    "count": 29997
+                }
+            ]
+        },
+        {
+            "type_id": 4,
+            "type_name": "MOVIE_INFO_IDX",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "TITLE",
+                    "destination_vertex": "INFO_TYPE",
+                    "count": 1380035
+                }
+            ]
+        }
+    ]
+}

--- a/interactive_engine/compiler/src/main/resources/statistics/imdb_statistics.json
+++ b/interactive_engine/compiler/src/main/resources/statistics/imdb_statistics.json
@@ -134,6 +134,17 @@
             ]
         },
         {
+            "type_id": 4,
+            "type_name": "MOVIE_INFO_IDX",
+            "vertex_type_pair_statistics": [
+                {
+                    "source_vertex": "TITLE",
+                    "destination_vertex": "INFO_TYPE",
+                    "count": 1380035
+                }
+            ]
+        },
+        {
             "type_id": 5,
             "type_name": "PERSON_INFO",
             "vertex_type_pair_statistics": [
@@ -266,8 +277,8 @@
             ]
         },
         {
-            "type_id": 18,
-            "type_name": "MOVIE_LINK_TITLE",
+            "type_id": 17,
+            "type_name": "MOVIE_LINK_LINKED_TITLE",
             "vertex_type_pair_statistics": [
                 {
                     "source_vertex": "MOVIE_LINK",
@@ -277,8 +288,8 @@
             ]
         },
         {
-            "type_id": 17,
-            "type_name": "MOVIE_LINK_LINKED_TITLE",
+            "type_id": 18,
+            "type_name": "MOVIE_LINK_TITLE",
             "vertex_type_pair_statistics": [
                 {
                     "source_vertex": "MOVIE_LINK",
@@ -295,17 +306,6 @@
                     "source_vertex": "MOVIE_LINK",
                     "destination_vertex": "LINK_TYPE",
                     "count": 29997
-                }
-            ]
-        },
-        {
-            "type_id": 4,
-            "type_name": "MOVIE_INFO_IDX",
-            "vertex_type_pair_statistics": [
-                {
-                    "source_vertex": "TITLE",
-                    "destination_vertex": "INFO_TYPE",
-                    "count": 1380035
                 }
             ]
         }

--- a/interactive_engine/executor/ir/core/resource/imdb_schema.yaml
+++ b/interactive_engine/executor/ir/core/resource/imdb_schema.yaml
@@ -1,0 +1,295 @@
+vertex_types:
+  - type_id: 0
+    type_name: AKA_NAME
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 1
+    type_name: AKA_TITLE
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 2
+    type_name: TITLE
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 3
+    type_name: CHAR_NAME
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 4
+    type_name: COMP_CAST_TYPE
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 5
+    type_name: COMPANY_NAME
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 6
+    type_name: COMPANY_TYPE
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 7
+    type_name: INFO_TYPE
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 8
+    type_name: KEYWORD
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 9
+    type_name: KIND_TYPE
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 10
+    type_name: LINK_TYPE
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 11
+    type_name: NAME
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 12
+    type_name: ROLE_TYPE
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 13
+    type_name: CAST_INFO
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 14
+    type_name: COMPLETE_CAST
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 15
+    type_name: MOVIE_COMPANIES
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+  - type_id: 16
+    type_name: MOVIE_LINK
+    properties:
+      - property_id: 0
+        property_name: id
+        property_type:
+          primitive_type: DT_SIGNED_INT64
+    primary_keys:
+      - id
+edge_types:
+  - type_id: 0
+    type_name: ALSO_KNOWN_AS_NAME
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: NAME
+        relation: MANY_TO_MANY
+        source_vertex: AKA_NAME
+  - type_id: 1
+    type_name: ALSO_KNOWN_AS_TITLE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: TITLE
+        relation: MANY_TO_MANY
+        source_vertex: AKA_TITLE
+  - type_id: 2
+    type_name: KIND_TYPE_TITLE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: TITLE
+        relation: MANY_TO_MANY
+        source_vertex: KIND_TYPE
+  - type_id: 3
+    type_name: MOVIE_INFO
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: INFO_TYPE
+        relation: MANY_TO_MANY
+        source_vertex: TITLE
+  - type_id: 4
+    type_name: MOVIE_INFO_IDX
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: INFO_TYPE
+        relation: MANY_TO_MANY
+        source_vertex: TITLE
+  - type_id: 5
+    type_name: PERSON_INFO
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: INFO_TYPE
+        relation: MANY_TO_MANY
+        source_vertex: NAME
+  - type_id: 6
+    type_name: MOVIE_KEYWORD
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: KEYWORD
+        relation: MANY_TO_MANY
+        source_vertex: TITLE
+  - type_id: 7
+    type_name: CAST_INFO_NAME
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: NAME
+        relation: MANY_TO_MANY
+        source_vertex: CAST_INFO
+  - type_id: 8
+    type_name: CAST_INFO_TITLE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: TITLE
+        relation: MANY_TO_MANY
+        source_vertex: CAST_INFO
+  - type_id: 9
+    type_name: CAST_INFO_CHAR
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: CHAR_NAME
+        relation: MANY_TO_MANY
+        source_vertex: CAST_INFO
+  - type_id: 10
+    type_name: CAST_INFO_ROLE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: ROLE_TYPE
+        relation: MANY_TO_MANY
+        source_vertex: CAST_INFO
+  - type_id: 11
+    type_name: COMPLETE_CAST_TITLE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: TITLE
+        relation: MANY_TO_MANY
+        source_vertex: COMPLETE_CAST
+  - type_id: 12
+    type_name: COMPLETE_CAST_SUBJECT
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: COMP_CAST_TYPE
+        relation: MANY_TO_MANY
+        source_vertex: COMPLETE_CAST
+  - type_id: 13
+    type_name: COMPLETE_CAST_STATUS
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: COMP_CAST_TYPE
+        relation: MANY_TO_MANY
+        source_vertex: COMPLETE_CAST
+  - type_id: 14
+    type_name: MOVIE_COMPANIES_TITLE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: TITLE
+        relation: MANY_TO_MANY
+        source_vertex: MOVIE_COMPANIES
+  - type_id: 15
+    type_name: MOVIE_COMPANIES_COMPANY_NAME
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: COMPANY_NAME
+        relation: MANY_TO_MANY
+        source_vertex: MOVIE_COMPANIES
+  - type_id: 16
+    type_name: MOVIE_COMPANIES_TYPE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: COMPANY_TYPE
+        relation: MANY_TO_MANY
+        source_vertex: MOVIE_COMPANIES
+  - type_id: 17
+    type_name: MOVIE_LINK_LINKED_TITLE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: TITLE
+        relation: MANY_TO_MANY
+        source_vertex: MOVIE_LINK
+  - type_id: 18
+    type_name: MOVIE_LINK_TITLE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: TITLE
+        relation: MANY_TO_MANY
+        source_vertex: MOVIE_LINK
+  - type_id: 19
+    type_name: MOVIE_LINK_LINKED_TYPE
+    properties: []
+    vertex_type_pair_relations:
+      - destination_vertex: LINK_TYPE
+        relation: MANY_TO_MANY
+        source_vertex: MOVIE_LINK

--- a/interactive_engine/executor/ir/core/resource/imdb_schema.yaml
+++ b/interactive_engine/executor/ir/core/resource/imdb_schema.yaml
@@ -1,295 +1,298 @@
-vertex_types:
-  - type_id: 0
-    type_name: AKA_NAME
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 1
-    type_name: AKA_TITLE
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 2
-    type_name: TITLE
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 3
-    type_name: CHAR_NAME
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 4
-    type_name: COMP_CAST_TYPE
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 5
-    type_name: COMPANY_NAME
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 6
-    type_name: COMPANY_TYPE
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 7
-    type_name: INFO_TYPE
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 8
-    type_name: KEYWORD
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 9
-    type_name: KIND_TYPE
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 10
-    type_name: LINK_TYPE
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 11
-    type_name: NAME
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 12
-    type_name: ROLE_TYPE
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 13
-    type_name: CAST_INFO
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 14
-    type_name: COMPLETE_CAST
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 15
-    type_name: MOVIE_COMPANIES
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-  - type_id: 16
-    type_name: MOVIE_LINK
-    properties:
-      - property_id: 0
-        property_name: id
-        property_type:
-          primitive_type: DT_SIGNED_INT64
-    primary_keys:
-      - id
-edge_types:
-  - type_id: 0
-    type_name: ALSO_KNOWN_AS_NAME
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: NAME
-        relation: MANY_TO_MANY
-        source_vertex: AKA_NAME
-  - type_id: 1
-    type_name: ALSO_KNOWN_AS_TITLE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: TITLE
-        relation: MANY_TO_MANY
-        source_vertex: AKA_TITLE
-  - type_id: 2
-    type_name: KIND_TYPE_TITLE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: TITLE
-        relation: MANY_TO_MANY
-        source_vertex: KIND_TYPE
-  - type_id: 3
-    type_name: MOVIE_INFO
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: INFO_TYPE
-        relation: MANY_TO_MANY
-        source_vertex: TITLE
-  - type_id: 4
-    type_name: MOVIE_INFO_IDX
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: INFO_TYPE
-        relation: MANY_TO_MANY
-        source_vertex: TITLE
-  - type_id: 5
-    type_name: PERSON_INFO
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: INFO_TYPE
-        relation: MANY_TO_MANY
-        source_vertex: NAME
-  - type_id: 6
-    type_name: MOVIE_KEYWORD
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: KEYWORD
-        relation: MANY_TO_MANY
-        source_vertex: TITLE
-  - type_id: 7
-    type_name: CAST_INFO_NAME
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: NAME
-        relation: MANY_TO_MANY
-        source_vertex: CAST_INFO
-  - type_id: 8
-    type_name: CAST_INFO_TITLE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: TITLE
-        relation: MANY_TO_MANY
-        source_vertex: CAST_INFO
-  - type_id: 9
-    type_name: CAST_INFO_CHAR
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: CHAR_NAME
-        relation: MANY_TO_MANY
-        source_vertex: CAST_INFO
-  - type_id: 10
-    type_name: CAST_INFO_ROLE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: ROLE_TYPE
-        relation: MANY_TO_MANY
-        source_vertex: CAST_INFO
-  - type_id: 11
-    type_name: COMPLETE_CAST_TITLE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: TITLE
-        relation: MANY_TO_MANY
-        source_vertex: COMPLETE_CAST
-  - type_id: 12
-    type_name: COMPLETE_CAST_SUBJECT
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: COMP_CAST_TYPE
-        relation: MANY_TO_MANY
-        source_vertex: COMPLETE_CAST
-  - type_id: 13
-    type_name: COMPLETE_CAST_STATUS
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: COMP_CAST_TYPE
-        relation: MANY_TO_MANY
-        source_vertex: COMPLETE_CAST
-  - type_id: 14
-    type_name: MOVIE_COMPANIES_TITLE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: TITLE
-        relation: MANY_TO_MANY
-        source_vertex: MOVIE_COMPANIES
-  - type_id: 15
-    type_name: MOVIE_COMPANIES_COMPANY_NAME
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: COMPANY_NAME
-        relation: MANY_TO_MANY
-        source_vertex: MOVIE_COMPANIES
-  - type_id: 16
-    type_name: MOVIE_COMPANIES_TYPE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: COMPANY_TYPE
-        relation: MANY_TO_MANY
-        source_vertex: MOVIE_COMPANIES
-  - type_id: 17
-    type_name: MOVIE_LINK_LINKED_TITLE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: TITLE
-        relation: MANY_TO_MANY
-        source_vertex: MOVIE_LINK
-  - type_id: 18
-    type_name: MOVIE_LINK_TITLE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: TITLE
-        relation: MANY_TO_MANY
-        source_vertex: MOVIE_LINK
-  - type_id: 19
-    type_name: MOVIE_LINK_LINKED_TYPE
-    properties: []
-    vertex_type_pair_relations:
-      - destination_vertex: LINK_TYPE
-        relation: MANY_TO_MANY
-        source_vertex: MOVIE_LINK
+name: imdb
+version: v0.1
+schema:
+  vertex_types:
+    - type_id: 0
+      type_name: AKA_NAME
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 1
+      type_name: AKA_TITLE
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 2
+      type_name: TITLE
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 3
+      type_name: CHAR_NAME
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 4
+      type_name: COMP_CAST_TYPE
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 5
+      type_name: COMPANY_NAME
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 6
+      type_name: COMPANY_TYPE
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 7
+      type_name: INFO_TYPE
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 8
+      type_name: KEYWORD
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 9
+      type_name: KIND_TYPE
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 10
+      type_name: LINK_TYPE
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 11
+      type_name: NAME
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 12
+      type_name: ROLE_TYPE
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 13
+      type_name: CAST_INFO
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 14
+      type_name: COMPLETE_CAST
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 15
+      type_name: MOVIE_COMPANIES
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+    - type_id: 16
+      type_name: MOVIE_LINK
+      properties:
+        - property_id: 0
+          property_name: id
+          property_type:
+            primitive_type: DT_SIGNED_INT64
+      primary_keys:
+        - id
+  edge_types:
+    - type_id: 0
+      type_name: ALSO_KNOWN_AS_NAME
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: NAME
+          relation: MANY_TO_MANY
+          source_vertex: AKA_NAME
+    - type_id: 1
+      type_name: ALSO_KNOWN_AS_TITLE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: TITLE
+          relation: MANY_TO_MANY
+          source_vertex: AKA_TITLE
+    - type_id: 2
+      type_name: KIND_TYPE_TITLE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: TITLE
+          relation: MANY_TO_MANY
+          source_vertex: KIND_TYPE
+    - type_id: 3
+      type_name: MOVIE_INFO
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: INFO_TYPE
+          relation: MANY_TO_MANY
+          source_vertex: TITLE
+    - type_id: 4
+      type_name: MOVIE_INFO_IDX
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: INFO_TYPE
+          relation: MANY_TO_MANY
+          source_vertex: TITLE
+    - type_id: 5
+      type_name: PERSON_INFO
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: INFO_TYPE
+          relation: MANY_TO_MANY
+          source_vertex: NAME
+    - type_id: 6
+      type_name: MOVIE_KEYWORD
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: KEYWORD
+          relation: MANY_TO_MANY
+          source_vertex: TITLE
+    - type_id: 7
+      type_name: CAST_INFO_NAME
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: NAME
+          relation: MANY_TO_MANY
+          source_vertex: CAST_INFO
+    - type_id: 8
+      type_name: CAST_INFO_TITLE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: TITLE
+          relation: MANY_TO_MANY
+          source_vertex: CAST_INFO
+    - type_id: 9
+      type_name: CAST_INFO_CHAR
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: CHAR_NAME
+          relation: MANY_TO_MANY
+          source_vertex: CAST_INFO
+    - type_id: 10
+      type_name: CAST_INFO_ROLE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: ROLE_TYPE
+          relation: MANY_TO_MANY
+          source_vertex: CAST_INFO
+    - type_id: 11
+      type_name: COMPLETE_CAST_TITLE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: TITLE
+          relation: MANY_TO_MANY
+          source_vertex: COMPLETE_CAST
+    - type_id: 12
+      type_name: COMPLETE_CAST_SUBJECT
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: COMP_CAST_TYPE
+          relation: MANY_TO_MANY
+          source_vertex: COMPLETE_CAST
+    - type_id: 13
+      type_name: COMPLETE_CAST_STATUS
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: COMP_CAST_TYPE
+          relation: MANY_TO_MANY
+          source_vertex: COMPLETE_CAST
+    - type_id: 14
+      type_name: MOVIE_COMPANIES_TITLE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: TITLE
+          relation: MANY_TO_MANY
+          source_vertex: MOVIE_COMPANIES
+    - type_id: 15
+      type_name: MOVIE_COMPANIES_COMPANY_NAME
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: COMPANY_NAME
+          relation: MANY_TO_MANY
+          source_vertex: MOVIE_COMPANIES
+    - type_id: 16
+      type_name: MOVIE_COMPANIES_TYPE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: COMPANY_TYPE
+          relation: MANY_TO_MANY
+          source_vertex: MOVIE_COMPANIES
+    - type_id: 17
+      type_name: MOVIE_LINK_LINKED_TITLE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: TITLE
+          relation: MANY_TO_MANY
+          source_vertex: MOVIE_LINK
+    - type_id: 18
+      type_name: MOVIE_LINK_TITLE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: TITLE
+          relation: MANY_TO_MANY
+          source_vertex: MOVIE_LINK
+    - type_id: 19
+      type_name: MOVIE_LINK_LINKED_TYPE
+      properties: []
+      vertex_type_pair_relations:
+        - destination_vertex: LINK_TYPE
+          relation: MANY_TO_MANY
+          source_vertex: MOVIE_LINK

--- a/interactive_engine/executor/ir/core/resource/imdb_schema.yaml
+++ b/interactive_engine/executor/ir/core/resource/imdb_schema.yaml
@@ -2,297 +2,666 @@ name: imdb
 version: v0.1
 schema:
   vertex_types:
-    - type_id: 0
-      type_name: AKA_NAME
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 1
-      type_name: AKA_TITLE
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 2
-      type_name: TITLE
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 3
-      type_name: CHAR_NAME
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 4
-      type_name: COMP_CAST_TYPE
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 5
-      type_name: COMPANY_NAME
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 6
-      type_name: COMPANY_TYPE
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 7
-      type_name: INFO_TYPE
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 8
-      type_name: KEYWORD
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 9
-      type_name: KIND_TYPE
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 10
-      type_name: LINK_TYPE
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 11
-      type_name: NAME
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 12
-      type_name: ROLE_TYPE
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 13
-      type_name: CAST_INFO
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 14
-      type_name: COMPLETE_CAST
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 15
-      type_name: MOVIE_COMPANIES
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
-    - type_id: 16
-      type_name: MOVIE_LINK
-      properties:
-        - property_id: 0
-          property_name: id
-          property_type:
-            primitive_type: DT_SIGNED_INT64
-      primary_keys:
-        - id
+  - type_id: 0
+    type_name: AKA_NAME
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: name
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: imdb_index
+      property_type:
+        string:
+          long_text: 
+    - property_id: 3
+      property_name: name_pcode_cf
+      property_type:
+        string:
+          long_text: 
+    - property_id: 4
+      property_name: name_pcode_nf
+      property_type:
+        string:
+          long_text: 
+    - property_id: 5
+      property_name: surname_pcode
+      property_type:
+        string:
+          long_text: 
+    - property_id: 6
+      property_name: md5sum
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 1
+    type_name: AKA_TITLE
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: title
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: imdb_index
+      property_type:
+        string:
+          long_text: 
+    - property_id: 3
+      property_name: kind_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 4
+      property_name: production_year
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 5
+      property_name: phonetic_code
+      property_type:
+        string:
+          long_text: 
+    - property_id: 6
+      property_name: episode_of_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 7
+      property_name: season_nr
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 8
+      property_name: episode_nr
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 9
+      property_name: note
+      property_type:
+        string:
+          long_text: 
+    - property_id: 10
+      property_name: md5sum
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 2
+    type_name: TITLE
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: title
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: imdb_index
+      property_type:
+        string:
+          long_text: 
+    - property_id: 3
+      property_name: production_year
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 4
+      property_name: imdb_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 5
+      property_name: phonetic_code
+      property_type:
+        string:
+          long_text: 
+    - property_id: 6
+      property_name: episode_of_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 7
+      property_name: season_nr
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 8
+      property_name: episode_nr
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 9
+      property_name: series_years
+      property_type:
+        string:
+          long_text: 
+    - property_id: 10
+      property_name: md5sum
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 3
+    type_name: CHAR_NAME
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: name
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: imdb_index
+      property_type:
+        string:
+          long_text: 
+    - property_id: 3
+      property_name: imdb_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 4
+      property_name: name_pcode_nf
+      property_type:
+        string:
+          long_text: 
+    - property_id: 5
+      property_name: surname_pcode
+      property_type:
+        string:
+          long_text: 
+    - property_id: 6
+      property_name: md5sum
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 4
+    type_name: COMP_CAST_TYPE
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: kind
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 5
+    type_name: COMPANY_NAME
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: name
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: country_code
+      property_type:
+        string:
+          long_text: 
+    - property_id: 3
+      property_name: imdb_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 4
+      property_name: name_pcode_nf
+      property_type:
+        string:
+          long_text: 
+    - property_id: 5
+      property_name: name_pcode_sf
+      property_type:
+        string:
+          long_text: 
+    - property_id: 6
+      property_name: md5sum
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 6
+    type_name: COMPANY_TYPE
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: kind
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 7
+    type_name: INFO_TYPE
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: info
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 8
+    type_name: KEYWORD
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: keyword
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: phonetic_code
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 9
+    type_name: KIND_TYPE
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: kind
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 10
+    type_name: LINK_TYPE
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: link
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 11
+    type_name: NAME
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: name
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: imdb_index
+      property_type:
+        string:
+          long_text: 
+    - property_id: 3
+      property_name: imdb_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 4
+      property_name: gender
+      property_type:
+        string:
+          long_text: 
+    - property_id: 5
+      property_name: name_pcode_cf
+      property_type:
+        string:
+          long_text: 
+    - property_id: 6
+      property_name: name_pcode_nf
+      property_type:
+        string:
+          long_text: 
+    - property_id: 7
+      property_name: surname_pcode
+      property_type:
+        string:
+          long_text: 
+    - property_id: 8
+      property_name: md5sum
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 12
+    type_name: ROLE_TYPE
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: role
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 13
+    type_name: CAST_INFO
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: person_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 2
+      property_name: movie_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 3
+      property_name: person_role_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 4
+      property_name: note
+      property_type:
+        string:
+          long_text: 
+    - property_id: 5
+      property_name: nr_order
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 6
+      property_name: role_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    primary_keys:
+    - id
+  - type_id: 14
+    type_name: COMPLETE_CAST
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: movie_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 2
+      property_name: subject_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 3
+      property_name: status_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    primary_keys:
+    - id
+  - type_id: 15
+    type_name: MOVIE_COMPANIES
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: movie_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 2
+      property_name: company_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 3
+      property_name: company_type_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 4
+      property_name: note
+      property_type:
+        string:
+          long_text: 
+    primary_keys:
+    - id
+  - type_id: 16
+    type_name: MOVIE_LINK
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT64
+    - property_id: 1
+      property_name: movie_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 2
+      property_name: linked_movie_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    - property_id: 3
+      property_name: link_type_id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    primary_keys:
+    - id
   edge_types:
-    - type_id: 0
-      type_name: ALSO_KNOWN_AS_NAME
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: NAME
-          relation: MANY_TO_MANY
-          source_vertex: AKA_NAME
-    - type_id: 1
-      type_name: ALSO_KNOWN_AS_TITLE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: TITLE
-          relation: MANY_TO_MANY
-          source_vertex: AKA_TITLE
-    - type_id: 2
-      type_name: KIND_TYPE_TITLE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: TITLE
-          relation: MANY_TO_MANY
-          source_vertex: KIND_TYPE
-    - type_id: 3
-      type_name: MOVIE_INFO
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: INFO_TYPE
-          relation: MANY_TO_MANY
-          source_vertex: TITLE
-    - type_id: 4
-      type_name: MOVIE_INFO_IDX
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: INFO_TYPE
-          relation: MANY_TO_MANY
-          source_vertex: TITLE
-    - type_id: 5
-      type_name: PERSON_INFO
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: INFO_TYPE
-          relation: MANY_TO_MANY
-          source_vertex: NAME
-    - type_id: 6
-      type_name: MOVIE_KEYWORD
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: KEYWORD
-          relation: MANY_TO_MANY
-          source_vertex: TITLE
-    - type_id: 7
-      type_name: CAST_INFO_NAME
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: NAME
-          relation: MANY_TO_MANY
-          source_vertex: CAST_INFO
-    - type_id: 8
-      type_name: CAST_INFO_TITLE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: TITLE
-          relation: MANY_TO_MANY
-          source_vertex: CAST_INFO
-    - type_id: 9
-      type_name: CAST_INFO_CHAR
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: CHAR_NAME
-          relation: MANY_TO_MANY
-          source_vertex: CAST_INFO
-    - type_id: 10
-      type_name: CAST_INFO_ROLE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: ROLE_TYPE
-          relation: MANY_TO_MANY
-          source_vertex: CAST_INFO
-    - type_id: 11
-      type_name: COMPLETE_CAST_TITLE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: TITLE
-          relation: MANY_TO_MANY
-          source_vertex: COMPLETE_CAST
-    - type_id: 12
-      type_name: COMPLETE_CAST_SUBJECT
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: COMP_CAST_TYPE
-          relation: MANY_TO_MANY
-          source_vertex: COMPLETE_CAST
-    - type_id: 13
-      type_name: COMPLETE_CAST_STATUS
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: COMP_CAST_TYPE
-          relation: MANY_TO_MANY
-          source_vertex: COMPLETE_CAST
-    - type_id: 14
-      type_name: MOVIE_COMPANIES_TITLE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: TITLE
-          relation: MANY_TO_MANY
-          source_vertex: MOVIE_COMPANIES
-    - type_id: 15
-      type_name: MOVIE_COMPANIES_COMPANY_NAME
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: COMPANY_NAME
-          relation: MANY_TO_MANY
-          source_vertex: MOVIE_COMPANIES
-    - type_id: 16
-      type_name: MOVIE_COMPANIES_TYPE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: COMPANY_TYPE
-          relation: MANY_TO_MANY
-          source_vertex: MOVIE_COMPANIES
-    - type_id: 17
-      type_name: MOVIE_LINK_LINKED_TITLE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: TITLE
-          relation: MANY_TO_MANY
-          source_vertex: MOVIE_LINK
-    - type_id: 18
-      type_name: MOVIE_LINK_TITLE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: TITLE
-          relation: MANY_TO_MANY
-          source_vertex: MOVIE_LINK
-    - type_id: 19
-      type_name: MOVIE_LINK_LINKED_TYPE
-      properties: []
-      vertex_type_pair_relations:
-        - destination_vertex: LINK_TYPE
-          relation: MANY_TO_MANY
-          source_vertex: MOVIE_LINK
+  - type_id: 0
+    type_name: ALSO_KNOWN_AS_NAME
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: NAME
+      relation: MANY_TO_MANY
+      source_vertex: AKA_NAME
+  - type_id: 1
+    type_name: ALSO_KNOWN_AS_TITLE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: TITLE
+      relation: MANY_TO_MANY
+      source_vertex: AKA_TITLE
+  - type_id: 2
+    type_name: KIND_TYPE_TITLE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: TITLE
+      relation: MANY_TO_MANY
+      source_vertex: KIND_TYPE
+  - type_id: 3
+    type_name: MOVIE_INFO
+    properties:
+    - property_id: 0
+      property_name: info
+      property_type:
+        string:
+          long_text: 
+    - property_id: 1
+      property_name: note
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    vertex_type_pair_relations:
+    - destination_vertex: INFO_TYPE
+      relation: MANY_TO_MANY
+      source_vertex: TITLE
+  - type_id: 4
+    type_name: MOVIE_INFO_IDX
+    properties:
+    - property_id: 0
+      property_name: info
+      property_type:
+        string:
+          long_text: 
+    - property_id: 1
+      property_name: note
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    vertex_type_pair_relations:
+    - destination_vertex: INFO_TYPE
+      relation: MANY_TO_MANY
+      source_vertex: TITLE
+  - type_id: 5
+    type_name: PERSON_INFO
+    properties:
+    - property_id: 0
+      property_name: info
+      property_type:
+        string:
+          long_text: 
+    - property_id: 1
+      property_name: note
+      property_type:
+        string:
+          long_text: 
+    - property_id: 2
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    vertex_type_pair_relations:
+    - destination_vertex: INFO_TYPE
+      relation: MANY_TO_MANY
+      source_vertex: NAME
+  - type_id: 6
+    type_name: MOVIE_KEYWORD
+    properties:
+    - property_id: 0
+      property_name: id
+      property_type:
+        primitive_type: DT_SIGNED_INT32
+    vertex_type_pair_relations:
+    - destination_vertex: KEYWORD
+      relation: MANY_TO_MANY
+      source_vertex: TITLE
+  - type_id: 7
+    type_name: CAST_INFO_NAME
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: NAME
+      relation: MANY_TO_MANY
+      source_vertex: CAST_INFO
+  - type_id: 8
+    type_name: CAST_INFO_TITLE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: TITLE
+      relation: MANY_TO_MANY
+      source_vertex: CAST_INFO
+  - type_id: 9
+    type_name: CAST_INFO_CHAR
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: CHAR_NAME
+      relation: MANY_TO_MANY
+      source_vertex: CAST_INFO
+  - type_id: 10
+    type_name: CAST_INFO_ROLE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: ROLE_TYPE
+      relation: MANY_TO_MANY
+      source_vertex: CAST_INFO
+  - type_id: 11
+    type_name: COMPLETE_CAST_TITLE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: TITLE
+      relation: MANY_TO_MANY
+      source_vertex: COMPLETE_CAST
+  - type_id: 12
+    type_name: COMPLETE_CAST_SUBJECT
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: COMP_CAST_TYPE
+      relation: MANY_TO_MANY
+      source_vertex: COMPLETE_CAST
+  - type_id: 13
+    type_name: COMPLETE_CAST_STATUS
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: COMP_CAST_TYPE
+      relation: MANY_TO_MANY
+      source_vertex: COMPLETE_CAST
+  - type_id: 14
+    type_name: MOVIE_COMPANIES_TITLE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: TITLE
+      relation: MANY_TO_MANY
+      source_vertex: MOVIE_COMPANIES
+  - type_id: 15
+    type_name: MOVIE_COMPANIES_COMPANY_NAME
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: COMPANY_NAME
+      relation: MANY_TO_MANY
+      source_vertex: MOVIE_COMPANIES
+  - type_id: 16
+    type_name: MOVIE_COMPANIES_TYPE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: COMPANY_TYPE
+      relation: MANY_TO_MANY
+      source_vertex: MOVIE_COMPANIES
+  - type_id: 17
+    type_name: MOVIE_LINK_LINKED_TITLE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: TITLE
+      relation: MANY_TO_MANY
+      source_vertex: MOVIE_LINK
+  - type_id: 18
+    type_name: MOVIE_LINK_TITLE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: TITLE
+      relation: MANY_TO_MANY
+      source_vertex: MOVIE_LINK
+  - type_id: 19
+    type_name: MOVIE_LINK_LINKED_TYPE
+    properties: []
+    vertex_type_pair_relations:
+    - destination_vertex: LINK_TYPE
+      relation: MANY_TO_MANY
+      source_vertex: MOVIE_LINK

--- a/interactive_engine/executor/store/exp_store/data/imdb_metadata.json
+++ b/interactive_engine/executor/store/exp_store/data/imdb_metadata.json
@@ -1,0 +1,929 @@
+{
+  "vertex_table_to_type": {
+    "AKA_NAME.csv": "AKA_NAME",
+    "AKA_TITLE.csv": "AKA_TITLE",
+    "TITLE.csv": "TITLE",
+    "CHAR_NAME.csv": "CHAR_NAME",
+    "COMP_CAST_TYPE.csv": "COMP_CAST_TYPE",
+    "COMPANY_NAME.csv": "COMPANY_NAME",
+    "COMPANY_TYPE.csv": "COMPANY_TYPE",
+    "INFO_TYPE.csv": "INFO_TYPE",
+    "KEYWORD.csv": "KEYWORD",
+    "KIND_TYPE.csv": "KIND_TYPE",
+    "LINK_TYPE.csv": "LINK_TYPE",
+    "NAME.csv": "NAME",
+    "ROLE_TYPE.csv": "ROLE_TYPE",
+    "CAST_INFO.csv": "CAST_INFO",
+    "COMPLETE_CAST.csv": "COMPLETE_CAST",
+    "MOVIE_COMPANIES.csv": "MOVIE_COMPANIES",
+    "MOVIE_LINK.csv": "MOVIE_LINK"
+  },
+  "edge_table_to_type": {
+    "ALSO_KNOWN_AS_NAME.csv": {
+      "etype": "ALSO_KNOWN_AS_NAME",
+      "src_vertex_type": "AKA_NAME",
+      "dst_vertex_type": "NAME"
+    },
+    "ALSO_KNOWN_AS_TITLE.csv": {
+      "etype": "ALSO_KNOWN_AS_TITLE",
+      "src_vertex_type": "AKA_TITLE",
+      "dst_vertex_type": "TITLE"
+    },
+    "KIND_TYPE_TITLE.csv": {
+      "etype": "KIND_TYPE_TITLE",
+      "src_vertex_type": "KIND_TYPE",
+      "dst_vertex_type": "TITLE"
+    },
+    "MOVIE_INFO.csv": {
+      "etype": "MOVIE_INFO",
+      "src_vertex_type": "TITLE",
+      "dst_vertex_type": "INFO_TYPE"
+    },
+    "PERSON_INFO.csv": {
+      "etype": "PERSON_INFO",
+      "src_vertex_type": "NAME",
+      "dst_vertex_type": "INFO_TYPE"
+    },
+    "MOVIE_KEYWORD.csv": {
+      "etype": "MOVIE_KEYWORD",
+      "src_vertex_type": "TITLE",
+      "dst_vertex_type": "KEYWORD"
+    },
+    "CAST_INFO_NAME.csv": {
+      "etype": "CAST_INFO_NAME",
+      "src_vertex_type": "CAST_INFO",
+      "dst_vertex_type": "NAME"
+    },
+    "CAST_INFO_TITLE.csv": {
+      "etype": "CAST_INFO_TITLE",
+      "src_vertex_type": "CAST_INFO",
+      "dst_vertex_type": "TITLE"
+    },
+    "CAST_INFO_CHAR.csv": {
+      "etype": "CAST_INFO_CHAR",
+      "src_vertex_type": "CAST_INFO",
+      "dst_vertex_type": "CHAR_NAME"
+    },
+    "CAST_INFO_ROLE.csv": {
+      "etype": "CAST_INFO_ROLE",
+      "src_vertex_type": "CAST_INFO",
+      "dst_vertex_type": "ROLE_TYPE"
+    },
+    "COMPLETE_CAST_TITLE.csv": {
+      "etype": "COMPLETE_CAST_TITLE",
+      "src_vertex_type": "COMPLETE_CAST",
+      "dst_vertex_type": "TITLE"
+    },
+    "COMPLETE_CAST_SUBJECT.csv": {
+      "etype": "COMPLETE_CAST_SUBJECT",
+      "src_vertex_type": "COMPLETE_CAST",
+      "dst_vertex_type": "COMP_CAST_TYPE"
+    },
+    "COMPLETE_CAST_STATUS.csv": {
+      "etype": "COMPLETE_CAST_STATUS",
+      "src_vertex_type": "COMPLETE_CAST",
+      "dst_vertex_type": "COMP_CAST_TYPE"
+    },
+    "MOVIE_COMPANIES_TITLE.csv": {
+      "etype": "MOVIE_COMPANIES_TITLE",
+      "src_vertex_type": "MOVIE_COMPANIES",
+      "dst_vertex_type": "TITLE"
+    },
+    "MOVIE_COMPANIES_COMPANY_NAME.csv": {
+      "etype": "MOVIE_COMPANIES_COMPANY_NAME",
+      "src_vertex_type": "MOVIE_COMPANIES",
+      "dst_vertex_type": "COMPANY_NAME"
+    },
+    "MOVIE_COMPANIES_TYPE.csv": {
+      "etype": "MOVIE_COMPANIES_TYPE",
+      "src_vertex_type": "MOVIE_COMPANIES",
+      "dst_vertex_type": "COMPANY_TYPE"
+    },
+    "MOVIE_LINK_TITLE.csv": {
+      "etype": "MOVIE_LINK_TITLE",
+      "src_vertex_type": "MOVIE_LINK",
+      "dst_vertex_type": "TITLE"
+    },
+    "MOVIE_LINK_LINKED_TITLE.csv": {
+      "etype": "MOVIE_LINK_LINKED_TITLE",
+      "src_vertex_type": "MOVIE_LINK",
+      "dst_vertex_type": "TITLE"
+    },
+    "MOVIE_LINK_LINKED_TYPE.csv": {
+      "etype": "MOVIE_LINK_LINKED_TYPE",
+      "src_vertex_type": "MOVIE_LINK",
+      "dst_vertex_type": "LINK_TYPE"
+    },
+    "MOVIE_INFO_IDX.csv": {
+      "etype": "MOVIE_INFO_IDX",
+      "src_vertex_type": "TITLE",
+      "dst_vertex_type": "INFO_TYPE"
+    }
+  },
+  "vertex_columns": {
+    "AKA_NAME": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "name",
+        "String",
+        false
+      ],
+      [
+        "imdb_index",
+        "String",
+        false
+      ],
+      [
+        "name_pcode_cf",
+        "String",
+        false
+      ],
+      [
+        "name_pcode_nf",
+        "String",
+        false
+      ],
+      [
+        "surname_pcode",
+        "String",
+        false
+      ],
+      [
+        "md5sum",
+        "String",
+        false
+      ]
+    ],
+    "AKA_TITLE": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "title",
+        "String",
+        false
+      ],
+      [
+        "imdb_index",
+        "String",
+        false
+      ],
+      [
+        "kind_id",
+        "Integer",
+        false
+      ],
+      [
+        "production_year",
+        "Integer",
+        false
+      ],
+      [
+        "phonetic_code",
+        "String",
+        false
+      ],
+      [
+        "episode_of_id",
+        "Integer",
+        false
+      ],
+      [
+        "season_nr",
+        "Integer",
+        false
+      ],
+      [
+        "episode_nr",
+        "Integer",
+        false
+      ],
+      [
+        "note",
+        "String",
+        false
+      ],
+      [
+        "md5sum",
+        "String",
+        false
+      ]
+    ],
+    "TITLE": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "title",
+        "String",
+        false
+      ],
+      [
+        "imdb_index",
+        "String",
+        false
+      ],
+      [
+        "production_year",
+        "Integer",
+        false
+      ],
+      [
+        "imdb_id",
+        "Integer",
+        false
+      ],
+      [
+        "phonetic_code",
+        "String",
+        false
+      ],
+      [
+        "episode_of_id",
+        "Integer",
+        false
+      ],
+      [
+        "season_nr",
+        "Integer",
+        false
+      ],
+      [
+        "episode_nr",
+        "Integer",
+        false
+      ],
+      [
+        "series_years",
+        "String",
+        false
+      ],
+      [
+        "md5sum",
+        "String",
+        false
+      ]
+    ],
+    "CHAR_NAME": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "name",
+        "String",
+        false
+      ],
+      [
+        "imdb_index",
+        "String",
+        false
+      ],
+      [
+        "imdb_id",
+        "Integer",
+        false
+      ],
+      [
+        "name_pcode_nf",
+        "String",
+        false
+      ],
+      [
+        "surname_pcode",
+        "String",
+        false
+      ],
+      [
+        "md5sum",
+        "String",
+        false
+      ]
+    ],
+    "COMP_CAST_TYPE": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "kind",
+        "String",
+        false
+      ]
+    ],
+    "COMPANY_NAME": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "name",
+        "String",
+        false
+      ],
+      [
+        "country_code",
+        "String",
+        false
+      ],
+      [
+        "imdb_id",
+        "Integer",
+        false
+      ],
+      [
+        "name_pcode_nf",
+        "String",
+        false
+      ],
+      [
+        "name_pcode_sf",
+        "String",
+        false
+      ],
+      [
+        "md5sum",
+        "String",
+        false
+      ]
+    ],
+    "COMPANY_TYPE": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "kind",
+        "String",
+        false
+      ]
+    ],
+    "INFO_TYPE": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "info",
+        "String",
+        false
+      ]
+    ],
+    "KEYWORD": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "keyword",
+        "String",
+        false
+      ],
+      [
+        "phonetic_code",
+        "String",
+        false
+      ]
+    ],
+    "KIND_TYPE": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "kind",
+        "String",
+        false
+      ]
+    ],
+    "LINK_TYPE": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "link",
+        "String",
+        false
+      ]
+    ],
+    "NAME": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "name",
+        "String",
+        false
+      ],
+      [
+        "imdb_index",
+        "String",
+        false
+      ],
+      [
+        "imdb_id",
+        "Integer",
+        false
+      ],
+      [
+        "gender",
+        "String",
+        false
+      ],
+      [
+        "name_pcode_cf",
+        "String",
+        false
+      ],
+      [
+        "name_pcode_nf",
+        "String",
+        false
+      ],
+      [
+        "surname_pcode",
+        "String",
+        false
+      ],
+      [
+        "md5sum",
+        "String",
+        false
+      ]
+    ],
+    "ROLE_TYPE": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "role",
+        "String",
+        false
+      ]
+    ],
+    "CAST_INFO": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "person_id",
+        "Integer",
+        false
+      ],
+      [
+        "movie_id",
+        "Integer",
+        false
+      ],
+      [
+        "person_role_id",
+        "Integer",
+        false
+      ],
+      [
+        "note",
+        "String",
+        false
+      ],
+      [
+        "nr_order",
+        "Integer",
+        false
+      ],
+      [
+        "role_id",
+        "Integer",
+        false
+      ]
+    ],
+    "COMPLETE_CAST": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "movie_id",
+        "Integer",
+        false
+      ],
+      [
+        "subject_id",
+        "Integer",
+        false
+      ],
+      [
+        "status_id",
+        "Integer",
+        false
+      ]
+    ],
+    "MOVIE_COMPANIES": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "movie_id",
+        "Integer",
+        false
+      ],
+      [
+        "company_id",
+        "Integer",
+        false
+      ],
+      [
+        "company_type_id",
+        "Integer",
+        false
+      ],
+      [
+        "note",
+        "String",
+        false
+      ]
+    ],
+    "MOVIE_LINK": [
+      [
+        "id",
+        "ID",
+        true
+      ],
+      [
+        "movie_id",
+        "Integer",
+        false
+      ],
+      [
+        "linked_movie_id",
+        "Integer",
+        false
+      ],
+      [
+        "link_type_id",
+        "Integer",
+        false
+      ]
+    ]
+  },
+  "edge_columns": {
+    "ALSO_KNOWN_AS_NAME": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "ALSO_KNOWN_AS_TITLE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "KIND_TYPE_TITLE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "MOVIE_INFO": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ],
+      [
+        "info",
+        "String",
+        false
+      ],
+      [
+        "note",
+        "String",
+        false
+      ],
+      [
+        "id",
+        "Integer",
+        false
+      ]
+    ],
+    "PERSON_INFO": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ],
+      [
+        "info",
+        "String",
+        false
+      ],
+      [
+        "note",
+        "String",
+        false
+      ],
+      [
+        "id",
+        "Integer",
+        false
+      ]
+    ],
+    "MOVIE_KEYWORD": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ],
+      [
+        "id",
+        "ID",
+        false
+      ]
+    ],
+    "CAST_INFO_NAME": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "CAST_INFO_TITLE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "CAST_INFO_CHAR": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "CAST_INFO_ROLE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "COMPLETE_CAST_TITLE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "COMPLETE_CAST_SUBJECT": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "COMPLETE_CAST_STATUS": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "MOVIE_COMPANIES_TITLE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "MOVIE_COMPANIES_COMPANY_NAME": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "MOVIE_COMPANIES_TYPE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "MOVIE_LINK_TITLE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "MOVIE_LINK_LINKED_TITLE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "MOVIE_LINK_LINKED_TYPE": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ]
+    ],
+    "MOVIE_INFO_IDX": [
+      [
+        "start_id",
+        "ID",
+        true
+      ],
+      [
+        "end_id",
+        "ID",
+        true
+      ],
+      [
+        "info",
+        "String",
+        false
+      ],
+      [
+        "note",
+        "String",
+        false
+      ],
+      [
+        "id",
+        "Integer",
+        false
+      ]
+    ]
+  },
+  "vertex_type_to_id": {
+    "AKA_NAME": 0,
+    "AKA_TITLE": 1,
+    "TITLE": 2,
+    "CHAR_NAME": 3,
+    "COMP_CAST_TYPE": 4,
+    "COMPANY_NAME": 5,
+    "COMPANY_TYPE": 6,
+    "INFO_TYPE": 7,
+    "KEYWORD": 8,
+    "KIND_TYPE": 9,
+    "LINK_TYPE": 10,
+    "NAME": 11,
+    "ROLE_TYPE": 12,
+    "CAST_INFO": 13,
+    "COMPLETE_CAST": 14,
+    "MOVIE_COMPANIES": 15,
+    "MOVIE_LINK": 16
+  },
+  "edge_type_to_id": {
+    "ALSO_KNOWN_AS_NAME": 0,
+    "ALSO_KNOWN_AS_TITLE": 1,
+    "KIND_TYPE_TITLE": 2,
+    "MOVIE_INFO": 3,
+    "MOVIE_INFO_IDX": 4,
+    "PERSON_INFO": 5,
+    "MOVIE_KEYWORD": 6,
+    "CAST_INFO_NAME": 7,
+    "CAST_INFO_TITLE": 8,
+    "CAST_INFO_CHAR": 9,
+    "CAST_INFO_ROLE": 10,
+    "COMPLETE_CAST_TITLE": 11,
+    "COMPLETE_CAST_SUBJECT": 12,
+    "COMPLETE_CAST_STATUS": 13,
+    "MOVIE_COMPANIES_TITLE": 14,
+    "MOVIE_COMPANIES_COMPANY_NAME": 15,
+    "MOVIE_COMPANIES_TYPE": 16,
+    "MOVIE_LINK_LINKED_TITLE": 17,
+    "MOVIE_LINK_TITLE": 18,
+    "MOVIE_LINK_LINKED_TYPE": 19
+  },
+  "vertex_type_hierarchy": {},
+  "column_name_to_id": {}
+}

--- a/interactive_engine/executor/store/exp_store/src/parser.rs
+++ b/interactive_engine/executor/store/exp_store/src/parser.rs
@@ -19,6 +19,7 @@ use std::fmt::Debug;
 use std::str::FromStr;
 
 use chrono::offset::{TimeZone, Utc};
+use dyn_type::Object;
 
 use self::chrono::Datelike;
 use crate::common::{DefaultId, Label, LabelId};
@@ -170,19 +171,23 @@ pub fn parse_properties<'a, Iter: Iterator<Item = &'a str>>(
     while let Some(val) = record_iter.next() {
         // unwrap the property and type
         if let Some(ColumnMeta { name, data_type, is_primary_key: _ }) = header_iter.next() {
-            match data_type {
-                &DataType::String => properties.push(object!(val.to_string())),
-                &DataType::Integer => properties.push(object!(val.parse::<i32>()?)),
-                &DataType::Long => properties.push(object!(val.parse::<i64>()?)),
-                &DataType::Double => properties.push(object!(val.parse::<f64>()?)),
-                &DataType::Date => properties.push(object!(parse_datetime(val)?)),
-                &DataType::ID => {
-                    if name != START_ID_FIELD && name != END_ID_FIELD {
-                        properties.push(object!(val.parse::<DefaultId>()?));
+            if val.is_empty() && data_type != &DataType::String {
+                properties.push(Object::None);
+            } else {
+                match data_type {
+                    &DataType::String => properties.push(object!(val.to_string())),
+                    &DataType::Integer => properties.push(object!(val.parse::<i32>()?)),
+                    &DataType::Long => properties.push(object!(val.parse::<i64>()?)),
+                    &DataType::Double => properties.push(object!(val.parse::<f64>()?)),
+                    &DataType::Date => properties.push(object!(parse_datetime(val)?)),
+                    &DataType::ID => {
+                        if name != START_ID_FIELD && name != END_ID_FIELD {
+                            properties.push(object!(val.parse::<DefaultId>()?));
+                        }
                     }
+                    &DataType::LABEL => {}
+                    _ => return GDBResult::Err(GDBError::ParseError),
                 }
-                &DataType::LABEL => {}
-                _ => return GDBResult::Err(GDBError::ParseError),
             }
         }
     }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. For GOpt, add schema and statistics for IMDB dataset
2. For ExpStore, add dataloading metadata  for IMDB dataset, and support parsing an empty value (for the columns that are optional)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#4014 

