### PR TITLE
fix(interactive): fix query cardinality of non-exist types or patterns

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/rel/metadata/glogue/GlogueBasicCardinalityEstimationImpl.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/rel/metadata/glogue/GlogueBasicCardinalityEstimationImpl.java
@@ -161,7 +161,8 @@ public class GlogueBasicCardinalityEstimationImpl implements GlogueCardinalityEs
                 return this.patternCardinality.get(pattern);
             }
         }
-        return 0.0;
+        // if not exist, return 1.0
+        return 1.0;
     }
 
     @Override

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/rel/metadata/schema/GlogueSchema.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/rel/metadata/schema/GlogueSchema.java
@@ -21,6 +21,8 @@ import com.alibaba.graphscope.groot.common.schema.api.*;
 
 import org.jgrapht.Graph;
 import org.jgrapht.graph.DirectedPseudograph;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -30,6 +32,7 @@ public class GlogueSchema {
     private Graph<Integer, EdgeTypeId> schemaGraph;
     private HashMap<Integer, Double> vertexTypeCardinality;
     private HashMap<EdgeTypeId, Double> edgeTypeCardinality;
+    private static Logger logger = LoggerFactory.getLogger(GlogueSchema.class);
 
     public GlogueSchema(
             GraphSchema graphSchema,
@@ -69,6 +72,7 @@ public class GlogueSchema {
                 edgeTypeCardinality.put(edgeType, 1.0);
             }
         }
+        logger.debug("GlogueSchema created with default cardinality 1.0: {}", this);
     }
 
     public GlogueSchema(GraphSchema graphSchema, GraphStatistics statistics) {
@@ -108,6 +112,7 @@ public class GlogueSchema {
                 }
             }
         }
+        logger.debug("GlogueSchema created with statistics: {}", this);
     }
 
     public static GlogueSchema fromMeta(IrMetaStats irMeta) {
@@ -139,7 +144,9 @@ public class GlogueSchema {
     public Double getVertexTypeCardinality(Integer vertexType) {
         Double cardinality = this.vertexTypeCardinality.get(vertexType);
         if (cardinality == null) {
-            return 0.0;
+            logger.debug(
+                    "Vertex type {} not found in schema, assuming cardinality 1.0", vertexType);
+            return 1.0;
         } else {
             return cardinality;
         }
@@ -148,7 +155,8 @@ public class GlogueSchema {
     public Double getEdgeTypeCardinality(EdgeTypeId edgeType) {
         Double cardinality = this.edgeTypeCardinality.get(edgeType);
         if (cardinality == null) {
-            return 0.0;
+            logger.debug("Edge type {} not found in schema, assuming cardinality 1.0", edgeType);
+            return 1.0;
         } else {
             return cardinality;
         }

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/rel/metadata/GLogueSchemaTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/rel/metadata/GLogueSchemaTest.java
@@ -43,10 +43,12 @@ public class GLogueSchemaTest {
         // test get type cardinality
         Assert.assertEquals(4.0, g.getVertexTypeCardinality(person), delta);
         Assert.assertEquals(2.0, g.getVertexTypeCardinality(software), delta);
-        Assert.assertEquals(0.0, g.getVertexTypeCardinality(2), delta);
         Assert.assertEquals(2.0, g.getEdgeTypeCardinality(knows), delta);
         Assert.assertEquals(4.0, g.getEdgeTypeCardinality(creates), delta);
-        Assert.assertEquals(0.0, g.getEdgeTypeCardinality(new EdgeTypeId(0, 0, 2)), delta);
+
+        // when query a type that is not in the schema, return 1.0
+        Assert.assertEquals(1.0, g.getVertexTypeCardinality(2), delta);
+        Assert.assertEquals(1.0, g.getEdgeTypeCardinality(new EdgeTypeId(0, 0, 2)), delta);
 
         // test get types
         Assert.assertEquals(2, g.getAdjEdgeTypes(person).size());

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/rel/metadata/GlogueTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/rel/metadata/GlogueTest.java
@@ -77,6 +77,7 @@ public class GlogueTest {
         Assert.assertEquals(1.0d, count2, delta);
 
         // pattern3: person2 <- person1 <- software (not exist)
+        // Note the non-exist pattern will return a cardinality of 1.0
         Pattern pattern3 = new Pattern();
         pattern3.addVertex(v0);
         pattern3.addVertex(v1);
@@ -86,7 +87,7 @@ public class GlogueTest {
         pattern3.reordering();
 
         Double count3 = gl.getRowCount(pattern3);
-        Assert.assertEquals(0.0d, count3, delta);
+        Assert.assertEquals(1.0d, count3, delta);
     }
 
     @Test


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As titled. When query cardinality of non-exist types or patterns, return 1.0.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

