### PR TITLE
refactor(interactive): Fix some CI problem and code support procedure-query-only mode

### DIFF
--- a/flex/bin/load_plan_and_gen.sh
+++ b/flex/bin/load_plan_and_gen.sh
@@ -90,7 +90,7 @@ generate_cpp_yaml() {
   local output_yaml_file=$5
   local template_str="""
   name: ${procedure_name}
-  description: ${procedure_description}
+  description: \"${procedure_description}\"
   library: ${output_so_name}
   type: cpp
   query: |

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.graphscope.interactive.client;
 
+import com.alibaba.graphscope.interactive.client.common.Config;
 import com.alibaba.graphscope.interactive.client.common.Result;
 import com.alibaba.graphscope.interactive.client.impl.DefaultSession;
 import com.alibaba.graphscope.interactive.models.*;
@@ -74,6 +75,17 @@ public class Driver {
         return connect(adminUri, storedProcUri, cypherUri, gremlinUri);
     }
 
+    public static QueryInterface queryServiceOnly(String storedProcUri) {
+        return queryServiceOnly(storedProcUri, Config.newBuilder().build());
+    }
+
+    public static QueryInterface queryServiceOnly(String storedProcUri, Config config) {
+        if (storedProcUri == null || storedProcUri.isEmpty()) {
+            throw new IllegalArgumentException("uri is null or empty");
+        }
+        return DefaultSession.queryInterfaceOnly(storedProcUri, config);
+    }
+
     /**
      * Connect to the interactive service by specifying the URIs of the admin, stored procedure, cypher, and gremlin services.
      * @param adminUri The URI of the admin service.
@@ -99,6 +111,9 @@ public class Driver {
     }
 
     private Driver(String uri) {
+        if (uri == null){
+            throw new IllegalArgumentException("Invalid uri is null");
+        }
         this.adminUri = uri;
         this.storedProcUri = null;
         this.cypherUri = null;
@@ -127,10 +142,16 @@ public class Driver {
      * @return
      */
     public Session session() {
+        Config config = Config.newBuilder().build();
+        return session(config);
+    }
+
+    public Session session(Config config) {
         if (storedProcUri == null) {
-            return DefaultSession.newInstance(adminUri);
+            System.out.println("here");
+            return DefaultSession.newInstance(adminUri, config);
         } else {
-            return DefaultSession.newInstance(adminUri, storedProcUri);
+            return DefaultSession.newInstance(adminUri, storedProcUri, config);
         }
     }
 
@@ -251,14 +272,16 @@ public class Driver {
     }
 
     private void initHostPort() {
-        if (!adminUri.startsWith("http")) {
-            throw new IllegalArgumentException("Invalid uri: " + adminUri);
+        if (adminUri != null){
+            if (!adminUri.startsWith("http")) {
+                throw new IllegalArgumentException("Invalid uri: " + adminUri);
+            }
+            String[] parts = adminUri.split(":");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("Invalid uri: " + adminUri);
+            }
+            host = parts[1].substring(2);
+            port = Integer.parseInt(parts[2]);
         }
-        String[] parts = adminUri.split(":");
-        if (parts.length != 3) {
-            throw new IllegalArgumentException("Invalid uri: " + adminUri);
-        }
-        host = parts[1].substring(2);
-        port = Integer.parseInt(parts[2]);
     }
 }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
@@ -111,7 +111,7 @@ public class Driver {
     }
 
     private Driver(String uri) {
-        if (uri == null){
+        if (uri == null) {
             throw new IllegalArgumentException("Invalid uri is null");
         }
         this.adminUri = uri;
@@ -272,7 +272,7 @@ public class Driver {
     }
 
     private void initHostPort() {
-        if (adminUri != null){
+        if (adminUri != null) {
             if (!adminUri.startsWith("http")) {
                 throw new IllegalArgumentException("Invalid uri: " + adminUri);
             }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Driver.java
@@ -148,7 +148,6 @@ public class Driver {
 
     public Session session(Config config) {
         if (storedProcUri == null) {
-            System.out.println("here");
             return DefaultSession.newInstance(adminUri, config);
         } else {
             return DefaultSession.newInstance(adminUri, storedProcUri, config);

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/ProcedureInterface.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/ProcedureInterface.java
@@ -15,7 +15,6 @@
  */
 package com.alibaba.graphscope.interactive.client;
 
-import com.alibaba.graphscope.gaia.proto.IrResult;
 import com.alibaba.graphscope.interactive.client.common.Result;
 import com.alibaba.graphscope.interactive.models.*;
 

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/QueryInterface.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/QueryInterface.java
@@ -15,26 +15,20 @@
  */
 package com.alibaba.graphscope.interactive.client;
 
+import com.alibaba.graphscope.gaia.proto.GraphAlgebraPhysical;
 import com.alibaba.graphscope.gaia.proto.IrResult;
+import com.alibaba.graphscope.gaia.proto.StoredProcedure;
 import com.alibaba.graphscope.interactive.client.common.Result;
-import com.alibaba.graphscope.interactive.models.*;
+import com.alibaba.graphscope.interactive.models.QueryRequest;
 
-import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
-/**
- * All APIs about procedure management.
- * TODO(zhanglei): differ between ProcedureRequest and Procedure
- */
-public interface ProcedureInterface {
-    Result<CreateProcedureResponse> createProcedure(
-            String graphId, CreateProcedureRequest procedure);
+public interface QueryInterface {
+    Result<IrResult.CollectiveResults> callProcedure(String graphId, QueryRequest request);
 
-    Result<String> deleteProcedure(String graphId, String procedureName);
+    Result<IrResult.CollectiveResults> callProcedure(QueryRequest request);
 
-    Result<GetProcedureResponse> getProcedure(String graphId, String procedureName);
+    Result<byte[]> callProcedureRaw(String graphId, byte[] request);
 
-    Result<List<GetProcedureResponse>> listProcedures(String graphId);
-
-    Result<String> updateProcedure(
-            String graphId, String procedureId, UpdateProcedureRequest procedure);
+    Result<byte[]> callProcedureRaw(byte[] request);
 }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/QueryInterface.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/QueryInterface.java
@@ -15,13 +15,9 @@
  */
 package com.alibaba.graphscope.interactive.client;
 
-import com.alibaba.graphscope.gaia.proto.GraphAlgebraPhysical;
 import com.alibaba.graphscope.gaia.proto.IrResult;
-import com.alibaba.graphscope.gaia.proto.StoredProcedure;
 import com.alibaba.graphscope.interactive.client.common.Result;
 import com.alibaba.graphscope.interactive.models.QueryRequest;
-
-import java.util.concurrent.CompletableFuture;
 
 public interface QueryInterface {
     Result<IrResult.CollectiveResults> callProcedure(String graphId, QueryRequest request);

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Session.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/Session.java
@@ -22,5 +22,6 @@ public interface Session
                 JobInterface,
                 ProcedureInterface,
                 QueryServiceInterface,
+                QueryInterface,
                 AutoCloseable,
                 UtilsInterface {}

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Config.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Config.java
@@ -17,23 +17,75 @@ package com.alibaba.graphscope.interactive.client.common;
 
 public class Config {
     private boolean enableTracing;
+    private long readTimeout;
+    private long writeTimeout;
+    private long connectionTimeout;
+    private int maxIdleConnections;
+    private long keepAliveDuration;
 
-    private Config() {}
+    public static final long DEFAULT_READ_TIMEOUT = 5000000;
+    public static final long DEFAULT_WRITE_TIMEOUT =5000000;
+    private static final long DEFAULT_CONNECTION_TIMEOUT = 5000000;
+    private static final int DEFAULT_MAX_IDLE_CONNECTIONS = 128;
+    private static final long DEFAULT_KEEP_ALIVE_DURATION = 5000;
+
+    private Config() {
+        this.enableTracing = false; // default not enable tracing.
+        this.readTimeout = DEFAULT_READ_TIMEOUT;
+        this.writeTimeout = DEFAULT_WRITE_TIMEOUT;
+        this.connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+        this.maxIdleConnections = DEFAULT_MAX_IDLE_CONNECTIONS;
+        this.keepAliveDuration = DEFAULT_KEEP_ALIVE_DURATION;
+    }
 
     public boolean isEnableTracing() {
         return enableTracing;
     }
+
+    public long getReadTimeout() { return readTimeout;}
+
+    public long getWriteTimeout() { return writeTimeout;}
+
+    public long getConnectionTimeout() { return connectionTimeout;}
+
+    public int getMaxIdleConnections() { return maxIdleConnections;}
+
+    public long getKeepAliveDuration() { return keepAliveDuration;}
 
     public static class ConfigBuilder {
         Config config;
 
         public ConfigBuilder() {
             config = new Config();
-            config.enableTracing = false; // default not enable tracing.
         }
 
         public ConfigBuilder enableTracing(boolean value) {
             config.enableTracing = value;
+            return this;
+        }
+
+        public ConfigBuilder readTimeout(long readTimeout){
+            config.readTimeout = readTimeout;
+            return this;
+        }
+
+        public ConfigBuilder writeTimeout(long writeTimeout){
+            config.writeTimeout = writeTimeout;
+            return this;
+        }
+
+        public ConfigBuilder connectionTimeout(long connectionTimeout) {
+            config.connectionTimeout = connectionTimeout;
+            return this;
+        }
+
+        public ConfigBuilder connectionPoolMaxIdle(int maxPoolIdle){
+            config.maxIdleConnections = maxPoolIdle;
+            return this;
+        }
+
+        public ConfigBuilder keepAliveDuration(long keepAliveDuration){
+            config.keepAliveDuration = keepAliveDuration;
             return this;
         }
 

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Config.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Config.java
@@ -24,7 +24,7 @@ public class Config {
     private long keepAliveDuration;
 
     public static final long DEFAULT_READ_TIMEOUT = 5000000;
-    public static final long DEFAULT_WRITE_TIMEOUT =5000000;
+    public static final long DEFAULT_WRITE_TIMEOUT = 5000000;
     private static final long DEFAULT_CONNECTION_TIMEOUT = 5000000;
     private static final int DEFAULT_MAX_IDLE_CONNECTIONS = 128;
     private static final long DEFAULT_KEEP_ALIVE_DURATION = 5000;
@@ -42,15 +42,25 @@ public class Config {
         return enableTracing;
     }
 
-    public long getReadTimeout() { return readTimeout;}
+    public long getReadTimeout() {
+        return readTimeout;
+    }
 
-    public long getWriteTimeout() { return writeTimeout;}
+    public long getWriteTimeout() {
+        return writeTimeout;
+    }
 
-    public long getConnectionTimeout() { return connectionTimeout;}
+    public long getConnectionTimeout() {
+        return connectionTimeout;
+    }
 
-    public int getMaxIdleConnections() { return maxIdleConnections;}
+    public int getMaxIdleConnections() {
+        return maxIdleConnections;
+    }
 
-    public long getKeepAliveDuration() { return keepAliveDuration;}
+    public long getKeepAliveDuration() {
+        return keepAliveDuration;
+    }
 
     public static class ConfigBuilder {
         Config config;
@@ -64,12 +74,12 @@ public class Config {
             return this;
         }
 
-        public ConfigBuilder readTimeout(long readTimeout){
+        public ConfigBuilder readTimeout(long readTimeout) {
             config.readTimeout = readTimeout;
             return this;
         }
 
-        public ConfigBuilder writeTimeout(long writeTimeout){
+        public ConfigBuilder writeTimeout(long writeTimeout) {
             config.writeTimeout = writeTimeout;
             return this;
         }
@@ -79,12 +89,12 @@ public class Config {
             return this;
         }
 
-        public ConfigBuilder connectionPoolMaxIdle(int maxPoolIdle){
+        public ConfigBuilder connectionPoolMaxIdle(int maxPoolIdle) {
             config.maxIdleConnections = maxPoolIdle;
             return this;
         }
 
-        public ConfigBuilder keepAliveDuration(long keepAliveDuration){
+        public ConfigBuilder keepAliveDuration(long keepAliveDuration) {
             config.keepAliveDuration = keepAliveDuration;
             return this;
         }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Config.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Config.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.alibaba.graphscope.interactive.client.common;
+
+public class Config {
+    private boolean enableTracing;
+
+    private Config() {}
+
+    public boolean isEnableTracing() {
+        return enableTracing;
+    }
+
+    public static class ConfigBuilder {
+        Config config;
+
+        public ConfigBuilder() {
+            config = new Config();
+            config.enableTracing = false; // default not enable tracing.
+        }
+
+        public ConfigBuilder enableTracing(boolean value) {
+            config.enableTracing = value;
+            return this;
+        }
+
+        public Config build() {
+            return config;
+        }
+    }
+
+    public static ConfigBuilder newBuilder() {
+        return new ConfigBuilder();
+    }
+}

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Result.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Result.java
@@ -25,6 +25,11 @@ public class Result<T> {
     private final Status status;
     private final T value;
 
+    public Result(Status status) {
+        this.status = status;
+        this.value = null;
+    }
+
     public Result(Status status, T value) {
         this.status = status;
         this.value = value;
@@ -41,6 +46,10 @@ public class Result<T> {
 
     public String getStatusMessage() {
         return status.getMessage();
+    }
+
+    public Status.StatusCode getStatusCode() {
+        return status.getCode();
     }
 
     public T getValue() {

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Status.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/common/Status.java
@@ -48,6 +48,10 @@ public class Status {
         return message;
     }
 
+    public StatusCode getCode() {
+        return this.code;
+    }
+
     public Status(StatusCode code, String message) {
         this.code = code;
         this.message = message;

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
@@ -30,10 +30,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 
 import java.io.Closeable;
 import java.io.File;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /***
  * A default implementation of the GraphScope interactive session interface.

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
@@ -27,6 +27,7 @@ import com.alibaba.graphscope.interactive.client.common.Result;
 import com.alibaba.graphscope.interactive.client.common.Status;
 import com.alibaba.graphscope.interactive.models.*;
 import com.google.protobuf.InvalidProtocolBufferException;
+
 import okhttp3.ConnectionPool;
 import okhttp3.OkHttpClient;
 
@@ -833,11 +834,16 @@ public class DefaultSession implements Session {
         }
     }
 
-    private static OkHttpClient createHttpClient(Config config){
-        return new OkHttpClient.Builder().readTimeout(config.getReadTimeout(), TimeUnit.MILLISECONDS)
+    private static OkHttpClient createHttpClient(Config config) {
+        return new OkHttpClient.Builder()
+                .readTimeout(config.getReadTimeout(), TimeUnit.MILLISECONDS)
                 .writeTimeout(config.getWriteTimeout(), TimeUnit.MILLISECONDS)
                 .connectTimeout(config.getConnectionTimeout(), TimeUnit.MILLISECONDS)
-                .connectionPool(new ConnectionPool(config.getMaxIdleConnections(), config.getKeepAliveDuration(), TimeUnit.MILLISECONDS))
+                .connectionPool(
+                        new ConnectionPool(
+                                config.getMaxIdleConnections(),
+                                config.getKeepAliveDuration(),
+                                TimeUnit.MILLISECONDS))
                 .build();
     }
 }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/impl/DefaultSession.java
@@ -66,8 +66,9 @@ public class DefaultSession implements Session {
     private DefaultSession(String uri, String storedProcUri, Config config) {
         this.config = config;
         System.out.println("uri neq null" + (uri != null));
+        OkHttpClient httpClient = createHttpClient(config);
         if (uri != null) {
-            client = new ApiClient(createHttpClient(config));
+            client = new ApiClient(httpClient);
             client.setBasePath(uri);
             graphApi = new AdminServiceGraphManagementApi(client);
             jobApi = new AdminServiceJobManagementApi(client);
@@ -105,7 +106,7 @@ public class DefaultSession implements Session {
             throw new RuntimeException(
                     "DefaultSession need at least stored procedure uri specified, current is null");
         }
-        queryClient = new ApiClient(createHttpClient(config));
+        queryClient = new ApiClient(httpClient);
         queryClient.setBasePath(storedProcUri);
         queryApi = new QueryServiceApi(queryClient);
     }

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/utils/Decoder.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/utils/Decoder.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.alibaba.graphscope.interactive.client.utils;
+
+public class Decoder {
+    public Decoder(byte[] bs) {
+        this.bs = bs;
+        this.loc = 0;
+        this.len = this.bs.length;
+    }
+
+    public static int get_int(byte[] bs, int loc) {
+        int ret = (bs[loc + 3] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc + 2] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc + 1] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc] & 0xff);
+        return ret;
+    }
+
+    public static long get_long(byte[] bs, int loc) {
+        long ret = (bs[loc + 7] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc + 6] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc + 5] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc + 4] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc + 3] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc + 2] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc + 1] & 0xff);
+        ret <<= 8;
+        ret |= (bs[loc] & 0xff);
+        return ret;
+    }
+
+    public long get_long() {
+        long ret = get_long(this.bs, this.loc);
+        this.loc += 8;
+        return ret;
+    }
+
+    public int get_int() {
+        int ret = get_int(this.bs, this.loc);
+        this.loc += 4;
+        return ret;
+    }
+
+    public byte get_byte() {
+        return (byte) (bs[loc++] & 0xFF);
+    }
+
+    public String get_string() {
+        int strlen = this.get_int();
+        String ret = new String(this.bs, this.loc, strlen);
+        this.loc += strlen;
+        return ret;
+    }
+
+    public boolean empty() {
+        return loc == len;
+    }
+
+    byte[] bs;
+    int loc;
+    int len;
+}

--- a/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/utils/Encoder.java
+++ b/flex/interactive/sdk/java/src/main/java/com/alibaba/graphscope/interactive/client/utils/Encoder.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.alibaba.graphscope.interactive.client.utils;
+
+public class Encoder {
+    public Encoder(byte[] bs) {
+        this.bs = bs;
+        this.loc = 0;
+    }
+
+    public static int serialize_long(byte[] bytes, int offset, long value) {
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        return offset;
+    }
+
+    public static int serialize_double(byte[] bytes, int offset, double value) {
+        long long_value = Double.doubleToRawLongBits(value);
+        return serialize_long(bytes, offset, long_value);
+    }
+
+    public static int serialize_int(byte[] bytes, int offset, int value) {
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        value >>= 8;
+        bytes[offset++] = (byte) (value & 0xFF);
+        return offset;
+    }
+
+    public static int serialize_byte(byte[] bytes, int offset, byte value) {
+        bytes[offset++] = value;
+        return offset;
+    }
+
+    public static int serialize_bytes(byte[] bytes, int offset, byte[] value) {
+        offset = serialize_int(bytes, offset, value.length);
+        System.arraycopy(value, 0, bytes, offset, value.length);
+        return offset + value.length;
+    }
+
+    public void put_int(int value) {
+        this.loc = serialize_int(this.bs, this.loc, value);
+    }
+
+    public void put_byte(byte value) {
+        this.loc = serialize_byte(this.bs, this.loc, value);
+    }
+
+    public void put_long(long value) {
+        this.loc = serialize_long(this.bs, this.loc, value);
+    }
+
+    public void put_double(double value) {
+        this.loc = serialize_double(this.bs, this.loc, value);
+    }
+
+    public void put_bytes(byte[] bytes) {
+        this.loc = serialize_bytes(this.bs, this.loc, bytes);
+    }
+
+    byte[] bs;
+    int loc;
+}

--- a/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
+++ b/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
@@ -15,19 +15,17 @@
  */
 package com.alibaba.graphscope.interactive.client;
 
-import com.alibaba.graphscope.gaia.proto.Common;
 import com.alibaba.graphscope.gaia.proto.IrResult;
-import com.alibaba.graphscope.gaia.proto.StoredProcedure;
 import com.alibaba.graphscope.interactive.client.common.Result;
 import com.alibaba.graphscope.interactive.client.utils.Encoder;
 import com.alibaba.graphscope.interactive.models.*;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.driver.Client;
+import org.junit.Assert;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.Assert;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -35,7 +33,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
 public class DriverTest {
@@ -277,7 +274,6 @@ public class DriverTest {
         waitJobFinished(jobId);
     }
 
-    
     public void test3StartService() {
         Result<String> startServiceResponse =
                 session.startService(new StartServiceRequest().graphId(graphId));
@@ -294,29 +290,24 @@ public class DriverTest {
         }
     }
 
-    
     public void test4CypherAdhocQuery() {
         String query = "MATCH(a) return COUNT(a);";
         org.neo4j.driver.Result result = neo4jSession.run(query);
         logger.info("result: " + result.toString());
     }
 
-    
     public void test5GremlinAdhoQuery() {
         String query = "g.V().count();";
         try {
             List<org.apache.tinkerpop.gremlin.driver.Result> results =
-                gremlinClient.submit(query).all().get();
+                    gremlinClient.submit(query).all().get();
             logger.info("result: " + results.toString());
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             assert false;
         }
-        
     }
 
-    
     public void test6CreateCypherProcedure() {
         CreateProcedureRequest procedure = new CreateProcedureRequest();
         procedure.setName("cypherProcedure");
@@ -328,7 +319,6 @@ public class DriverTest {
         cypherProcedureId = "cypherProcedure";
     }
 
-    
     public void test7CreateCppProcedure1() {
         CreateProcedureRequest procedure = new CreateProcedureRequest();
         procedure.setName("cppProcedure1");
@@ -359,7 +349,6 @@ public class DriverTest {
         cppProcedureId1 = "cppProcedure1";
     }
 
-    
     public void test7CreateCppProcedure2() {
         CreateProcedureRequest procedure = new CreateProcedureRequest();
         procedure.setName("cppProcedure2");
@@ -390,7 +379,6 @@ public class DriverTest {
         cppProcedureId2 = "cppProcedure2";
     }
 
-    
     public void test8Restart() {
         Result<String> resp = session.startService(new StartServiceRequest().graphId(graphId));
         assertOk(resp);
@@ -403,14 +391,12 @@ public class DriverTest {
         logger.info("service restarted: " + resp.getValue());
     }
 
-    
     public void test9GetGraphStatistics() {
         Result<GetGraphStatisticsResponse> resp = session.getGraphStatistics(graphId);
         assertOk(resp);
         logger.info("graph statistics: " + resp.getValue());
     }
 
-    
     public void test9CallCppProcedureJson() {
         QueryRequest request = new QueryRequest();
         request.setQueryName(cppProcedureId1);
@@ -427,7 +413,6 @@ public class DriverTest {
         assertOk(resp);
     }
 
-    
     public void test9CallCppProcedure1Current() {
         QueryRequest request = new QueryRequest();
         request.setQueryName(cppProcedureId1);
@@ -448,7 +433,10 @@ public class DriverTest {
         byte[] bytes = new byte[4 + 1];
         Encoder encoder = new Encoder(bytes);
         encoder.put_int(1);
-        encoder.put_byte((byte) 3); // Assume the procedure index is 3. since the procedures are sorted by creation time.
+        encoder.put_byte(
+                (byte)
+                        3); // Assume the procedure index is 3. since the procedures are sorted by
+                            // creation time.
         Result<byte[]> resp = session.callProcedureRaw(graphId, bytes);
         assertOk(resp);
     }

--- a/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
+++ b/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
@@ -15,18 +15,19 @@
  */
 package com.alibaba.graphscope.interactive.client;
 
+import com.alibaba.graphscope.gaia.proto.Common;
 import com.alibaba.graphscope.gaia.proto.IrResult;
+import com.alibaba.graphscope.gaia.proto.StoredProcedure;
 import com.alibaba.graphscope.interactive.client.common.Result;
+import com.alibaba.graphscope.interactive.client.utils.Encoder;
 import com.alibaba.graphscope.interactive.models.*;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tinkerpop.gremlin.driver.Client;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.Assert;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -34,155 +35,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 
-@TestMethodOrder(OrderAnnotation.class)
 public class DriverTest {
-
-    public static class Encoder {
-        public Encoder(byte[] bs) {
-            this.bs = bs;
-            this.loc = 0;
-        }
-
-        public static int serialize_long(byte[] bytes, int offset, long value) {
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            return offset;
-        }
-
-        public static int serialize_double(byte[] bytes, int offset, double value) {
-            long long_value = Double.doubleToRawLongBits(value);
-            return serialize_long(bytes, offset, long_value);
-        }
-
-        public static int serialize_int(byte[] bytes, int offset, int value) {
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            value >>= 8;
-            bytes[offset++] = (byte) (value & 0xFF);
-            return offset;
-        }
-
-        public static int serialize_byte(byte[] bytes, int offset, byte value) {
-            bytes[offset++] = value;
-            return offset;
-        }
-
-        public static int serialize_bytes(byte[] bytes, int offset, byte[] value) {
-            offset = serialize_int(bytes, offset, value.length);
-            System.arraycopy(value, 0, bytes, offset, value.length);
-            return offset + value.length;
-        }
-
-        public void put_int(int value) {
-            this.loc = serialize_int(this.bs, this.loc, value);
-        }
-
-        public void put_byte(byte value) {
-            this.loc = serialize_byte(this.bs, this.loc, value);
-        }
-
-        public void put_long(long value) {
-            this.loc = serialize_long(this.bs, this.loc, value);
-        }
-
-        public void put_double(double value) {
-            this.loc = serialize_double(this.bs, this.loc, value);
-        }
-
-        public void put_bytes(byte[] bytes) {
-            this.loc = serialize_bytes(this.bs, this.loc, bytes);
-        }
-
-        byte[] bs;
-        int loc;
-    }
-
-    static final class Decoder {
-        public Decoder(byte[] bs) {
-            this.bs = bs;
-            this.loc = 0;
-            this.len = this.bs.length;
-        }
-
-        public static int get_int(byte[] bs, int loc) {
-            int ret = (bs[loc + 3] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc + 2] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc + 1] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc] & 0xff);
-            return ret;
-        }
-
-        public static long get_long(byte[] bs, int loc) {
-            long ret = (bs[loc + 7] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc + 6] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc + 5] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc + 4] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc + 3] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc + 2] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc + 1] & 0xff);
-            ret <<= 8;
-            ret |= (bs[loc] & 0xff);
-            return ret;
-        }
-
-        public long get_long() {
-            long ret = get_long(this.bs, this.loc);
-            this.loc += 8;
-            return ret;
-        }
-
-        public int get_int() {
-            int ret = get_int(this.bs, this.loc);
-            this.loc += 4;
-            return ret;
-        }
-
-        public byte get_byte() {
-            return (byte) (bs[loc++] & 0xFF);
-        }
-
-        public String get_string() {
-            int strlen = this.get_int();
-            String ret = new String(this.bs, this.loc, strlen);
-            this.loc += strlen;
-            return ret;
-        }
-
-        public boolean empty() {
-            return loc == len;
-        }
-
-        byte[] bs;
-        int loc;
-        int len;
-    }
 
     private static final Logger logger = Logger.getLogger(DriverTest.class.getName());
 
@@ -195,12 +51,15 @@ public class DriverTest {
     private static String cypherProcedureId;
     private static String cppProcedureId1;
     private static String cppProcedureId2;
+    private static String personNameValue = "marko";
 
     @BeforeAll
     public static void beforeClass() {
         String interactiveEndpoint =
                 System.getProperty("interactive.endpoint", "http://localhost:7777");
         driver = Driver.connect(interactiveEndpoint);
+        assert driver != null;
+        System.out.println("driver is not null: " + (driver != null));
         session = driver.session();
         String neo4jEndpoint = driver.getNeo4jEndpoint();
         if (neo4jEndpoint != null) {
@@ -213,8 +72,54 @@ public class DriverTest {
         logger.info("Finish setup");
     }
 
+    @AfterAll
+    public static void afterClass() {
+        logger.info("clean up");
+        {
+            Result<String> resp = session.startService(new StartServiceRequest().graphId("1"));
+            assertOk(resp);
+            logger.info("service restarted on initial graph");
+        }
+        if (graphId != null) {
+            if (cypherProcedureId != null) {
+                Result<String> resp = session.deleteProcedure(graphId, cypherProcedureId);
+                logger.info("cypherProcedure deleted: " + resp.getValue());
+            }
+            if (cppProcedureId1 != null) {
+                Result<String> resp = session.deleteProcedure(graphId, cppProcedureId1);
+                logger.info("cppProcedure1 deleted: " + resp.getValue());
+            }
+            if (cppProcedureId2 != null) {
+                Result<String> resp = session.deleteProcedure(graphId, cppProcedureId2);
+                logger.info("cppProcedure2 deleted: " + resp.getValue());
+            }
+            Result<String> resp = session.deleteGraph(graphId);
+            assertOk(resp);
+            logger.info("graph deleted: " + resp.getValue());
+        }
+    }
+
     @Test
-    @Order(1)
+    public void test() {
+        test0CreateGraph();
+        test1BulkLoading();
+        test2BulkLoadingUploading();
+        test3StartService();
+        test4CypherAdhocQuery();
+        test5GremlinAdhoQuery();
+        test6CreateCypherProcedure();
+        test7CreateCppProcedure1();
+        test7CreateCppProcedure2();
+        test8Restart();
+        test9GetGraphStatistics();
+        test9CallCppProcedureJson();
+        test9CallCppProcedure1Current();
+        test9CallCppProcedure2();
+        test10CallCypherProcedureViaNeo4j();
+        testQueryInterface();
+        test11CreateDriver();
+    }
+
     public void test0CreateGraph() {
         CreateGraphRequest graph = new CreateGraphRequest();
         graph.setName("testGraph");
@@ -291,8 +196,6 @@ public class DriverTest {
         logger.info("graphId: " + graphId);
     }
 
-    @Test
-    @Order(2)
     public void test1BulkLoading() {
         SchemaMapping schemaMapping = new SchemaMapping();
         {
@@ -333,9 +236,7 @@ public class DriverTest {
         waitJobFinished(jobId);
     }
 
-    @Test
-    @Order(3)
-    public void test1BulkLoadingUploading() {
+    public void test2BulkLoadingUploading() {
         SchemaMapping schemaMapping = new SchemaMapping();
         {
             SchemaMappingLoadingConfig loadingConfig = new SchemaMappingLoadingConfig();
@@ -376,8 +277,7 @@ public class DriverTest {
         waitJobFinished(jobId);
     }
 
-    @Test
-    @Order(4)
+    
     public void test3StartService() {
         Result<String> startServiceResponse =
                 session.startService(new StartServiceRequest().graphId(graphId));
@@ -394,38 +294,41 @@ public class DriverTest {
         }
     }
 
-    @Test
-    @Order(5)
+    
     public void test4CypherAdhocQuery() {
         String query = "MATCH(a) return COUNT(a);";
         org.neo4j.driver.Result result = neo4jSession.run(query);
         logger.info("result: " + result.toString());
     }
 
-    @Test
-    @Order(6)
-    public void test5GremlinAdhoQuery() throws Exception {
+    
+    public void test5GremlinAdhoQuery() {
         String query = "g.V().count();";
-        List<org.apache.tinkerpop.gremlin.driver.Result> results =
+        try {
+            List<org.apache.tinkerpop.gremlin.driver.Result> results =
                 gremlinClient.submit(query).all().get();
-        logger.info("result: " + results.toString());
+            logger.info("result: " + results.toString());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            assert false;
+        }
+        
     }
 
-    @Test
-    @Order(7)
+    
     public void test6CreateCypherProcedure() {
         CreateProcedureRequest procedure = new CreateProcedureRequest();
         procedure.setName("cypherProcedure");
         procedure.setDescription("a simple test procedure");
-        procedure.setQuery("MATCH(p:person) RETURN COUNT(p);");
+        procedure.setQuery("MATCH(p:person) where p.name=$personName RETURN p.id,p.age;");
         procedure.setType(CreateProcedureRequest.TypeEnum.CYPHER);
         Result<CreateProcedureResponse> resp = session.createProcedure(graphId, procedure);
         assertOk(resp);
         cypherProcedureId = "cypherProcedure";
     }
 
-    @Test
-    @Order(8)
+    
     public void test7CreateCppProcedure1() {
         CreateProcedureRequest procedure = new CreateProcedureRequest();
         procedure.setName("cppProcedure1");
@@ -456,8 +359,7 @@ public class DriverTest {
         cppProcedureId1 = "cppProcedure1";
     }
 
-    @Test
-    @Order(9)
+    
     public void test7CreateCppProcedure2() {
         CreateProcedureRequest procedure = new CreateProcedureRequest();
         procedure.setName("cppProcedure2");
@@ -488,8 +390,7 @@ public class DriverTest {
         cppProcedureId2 = "cppProcedure2";
     }
 
-    @Test
-    @Order(10)
+    
     public void test8Restart() {
         Result<String> resp = session.startService(new StartServiceRequest().graphId(graphId));
         assertOk(resp);
@@ -502,17 +403,15 @@ public class DriverTest {
         logger.info("service restarted: " + resp.getValue());
     }
 
-    @Test
-    @Order(11)
+    
     public void test9GetGraphStatistics() {
         Result<GetGraphStatisticsResponse> resp = session.getGraphStatistics(graphId);
         assertOk(resp);
         logger.info("graph statistics: " + resp.getValue());
     }
 
-    @Test
-    @Order(12)
-    public void test9CallCppProcedure1() {
+    
+    public void test9CallCppProcedureJson() {
         QueryRequest request = new QueryRequest();
         request.setQueryName(cppProcedureId1);
         request.addArgumentsItem(
@@ -528,8 +427,7 @@ public class DriverTest {
         assertOk(resp);
     }
 
-    @Test
-    @Order(13)
+    
     public void test9CallCppProcedure1Current() {
         QueryRequest request = new QueryRequest();
         request.setQueryName(cppProcedureId1);
@@ -546,27 +444,34 @@ public class DriverTest {
         assertOk(resp);
     }
 
-    @Test
-    @Order(14)
     public void test9CallCppProcedure2() {
         byte[] bytes = new byte[4 + 1];
         Encoder encoder = new Encoder(bytes);
         encoder.put_int(1);
-        encoder.put_byte((byte) 1); // Assume the procedure index is 1
+        encoder.put_byte((byte) 3); // Assume the procedure index is 3. since the procedures are sorted by creation time.
         Result<byte[]> resp = session.callProcedureRaw(graphId, bytes);
         assertOk(resp);
     }
 
-    @Test
-    @Order(15)
     public void test10CallCypherProcedureViaNeo4j() {
-        String query = "CALL " + cypherProcedureId + "() YIELD *;";
+        String query = "CALL " + cypherProcedureId + "(\"" + personNameValue + "\") YIELD *;";
+        logger.info("calling query: " + query);
         org.neo4j.driver.Result result = neo4jSession.run(query);
         logger.info("result: " + result.toString());
     }
 
-    @Test
-    @Order(16)
+    public void testQueryInterface() {
+        String queryEndpoint =
+                System.getProperty("interactive.procedure.endpoint", "http://localhost:10000");
+        QueryInterface queryInterface = Driver.queryServiceOnly(queryEndpoint);
+        byte[] bytes = new byte[4 + 1];
+        Encoder encoder = new Encoder(bytes);
+        encoder.put_int(1);
+        encoder.put_byte((byte) 3); // Assume the procedure index is 3
+        Result<byte[]> resp = queryInterface.callProcedureRaw(graphId, bytes);
+        assertOk(resp);
+    }
+
     public void test11CreateDriver() {
         // Create a new driver with all endpoints specified.
         // Assume the environment variables are set
@@ -574,37 +479,9 @@ public class DriverTest {
         Session session = driver.session();
     }
 
-    @AfterAll
-    public static void afterClass() {
-        logger.info("clean up");
-        {
-            Result<String> resp = session.startService(new StartServiceRequest().graphId("1"));
-            assertOk(resp);
-            logger.info("service restarted on initial graph");
-        }
-        if (graphId != null) {
-            if (cypherProcedureId != null) {
-                Result<String> resp = session.deleteProcedure(graphId, cypherProcedureId);
-                logger.info("cypherProcedure deleted: " + resp.getValue());
-            }
-            if (cppProcedureId1 != null) {
-                Result<String> resp = session.deleteProcedure(graphId, cppProcedureId1);
-                logger.info("cppProcedure1 deleted: " + resp.getValue());
-            }
-            if (cppProcedureId2 != null) {
-                Result<String> resp = session.deleteProcedure(graphId, cppProcedureId2);
-                logger.info("cppProcedure2 deleted: " + resp.getValue());
-            }
-            Result<String> resp = session.deleteGraph(graphId);
-            assertOk(resp);
-            logger.info("graph deleted: " + resp.getValue());
-        }
-    }
-
     private static <T> boolean assertOk(Result<T> result) {
         if (!result.isOk()) {
-            System.out.println(result.getStatusMessage());
-            return false;
+            Assert.fail("error: " + result.getStatusMessage());
         }
         return true;
     }

--- a/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
+++ b/flex/interactive/sdk/java/src/test/java/com/alibaba/graphscope/interactive/client/DriverTest.java
@@ -434,9 +434,8 @@ public class DriverTest {
         Encoder encoder = new Encoder(bytes);
         encoder.put_int(1);
         encoder.put_byte(
-                (byte)
-                        3); // Assume the procedure index is 3. since the procedures are sorted by
-                            // creation time.
+                (byte) 3); // Assume the procedure index is 3. since the procedures are sorted by
+        // creation time.
         Result<byte[]> resp = session.callProcedureRaw(graphId, bytes);
         assertOk(resp);
     }


### PR DESCRIPTION
- Fix some interactive java sdk test problem
- Interactive Java SDK could be initiated without admin endpoint.
- Introduce configuration class.

User can submit query to the query interface without connecting to admin service.

```java
QueryInterface queryInterface = Driver.queryServiceOnly(queryEndpoint);
byte[] bytes = new byte[4 + 1];
Encoder encoder = new Encoder(bytes);
encoder.put_int(1);
encoder.put_byte((byte) 3); // Assume the procedure index is 3
Result<byte[]> resp = queryInterface.callProcedureRaw(graphId, bytes);
```