### PR TITLE
fix(interactive): fix bulkloading data from csv files without header and add null_values option for arrow

### DIFF
--- a/docs/flex/interactive/data_import.md
+++ b/docs/flex/interactive/data_import.md
@@ -234,6 +234,7 @@ The table below offers a detailed breakdown of each configuration item. In this 
 | loading_config.format.metadata.double_quote | true |  Whether a quote inside a value is double-quoted | No |
 | loading_config.format.metadata.escaping | false | Whether escaping is used | No |
 | loading_config.format.metadata.escape_char | '\\' | Escaping character (if `escaping` is true) | No |
+| loading_config.format.metadata.null_values | [] | Recognized spellings for null values | No |
 | loading_config.format.metadata.batch_size | 4MB | The size of batch for reading from files | No |
 | loading_config.x_csr_params.parallelism | 1 | Number of threads used for bulk loading | No |
 | loading_config.x_csr_params.build_csr_in_mem | false | Whether to build csr fully in memory | No |
@@ -274,9 +275,10 @@ The **loading_config** section defines the primary settings for data loading. Th
 	- loading_config.format.metadata.quoting: Whether quoting is used
 	- loading_config.format.metadata.quote_char: Quoting character (if `quoting` is true)
 	- loading_config.format.metadata.double_quote:  Whether a quote inside a value is double-quoted
-  - loading_config.format.metadata.escape_char: Whether escaping is used
+	- loading_config.format.metadata.escaping: Whether escaping is used
 	- loading_config.format.metadata.escape_char: Escaping character (if `escaping` is true)
 	- loading_config.format.metadata.block_size: The size of batch for reading from files
+	- loading_config.format.metadata.null_values: Recognized spellings for null values
 
 ### Vertex Mappings
 The **vertex_mappings** section outlines how raw data maps to graph vertices based on the defined schema. 

--- a/flex/interactive/examples/modern_graph/bulk_load.yaml
+++ b/flex/interactive/examples/modern_graph/bulk_load.yaml
@@ -16,6 +16,7 @@ loading_config:
       escaping: false
       block_size: 4MB
       batch_reader: true
+      null_values: [""]
 
 vertex_mappings:
   - type_name: person  # must align with the schema

--- a/flex/storages/rt_mutable_graph/loading_config.cc
+++ b/flex/storages/rt_mutable_graph/loading_config.cc
@@ -618,6 +618,10 @@ Status parse_bulk_load_config_yaml(const YAML::Node& root, const Schema& schema,
                 auto block_size = parse_block_size(block_size_str);
                 load_config.metadata_[reader_options::BATCH_SIZE_KEY] =
                     std::to_string(block_size);
+              } else if (key == reader_options::NULL_VALUES) {
+                // special case for null values
+                auto null_values = it->second.as<std::vector<std::string>>();
+                load_config.null_values_ = null_values;
               } else {
                 load_config.metadata_[key] = it->second.as<std::string>();
               }
@@ -842,6 +846,10 @@ bool LoadingConfig::GetIsQuoting() const {
 bool LoadingConfig::GetIsDoubleQuoting() const {
   auto str = metadata_.at(reader_options::DOUBLE_QUOTE);
   return str == "true" || str == "True" || str == "TRUE";
+}
+
+const std::vector<std::string>& LoadingConfig::GetNullValues() const {
+  return null_values_;
 }
 
 int32_t LoadingConfig::GetBatchSize() const {

--- a/flex/storages/rt_mutable_graph/loading_config.h
+++ b/flex/storages/rt_mutable_graph/loading_config.h
@@ -53,11 +53,12 @@ static const char* BATCH_SIZE_KEY = "batch_size";
 // whether or not to use record batch reader. If true, the reader will read
 // data in batches, otherwise, the reader will read data row by row.
 static const char* BATCH_READER = "batch_reader";
+static const char* NULL_VALUES = "null_values";
 
 static const std::unordered_set<std::string> CSV_META_KEY_WORDS = {
     DELIMITER,    HEADER_ROW,     INCLUDE_COLUMNS, COLUMN_TYPES,
     ESCAPING,     ESCAPE_CHAR,    QUOTING,         QUOTE_CHAR,
-    DOUBLE_QUOTE, BATCH_SIZE_KEY, BATCH_READER};
+    DOUBLE_QUOTE, BATCH_SIZE_KEY, BATCH_READER,    NULL_VALUES};
 
 }  // namespace reader_options
 
@@ -131,6 +132,7 @@ class LoadingConfig {
   char GetQuotingChar() const;
   bool GetIsQuoting() const;
   bool GetIsDoubleQuoting() const;
+  const std::vector<std::string>& GetNullValues() const;
   int32_t GetBatchSize() const;
   bool GetIsBatchReader() const;
   std::string GetMetaData(const std::string& key) const;
@@ -178,6 +180,8 @@ class LoadingConfig {
   int32_t parallelism_;    // Number of thread should be used in loading
   bool build_csr_in_mem_;  // Whether to build csr in memory
   bool use_mmap_vector_;   // Whether to use mmap vector
+
+  std::vector<std::string> null_values_;
 
   // meta_data, stores all the meta info about loading
   std::unordered_map<std::string, std::string> metadata_;


### PR DESCRIPTION
as titled.