### PR TITLE
refactor(interactive): Add error handling for adhoc queries

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 {
 	"name": "GraphScope",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:latest",
+	"image": "registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.0-amd", // TODO(fixme)
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
     "features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 {
 	"name": "GraphScope",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.0-amd", // TODO(fixme)
+	"image": "registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.0-amd",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
     "features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 {
 	"name": "GraphScope",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.0-amd",
+	"image": "registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.2-amd64",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
     "features": {

--- a/.github/workflows/interactive.yml
+++ b/.github/workflows/interactive.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.23.0
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.2-amd64
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/interactive.yml
+++ b/.github/workflows/interactive.yml
@@ -136,7 +136,6 @@ jobs:
       env: 
         FLEX_DATA_DIR: ${{ github.workspace }}/flex/interactive/examples/modern_graph
         TMP_INTERACTIVE_WORKSPACE: /tmp/temp_workspace
-        LD_LIBRARY_PATH: /usr/local/lib
       run: |
         cd ${GITHUB_WORKSPACE}/flex/interactive/sdk/
 
@@ -209,7 +208,6 @@ jobs:
         TMP_INTERACTIVE_WORKSPACE: /tmp/temp_workspace
         PLUGIN_DIR: /tmp/temp_workspace/data/modern_graph/plugins
         FLEX_DATA_DIR: ${{ github.workspace }}/flex/interactive/examples/modern_graph
-        LD_LIBRARY_PATH: /usr/local/lib
       run: |
         rm -rf ${TMP_INTERACTIVE_WORKSPACE}
         cd ${GITHUB_WORKSPACE}/flex/build/
@@ -270,7 +268,6 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
         HOME : /home/graphscope/
         INTERACTIVE_WORKSPACE: /tmp/interactive_workspace
-        LD_LIBRARY_PATH: /usr/local/lib
       run: |
         cd ${GITHUB_WORKSPACE}/flex/tests/hqps/
         export ENGINE_TYPE=hiactor
@@ -284,7 +281,6 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
         HOME : /home/graphscope/
         INTERACTIVE_WORKSPACE: /tmp/interactive_workspace
-        LD_LIBRARY_PATH: /usr/local/lib
       run: |
         cd ${GITHUB_WORKSPACE}/flex/tests/hqps/
         export ENGINE_TYPE=hiactor
@@ -298,7 +294,6 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
         HOME : /home/graphscope/
         INTERACTIVE_WORKSPACE: /tmp/interactive_workspace
-        LD_LIBRARY_PATH: /usr/local/lib
       run: |
         cd ${GITHUB_WORKSPACE}/flex/tests/hqps/
         export ENGINE_TYPE=hiactor
@@ -312,7 +307,6 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
         HOME : /home/graphscope/
         INTERACTIVE_WORKSPACE: /tmp/interactive_workspace
-        LD_LIBRARY_PATH: /usr/local/lib
       run: |
         cd ${GITHUB_WORKSPACE}/flex/tests/hqps/
         export ENGINE_TYPE=hiactor

--- a/.github/workflows/interactive.yml
+++ b/.github/workflows/interactive.yml
@@ -121,7 +121,6 @@ jobs:
         GS_TEST_DIR: ${{ github.workspace }}/gstest
         FLEX_DATA_DIR: ${{ github.workspace }}/flex/interactive/examples/modern_graph
         TMP_INTERACTIVE_WORKSPACE: /tmp/temp_workspace
-        LD_LIBRARY_PATH: /usr/local/lib
       run: |
         rm -rf ${TMP_INTERACTIVE_WORKSPACE}
         cd ${GITHUB_WORKSPACE}/flex/build/
@@ -353,7 +352,7 @@ jobs:
   test-cmake-options:
     runs-on: ubuntu-20.04
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.23.0
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.2-amd64
     strategy:
       matrix:
         BUILD_TEST: [ON, OFF]
@@ -373,7 +372,7 @@ jobs:
   test-AOCC-compilation:
     runs-on: ubuntu-20.04
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.23.0
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.2-amd64
     steps:
     - uses: actions/checkout@v4
 
@@ -402,7 +401,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ github.repository == 'alibaba/GraphScope' }}
     container:
-      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.23.0
+      image: registry.cn-hongkong.aliyuncs.com/graphscope/graphscope-dev:v0.24.2-amd64
     steps:
     - uses: actions/checkout@v4
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,7 @@
 [submodule "flex/third_party/nlohmann-json"]
 	path = flex/third_party/nlohmann-json
 	url = https://github.com/nlohmann/json.git
+
+[submodule "flex/third_party/leaf"]
+	path = flex/third_party/leaf
+	url = https://github.com/boostorg/leaf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,3 @@
 	path = flex/third_party/nlohmann-json
 	url = https://github.com/nlohmann/json.git
 
-[submodule "flex/third_party/leaf"]
-	path = flex/third_party/leaf
-	url = https://github.com/boostorg/leaf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,4 +13,3 @@
 [submodule "flex/third_party/nlohmann-json"]
 	path = flex/third_party/nlohmann-json
 	url = https://github.com/nlohmann/json.git
-

--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -192,13 +192,6 @@ if (NOT EXISTS ${CMAKE_SOURCE_DIR}/third_party/nlohmann-json/single_include/nloh
 endif()
 include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/third_party/nlohmann-json/single_include)
 
-# Check whether ${CMAKE_SOURCE_DIR}/third_party/leaf/include/leaf.hpp exists
-if (NOT EXISTS ${CMAKE_SOURCE_DIR}/third_party/leaf/include/boost/leaf.hpp)
-    message(FATAL_ERROR "${CMAKE_SOURCE_DIR}/third_party/leaf/include/boost/leaf.hpp not found, "
-                         "please run `git submodule update --init` to download third_party")
-endif()
-include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/third_party/leaf/include)
-
 if (BUILD_ODPS_FRAGMENT_LOADER)
     include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/third_party/odps/include)
 endif()

--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -125,6 +125,7 @@ find_package(Boost REQUIRED COMPONENTS system filesystem
              # required by folly
              context program_options regex thread date_time)
 add_definitions("-DBOOST_BIND_GLOBAL_PLACEHOLDERS")
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 #find hiactor----------------------------------------------------------------------
 find_package(Hiactor)

--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -192,6 +192,13 @@ if (NOT EXISTS ${CMAKE_SOURCE_DIR}/third_party/nlohmann-json/single_include/nloh
 endif()
 include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/third_party/nlohmann-json/single_include)
 
+# Check whether ${CMAKE_SOURCE_DIR}/third_party/leaf/include/leaf.hpp exists
+if (NOT EXISTS ${CMAKE_SOURCE_DIR}/third_party/leaf/include/boost/leaf.hpp)
+    message(FATAL_ERROR "${CMAKE_SOURCE_DIR}/third_party/leaf/include/boost/leaf.hpp not found, "
+                         "please run `git submodule update --init` to download third_party")
+endif()
+include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/third_party/leaf/include)
+
 if (BUILD_ODPS_FRAGMENT_LOADER)
     include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/third_party/odps/include)
 endif()

--- a/flex/bin/adhoc_runner.cc
+++ b/flex/bin/adhoc_runner.cc
@@ -159,8 +159,12 @@ int main(int argc, char** argv) {
   for (int i = 0; i < query_num; ++i) {
     auto& m = map[i % params_num];
     auto ctx = gs::runtime::runtime_eval(pb, txn, m);
+    if (!ctx) {
+      LOG(ERROR) << "Eval plan failed: " << ctx.error();
+      return -1;
+    }
     gs::Encoder output(outputs[i]);
-    gs::runtime::eval_sink(ctx, txn, output);
+    gs::runtime::eval_sink(ctx.value(), txn, output);
   }
   t1 += grape::GetCurrentTime();
 
@@ -168,9 +172,13 @@ int main(int argc, char** argv) {
   for (int i = 0; i < query_num; ++i) {
     auto& m = map[i % params_num];
     auto ctx = gs::runtime::runtime_eval(pb, txn, m);
+    if (!ctx) {
+      LOG(ERROR) << "Eval plan failed: " << ctx.error();
+      return -1;
+    }
     outputs[i].clear();
     gs::Encoder output(outputs[i]);
-    gs::runtime::eval_sink(ctx, txn, output);
+    gs::runtime::eval_sink(ctx.value(), txn, output);
   }
   t2 += grape::GetCurrentTime();
 
@@ -178,9 +186,13 @@ int main(int argc, char** argv) {
   for (int i = 0; i < query_num; ++i) {
     auto& m = map[i % params_num];
     auto ctx = gs::runtime::runtime_eval(pb, txn, m);
+    if (!ctx) {
+      LOG(ERROR) << "Eval plan failed: " << ctx.error();
+      return -1;
+    }
     outputs[i].clear();
     gs::Encoder output(outputs[i]);
-    gs::runtime::eval_sink(ctx, txn, output);
+    gs::runtime::eval_sink(ctx.value(), txn, output);
   }
   t3 += grape::GetCurrentTime();
 

--- a/flex/bin/adhoc_runner.cc
+++ b/flex/bin/adhoc_runner.cc
@@ -23,6 +23,7 @@
 #include "flex/engines/graph_db/runtime/adhoc/runtime.h"
 
 namespace bpo = boost::program_options;
+namespace bl = boost::leaf;
 
 std::string read_pb(const std::string& filename) {
   std::ifstream file(filename, std::ios::binary);
@@ -72,6 +73,32 @@ void load_params(const std::string& filename,
     }
     map.push_back(m);
   }
+}
+
+gs::runtime::Context eval_plan(
+    const physical::PhysicalPlan& plan, gs::ReadTransaction& txn,
+    const std::map<std::string, std::string>& params) {
+  gs::runtime::Context ctx;
+  {
+    ctx = bl::try_handle_all(
+        [&plan, &txn, &params]() {
+          return gs::runtime::runtime_eval(plan, txn, params);
+        },
+        [&ctx](const gs::Status& err) {
+          LOG(FATAL) << "Error in execution: " << err.error_message();
+          return ctx;
+        },
+        [&](const bl::error_info& err) {
+          LOG(FATAL) << "boost leaf error: " << err.error().value() << ", "
+                     << err.exception()->what();
+          return ctx;
+        },
+        [&]() {
+          LOG(FATAL) << "Unknown error in execution";
+          return ctx;
+        });
+  }
+  return ctx;
 }
 
 int main(int argc, char** argv) {
@@ -158,41 +185,29 @@ int main(int argc, char** argv) {
   double t1 = -grape::GetCurrentTime();
   for (int i = 0; i < query_num; ++i) {
     auto& m = map[i % params_num];
-    auto ctx = gs::runtime::runtime_eval(pb, txn, m);
-    if (!ctx) {
-      LOG(ERROR) << "Eval plan failed: " << ctx.error();
-      return -1;
-    }
+    auto ctx = eval_plan(pb, txn, m);
     gs::Encoder output(outputs[i]);
-    gs::runtime::eval_sink(ctx.value(), txn, output);
+    gs::runtime::eval_sink(ctx, txn, output);
   }
   t1 += grape::GetCurrentTime();
 
   double t2 = -grape::GetCurrentTime();
   for (int i = 0; i < query_num; ++i) {
     auto& m = map[i % params_num];
-    auto ctx = gs::runtime::runtime_eval(pb, txn, m);
-    if (!ctx) {
-      LOG(ERROR) << "Eval plan failed: " << ctx.error();
-      return -1;
-    }
+    auto ctx = eval_plan(pb, txn, m);
     outputs[i].clear();
     gs::Encoder output(outputs[i]);
-    gs::runtime::eval_sink(ctx.value(), txn, output);
+    gs::runtime::eval_sink(ctx, txn, output);
   }
   t2 += grape::GetCurrentTime();
 
   double t3 = -grape::GetCurrentTime();
   for (int i = 0; i < query_num; ++i) {
     auto& m = map[i % params_num];
-    auto ctx = gs::runtime::runtime_eval(pb, txn, m);
-    if (!ctx) {
-      LOG(ERROR) << "Eval plan failed: " << ctx.error();
-      return -1;
-    }
+    auto ctx = eval_plan(pb, txn, m);
     outputs[i].clear();
     gs::Encoder output(outputs[i]);
-    gs::runtime::eval_sink(ctx.value(), txn, output);
+    gs::runtime::eval_sink(ctx, txn, output);
   }
   t3 += grape::GetCurrentTime();
 

--- a/flex/engines/graph_db/app/adhoc_app.cc
+++ b/flex/engines/graph_db/app/adhoc_app.cc
@@ -42,7 +42,7 @@ bool AdhocReadApp::Query(const GraphDBSession& graph, Decoder& input,
   {
     ctx = bl::try_handle_all(
         [&plan, &txn]() { return runtime::runtime_eval(plan, txn, {}); },
-        [&output, &ctx, &status](const gs::Status& err) {
+        [&ctx, &status](const gs::Status& err) {
           status = err;
           return ctx;
         },

--- a/flex/engines/graph_db/app/adhoc_app.cc
+++ b/flex/engines/graph_db/app/adhoc_app.cc
@@ -1,9 +1,26 @@
-#include "flex/engines/graph_db/app/adhoc_app.h"
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
+#include "flex/engines/graph_db/app/adhoc_app.h"
 #include "flex/engines/graph_db/runtime/adhoc/operators/operators.h"
 #include "flex/engines/graph_db/runtime/adhoc/runtime.h"
-
 #include "flex/proto_generated_gie/physical.pb.h"
+
+#include <string>
+
+namespace bl = boost::leaf;
 
 namespace gs {
 
@@ -20,7 +37,35 @@ bool AdhocReadApp::Query(const GraphDBSession& graph, Decoder& input,
 
   LOG(INFO) << "plan: " << plan.DebugString();
 
-  auto ctx = runtime::runtime_eval(plan, txn, {});
+  gs::runtime::Context ctx;
+  gs::Status status = gs::Status::OK();
+  {
+    ctx = bl::try_handle_all(
+        [&plan, &txn]() { return runtime::runtime_eval(plan, txn, {}); },
+        [&output, &ctx, &status](const gs::Status& err) {
+          status = err;
+          return ctx;
+        },
+        [&](const bl::error_info& err) {
+          status = gs::Status(
+              gs::StatusCode::INTERNAL_ERROR,
+              "BOOST LEAF Error: " + std::to_string(err.error().value()) +
+                  ", Exception: " + err.exception()->what());
+          return ctx;
+        },
+        [&]() {
+          status = gs::Status(gs::StatusCode::UNKNOWN, "Unknown error");
+          return ctx;
+        });
+  }
+
+  if (!status.ok()) {
+    LOG(ERROR) << "Error: " << status.ToString();
+    // We encode the error message to the output, so that the client can
+    // get the error message.
+    output.put_string(status.ToString());
+    return false;
+  }
 
   runtime::eval_sink(ctx, txn, output);
 

--- a/flex/engines/graph_db/database/graph_db_session.cc
+++ b/flex/engines/graph_db/database/graph_db_session.cc
@@ -166,10 +166,20 @@ Result<std::vector<char>> GraphDBSession::Eval(const std::string& input) {
       std::chrono::duration_cast<std::chrono::microseconds>(end - start)
           .count());
   ++query_num_;
-  return Result<std::vector<char>>(
-      StatusCode::QUERY_FAILED,
-      "Query failed for procedure id:" + std::to_string((int) type),
-      result_buffer);
+  // When query failed, we assume the user may put the error message in the
+  // output buffer.
+  // For example, for adhoc_app.cc, if the query failed, the error info will
+  // be put in the output buffer.
+  if (result_buffer.size() > 0) {
+    return Result<std::vector<char>>(
+        StatusCode::QUERY_FAILED,
+        std::string{result_buffer.data(), result_buffer.size()}, result_buffer);
+  } else {
+    return Result<std::vector<char>>(
+        StatusCode::QUERY_FAILED,
+        "Query failed for procedure id:" + std::to_string((int) type),
+        result_buffer);
+  }
 }
 
 void GraphDBSession::GetAppInfo(Encoder& result) { db_.GetAppInfo(result); }

--- a/flex/engines/graph_db/runtime/CMakeLists.txt
+++ b/flex/engines/graph_db/runtime/CMakeLists.txt
@@ -6,6 +6,7 @@ install_flex_target(runtime_common)
 file(GLOB_RECURSE ADHOC_SOURCES "adhoc/*.cc")
 add_library(runtime_adhoc SHARED ${ADHOC_SOURCES})
 target_link_libraries(runtime_adhoc runtime_common)
+target_link_libraries(runtime_adhoc Boost::headers)
 install_flex_target(runtime_adhoc)
 
 

--- a/flex/engines/graph_db/runtime/adhoc/operators/dedup.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/dedup.cc
@@ -21,8 +21,8 @@ namespace gs {
 
 namespace runtime {
 
-Context eval_dedup(const algebra::Dedup& opr, const ReadTransaction& txn,
-                   Context&& ctx) {
+bl::result<Context> eval_dedup(const algebra::Dedup& opr,
+                               const ReadTransaction& txn, Context&& ctx) {
   std::vector<size_t> keys;
   std::vector<std::function<RTAny(size_t)>> vars;
   int keys_num = opr.keys_size();

--- a/flex/engines/graph_db/runtime/adhoc/operators/edge_expand.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/edge_expand.cc
@@ -23,10 +23,10 @@ namespace gs {
 
 namespace runtime {
 
-Context eval_edge_expand(const physical::EdgeExpand& opr,
-                         const ReadTransaction& txn, Context&& ctx,
-                         const std::map<std::string, std::string>& params,
-                         const physical::PhysicalOpr_MetaData& meta) {
+bl::result<Context> eval_edge_expand(
+    const physical::EdgeExpand& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params,
+    const physical::PhysicalOpr_MetaData& meta) {
   int v_tag;
   if (!opr.has_v_tag()) {
     v_tag = -1;
@@ -49,7 +49,9 @@ Context eval_edge_expand(const physical::EdgeExpand& opr,
   if (opr.expand_opt() ==
       physical::EdgeExpand_ExpandOpt::EdgeExpand_ExpandOpt_VERTEX) {
     if (query_params.has_predicate()) {
-      LOG(FATAL) << "not support";
+      LOG(ERROR) << "edge expand vertex with predicate is not supported";
+      RETURN_UNSUPPORTED_ERROR(
+          "edge expand vertex with predicate is not supported");
     } else {
       EdgeExpandParams eep;
       eep.v_tag = v_tag;
@@ -82,7 +84,12 @@ Context eval_edge_expand(const physical::EdgeExpand& opr,
                                                        eep);
     }
   } else {
-    LOG(FATAL) << "not support";
+    LOG(ERROR) << "EdgeExpand with expand_opt: " << opr.expand_opt()
+               << " is "
+                  "not supported";
+    RETURN_UNSUPPORTED_ERROR(
+        "EdgeExpand with expand_opt is not supported: " +
+        std::to_string(static_cast<int>(opr.expand_opt())));
   }
   return ctx;
 }

--- a/flex/engines/graph_db/runtime/adhoc/operators/get_v.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/get_v.cc
@@ -39,9 +39,9 @@ VOpt parse_opt(const physical::GetV_VOpt& opt) {
   }
 }
 
-Context eval_get_v(const physical::GetV& opr, const ReadTransaction& txn,
-                   Context&& ctx,
-                   const std::map<std::string, std::string>& params) {
+bl::result<Context> eval_get_v(
+    const physical::GetV& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params) {
   int tag = -1;
   if (opr.has_tag()) {
     tag = opr.tag().value();
@@ -76,7 +76,8 @@ Context eval_get_v(const physical::GetV& opr, const ReadTransaction& txn,
     }
   }
 
-  LOG(FATAL) << "not support";
+  LOG(ERROR) << "Unsupported GetV operation: " << opr.DebugString();
+  RETURN_UNSUPPORTED_ERROR("Unsupported GetV operation: " + opr.DebugString());
   return ctx;
 }
 

--- a/flex/engines/graph_db/runtime/adhoc/operators/intersect.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/intersect.cc
@@ -20,9 +20,9 @@
 namespace gs {
 namespace runtime {
 
-Context eval_intersect(const ReadTransaction& txn,
-                       const physical::Intersect& opr,
-                       std::vector<Context>&& ctxs) {
+bl::result<Context> eval_intersect(const ReadTransaction& txn,
+                                   const physical::Intersect& opr,
+                                   std::vector<Context>&& ctxs) {
   int32_t key = opr.key();
   if (ctxs.size() == 1) {
     return std::move(ctxs[0]);

--- a/flex/engines/graph_db/runtime/adhoc/operators/join.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/join.cc
@@ -18,19 +18,22 @@
 
 namespace gs {
 namespace runtime {
-Context eval_join(const physical::Join& opr, Context&& ctx, Context&& ctx2) {
+bl::result<Context> eval_join(const physical::Join& opr, Context&& ctx,
+                              Context&& ctx2) {
   JoinParams p;
   auto left_keys = opr.left_keys();
   for (int i = 0; i < left_keys.size(); i++) {
     if (!left_keys.Get(i).has_tag()) {
-      LOG(FATAL) << "left_keys should have tag";
+      LOG(ERROR) << "left_keys should have tag";
+      RETURN_BAD_REQUEST_ERROR("left_keys should have tag");
     }
     p.left_columns.push_back(left_keys.Get(i).tag().id());
   }
   auto right_keys = opr.right_keys();
   for (int i = 0; i < right_keys.size(); i++) {
     if (!right_keys.Get(i).has_tag()) {
-      LOG(FATAL) << "right_keys should have tag";
+      LOG(ERROR) << "right_keys should have tag";
+      RETURN_BAD_REQUEST_ERROR("right_keys should have tag");
     }
     p.right_columns.push_back(right_keys.Get(i).tag().id());
   }
@@ -48,7 +51,7 @@ Context eval_join(const physical::Join& opr, Context&& ctx, Context&& ctx2) {
     p.join_type = JoinKind::kLeftOuterJoin;
     break;
   default:
-    LOG(FATAL) << "unsupported join kind" << opr.join_kind();
+    RETURN_UNSUPPORTED_ERROR("Unsupported join kind: " + opr.join_kind());
   }
   return Join::join(std::move(ctx), std::move(ctx2), p);
 }

--- a/flex/engines/graph_db/runtime/adhoc/operators/join.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/join.cc
@@ -51,7 +51,8 @@ bl::result<Context> eval_join(const physical::Join& opr, Context&& ctx,
     p.join_type = JoinKind::kLeftOuterJoin;
     break;
   default:
-    RETURN_UNSUPPORTED_ERROR("Unsupported join kind: " + opr.join_kind());
+    RETURN_UNSUPPORTED_ERROR("Unsupported join kind: " +
+                             std::to_string(static_cast<int>(opr.join_kind())));
   }
   return Join::join(std::move(ctx), std::move(ctx2), p);
 }

--- a/flex/engines/graph_db/runtime/adhoc/operators/limit.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/limit.cc
@@ -19,7 +19,7 @@
 namespace gs {
 namespace runtime {
 
-Context eval_limit(const algebra::Limit& opr, Context&& ctx) {
+bl::result<Context> eval_limit(const algebra::Limit& opr, Context&& ctx) {
   int lower = 0;
   int upper = ctx.row_num();
 

--- a/flex/engines/graph_db/runtime/adhoc/operators/operators.h
+++ b/flex/engines/graph_db/runtime/adhoc/operators/operators.h
@@ -21,61 +21,62 @@
 
 #include "flex/engines/graph_db/database/read_transaction.h"
 #include "flex/engines/graph_db/runtime/common/context.h"
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
 #include "flex/utils/app_utils.h"
 
 namespace gs {
 
 namespace runtime {
 
-Context eval_dedup(const algebra::Dedup& opr, const ReadTransaction& txn,
-                   Context&& ctx);
+bl::result<Context> eval_dedup(const algebra::Dedup& opr,
+                               const ReadTransaction& txn, Context&& ctx);
 
-Context eval_group_by(const physical::GroupBy& opr, const ReadTransaction& txn,
-                      Context&& ctx);
+bl::result<Context> eval_group_by(const physical::GroupBy& opr,
+                                  const ReadTransaction& txn, Context&& ctx);
 
-Context eval_order_by(const algebra::OrderBy& opr, const ReadTransaction& txn,
-                      Context&& ctx);
+bl::result<Context> eval_order_by(const algebra::OrderBy& opr,
+                                  const ReadTransaction& txn, Context&& ctx);
 
-Context eval_path_expand_v(const physical::PathExpand& opr,
-                           const ReadTransaction& txn, Context&& ctx,
-                           const std::map<std::string, std::string>& params,
-                           const physical::PhysicalOpr_MetaData& meta,
-                           int alias);
+bl::result<Context> eval_path_expand_v(
+    const physical::PathExpand& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params,
+    const physical::PhysicalOpr_MetaData& meta, int alias);
 
-Context eval_path_expand_p(const physical::PathExpand& opr,
-                           const ReadTransaction& txn, Context&& ctx,
-                           const std::map<std::string, std::string>& params,
-                           const physical::PhysicalOpr_MetaData& meta,
-                           int alias);
+bl::result<Context> eval_path_expand_p(
+    const physical::PathExpand& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params,
+    const physical::PhysicalOpr_MetaData& meta, int alias);
 
-Context eval_project(const physical::Project& opr, const ReadTransaction& txn,
-                     Context&& ctx,
-                     const std::map<std::string, std::string>& params,
-                     const std::vector<common::IrDataType>& data_types);
+bl::result<Context> eval_project(
+    const physical::Project& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params,
+    const std::vector<common::IrDataType>& data_types);
 
-Context eval_scan(const physical::Scan& scan_opr, const ReadTransaction& txn,
-                  const std::map<std::string, std::string>& params);
+bl::result<Context> eval_scan(const physical::Scan& scan_opr,
+                              const ReadTransaction& txn,
+                              const std::map<std::string, std::string>& params);
 
-Context eval_select(const algebra::Select& opr, const ReadTransaction& txn,
-                    Context&& ctx,
-                    const std::map<std::string, std::string>& params);
+bl::result<Context> eval_select(
+    const algebra::Select& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params);
 
-Context eval_edge_expand(const physical::EdgeExpand& opr,
-                         const ReadTransaction& txn, Context&& ctx,
-                         const std::map<std::string, std::string>& params,
-                         const physical::PhysicalOpr_MetaData& meta);
+bl::result<Context> eval_edge_expand(
+    const physical::EdgeExpand& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params,
+    const physical::PhysicalOpr_MetaData& meta);
 
-Context eval_get_v(const physical::GetV& opr, const ReadTransaction& txn,
-                   Context&& ctx,
-                   const std::map<std::string, std::string>& params);
+bl::result<Context> eval_get_v(
+    const physical::GetV& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params);
 
-Context eval_intersect(const ReadTransaction& txn,
-                       const physical::Intersect& opr,
-                       std::vector<Context>&& ctx);
+bl::result<Context> eval_intersect(const ReadTransaction& txn,
+                                   const physical::Intersect& opr,
+                                   std::vector<Context>&& ctx);
 
-Context eval_join(const physical::Join& opr, Context&& ctx, Context&& ctx2);
+bl::result<Context> eval_join(const physical::Join& opr, Context&& ctx,
+                              Context&& ctx2);
 
-Context eval_limit(const algebra::Limit& opr, Context&& ctx);
+bl::result<Context> eval_limit(const algebra::Limit& opr, Context&& ctx);
 
 void eval_sink(const Context& ctx, const ReadTransaction& txn, Encoder& output);
 

--- a/flex/engines/graph_db/runtime/adhoc/operators/order_by.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/order_by.cc
@@ -57,8 +57,8 @@ class GeneralComparer {
   size_t keys_num_;
 };
 
-Context eval_order_by(const algebra::OrderBy& opr, const ReadTransaction& txn,
-                      Context&& ctx) {
+bl::result<Context> eval_order_by(const algebra::OrderBy& opr,
+                                  const ReadTransaction& txn, Context&& ctx) {
   int lower = 0;
   int upper = std::numeric_limits<int>::max();
   if (opr.has_limit()) {

--- a/flex/engines/graph_db/runtime/adhoc/operators/path_expand.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/path_expand.cc
@@ -21,11 +21,10 @@ namespace gs {
 
 namespace runtime {
 
-Context eval_path_expand_v(const physical::PathExpand& opr,
-                           const ReadTransaction& txn, Context&& ctx,
-                           const std::map<std::string, std::string>& params,
-                           const physical::PhysicalOpr_MetaData& meta,
-                           int alias) {
+bl::result<Context> eval_path_expand_v(
+    const physical::PathExpand& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params,
+    const physical::PhysicalOpr_MetaData& meta, int alias) {
   CHECK(opr.has_start_tag());
   int start_tag = opr.start_tag().value();
   CHECK(opr.path_opt() ==
@@ -54,22 +53,24 @@ Context eval_path_expand_v(const physical::PathExpand& opr,
   if (opr.base().edge_expand().expand_opt() ==
       physical::EdgeExpand_ExpandOpt::EdgeExpand_ExpandOpt_VERTEX) {
     if (query_params.has_predicate()) {
-      LOG(FATAL) << "not support";
+      LOG(ERROR) << "path expand vertex with predicate is not supported";
+      RETURN_UNSUPPORTED_ERROR(
+          "path expand vertex with predicate is not supported");
     } else {
       return PathExpand::edge_expand_v(txn, std::move(ctx), pep);
     }
   } else {
-    LOG(FATAL) << "not support";
+    LOG(ERROR) << "Currently only support edge expand to vertex";
+    RETURN_UNSUPPORTED_ERROR("Currently only support edge expand to vertex");
   }
 
   return ctx;
 }
 
-Context eval_path_expand_p(const physical::PathExpand& opr,
-                           const ReadTransaction& txn, Context&& ctx,
-                           const std::map<std::string, std::string>& params,
-                           const physical::PhysicalOpr_MetaData& meta,
-                           int alias) {
+bl::result<Context> eval_path_expand_p(
+    const physical::PathExpand& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params,
+    const physical::PhysicalOpr_MetaData& meta, int alias) {
   CHECK(opr.has_start_tag());
   int start_tag = opr.start_tag().value();
   CHECK(opr.path_opt() ==
@@ -94,7 +95,9 @@ Context eval_path_expand_p(const physical::PathExpand& opr,
   pep.labels = parse_label_triplets(meta);
 
   if (query_params.has_predicate()) {
-    LOG(FATAL) << "not support";
+    LOG(ERROR) << "Currently can not support predicate in path expand";
+    RETURN_UNSUPPORTED_ERROR(
+        "Currently can not support predicate in path expand");
   } else {
     return PathExpand::edge_expand_p(txn, std::move(ctx), pep);
   }

--- a/flex/engines/graph_db/runtime/adhoc/operators/project.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/project.cc
@@ -42,10 +42,10 @@ bool exchange_tag_alias(const physical::Project_ExprAlias& m, int& tag,
   return false;
 }
 
-Context eval_project(const physical::Project& opr, const ReadTransaction& txn,
-                     Context&& ctx,
-                     const std::map<std::string, std::string>& params,
-                     const std::vector<common::IrDataType>& data_types) {
+bl::result<Context> eval_project(
+    const physical::Project& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params,
+    const std::vector<common::IrDataType>& data_types) {
   bool is_append = opr.is_append();
   Context ret;
   if (is_append) {

--- a/flex/engines/graph_db/runtime/adhoc/operators/scan.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/scan.cc
@@ -230,8 +230,9 @@ bool parse_idx_predicate(const algebra::IndexPredicate& predicate,
   return true;
 }
 
-Context eval_scan(const physical::Scan& scan_opr, const ReadTransaction& txn,
-                  const std::map<std::string, std::string>& params) {
+bl::result<Context> eval_scan(
+    const physical::Scan& scan_opr, const ReadTransaction& txn,
+    const std::map<std::string, std::string>& params) {
   label_t label;
   int64_t vertex_id;
   int alias;
@@ -260,7 +261,8 @@ Context eval_scan(const physical::Scan& scan_opr, const ReadTransaction& txn,
       scan_params.tables.push_back(table.id());
       const auto& pks = txn.schema().get_vertex_primary_key(table.id());
       if (pks.size() > 1) {
-        LOG(FATAL) << "only support one primary key";
+        LOG(ERROR) << "only support one primary key";
+        RETURN_UNSUPPORTED_ERROR("only support one primary key");
       }
       auto [type, _, __] = pks[0];
       if (type != PropertyType::kInt64) {
@@ -379,8 +381,9 @@ Context eval_scan(const physical::Scan& scan_opr, const ReadTransaction& txn,
                                [](label_t, vid_t) { return true; });
     }
   }
-  LOG(FATAL) << "unsupport scan option " << scan_opr.DebugString()
+  LOG(ERROR) << "unsupport scan option " << scan_opr.DebugString()
              << " we only support scan vertex currently";
+  RETURN_UNSUPPORTED_ERROR("unsupport scan option " + scan_opr.DebugString());
   return Context();
 }
 

--- a/flex/engines/graph_db/runtime/adhoc/operators/select.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/select.cc
@@ -20,9 +20,9 @@ namespace gs {
 
 namespace runtime {
 
-Context eval_select(const algebra::Select& opr, const ReadTransaction& txn,
-                    Context&& ctx,
-                    const std::map<std::string, std::string>& params) {
+bl::result<Context> eval_select(
+    const algebra::Select& opr, const ReadTransaction& txn, Context&& ctx,
+    const std::map<std::string, std::string>& params) {
   Expr expr(txn, ctx, params, opr.predicate(), VarType::kPathVar);
   std::vector<size_t> offsets;
   size_t row_num = ctx.row_num();

--- a/flex/engines/graph_db/runtime/adhoc/runtime.cc
+++ b/flex/engines/graph_db/runtime/adhoc/runtime.cc
@@ -225,9 +225,9 @@ Context runtime_eval_impl(const physical::PhysicalPlan& plan, Context&& ctx,
   return ret;
 }
 
-Context runtime_eval(const physical::PhysicalPlan& plan,
-                     const ReadTransaction& txn,
-                     const std::map<std::string, std::string>& params) {
+bl::result<Context> runtime_eval(
+    const physical::PhysicalPlan& plan, const ReadTransaction& txn,
+    const std::map<std::string, std::string>& params) {
   return runtime_eval_impl(plan, Context(), txn, params);
 }
 

--- a/flex/engines/graph_db/runtime/adhoc/runtime.cc
+++ b/flex/engines/graph_db/runtime/adhoc/runtime.cc
@@ -128,6 +128,8 @@ bl::result<Context> runtime_eval_impl(
           data_types.push_back(opr.meta_data(i).type());
         }
       }
+      BOOST_LEAF_ASSIGN(ret, eval_project(opr.opr().project(), txn,
+                                          std::move(ret), params, data_types));
       t += grape::GetCurrentTime();
       op_cost["project"] += t;
     } break;

--- a/flex/engines/graph_db/runtime/adhoc/runtime.h
+++ b/flex/engines/graph_db/runtime/adhoc/runtime.h
@@ -20,9 +20,9 @@
 
 #include "boost/leaf.hpp"
 
-namespace gs {
-
 namespace bl = boost::leaf;
+
+namespace gs {
 
 namespace runtime {
 

--- a/flex/engines/graph_db/runtime/adhoc/runtime.h
+++ b/flex/engines/graph_db/runtime/adhoc/runtime.h
@@ -18,13 +18,17 @@
 #include "flex/engines/graph_db/runtime/adhoc/operators/operators.h"
 #include "flex/proto_generated_gie/physical.pb.h"
 
+#include "boost/leaf.hpp"
+
 namespace gs {
+
+namespace bl = boost::leaf;
 
 namespace runtime {
 
-Context runtime_eval(const physical::PhysicalPlan& plan,
-                     const ReadTransaction& txn,
-                     const std::map<std::string, std::string>& params);
+bl::result<Context> runtime_eval(
+    const physical::PhysicalPlan& plan, const ReadTransaction& txn,
+    const std::map<std::string, std::string>& params);
 
 }  // namespace runtime
 

--- a/flex/engines/graph_db/runtime/common/leaf_utils.h
+++ b/flex/engines/graph_db/runtime/common/leaf_utils.h
@@ -16,7 +16,7 @@
 #ifndef RUNTIME_COMMON_LEAF_UTILS_H_
 #define RUNTIME_COMMON_LEAF_UTILS_H_
 
-#include "boost/leaf.hpp"
+#include <boost/leaf.hpp>
 #include "flex/utils/result.h"
 
 namespace bl = boost::leaf;

--- a/flex/engines/graph_db/runtime/common/leaf_utils.h
+++ b/flex/engines/graph_db/runtime/common/leaf_utils.h
@@ -1,0 +1,39 @@
+/** Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RUNTIME_COMMON_LEAF_UTILS_H_
+#define RUNTIME_COMMON_LEAF_UTILS_H_
+
+#include "boost/leaf.hpp"
+#include "flex/utils/result.h"
+
+namespace bl = boost::leaf;
+
+// Define a macro which returns a unsupported error
+#define RETURN_UNSUPPORTED_ERROR(msg) \
+  return ::boost::leaf::new_error(    \
+      ::gs::Status(::gs::StatusCode::UNSUPPORTED_OPERATION, msg))
+
+// Define a macro which returns a bad request error
+#define RETURN_BAD_REQUEST_ERROR(msg) \
+  return ::boost::leaf::new_error(    \
+      ::gs::Status(::gs::StatusCode::BAD_REQUEST, msg))
+
+// Define a macro which returns a not implemented error
+#define RETURN_NOT_IMPLEMENTED_ERROR(msg) \
+  return ::boost::leaf::new_error(        \
+      ::gs::Status(::gs::StatusCode::UNIMPLEMENTED, msg))
+
+#endif  // RUNTIME_COMMON_LEAF_UTILS_H_

--- a/flex/engines/graph_db/runtime/common/leaf_utils.h
+++ b/flex/engines/graph_db/runtime/common/leaf_utils.h
@@ -21,17 +21,14 @@
 
 namespace bl = boost::leaf;
 
-// Define a macro which returns a unsupported error
 #define RETURN_UNSUPPORTED_ERROR(msg) \
   return ::boost::leaf::new_error(    \
       ::gs::Status(::gs::StatusCode::UNSUPPORTED_OPERATION, msg))
 
-// Define a macro which returns a bad request error
 #define RETURN_BAD_REQUEST_ERROR(msg) \
   return ::boost::leaf::new_error(    \
       ::gs::Status(::gs::StatusCode::BAD_REQUEST, msg))
 
-// Define a macro which returns a not implemented error
 #define RETURN_NOT_IMPLEMENTED_ERROR(msg) \
   return ::boost::leaf::new_error(        \
       ::gs::Status(::gs::StatusCode::UNIMPLEMENTED, msg))

--- a/flex/engines/graph_db/runtime/common/operators/edge_expand.cc
+++ b/flex/engines/graph_db/runtime/common/operators/edge_expand.cc
@@ -46,7 +46,7 @@ static std::vector<LabelTriplet> get_expand_label_set(
   return label_triplets;
 }
 
-Context EdgeExpand::expand_edge_without_predicate(
+bl::result<Context> EdgeExpand::expand_edge_without_predicate(
     const ReadTransaction& txn, Context&& ctx, const EdgeExpandParams& params) {
   std::vector<size_t> shuffle_offset;
 
@@ -350,11 +350,13 @@ Context EdgeExpand::expand_edge_without_predicate(
     }
   }
 
-  LOG(FATAL) << "not support";
-  return ctx;
+  LOG(ERROR) << "Unsupported edge expand direction: "
+             << static_cast<int>(params.dir);
+  RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
+                           static_cast<int>(params.dir));
 }
 
-Context EdgeExpand::expand_vertex_without_predicate(
+bl::result<Context> EdgeExpand::expand_vertex_without_predicate(
     const ReadTransaction& txn, Context&& ctx, const EdgeExpandParams& params) {
   std::shared_ptr<IVertexColumn> input_vertex_list =
       std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.v_tag));
@@ -504,7 +506,8 @@ Context EdgeExpand::expand_vertex_without_predicate(
           ctx.set_with_reshuffle(params.alias, builder.finish(),
                                  shuffle_offset);
         } else {
-          LOG(FATAL) << "xxx";
+          LOG(ERROR) << "Unsupported edge expand direction";
+          RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction");
         }
       } else {
         MLVertexColumnBuilder builder;
@@ -552,7 +555,8 @@ Context EdgeExpand::expand_vertex_without_predicate(
       auto casted_input_vertex_list =
           std::dynamic_pointer_cast<MLVertexColumn>(input_vertex_list);
       if (params.dir == Direction::kBoth) {
-        LOG(FATAL) << "AAAAAAAAA";
+        LOG(ERROR) << "Unsupported edge expand direction";
+        RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction");
       } else if (params.dir == Direction::kIn) {
         casted_input_vertex_list->foreach_vertex(
             [&](size_t index, label_t label, vid_t v) {
@@ -588,13 +592,19 @@ Context EdgeExpand::expand_vertex_without_predicate(
             });
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
       } else {
-        LOG(FATAL) << "xxx";
+        LOG(ERROR) << "Unsupported edge expand direction: "
+                   << static_cast<int>(params.dir);
+        RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
+                                 static_cast<int>(params.dir));
       }
     } else if (input_vertex_list_type == VertexColumnType::kMultiSegment) {
       auto casted_input_vertex_list =
           std::dynamic_pointer_cast<MSVertexColumn>(input_vertex_list);
       if (params.dir == Direction::kBoth) {
-        LOG(FATAL) << "AAAAAAAAA";
+        LOG(ERROR) << "Unsupported edge expand direction: "
+                   << static_cast<int>(params.dir);
+        RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
+                                 static_cast<int>(params.dir));
       } else if (params.dir == Direction::kIn) {
         casted_input_vertex_list->foreach_vertex(
             [&](size_t index, label_t label, vid_t v) {
@@ -630,10 +640,14 @@ Context EdgeExpand::expand_vertex_without_predicate(
             });
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
       } else {
-        LOG(FATAL) << "xxx";
+        LOG(ERROR) << "Unsupported edge expand direction: "
+                   << static_cast<int>(params.dir);
+        RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
+                                 static_cast<int>(params.dir));
       }
     } else {
-      LOG(FATAL) << "unexpected input vertex list type";
+      LOG(ERROR) << "unexpected input vertex list type";
+      RETURN_UNSUPPORTED_ERROR("unexpected input vertex list type");
     }
   } else {
     if (input_vertex_list_type == VertexColumnType::kSingle) {
@@ -672,7 +686,10 @@ Context EdgeExpand::expand_vertex_without_predicate(
       for (label_t output_vertex_label : output_vertex_set) {
         builder.start_label(output_vertex_label);
         if (params.dir == Direction::kBoth) {
-          LOG(FATAL) << "AAAAA";
+          LOG(ERROR) << "Unsupported edge expand direction: "
+                     << static_cast<int>(params.dir);
+          RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
+                                   static_cast<int>(params.dir));
         } else if (params.dir == Direction::kIn) {
           for (auto& triplet : params.labels) {
             if (triplet.dst_label == input_vertex_label &&
@@ -691,7 +708,10 @@ Context EdgeExpand::expand_vertex_without_predicate(
             }
           }
         } else if (params.dir == Direction::kOut) {
-          LOG(FATAL) << "AAAAA";
+          LOG(ERROR) << "Unsupported edge expand direction: "
+                     << static_cast<int>(params.dir);
+          RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
+                                   static_cast<int>(params.dir));
         }
       }
 #endif
@@ -754,16 +774,19 @@ Context EdgeExpand::expand_vertex_without_predicate(
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
         return ctx;
       } else {
-        LOG(FATAL) << "not support";
+        LOG(ERROR) << "Unsupported edge expand direction: "
+                   << static_cast<int>(params.dir);
       }
-      LOG(FATAL) << "edge expand vertex input multiple vertex label";
+      LOG(ERROR) << "edge expand vertex input multiple vertex label";
+      RETURN_UNSUPPORTED_ERROR(
+          "edge expand vertex input multiple vertex label");
     }
   }
 
   return ctx;
 }
 
-Context EdgeExpand::expand_2d_vertex_without_predicate(
+bl::result<Context> EdgeExpand::expand_2d_vertex_without_predicate(
     const ReadTransaction& txn, Context&& ctx, const EdgeExpandParams& params1,
     const EdgeExpandParams& params2) {
   std::shared_ptr<IVertexColumn> input_vertex_list =
@@ -824,9 +847,13 @@ Context EdgeExpand::expand_2d_vertex_without_predicate(
       }
     }
   }
-  LOG(FATAL) << "XXXX";
-
-  return ctx;
+  LOG(ERROR) << "Unsupported edge expand 2d vertex without predicate, "
+             << "params1.dir: " << static_cast<int>(params1.dir)
+             << ", params2.dir: " << static_cast<int>(params2.dir)
+             << ", params1.labels.size: " << params1.labels.size()
+             << ", params2.labels.size: " << params2.labels.size();
+  RETURN_UNSUPPORTED_ERROR(
+      "Unsupported params for edge expand 2d vertex without predicate");
 }
 
 }  // namespace runtime

--- a/flex/engines/graph_db/runtime/common/operators/edge_expand.cc
+++ b/flex/engines/graph_db/runtime/common/operators/edge_expand.cc
@@ -350,10 +350,9 @@ bl::result<Context> EdgeExpand::expand_edge_without_predicate(
     }
   }
 
-  LOG(ERROR) << "Unsupported edge expand direction: "
-             << static_cast<int>(params.dir);
+  LOG(ERROR) << "Unsupported edge expand direction: " << params.dir;
   RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
-                           static_cast<int>(params.dir));
+                           std::to_string(params.dir));
 }
 
 bl::result<Context> EdgeExpand::expand_vertex_without_predicate(
@@ -592,19 +591,17 @@ bl::result<Context> EdgeExpand::expand_vertex_without_predicate(
             });
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
       } else {
-        LOG(ERROR) << "Unsupported edge expand direction: "
-                   << static_cast<int>(params.dir);
+        LOG(ERROR) << "Unsupported edge expand direction: " << params.dir;
         RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
-                                 static_cast<int>(params.dir));
+                                 std::to_string(params.dir));
       }
     } else if (input_vertex_list_type == VertexColumnType::kMultiSegment) {
       auto casted_input_vertex_list =
           std::dynamic_pointer_cast<MSVertexColumn>(input_vertex_list);
       if (params.dir == Direction::kBoth) {
-        LOG(ERROR) << "Unsupported edge expand direction: "
-                   << static_cast<int>(params.dir);
+        LOG(ERROR) << "Unsupported edge expand direction: " << params.dir;
         RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
-                                 static_cast<int>(params.dir));
+                                 std::to_string(params.dir));
       } else if (params.dir == Direction::kIn) {
         casted_input_vertex_list->foreach_vertex(
             [&](size_t index, label_t label, vid_t v) {
@@ -640,10 +637,9 @@ bl::result<Context> EdgeExpand::expand_vertex_without_predicate(
             });
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
       } else {
-        LOG(ERROR) << "Unsupported edge expand direction: "
-                   << static_cast<int>(params.dir);
+        LOG(ERROR) << "Unsupported edge expand direction: " << params.dir;
         RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
-                                 static_cast<int>(params.dir));
+                                 std::to_string(params.dir));
       }
     } else {
       LOG(ERROR) << "unexpected input vertex list type";
@@ -686,10 +682,9 @@ bl::result<Context> EdgeExpand::expand_vertex_without_predicate(
       for (label_t output_vertex_label : output_vertex_set) {
         builder.start_label(output_vertex_label);
         if (params.dir == Direction::kBoth) {
-          LOG(ERROR) << "Unsupported edge expand direction: "
-                     << static_cast<int>(params.dir);
+          LOG(ERROR) << "Unsupported edge expand direction: " << params.dir;
           RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
-                                   static_cast<int>(params.dir));
+                                   std::to_string(params.dir));
         } else if (params.dir == Direction::kIn) {
           for (auto& triplet : params.labels) {
             if (triplet.dst_label == input_vertex_label &&
@@ -708,10 +703,9 @@ bl::result<Context> EdgeExpand::expand_vertex_without_predicate(
             }
           }
         } else if (params.dir == Direction::kOut) {
-          LOG(ERROR) << "Unsupported edge expand direction: "
-                     << static_cast<int>(params.dir);
+          LOG(ERROR) << "Unsupported edge expand direction: " << params.dir;
           RETURN_UNSUPPORTED_ERROR("Unsupported edge expand direction" +
-                                   static_cast<int>(params.dir));
+                                   std::to_string(params.dir));
         }
       }
 #endif

--- a/flex/engines/graph_db/runtime/common/operators/edge_expand.h
+++ b/flex/engines/graph_db/runtime/common/operators/edge_expand.h
@@ -22,6 +22,7 @@
 #include "flex/engines/graph_db/runtime/common/columns/edge_columns.h"
 #include "flex/engines/graph_db/runtime/common/columns/vertex_columns.h"
 #include "flex/engines/graph_db/runtime/common/context.h"
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
 
 #include "glog/logging.h"
 
@@ -38,9 +39,10 @@ struct EdgeExpandParams {
 class EdgeExpand {
  public:
   template <typename PRED_T>
-  static Context expand_edge(const ReadTransaction& txn, Context&& ctx,
-                             const EdgeExpandParams& params,
-                             const PRED_T& pred) {
+  static bl::result<Context> expand_edge(const ReadTransaction& txn,
+                                         Context&& ctx,
+                                         const EdgeExpandParams& params,
+                                         const PRED_T& pred) {
     std::vector<size_t> shuffle_offset;
     if (params.labels.size() == 1) {
       if (params.dir == Direction::kIn) {
@@ -124,7 +126,8 @@ class EdgeExpand {
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
         return ctx;
       } else {
-        LOG(FATAL) << "expand edge both";
+        LOG(ERROR) << "Unsupported direction: " << static_cast<int>(params.dir);
+        RETURN_UNSUPPORTED_ERROR("Unsupported direction");
       }
     } else {
       if (params.dir == Direction::kBoth) {
@@ -219,19 +222,22 @@ class EdgeExpand {
             });
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
         return ctx;
+      } else {
+        LOG(ERROR) << "Unsupported direction: " << static_cast<int>(params.dir);
+        RETURN_UNSUPPORTED_ERROR("Unsupported direction");
       }
     }
-    LOG(FATAL) << "not support";
   }
 
-  static Context expand_edge_without_predicate(const ReadTransaction& txn,
-                                               Context&& ctx,
-                                               const EdgeExpandParams& params);
+  static bl::result<Context> expand_edge_without_predicate(
+      const ReadTransaction& txn, Context&& ctx,
+      const EdgeExpandParams& params);
 
   template <typename PRED_T>
-  static Context expand_vertex(const ReadTransaction& txn, Context&& ctx,
-                               const EdgeExpandParams& params,
-                               const PRED_T& pred) {
+  static bl::result<Context> expand_vertex(const ReadTransaction& txn,
+                                           Context&& ctx,
+                                           const EdgeExpandParams& params,
+                                           const PRED_T& pred) {
     std::shared_ptr<IVertexColumn> input_vertex_list =
         std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.v_tag));
     VertexColumnType input_vertex_list_type =
@@ -268,7 +274,8 @@ class EdgeExpand {
     }
 
     if (output_vertex_set.empty()) {
-      LOG(FATAL) << "output vertex label set is empty...";
+      LOG(ERROR) << "No output vertex label found...";
+      RETURN_UNSUPPORTED_ERROR("No output vertex label found...");
     }
 
     std::vector<size_t> shuffle_offset;
@@ -335,13 +342,18 @@ class EdgeExpand {
             ctx.set_with_reshuffle(params.alias, builder.finish(),
                                    shuffle_offset);
           } else {
-            LOG(FATAL) << "xxx, " << (int) params.dir;
+            LOG(ERROR) << "Unsupported direction and label triplet...";
+            RETURN_UNSUPPORTED_ERROR(
+                "Unsupported direction and label triplet...");
           }
         } else {
-          LOG(FATAL) << "multiple label triplet...";
+          LOG(ERROR) << "multiple label triplet...";
+          RETURN_UNSUPPORTED_ERROR("multiple label triplet...");
         }
       } else {
-        LOG(FATAL) << "edge expand vertex input multiple vertex label";
+        LOG(ERROR) << "edge expand vertex input multiple vertex label";
+        RETURN_UNSUPPORTED_ERROR(
+            "edge expand vertex input multiple vertex label");
       }
     } else {
       MLVertexColumnBuilder builder;
@@ -352,7 +364,9 @@ class EdgeExpand {
         label_t input_vertex_label = casted_input_vertex_list->label();
         for (label_t output_vertex_label : output_vertex_set) {
           if (params.dir == Direction::kBoth) {
-            LOG(FATAL) << "AAAAA";
+            LOG(ERROR) << "expand vertex with both direction is not supported";
+            RETURN_UNSUPPORTED_ERROR(
+                "expand vertex with both direction is not supported");
           } else if (params.dir == Direction::kIn) {
             for (auto& triplet : params.labels) {
               if (triplet.dst_label == input_vertex_label &&
@@ -375,23 +389,31 @@ class EdgeExpand {
               }
             }
           } else if (params.dir == Direction::kOut) {
-            LOG(FATAL) << "AAAAA";
+            LOG(ERROR) << "expand vertex with out direction is not supported";
+            RETURN_UNSUPPORTED_ERROR(
+                "expand vertex with out direction is not supported");
+          } else {
+            // Must be both
+            LOG(ERROR) << "Unknow direction";
+            RETURN_UNSUPPORTED_ERROR("Unknow direction");
           }
         }
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
       } else {
-        LOG(FATAL) << "edge expand vertex input multiple vertex label";
+        LOG(ERROR) << "edge expand vertex input multiple vertex label";
+        RETURN_UNSUPPORTED_ERROR(
+            "edge expand vertex input multiple vertex label");
       }
     }
 
     return ctx;
   }
 
-  static Context expand_vertex_without_predicate(
+  static bl::result<Context> expand_vertex_without_predicate(
       const ReadTransaction& txn, Context&& ctx,
       const EdgeExpandParams& params);
 
-  static Context expand_2d_vertex_without_predicate(
+  static bl::result<Context> expand_2d_vertex_without_predicate(
       const ReadTransaction& txn, Context&& ctx,
       const EdgeExpandParams& params1, const EdgeExpandParams& params2);
 };

--- a/flex/engines/graph_db/runtime/common/operators/edge_expand.h
+++ b/flex/engines/graph_db/runtime/common/operators/edge_expand.h
@@ -126,8 +126,9 @@ class EdgeExpand {
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
         return ctx;
       } else {
-        LOG(ERROR) << "Unsupported direction: " << static_cast<int>(params.dir);
-        RETURN_UNSUPPORTED_ERROR("Unsupported direction");
+        LOG(ERROR) << "Unsupported direction: " << params.dir;
+        RETURN_UNSUPPORTED_ERROR("Unsupported direction: " +
+                                 std::to_string(params.dir));
       }
     } else {
       if (params.dir == Direction::kBoth) {
@@ -223,8 +224,9 @@ class EdgeExpand {
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
         return ctx;
       } else {
-        LOG(ERROR) << "Unsupported direction: " << static_cast<int>(params.dir);
-        RETURN_UNSUPPORTED_ERROR("Unsupported direction");
+        LOG(ERROR) << "Unsupported direction: " << params.dir;
+        RETURN_UNSUPPORTED_ERROR("Unsupported direction" +
+                                 std::to_string(params.dir));
       }
     }
   }

--- a/flex/engines/graph_db/runtime/common/operators/get_v.h
+++ b/flex/engines/graph_db/runtime/common/operators/get_v.h
@@ -19,6 +19,7 @@
 #include "flex/engines/graph_db/runtime/common/columns/path_columns.h"
 #include "flex/engines/graph_db/runtime/common/columns/vertex_columns.h"
 #include "flex/engines/graph_db/runtime/common/context.h"
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
 
 namespace gs {
 namespace runtime {
@@ -30,9 +31,9 @@ struct GetVParams {
   int alias;
 };
 
-std::vector<label_t> extract_labels(const std::vector<LabelTriplet>& labels,
-                                    const std::vector<label_t>& tables,
-                                    VOpt opt) {
+bl::result<std::vector<label_t>> extract_labels(
+    const std::vector<LabelTriplet>& labels, const std::vector<label_t>& tables,
+    VOpt opt) {
   std::vector<label_t> output_labels;
   for (const auto& label : labels) {
     if (opt == VOpt::kStart) {
@@ -48,7 +49,9 @@ std::vector<label_t> extract_labels(const std::vector<LabelTriplet>& labels,
         output_labels.push_back(label.dst_label);
       }
     } else {
-      LOG(FATAL) << "not support" << static_cast<int>(opt);
+      LOG(ERROR) << "Vopt: " << static_cast<int>(opt) << " not supported";
+      RETURN_UNSUPPORTED_ERROR("Vopt not supported: " +
+                               std::to_string(static_cast<int>(opt)));
     }
   }
   return output_labels;
@@ -56,9 +59,10 @@ std::vector<label_t> extract_labels(const std::vector<LabelTriplet>& labels,
 class GetV {
  public:
   template <typename PRED_T>
-  static Context get_vertex_from_edges(const ReadTransaction& txn,
-                                       Context&& ctx, const GetVParams& params,
-                                       const PRED_T& pred) {
+  static bl::result<Context> get_vertex_from_edges(const ReadTransaction& txn,
+                                                   Context&& ctx,
+                                                   const GetVParams& params,
+                                                   const PRED_T& pred) {
     std::vector<size_t> shuffle_offset;
     auto col = ctx.get(params.tag);
     if (col->column_type() == ContextColumnType::kPath) {
@@ -97,7 +101,9 @@ class GetV {
       } else if (opt == VOpt::kEnd) {
         output_vertex_label = edge_label.dst_label;
       } else {
-        LOG(FATAL) << "not support";
+        LOG(ERROR) << "Vopt: " << static_cast<int>(opt) << " not supported";
+        RETURN_UNSUPPORTED_ERROR("Vopt not supported: " +
+                                 std::to_string(static_cast<int>(opt)));
       }
       // params tables size may be 0
       if (params.tables.size() == 1) {
@@ -123,7 +129,9 @@ class GetV {
               }
             });
       } else {
-        LOG(FATAL) << "not support";
+        LOG(ERROR) << "Vopt: " << static_cast<int>(opt) << " not supported";
+        RETURN_UNSUPPORTED_ERROR("Vopt not supported: " +
+                                 std::to_string(static_cast<int>(opt)));
       }
       ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
       return ctx;
@@ -139,8 +147,8 @@ class GetV {
         }
       }
 
-      auto labels =
-          extract_labels(input_edge_list.get_labels(), params.tables, opt);
+      BOOST_LEAF_AUTO(labels, extract_labels(input_edge_list.get_labels(),
+                                             params.tables, opt));
       if (labels.size() == 0) {
         MLVertexColumnBuilder builder;
         ctx.set_with_reshuffle(params.alias, builder.finish(), {});
@@ -171,7 +179,9 @@ class GetV {
             }
           });
         } else {
-          LOG(FATAL) << "not support";
+          LOG(ERROR) << "Vopt: " << static_cast<int>(opt) << " not supported";
+          RETURN_UNSUPPORTED_ERROR("Vopt not supported: " +
+                                   std::to_string(static_cast<int>(opt)));
         }
         ctx.set_with_reshuffle(params.alias, builder.finish(), shuffle_offset);
         return ctx;
@@ -337,9 +347,11 @@ class GetV {
         return ctx;
       }
     }
-
-    LOG(FATAL) << "not support" << static_cast<int>(column->edge_column_type());
-    return ctx;
+    LOG(ERROR) << "Unsupported edge column type: "
+               << static_cast<int>(column->edge_column_type());
+    RETURN_UNSUPPORTED_ERROR(
+        "Unsupported edge column type: " +
+        std::to_string(static_cast<int>(column->edge_column_type())));
   }
 
   template <typename PRED_T>

--- a/flex/engines/graph_db/runtime/common/operators/intersect.cc
+++ b/flex/engines/graph_db/runtime/common/operators/intersect.cc
@@ -31,9 +31,9 @@ static void ensure_sorted(std::shared_ptr<ValueColumn<size_t>> idx_col,
   }
 }
 
-Context Intersect::intersect(Context&& ctx,
-                             std::vector<std::tuple<Context, int, int>>&& ctxs,
-                             int alias) {
+bl::result<Context> Intersect::intersect(
+    Context&& ctx, std::vector<std::tuple<Context, int, int>>&& ctxs,
+    int alias) {
   std::vector<std::pair<std::shared_ptr<ValueColumn<size_t>>,
                         std::shared_ptr<IContextColumn>>>
       cols;
@@ -99,11 +99,13 @@ Context Intersect::intersect(Context&& ctx,
       }
     }
   }
-
-  LOG(FATAL) << "not support";
+  LOG(ERROR) << "Currently we only support intersect on two columns";
+  RETURN_NOT_IMPLEMENTED_ERROR(
+      "Currently we only support intersect on two columns");
 }
 
-static Context intersect_impl(std::vector<Context>&& ctxs, int key) {
+static bl::result<Context> intersect_impl(std::vector<Context>&& ctxs,
+                                          int key) {
   if (ctxs[0].get(key)->column_type() == ContextColumnType::kVertex) {
     if (ctxs.size() == 2) {
       auto& vlist0 =
@@ -176,11 +178,13 @@ static Context intersect_impl(std::vector<Context>&& ctxs, int key) {
       return ctxs[0];
     }
   }
-  LOG(FATAL) << "not support";
-  return Context();
+  LOG(ERROR) << "Currently we only support intersect on vertex columns";
+  RETURN_NOT_IMPLEMENTED_ERROR(
+      "Currently we only support intersect on vertex "
+      "columns");
 }
 
-Context Intersect::intersect(std::vector<Context>&& ctxs, int key) {
+bl::result<Context> Intersect::intersect(std::vector<Context>&& ctxs, int key) {
   return intersect_impl(std::move(ctxs), key);
 }
 

--- a/flex/engines/graph_db/runtime/common/operators/intersect.h
+++ b/flex/engines/graph_db/runtime/common/operators/intersect.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "flex/engines/graph_db/runtime/common/context.h"
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
 
 namespace gs {
 
@@ -27,11 +28,11 @@ namespace runtime {
 
 class Intersect {
  public:
-  static Context intersect(Context&& ctx,
-                           std::vector<std::tuple<Context, int, int>>&& ctxs,
-                           int alias);
+  static bl::result<Context> intersect(
+      Context&& ctx, std::vector<std::tuple<Context, int, int>>&& ctxs,
+      int alias);
 
-  static Context intersect(std::vector<Context>&& ctxs, int key);
+  static bl::result<Context> intersect(std::vector<Context>&& ctxs, int key);
 };
 
 }  // namespace runtime

--- a/flex/engines/graph_db/runtime/common/operators/join.cc
+++ b/flex/engines/graph_db/runtime/common/operators/join.cc
@@ -16,10 +16,13 @@
 #include "flex/engines/graph_db/runtime/common/operators/join.h"
 #include "flex/engines/graph_db/runtime/common/columns/vertex_columns.h"
 
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
+
 namespace gs {
 
 namespace runtime {
-Context Join::join(Context&& ctx, Context&& ctx2, const JoinParams& params) {
+bl::result<Context> Join::join(Context&& ctx, Context&& ctx2,
+                               const JoinParams& params) {
   CHECK(params.left_columns.size() == params.right_columns.size())
       << "Join columns size mismatch";
   if (params.join_type == JoinKind::kSemiJoin ||
@@ -176,8 +179,13 @@ Context Join::join(Context&& ctx, Context&& ctx2, const JoinParams& params) {
     }
 
     return ctx;
+  } else {
+    LOG(ERROR) << "Unsupported join type: "
+               << static_cast<int>(params.join_type);
+    RETURN_NOT_IMPLEMENTED_ERROR(
+        "Join of type " + std::to_string(static_cast<int>(params.join_type)) +
+        " is not supported");
   }
-  LOG(FATAL) << "Unsupported join type";
 
   return Context();
 }

--- a/flex/engines/graph_db/runtime/common/operators/join.h
+++ b/flex/engines/graph_db/runtime/common/operators/join.h
@@ -19,6 +19,8 @@
 #include <vector>
 #include "flex/engines/graph_db/runtime/common/context.h"
 
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
+
 namespace gs {
 namespace runtime {
 
@@ -30,7 +32,8 @@ struct JoinParams {
 
 class Join {
  public:
-  static Context join(Context&& ctx, Context&& ctx2, const JoinParams& params);
+  static bl::result<Context> join(Context&& ctx, Context&& ctx2,
+                                  const JoinParams& params);
 };
 }  // namespace runtime
 }  // namespace gs

--- a/flex/engines/graph_db/runtime/common/operators/path_expand.cc
+++ b/flex/engines/graph_db/runtime/common/operators/path_expand.cc
@@ -19,8 +19,9 @@ namespace gs {
 
 namespace runtime {
 
-Context PathExpand::edge_expand_v(const ReadTransaction& txn, Context&& ctx,
-                                  const PathExpandParams& params) {
+bl::result<Context> PathExpand::edge_expand_v(const ReadTransaction& txn,
+                                              Context&& ctx,
+                                              const PathExpandParams& params) {
   std::vector<size_t> shuffle_offset;
   if (params.labels.size() == 1) {
     if (params.dir == Direction::kOut) {
@@ -85,10 +86,10 @@ Context PathExpand::edge_expand_v(const ReadTransaction& txn, Context&& ctx,
       CHECK_GE(params.hop_lower, 0);
       CHECK_GE(params.hop_upper, params.hop_lower);
       if (params.hop_lower == 0) {
-        LOG(FATAL) << "xxx";
+        RETURN_BAD_REQUEST_ERROR("hop_lower should be greater than 0");
       } else {
         if (params.hop_upper == 1) {
-          LOG(FATAL) << "xxx";
+          RETURN_BAD_REQUEST_ERROR("hop_upper should be greater than 1");
         } else {
           input_vertex_list.foreach_vertex(
               [&](size_t index, label_t label, vid_t v) {
@@ -262,14 +263,17 @@ Context PathExpand::edge_expand_v(const ReadTransaction& txn, Context&& ctx,
       ctx.set_with_reshuffle_beta(params.alias, builder.finish(),
                                   shuffle_offset, params.keep_cols);
       return ctx;
+    } else {
+      LOG(ERROR) << "Not implemented yet";
+      RETURN_NOT_IMPLEMENTED_ERROR("Not implemented yet for direction in");
     }
   }
-  LOG(FATAL) << "not support...";
   return ctx;
 }
 
-Context PathExpand::edge_expand_p(const ReadTransaction& txn, Context&& ctx,
-                                  const PathExpandParams& params) {
+bl::result<Context> PathExpand::edge_expand_p(const ReadTransaction& txn,
+                                              Context&& ctx,
+                                              const PathExpandParams& params) {
   std::vector<size_t> shuffle_offset;
   auto& input_vertex_list =
       *std::dynamic_pointer_cast<IVertexColumn>(ctx.get(params.start_tag));
@@ -383,8 +387,10 @@ Context PathExpand::edge_expand_p(const ReadTransaction& txn, Context&& ctx,
     ctx.set_with_reshuffle_beta(params.alias, builder.finish(), shuffle_offset,
                                 params.keep_cols);
     return ctx;
+  } else {
+    LOG(ERROR) << "Not implemented yet";
+    RETURN_NOT_IMPLEMENTED_ERROR("Not implemented yet for direction in");
   }
-  LOG(FATAL) << "not support...";
   return ctx;
 }
 

--- a/flex/engines/graph_db/runtime/common/operators/path_expand.h
+++ b/flex/engines/graph_db/runtime/common/operators/path_expand.h
@@ -24,6 +24,8 @@
 #include "flex/engines/graph_db/runtime/common/context.h"
 #include "flex/engines/graph_db/runtime/common/types.h"
 
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
+
 namespace gs {
 
 namespace runtime {
@@ -42,15 +44,18 @@ class PathExpand {
  public:
   // PathExpand(expandOpt == Vertex && alias == -1 && resultOpt == END_V) +
   // GetV(opt == END)
-  static Context edge_expand_v(const ReadTransaction& txn, Context&& ctx,
-                               const PathExpandParams& params);
-  static Context edge_expand_p(const ReadTransaction& txn, Context&& ctx,
-                               const PathExpandParams& params);
+  static bl::result<Context> edge_expand_v(const ReadTransaction& txn,
+                                           Context&& ctx,
+                                           const PathExpandParams& params);
+  static bl::result<Context> edge_expand_p(const ReadTransaction& txn,
+                                           Context&& ctx,
+                                           const PathExpandParams& params);
 
   template <typename PRED_T>
-  static Context edge_expand_v_pred(const ReadTransaction& txn, Context&& ctx,
-                                    const PathExpandParams& params,
-                                    const PRED_T& pred) {
+  static bl::result<Context> edge_expand_v_pred(const ReadTransaction& txn,
+                                                Context&& ctx,
+                                                const PathExpandParams& params,
+                                                const PRED_T& pred) {
     std::vector<size_t> shuffle_offset;
     if (params.labels.size() == 1 &&
         params.labels[0].src_label == params.labels[0].dst_label) {
@@ -148,7 +153,9 @@ class PathExpand {
         return ctx;
       }
     }
-    LOG(FATAL) << "not support...";
+    RETURN_UNSUPPORTED_ERROR(
+        "Unsupported path expand. Currently only support "
+        "single edge label expand with src_label = dst_label.");
     return ctx;
   }
 };

--- a/flex/engines/graph_db/runtime/common/operators/project.h
+++ b/flex/engines/graph_db/runtime/common/operators/project.h
@@ -22,6 +22,8 @@
 #include "flex/engines/graph_db/runtime/common/columns/i_context_column.h"
 #include "flex/engines/graph_db/runtime/common/columns/value_columns.h"
 
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
+
 namespace gs {
 
 namespace runtime {
@@ -133,7 +135,7 @@ class Project {
   }
 
   template <typename EXPR_T>
-  static Context map_value_general(
+  static bl::result<Context> map_value_general(
       const ReadTransaction& txn, Context&& ctx,
       const std::vector<ProjectExpr<EXPR_T>>& expressions, bool is_append) {
     if (!is_append) {
@@ -146,9 +148,8 @@ class Project {
         }
       }
     }
-
-    LOG(FATAL) << "not support";
-    return ctx;
+    RETURN_UNSUPPORTED_ERROR(
+        "Currently we don't support project with is_append=true");
   }
 };
 

--- a/flex/engines/graph_db/runtime/common/operators/scan.cc
+++ b/flex/engines/graph_db/runtime/common/operators/scan.cc
@@ -15,11 +15,14 @@
 
 #include "flex/engines/graph_db/runtime/common/operators/scan.h"
 
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
+
 namespace gs {
 namespace runtime {
 
-Context Scan::find_vertex_with_id(const ReadTransaction& txn, label_t label,
-                                  const Any& pk, int alias, bool scan_oid) {
+bl::result<Context> Scan::find_vertex_with_id(const ReadTransaction& txn,
+                                              label_t label, const Any& pk,
+                                              int alias, bool scan_oid) {
   if (scan_oid) {
     SLVertexColumnBuilder builder(label);
     vid_t vid;
@@ -38,7 +41,9 @@ Context Scan::find_vertex_with_id(const ReadTransaction& txn, label_t label,
     } else if (pk.type == PropertyType::kInt32) {
       gid = pk.AsInt32();
     } else {
-      LOG(FATAL) << "Unsupported primary key type";
+      LOG(ERROR) << "Unsupported primary key type " << pk.type;
+      RETURN_UNSUPPORTED_ERROR("Unsupported primary key type" +
+                               pk.type.ToString());
     }
     if (GlobalId::get_label_id(gid) == label) {
       vid = GlobalId::get_vid(gid);

--- a/flex/engines/graph_db/runtime/common/operators/scan.h
+++ b/flex/engines/graph_db/runtime/common/operators/scan.h
@@ -19,6 +19,9 @@
 #include "flex/engines/graph_db/runtime/common/columns/vertex_columns.h"
 #include "flex/engines/graph_db/runtime/common/context.h"
 
+#include "boost/leaf.hpp"
+
+namespace bl = boost::leaf;
 namespace gs {
 
 namespace runtime {
@@ -29,9 +32,9 @@ struct ScanParams {
 class Scan {
  public:
   template <typename PRED_T>
-  static Context scan_vertex(const ReadTransaction& txn,
-                             const ScanParams& params,
-                             const PRED_T& predicate) {
+  static bl::result<Context> scan_vertex(const ReadTransaction& txn,
+                                         const ScanParams& params,
+                                         const PRED_T& predicate) {
     Context ctx;
     if (params.tables.size() == 1) {
       label_t label = params.tables[0];
@@ -150,8 +153,9 @@ class Scan {
     return ctx;
   }
 
-  static Context find_vertex_with_id(const ReadTransaction& txn, label_t label,
-                                     const Any& pk, int alias, bool scan_oid);
+  static bl::result<Context> find_vertex_with_id(const ReadTransaction& txn,
+                                                 label_t label, const Any& pk,
+                                                 int alias, bool scan_oid);
 };
 
 }  // namespace runtime

--- a/flex/engines/graph_db/runtime/common/types.h
+++ b/flex/engines/graph_db/runtime/common/types.h
@@ -84,4 +84,37 @@ struct LabelTriplet {
 
 }  // namespace gs
 
+namespace std {
+
+// operator << for Direction
+inline std::ostream& operator<<(std::ostream& os,
+                                const gs::runtime::Direction& dir) {
+  switch (dir) {
+  case gs::runtime::Direction::kOut:
+    os << "OUT";
+    break;
+  case gs::runtime::Direction::kIn:
+    os << "IN";
+    break;
+  case gs::runtime::Direction::kBoth:
+    os << "BOTH";
+    break;
+  }
+  return os;
+}
+
+// std::to_string
+inline std::string to_string(const gs::runtime::Direction& dir) {
+  switch (dir) {
+  case gs::runtime::Direction::kOut:
+    return "OUT";
+  case gs::runtime::Direction::kIn:
+    return "IN";
+  case gs::runtime::Direction::kBoth:
+    return "BOTH";
+  }
+  return "UNKNOWN";
+}
+}  // namespace std
+
 #endif  // RUNTIME_COMMON_TYPES_H_

--- a/flex/engines/http_server/handler/graph_db_http_handler.cc
+++ b/flex/engines/http_server/handler/graph_db_http_handler.cc
@@ -863,7 +863,7 @@ graph_db_http_handler::graph_db_http_handler(uint16_t http_port,
       actors_running_(true) {
   current_graph_query_handlers_.resize(shard_num);
   all_graph_query_handlers_.resize(shard_num);
-  adhoc_query_handlers_.resize(shard_num); 
+  adhoc_query_handlers_.resize(shard_num);
   vertex_handlers_.resize(shard_num);
   edge_handlers_.resize(shard_num);
   if (enable_adhoc_handlers_) {

--- a/flex/engines/http_server/types.h
+++ b/flex/engines/http_server/types.h
@@ -60,7 +60,8 @@ using admin_query_result = payload<gs::Result<seastar::sstring>>;
 using graph_management_param =
     payload<std::pair<seastar::sstring, seastar::sstring>>;
 using graph_management_query_param =
-    payload<std::pair<seastar::sstring, std::unordered_map<seastar::sstring, seastar::sstring>>>;
+    payload<std::pair<seastar::sstring,
+                      std::unordered_map<seastar::sstring, seastar::sstring>>>;
 using procedure_query_param =
     payload<std::pair<seastar::sstring, seastar::sstring>>;
 using create_procedure_query_param =

--- a/flex/scripts/install_dependencies.sh
+++ b/flex/scripts/install_dependencies.sh
@@ -25,7 +25,7 @@ curl -L -o boost_1_75_0.tar.gz "https://graphscope.oss-cn-beijing.aliyuncs.com/d
 tar -xzf boost_1_75_0.tar.gz
 pushd boost_1_75_0 && ./bootstrap.sh --with-libraries=system,filesystem,context,program_options,regex,thread,chrono,date_time,test # unit_test_framework used by seastar
 sudo ./b2 install link=shared runtime-link=shared variant=release threading=multi
-popd && rm -rf boost_1_75_0
+popd && sudo rm -rf boost_1_75_0
 popd && rm boost_1_75_0.tar.gz
 
 pushd /tmp

--- a/flex/scripts/install_dependencies.sh
+++ b/flex/scripts/install_dependencies.sh
@@ -14,10 +14,20 @@ echo "parallelism: $parallelism"
 sudo apt-get update && sudo apt install -y \
       ninja-build ragel libhwloc-dev libnuma-dev libpciaccess-dev vim wget curl \
       git g++ libunwind-dev libgoogle-glog-dev cmake libopenmpi-dev default-jdk libcrypto++-dev \
-      libboost-all-dev libxml2-dev protobuf-compiler libprotobuf-dev libncurses5-dev libcurl4-openssl-dev
+      libxml2-dev protobuf-compiler libprotobuf-dev libncurses5-dev libcurl4-openssl-dev
 sudo apt install -y xfslibs-dev libgnutls28-dev liblz4-dev maven openssl pkg-config \
       libsctp-dev gcc make python3 systemtap-sdt-dev libtool libyaml-cpp-dev \
       libc-ares-dev stow libfmt-dev diffutils valgrind doxygen python3-pip net-tools graphviz
+
+# install boost
+pushd /tmp/
+curl -L -o boost_1_75_0.tar.gz "https://graphscope.oss-cn-beijing.aliyuncs.com/dependencies/boost_1_75_0.tar.gz"
+tar -xzf boost_1_75_0.tar.gz
+pushd boost_1_75_0 && ./bootstrap.sh \
+--with-libraries=system,filesystem,context,program_options,regex,thread,chrono,date_time # unit_test_framework used by seastar
+./b2 install link=shared runtime-link=shared variant=release threading=multi --with-test
+popd && rm -rf boost_1_75_0
+popd && rm boost_1_75_0.tar.gz
 
 pushd /tmp
 git clone https://github.com/alibaba/libgrape-lite.git

--- a/flex/scripts/install_dependencies.sh
+++ b/flex/scripts/install_dependencies.sh
@@ -23,7 +23,7 @@ sudo apt install -y xfslibs-dev libgnutls28-dev liblz4-dev maven openssl pkg-con
 pushd /tmp/
 curl -L -o boost_1_75_0.tar.gz "https://graphscope.oss-cn-beijing.aliyuncs.com/dependencies/boost_1_75_0.tar.gz"
 tar -xzf boost_1_75_0.tar.gz
-pushd boost_1_75_0 && ./bootstrap.sh --with-libraries=system,filesystem,context,program_options,regex,thread,chrono,date_time,test # unit_test_framework used by seastar
+pushd boost_1_75_0 && ./bootstrap.sh --with-libraries=system,filesystem,context,atomic,program_options,regex,thread,chrono,date_time,test # unit_test_framework used by seastar
 sudo ./b2 install link=shared runtime-link=shared variant=release threading=multi
 popd && sudo rm -rf boost_1_75_0
 rm boost_1_75_0.tar.gz

--- a/flex/scripts/install_dependencies.sh
+++ b/flex/scripts/install_dependencies.sh
@@ -26,7 +26,7 @@ tar -xzf boost_1_75_0.tar.gz
 pushd boost_1_75_0 && ./bootstrap.sh --with-libraries=system,filesystem,context,program_options,regex,thread,chrono,date_time,test # unit_test_framework used by seastar
 sudo ./b2 install link=shared runtime-link=shared variant=release threading=multi
 popd && sudo rm -rf boost_1_75_0
-popd && rm boost_1_75_0.tar.gz
+rm boost_1_75_0.tar.gz
 
 pushd /tmp
 git clone https://github.com/alibaba/libgrape-lite.git

--- a/flex/scripts/install_dependencies.sh
+++ b/flex/scripts/install_dependencies.sh
@@ -23,9 +23,8 @@ sudo apt install -y xfslibs-dev libgnutls28-dev liblz4-dev maven openssl pkg-con
 pushd /tmp/
 curl -L -o boost_1_75_0.tar.gz "https://graphscope.oss-cn-beijing.aliyuncs.com/dependencies/boost_1_75_0.tar.gz"
 tar -xzf boost_1_75_0.tar.gz
-pushd boost_1_75_0 && ./bootstrap.sh \
---with-libraries=system,filesystem,context,program_options,regex,thread,chrono,date_time # unit_test_framework used by seastar
-./b2 install link=shared runtime-link=shared variant=release threading=multi --with-test
+pushd boost_1_75_0 && ./bootstrap.sh --with-libraries=system,filesystem,context,program_options,regex,thread,chrono,date_time,test # unit_test_framework used by seastar
+sudo ./b2 install link=shared runtime-link=shared variant=release threading=multi
 popd && rm -rf boost_1_75_0
 popd && rm boost_1_75_0.tar.gz
 

--- a/flex/utils/property/types.cc
+++ b/flex/utils/property/types.cc
@@ -226,6 +226,53 @@ bool PropertyType::IsVarchar() const {
   return type_enum == impl::PropertyTypeImpl::kVarChar;
 }
 
+std::string PropertyType::ToString() const {
+  switch (type_enum) {
+  case impl::PropertyTypeImpl::kEmpty:
+    return "Empty";
+  case impl::PropertyTypeImpl::kBool:
+    return "Bool";
+  case impl::PropertyTypeImpl::kUInt8:
+    return "UInt8";
+  case impl::PropertyTypeImpl::kUInt16:
+    return "UInt16";
+  case impl::PropertyTypeImpl::kInt32:
+    return "Int32";
+  case impl::PropertyTypeImpl::kUInt32:
+    return "UInt32";
+  case impl::PropertyTypeImpl::kFloat:
+    return "Float";
+  case impl::PropertyTypeImpl::kInt64:
+    return "Int64";
+  case impl::PropertyTypeImpl::kUInt64:
+    return "UInt64";
+  case impl::PropertyTypeImpl::kDouble:
+    return "Double";
+  case impl::PropertyTypeImpl::kDate:
+    return "Date";
+  case impl::PropertyTypeImpl::kDay:
+    return "Day";
+  case impl::PropertyTypeImpl::kString:
+    return "String";
+  case impl::PropertyTypeImpl::kStringView:
+    return "StringView";
+  case impl::PropertyTypeImpl::kStringMap:
+    return "StringMap";
+  case impl::PropertyTypeImpl::kVertexGlobalId:
+    return "VertexGlobalId";
+  case impl::PropertyTypeImpl::kLabel:
+    return "Label";
+  case impl::PropertyTypeImpl::kRecordView:
+    return "RecordView";
+  case impl::PropertyTypeImpl::kRecord:
+    return "Record";
+  case impl::PropertyTypeImpl::kVarChar:
+    return "VarChar";
+  default:
+    return "Unknown";
+  }
+}
+
 /////////////////////////////// Get Type Instance
 //////////////////////////////////
 PropertyType PropertyType::Empty() {
@@ -508,7 +555,8 @@ Any ConvertStringToAny(const std::string& value, const gs::PropertyType& type) {
     return gs::Any(gs::Date(static_cast<int64_t>(std::stoll(value))));
   } else if (type == gs::PropertyType::Day()) {
     return gs::Any(gs::Day(static_cast<int64_t>(std::stoll(value))));
-  } else if (type == gs::PropertyType::String() || type == gs::PropertyType::StringMap()) {
+  } else if (type == gs::PropertyType::String() ||
+             type == gs::PropertyType::StringMap()) {
     return gs::Any(std::string(value));
   } else if (type == gs::PropertyType::Int64()) {
     return gs::Any(static_cast<int64_t>(std::stoll(value)));

--- a/flex/utils/property/types.h
+++ b/flex/utils/property/types.h
@@ -107,6 +107,7 @@ struct PropertyType {
   }
 
   bool IsVarchar() const;
+  std::string ToString() const;
 
   static PropertyType Empty();
   static PropertyType Bool();

--- a/flex/utils/result.h
+++ b/flex/utils/result.h
@@ -148,6 +148,12 @@ struct is_gs_status_type<Status> : std::true_type {};
 // calling code of a function, the function name, and the variable name.
 #define FLEX_AUTO(var, expr) ASSIGN_AND_RETURN_IF_NOT_OK(auto var, expr)
 
+// Return boost::leaf::error object with error code and error message,
+
+#define RETURN_FLEX_LEAF_ERROR(code, msg) \
+  return ::boost::leaf::new_error(        \
+      gs::Status(::gs::flex::interactive::Code::code, msg))
+
 }  // namespace gs
 
 namespace std {

--- a/flex/utils/service_utils.cc
+++ b/flex/utils/service_utils.cc
@@ -20,13 +20,6 @@ namespace gs {
 static unsigned long long lastTotalUser, lastTotalUserLow, lastTotalSys,
     lastTotalIdle;
 
-FlexException::FlexException(std::string&& error_msg)
-    : std::exception(), _err_msg(error_msg) {}
-
-FlexException::~FlexException() {}
-
-const char* FlexException::what() const noexcept { return _err_msg.c_str(); }
-
 // get current executable's directory
 std::string get_current_dir() {
   char buf[1024];

--- a/flex/utils/service_utils.h
+++ b/flex/utils/service_utils.h
@@ -123,17 +123,6 @@ inline std::string jsonToString(const nlohmann::json& json) {
   }
 }
 
-class FlexException : public std::exception {
- public:
-  explicit FlexException(std::string&& error_msg);
-  ~FlexException() override;
-
-  const char* what() const noexcept override;
-
- private:
-  std::string _err_msg;
-};
-
 // Get the directory of the current executable
 std::string get_current_dir();
 


### PR DESCRIPTION
We Introduce boost::leaf for lightweight error handling in the Interactive Ad Hoc Query Service.
For each operator, we refactor it returns a `bl::result` value, allowing the error to be caught and returned at the most outside, i.e. `adhoc_app.cc`.

In this PR, we only wrap the errors about `UNSUPPORTED` `UNIMPLEMENTED` and `BAD_REQUET` at operator level. For lower level errors, we still let it crash.  

TBD:
- GAE depends on boost::leaf via vineyard, but we don't want to depend on vineyard, so a new submodule is introduced, is this ok?

Fix #4189 


We will continue to resolve these `UNSUPPORTED` and `UNIMPLEMENTED` errors, by covering all combination of all params and operators in physical plan. 
TODO #4190