### PR TITLE
fix(interactive): Improve the codegen error propagation from server to client 

### DIFF
--- a/.github/workflows/interactive.yml
+++ b/.github/workflows/interactive.yml
@@ -144,7 +144,7 @@ jobs:
         bash generate_sdk.sh -g java
         bash generate_sdk.sh -g python
         cd java
-        mvn clean install -DskipTests
+        mvn clean install -DskipTests -q
         cd ../python
         pip3 install -r requirements.txt
         pip3 install -r test-requirements.txt

--- a/flex/bin/load_plan_and_gen.sh
+++ b/flex/bin/load_plan_and_gen.sh
@@ -89,17 +89,17 @@ generate_cpp_yaml() {
   local procedure_query=$4
   local output_yaml_file=$5
   local template_str="""
-  name: ${procedure_name}
-  description: ${procedure_description}
-  library: ${output_so_name}
-  type: cpp
-  query: |
+name: ${procedure_name}
+description: \"${procedure_description}\"
+library: ${output_so_name}
+type: cpp
+query: |
   """
   # for each line in procedure_query, add 2 spaces
   while IFS= read -r line; do
     # add newline after each line
     template_str="${template_str}  ${line}\n"
-  done <<< "${procedure_query}"
+  done <<< "'${procedure_query}'"
   echo "${template_str}" > ${output_yaml_file}
   info "Generate yaml file to ${output_yaml_file}"
 }

--- a/flex/codegen/gen_code_from_plan.cc
+++ b/flex/codegen/gen_code_from_plan.cc
@@ -122,8 +122,9 @@ int main(int argc, char** argv) {
       "graph schema path");
   google::InitGoogleLogging(argv[0]);
   FLAGS_logtostderr =
-      false;  // we don't want to log stderr, since interactive
-              // server will try to catch the error log from stderr.
+      false;  // We avoid outputting logs to stderr to allow the interactive
+              // server capturing error logs and returning them to the
+              // client when code generation fails.
 
   bpo::variables_map vm;
   bpo::store(bpo::command_line_parser(argc, argv).options(desc).run(), vm);

--- a/flex/codegen/gen_code_from_plan.cc
+++ b/flex/codegen/gen_code_from_plan.cc
@@ -120,6 +120,10 @@ int main(int argc, char** argv) {
       "output,o", bpo::value<std::string>(), "output file path")(
       "graph,g", bpo::value<std::string>()->default_value(""),
       "graph schema path");
+  google::InitGoogleLogging(argv[0]);
+  FLAGS_logtostderr =
+      false;  // we don't want to log stderr, since interactive
+              // server will try to catch the error log from stderr.
 
   bpo::variables_map vm;
   bpo::store(bpo::command_line_parser(argc, argv).options(desc).run(), vm);

--- a/flex/engines/http_server/codegen_proxy.cc
+++ b/flex/engines/http_server/codegen_proxy.cc
@@ -94,27 +94,19 @@ seastar::future<std::pair<int32_t, std::string>> CodegenProxy::DoGen(
   }
 
   return call_codegen_cmd(plan, cur_graph_schema_path)
-      .then_wrapped([this, next_job_id](auto&& future) {
-        int return_code;
-        try {
-          return_code = future.get();
-        } catch (std::exception& e) {
-          LOG(ERROR) << "Compilation failed: " << e.what();
-          return seastar::make_ready_future<std::pair<int32_t, std::string>>(
-              std::make_pair(next_job_id,
-                             std::string("Compilation failed: ") + e.what()));
-        }
-        if (return_code != 0) {
-          LOG(ERROR) << "Codegen failed";
+      .then([this, next_job_id](gs::Result<bool> codegen_res) {
+        if (!codegen_res.ok()) {
+          LOG(ERROR) << "Compilation failure: "
+                     << codegen_res.status().error_message();
           return seastar::make_exception_future<
-              std::pair<int32_t, std::string>>(
-              std::runtime_error("Codegen failed"));
+              std::pair<int32_t, std::string>>(std::runtime_error(
+              "Compilation failure: " + codegen_res.status().error_message()));
         }
         return get_res_lib_path_from_cache(next_job_id);
       });
 }
 
-seastar::future<int> CodegenProxy::call_codegen_cmd(
+seastar::future<gs::Result<bool>> CodegenProxy::call_codegen_cmd(
     const physical::PhysicalPlan& plan,
     const std::string& cur_graph_schema_path) {
   // if the desired query lib for next_job_id is in cache, just return 0
@@ -126,7 +118,7 @@ seastar::future<int> CodegenProxy::call_codegen_cmd(
 
   if (job_id_2_procedures_.find(next_job_id) != job_id_2_procedures_.end() &&
       job_id_2_procedures_[next_job_id].status == CodegenStatus::SUCCESS) {
-    return seastar::make_ready_future<int>(0);
+    return seastar::make_ready_future<gs::Result<bool>>(true);
   }
 
   insert_or_update(next_job_id, CodegenStatus::RUNNING, "");
@@ -134,7 +126,7 @@ seastar::future<int> CodegenProxy::call_codegen_cmd(
   plan_path = prepare_next_job_dir(work_dir, query_name, plan);
   if (plan_path.empty()) {
     insert_or_update(next_job_id, CodegenStatus::FAILED, "");
-    return seastar::make_exception_future<int>(std::runtime_error(
+    return seastar::make_exception_future<gs::Result<bool>>(std::runtime_error(
         "Fail to prepare next job dir for " + query_name + ", job id: " +
         std::to_string(next_job_id) + ", plan path: " + plan_path));
   }
@@ -142,25 +134,29 @@ seastar::future<int> CodegenProxy::call_codegen_cmd(
   std::string expected_res_lib_path = work_dir + "/lib" + query_name + ".so";
   return CallCodegenCmd(codegen_bin_, plan_path, query_name, work_dir, work_dir,
                         cur_graph_schema_path, ir_compiler_prop_)
-      .then([this, next_job_id, expected_res_lib_path](int codegen_res) {
-        if (codegen_res != 0 ||
-            !std::filesystem::exists(expected_res_lib_path)) {
-          LOG(ERROR) << "Expected lib path " << expected_res_lib_path
-                     << " not exists, or compilation failure: " << codegen_res
-                     << " compilation failed";
-
+      .then([this, next_job_id,
+             expected_res_lib_path](gs::Result<bool> codegen_res) {
+        if (!codegen_res.ok()) {
+          LOG(ERROR) << "Compilation failure: "
+                     << codegen_res.status().error_message();
+          insert_or_update(next_job_id, CodegenStatus::FAILED, "");
+          return seastar::make_ready_future<gs::Result<bool>>(codegen_res);
+        }
+        if (!std::filesystem::exists(expected_res_lib_path)) {
+          LOG(ERROR) << "Compilation success, but generated lib not exists: "
+                     << expected_res_lib_path;
           insert_or_update(next_job_id, CodegenStatus::FAILED, "");
           VLOG(10) << "Compilation failed, job id: " << next_job_id;
-        } else {
-          VLOG(10) << "Compilation success, job id: " << next_job_id;
-          insert_or_update(next_job_id, CodegenStatus::SUCCESS,
-                           expected_res_lib_path);
+          return seastar::make_ready_future<gs::Result<bool>>(codegen_res);
         }
+        VLOG(10) << "Compilation success, job id: " << next_job_id;
+        insert_or_update(next_job_id, CodegenStatus::SUCCESS,
+                         expected_res_lib_path);
         {
           std::lock_guard<std::mutex> lock(mutex_);
           cv_.notify_all();
         }
-        return seastar::make_ready_future<int>(codegen_res);
+        return seastar::make_ready_future<gs::Result<bool>>(true);
       });
 }
 
@@ -181,15 +177,34 @@ CodegenProxy::get_res_lib_path_from_cache(int32_t next_job_id) {
   }
 }
 
-seastar::future<int> CodegenProxy::CallCodegenCmd(
+seastar::future<gs::Result<bool>> CodegenProxy::CallCodegenCmd(
     const std::string& codegen_bin, const std::string& plan_path,
     const std::string& query_name, const std::string& work_dir,
     const std::string& output_dir, const std::string& graph_schema_path,
     const std::string& engine_config, const std::string& procedure_desc) {
+  if (query_name.empty()) {
+    return seastar::make_exception_future<gs::Result<bool>>(
+        std::runtime_error("query_name is empty"));
+  }
+  // query_name can not start with number, and should only contains digits,
+  // letters and underscores
+  if (!std::isalpha(query_name[0])) {
+    return seastar::make_exception_future<gs::Result<bool>>(
+        std::runtime_error("query_name should start with alphabet"));
+  }
+  if (!std::all_of(query_name.begin(), query_name.end(), [](char c) {
+        return std::isalnum(c) || c == '_' || c == '-';
+      })) {
+    return seastar::make_exception_future<gs::Result<bool>>(
+        std::runtime_error("query_name should only contains digits, letters "
+                           "and underscores: " +
+                           query_name));
+  }
+
   // TODO: different suffix for different platform
   std::string cmd = codegen_bin + " -e=hqps " + " -i=" + plan_path +
-                    " -o=" + output_dir + " --procedure_name=\"" + query_name +
-                    "\" -w=" + work_dir + " --ir_conf=" + engine_config +
+                    " -o=" + output_dir + " --procedure_name=" + query_name +
+                    " -w=" + work_dir + " --ir_conf=" + engine_config +
                     " --graph_schema_path=" + graph_schema_path;
   if (!procedure_desc.empty()) {
     cmd += " --procedure_desc=\'" + procedure_desc + "\'";
@@ -197,20 +212,29 @@ seastar::future<int> CodegenProxy::CallCodegenCmd(
   LOG(INFO) << "Start call codegen cmd: [" << cmd << "]";
 
   return hiactor::thread_resource_pool::submit_work([cmd] {
-           auto res = std::system(cmd.c_str());
-           LOG(INFO) << "Codegen cmd: [" << cmd << "] return: " << res;
-           return res;
-         })
-      .then_wrapped([](auto fut) {
-        VLOG(10) << "try";
-        try {
-          VLOG(10) << "Got future ";
-          return seastar::make_ready_future<int>(fut.get0());
-        } catch (std::exception& e) {
-          LOG(ERROR) << "Compilation failed: " << e.what();
-          return seastar::make_ready_future<int>(-1);
-        }
-      });
+    //  auto res = std::system(cmd.c_str());
+    boost::process::ipstream stdout_pipe;
+    boost::process::ipstream stderr_pipe;
+    boost::process::child codegen_process(
+        cmd, boost::process::std_out > stdout_pipe,
+        boost::process::std_err > stderr_pipe);
+
+    std::stringstream ss;
+    std::string stderr_res;
+    while (std::getline(stderr_pipe, stderr_res)) {
+      ss << stderr_res + "\n";
+    }
+
+    codegen_process.wait();
+    int res = codegen_process.exit_code();
+    if (res != 0) {
+      return gs::Result<bool>(
+          gs::Status(gs::StatusCode::CodegenError, ss.str()), false);
+    }
+
+    LOG(INFO) << "Codegen cmd: [" << cmd << "] success! ";
+    return gs::Result<bool>(true);
+  });
 }
 
 std::string CodegenProxy::get_work_directory(int32_t job_id) {

--- a/flex/engines/http_server/codegen_proxy.cc
+++ b/flex/engines/http_server/codegen_proxy.cc
@@ -143,16 +143,14 @@ seastar::future<gs::Result<bool>> CodegenProxy::call_codegen_cmd(
           LOG(ERROR) << "Compilation failure: "
                      << codegen_res.status().error_message();
           insert_or_update(next_job_id, CodegenStatus::FAILED, "");
-          return seastar::make_ready_future<gs::Result<bool>>(codegen_res,
-                                                              false);
+          return seastar::make_ready_future<gs::Result<bool>>(codegen_res);
         }
         if (!std::filesystem::exists(expected_res_lib_path)) {
           LOG(ERROR) << "Compilation success, but generated lib not exists: "
                      << expected_res_lib_path;
           insert_or_update(next_job_id, CodegenStatus::FAILED, "");
           VLOG(10) << "Compilation failed, job id: " << next_job_id;
-          return seastar::make_ready_future<gs::Result<bool>>(codegen_res,
-                                                              false);
+          return seastar::make_ready_future<gs::Result<bool>>(codegen_res);
         }
         VLOG(10) << "Compilation success, job id: " << next_job_id;
         insert_or_update(next_job_id, CodegenStatus::SUCCESS,

--- a/flex/engines/http_server/codegen_proxy.cc
+++ b/flex/engines/http_server/codegen_proxy.cc
@@ -229,6 +229,8 @@ seastar::future<gs::Result<bool>> CodegenProxy::CallCodegenCmd(
     }
 
     codegen_process.wait();
+    stderr_pipe.close();
+    stdout_pipe.close();
     int res = codegen_process.exit_code();
     if (res != 0) {
       return gs::Result<bool>(

--- a/flex/engines/http_server/codegen_proxy.h
+++ b/flex/engines/http_server/codegen_proxy.h
@@ -27,6 +27,7 @@
 
 #include "flex/proto_generated_gie/job_service.pb.h"
 #include "flex/proto_generated_gie/physical.pb.h"
+#include "flex/utils/result.h"
 
 #include <boost/program_options.hpp>
 #include <hiactor/core/thread_resource_pool.hh>
@@ -82,15 +83,15 @@ class CodegenProxy {
   seastar::future<std::pair<int32_t, std::string>> DoGen(
       const physical::PhysicalPlan& plan);
 
-  static seastar::future<int> CallCodegenCmd(
+  static seastar::future<gs::Result<bool>> CallCodegenCmd(
       const std::string& codegen_bin, const std::string& plan_path,
       const std::string& query_name, const std::string& work_dir,
       const std::string& output_dir, const std::string& graph_schema_path,
       const std::string& engine_config, const std::string& description = "");
 
  private:
-  seastar::future<int> call_codegen_cmd(const physical::PhysicalPlan& plan,
-                                        const std::string& graph_schema_path);
+  seastar::future<gs::Result<bool>> call_codegen_cmd(
+      const physical::PhysicalPlan& plan, const std::string& graph_schema_path);
 
   seastar::future<std::pair<int32_t, std::string>> get_res_lib_path_from_cache(
       int32_t job_id);

--- a/flex/engines/http_server/workdir_manipulator.cc
+++ b/flex/engines/http_server/workdir_manipulator.cc
@@ -954,6 +954,11 @@ seastar::future<seastar::sstring> WorkDirManipulator::generate_procedure(
       .then_wrapped([plugin_id = plugin_id, output_dir](auto&& f) {
         try {
           auto res = f.get();
+          if (!res.ok()) {
+            return seastar::make_exception_future<seastar::sstring>(
+                std::runtime_error("Fail to generate procedure, error: " +
+                                   res.status().error_message()));
+          }
           std::string so_file;
           {
             std::stringstream ss;

--- a/flex/interactive/sdk/generate_sdk.sh
+++ b/flex/interactive/sdk/generate_sdk.sh
@@ -29,6 +29,7 @@ developerOrganizationUrl="https://graphscope.io"
 DEVELOPER_NAME="GraphScope Team"
 LICENSE_NAME="Apache-2.0"
 LICENSE_URL="https://www.apache.org/licenses/LICENSE-2.0.html"
+LOG_LEVEL="error"
 
 
 #get current bash scrip's directory
@@ -54,6 +55,7 @@ function do_gen_java() {
     addtional_properties="${addtional_properties},developerName=\"${DEVELOPER_NAME}\",developerOrganization=\"${ORGANIZATION}\""
     addtional_properties="${addtional_properties},developerOrganizationUrl=${developerOrganizationUrl}"
     addtional_properties="${addtional_properties},artifactVersion=${VERSION},hideGenerationTimestamp=true"
+    export JAVA_OPTS="-Dlog.level=${LOG_LEVEL}"
 
     cmd="openapi-generator-cli generate -i ${OPENAPI_SPEC_PATH} -g java -o ${OUTPUT_PATH}"
     cmd=" ${cmd} --api-package ${PACKAGE_NAME}.api"
@@ -71,6 +73,7 @@ function do_gen_java() {
 function do_gen_python() {
     echo "Generating Python SDK"
     OUTPUT_PATH="${CUR_DIR}/python"
+    export JAVA_OPTS="-Dlog.level=${LOG_LEVEL}"
     cmd="openapi-generator-cli generate -i ${OPENAPI_SPEC_PATH} -g python -o ${OUTPUT_PATH}"
     cmd=" ${cmd} --package-name ${PYTHON_PACKAGE_NAME}"
     cmd=" ${cmd} --additional-properties=packageVersion=${VERSION},pythonVersion=3"

--- a/flex/storages/metadata/local_file_metadata_store.cc
+++ b/flex/storages/metadata/local_file_metadata_store.cc
@@ -99,7 +99,6 @@ LocalFileMetadataStore::GetAllMeta(const meta_kind_t& meta_kind) {
         continue;
       }
       auto id_str = file_name.substr(strlen(META_FILE_PREFIX));
-      VLOG(10) << "Reading meta file: " << file_name;
       auto meta_file = get_meta_file(meta_kind, id_str);
       auto meta_value_res = read_file(meta_file);
       if (meta_value_res.ok()) {

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -1343,7 +1343,6 @@ bool Schema::has_edge_label(const std::string& src_label,
   auto src_label_id = get_vertex_label_id(src_label);
   auto dst_label_id = get_vertex_label_id(dst_label);
   if (!elabel_indexer_.get_index(label, edge_label_id)) {
-    LOG(ERROR) << "edge label not found:" << label;
     return false;
   }
   return has_edge_label(src_label_id, dst_label_id, edge_label_id);

--- a/flex/tests/hqps/admin_http_test.cc
+++ b/flex/tests/hqps/admin_http_test.cc
@@ -41,6 +41,8 @@ std::string get_file_name_from_path(const std::string& file_path) {
   auto file_name = file_path.substr(file_path.find_last_of('/') + 1);
   // remove extension
   file_name = file_name.substr(0, file_name.find_last_of('.'));
+  // prepend query_ before filename, to avoid name start with number
+  file_name = "query_" + file_name;
   return file_name;
 }
 


### PR DESCRIPTION
Improve the codegen error propagation from server to client. Including more detailed information instead of just an internal error message.

- Remove some unnecessary log
- Redirect the stderr of codegen process to a string, returns if the codegen process fails.