### PR TITLE
refactor(interactive): No need to restart compiler when restarting interactive

### DIFF
--- a/flex/engines/http_server/actor/admin_actor.act.cc
+++ b/flex/engines/http_server/actor/admin_actor.act.cc
@@ -1064,16 +1064,6 @@ seastar::future<admin_query_result> admin_actor::start_service(
       }
     }
     hqps_service.start_query_actors();  // start on a new scope.
-    LOG(INFO) << "Successfully restart query actors";
-    // now start the compiler
-    auto schema_path =
-        server::WorkDirManipulator::GetGraphSchemaPath(graph_name);
-    if (!hqps_service.start_compiler_subprocess(schema_path)) {
-      LOG(ERROR) << "Fail to start compiler";
-      return seastar::make_ready_future<admin_query_result>(
-          gs::Result<seastar::sstring>(gs::Status(gs::StatusCode::InternalError,
-                                                  "Fail to start compiler")));
-    }
     LOG(INFO) << "Successfully started service with graph: " << graph_name;
     hqps_service.reset_start_time();
     return seastar::make_ready_future<admin_query_result>(
@@ -1112,18 +1102,9 @@ seastar::future<admin_query_result> admin_actor::stop_service(
                              "Fail to clear running graph")));
         }
       }
-
-      if (hqps_service.stop_compiler_subprocess()) {
-        LOG(INFO) << "Successfully stop compiler";
-        return seastar::make_ready_future<admin_query_result>(
-            gs::Result<seastar::sstring>(
-                to_message_json("Successfully stop service")));
-      } else {
-        LOG(ERROR) << "Fail to stop compiler";
-        return seastar::make_ready_future<admin_query_result>(
-            gs::Result<seastar::sstring>(gs::Status(
-                gs::StatusCode::InternalError, "Fail to stop compiler")));
-      }
+      return seastar::make_ready_future<admin_query_result>(
+          gs::Result<seastar::sstring>(
+              to_message_json("Successfully stop service")));
     }
   });
 }

--- a/flex/engines/http_server/service/hqps_service.cc
+++ b/flex/engines/http_server/service/hqps_service.cc
@@ -98,12 +98,6 @@ void HQPSService::init(const ServiceConfig& config) {
       return;
     }
   }
-  if (config.start_compiler) {
-    if (!start_compiler_subprocess()) {
-      LOG(FATAL) << "Failed to start compiler subprocess! exiting...";
-    }
-  }
-  start_time_.store(gs::GetCurrentTimeStamp());
 }
 
 HQPSService::~HQPSService() {
@@ -170,6 +164,12 @@ void HQPSService::run_and_wait_for_exit() {
   if (admin_hdl_) {
     admin_hdl_->start();
   }
+  if (service_config_.start_compiler) {
+    if (!start_compiler_subprocess()) {
+      LOG(FATAL) << "Failed to start compiler subprocess! exiting...";
+    }
+  }
+  start_time_.store(gs::GetCurrentTimeStamp());
   running_.store(true);
   while (running_.load(std::memory_order_relaxed)) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/flex/interactive/sdk/python/test/test_driver.py
+++ b/flex/interactive/sdk/python/test/test_driver.py
@@ -400,6 +400,24 @@ class TestDriver(unittest.TestCase):
         with self._driver.getNeo4jSession() as session:
             result = session.run("CALL test_procedure();")
             print("call procedure result: ", result)
+    
+    def callPrcedureWithServiceStop(self):
+        # stop service
+        print("stop service: ")
+        stop_res = self._sess.stop_service()
+        assert stop_res.is_ok()
+        # call procedure on stopped service should raise exception
+        with self._driver.getNeo4jSession() as session:
+            with self.assertRaises(Exception) as context:
+                result = session.run("CALL test_procedure();")
+        # start service
+        print("start service: ")
+        start_res = self._sess.start_service(
+            start_service_request=StartServiceRequest(graph_id=self._graph_id)
+        )
+        assert start_res.is_ok()
+        # wait 5 seconds
+        time.sleep(5)
 
     def callProcedureWithHttp(self):
         req = QueryRequest(


### PR DESCRIPTION
There is no need to restart the compiler process when restarting the interactive query service, as the compiler already relies on HTTP requests.