### PR TITLE
fix(interactive): Expose config for Glogue size and pattern decomposition size in Compiler in Charts

### DIFF
--- a/charts/graphscope-store/templates/configmap.yaml
+++ b/charts/graphscope-store/templates/configmap.yaml
@@ -66,6 +66,8 @@ data:
     graph.physical.opt={{ .Values.graphPhysicalOpt }}
     gremlin.script.language.name={{ .Values.gremlinScriptLanguageName }}
     query.execution.timeout.ms={{ .Values.queryExecutionTimeoutMs }}
+    graph.planner.join.min.pattern.size={{ .Values.graphPlannerJoinMinPatternSize }}
+    graph.planner.cbo.glogue.size={{ .Values.graphPlannerCboGlogueSize }}
 
     log4rs.config=LOG4RS_CONFIG
     ## Auth config

--- a/charts/graphscope-store/values.yaml
+++ b/charts/graphscope-store/values.yaml
@@ -496,6 +496,8 @@ graphPlannerRules: FilterIntoJoinRule, FilterMatchRule, ExtendIntersectRule, Exp
 gremlinScriptLanguageName: antlr_gremlin_traversal
 graphPhysicalOpt: ffi
 queryExecutionTimeoutMs: 600000
+graphPlannerJoinMinPatternSize: 5
+graphPlannerCboGlogueSize: 3
 
 ## Key-value pair separated by ;
 ## For example extraConfig="k1=v1;k2=v2"

--- a/interactive_engine/groot-server/src/main/java/com/alibaba/graphscope/groot/servers/ir/IrServiceProducer.java
+++ b/interactive_engine/groot-server/src/main/java/com/alibaba/graphscope/groot/servers/ir/IrServiceProducer.java
@@ -141,6 +141,8 @@ public class IrServiceProducer {
         addToConfigMapIfExist(PlannerConfig.GRAPH_PLANNER_RULES.getKey(), configMap);
         addToConfigMapIfExist(FrontendConfig.GREMLIN_SCRIPT_LANGUAGE_NAME.getKey(), configMap);
         addToConfigMapIfExist(FrontendConfig.GRAPH_PHYSICAL_OPT.getKey(), configMap);
+        addToConfigMapIfExist(PlannerConfig.GRAPH_PLANNER_CBO_GLOGUE_SIZE.getKey(), configMap);
+        addToConfigMapIfExist(PlannerConfig.JOIN_MIN_PATTERN_SIZE.getKey(), configMap);
         return new com.alibaba.graphscope.common.config.Configs(configMap);
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As titled.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

