### PR TITLE
refactor(interactive): Support Fetching Meta By Calling Procedure in Compiler

### DIFF
--- a/docs/interactive_engine/neo4j/supported_cypher.md
+++ b/docs/interactive_engine/neo4j/supported_cypher.md
@@ -133,3 +133,12 @@ RETURN a, b;
 | ORDER BY |  | <input type="checkbox" disabled checked />  |  |
 | LIMIT |  | <input type="checkbox" disabled checked />  |    |
 
+Additionally, we support two types of procedure call invocations in Cypher:
+- We offer a set of built-in procedures that can be invoked directly within Cypher queries. These procedures are all prefixed with `gs.procedure.`.
+
+    | Keyword | Comments |  Example |
+    |:---|---|:---:|
+    | CALL | Retrieve schema information in a JSON format following the FLEX specification | `call gs.procedure.meta.schema();`  |
+    | CALL | Retrieve statistics information in a JSON format following the FLEX specification | `call gs.procedure.meta.statistics();`  |
+
+- User-defined procedures: Users can define custom procedures in GIE and invoke them within their Cypher queries.

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
@@ -28,6 +28,7 @@ import com.alibaba.graphscope.common.intermediate.process.SinkArg;
 import com.alibaba.graphscope.common.intermediate.process.SinkByColumns;
 import com.alibaba.graphscope.common.intermediate.process.SinkGraph;
 import com.alibaba.graphscope.common.ir.meta.IrMeta;
+import com.alibaba.graphscope.common.ir.meta.schema.SchemaSpec;
 import com.alibaba.graphscope.common.jna.IrCoreLibrary;
 import com.alibaba.graphscope.common.jna.type.*;
 import com.alibaba.graphscope.common.utils.ClassUtils;
@@ -825,7 +826,7 @@ public class IrPlan implements Closeable {
     }
 
     public IrPlan(IrMeta meta, InterOpCollection opCollection) {
-        irCoreLib.setSchema(meta.getSchema().schemaJson());
+        irCoreLib.setSchema(meta.getSchema().getSchemaSpec(SchemaSpec.Type.IR_CORE_IN_JSON));
         this.ptrPlan = irCoreLib.initLogicalPlan();
         // add snapshot to QueryParams
         for (InterOpBase op : opCollection.unmodifiableCollection()) {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/IrMeta.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/IrMeta.java
@@ -21,8 +21,6 @@ package com.alibaba.graphscope.common.ir.meta;
 import com.alibaba.graphscope.common.ir.meta.procedure.GraphStoredProcedures;
 import com.alibaba.graphscope.common.ir.meta.schema.IrGraphSchema;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 import java.util.Objects;
 
 /**
@@ -33,10 +31,10 @@ public class IrMeta {
     protected final GraphId graphId;
     protected final SnapshotId snapshotId;
     protected final IrGraphSchema schema;
-    protected final @Nullable GraphStoredProcedures storedProcedures;
+    protected final GraphStoredProcedures storedProcedures;
 
     public IrMeta(IrGraphSchema schema) {
-        this(SnapshotId.createEmpty(), schema);
+        this(GraphId.DEFAULT, SnapshotId.createEmpty(), schema, new GraphStoredProcedures());
     }
 
     public IrMeta(IrGraphSchema schema, GraphStoredProcedures storedProcedures) {
@@ -44,7 +42,7 @@ public class IrMeta {
     }
 
     public IrMeta(SnapshotId snapshotId, IrGraphSchema schema) {
-        this(GraphId.DEFAULT, snapshotId, schema, null);
+        this(GraphId.DEFAULT, snapshotId, schema, new GraphStoredProcedures());
     }
 
     public IrMeta(
@@ -55,7 +53,7 @@ public class IrMeta {
         this.graphId = graphId;
         this.snapshotId = Objects.requireNonNull(snapshotId);
         this.schema = Objects.requireNonNull(schema);
-        this.storedProcedures = storedProcedures;
+        this.storedProcedures = Objects.requireNonNull(storedProcedures);
     }
 
     public IrGraphSchema getSchema() {
@@ -66,7 +64,7 @@ public class IrMeta {
         return snapshotId;
     }
 
-    public @Nullable GraphStoredProcedures getStoredProcedures() {
+    public GraphStoredProcedures getStoredProcedures() {
         return storedProcedures;
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/fetcher/DynamicIrMetaFetcher.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/fetcher/DynamicIrMetaFetcher.java
@@ -72,7 +72,7 @@ public class DynamicIrMetaFetcher extends IrMetaFetcher implements AutoCloseable
             IrMeta meta = this.reader.readMeta();
             logger.debug(
                     "schema from remote: {}",
-                    (meta == null) ? null : meta.getSchema().schemaJson());
+                    (meta == null) ? null : meta.getSchema().getSchemaSpec());
             GraphStatistics curStats;
             // if the graph id or schema version is changed, we need to update the statistics
             if (this.currentState == null

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/fetcher/DynamicIrMetaFetcher.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/fetcher/DynamicIrMetaFetcher.java
@@ -25,6 +25,7 @@ import com.alibaba.graphscope.common.ir.meta.IrMeta;
 import com.alibaba.graphscope.common.ir.meta.IrMetaStats;
 import com.alibaba.graphscope.common.ir.meta.IrMetaTracker;
 import com.alibaba.graphscope.common.ir.meta.reader.IrMetaReader;
+import com.alibaba.graphscope.common.ir.meta.schema.SchemaSpec.Type;
 import com.alibaba.graphscope.groot.common.schema.api.GraphStatistics;
 
 import org.slf4j.Logger;
@@ -72,7 +73,7 @@ public class DynamicIrMetaFetcher extends IrMetaFetcher implements AutoCloseable
             IrMeta meta = this.reader.readMeta();
             logger.debug(
                     "schema from remote: {}",
-                    (meta == null) ? null : meta.getSchema().getSchemaSpec());
+                    (meta == null) ? null : meta.getSchema().getSchemaSpec(Type.IR_CORE_IN_JSON));
             GraphStatistics curStats;
             // if the graph id or schema version is changed, we need to update the statistics
             if (this.currentState == null

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/GraphStoredProcedures.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/GraphStoredProcedures.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class GraphStoredProcedures {
-    public static final String META_PROCEDURE_PREFIX = "graph.procedure.meta.";
+    public static final String META_PROCEDURE_PREFIX = "gs.procedure.meta.";
     private static final Logger logger = LoggerFactory.getLogger(GraphStoredProcedures.class);
     private final Map<String, StoredProcedureMeta> storedProcedureMetaMap;
     private final IrMetaReader metaReader;

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/GraphStoredProcedures.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/GraphStoredProcedures.java
@@ -18,8 +18,12 @@ package com.alibaba.graphscope.common.ir.meta.procedure;
 
 import com.alibaba.graphscope.common.ir.meta.IrMeta;
 import com.alibaba.graphscope.common.ir.meta.reader.IrMetaReader;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.commons.lang3.ObjectUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
@@ -34,9 +38,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class GraphStoredProcedures {
+    public static final String META_PROCEDURE_PREFIX = "graph.procedure.meta.";
     private static final Logger logger = LoggerFactory.getLogger(GraphStoredProcedures.class);
     private final Map<String, StoredProcedureMeta> storedProcedureMetaMap;
     private final IrMetaReader metaReader;
+
+    public GraphStoredProcedures() {
+        this.metaReader = null;
+        this.storedProcedureMetaMap = Maps.newLinkedHashMap();
+        registerBuiltInProcedures();
+    }
 
     public GraphStoredProcedures(InputStream metaStream, IrMetaReader metaReader) {
         Yaml yaml = new Yaml();
@@ -61,6 +72,38 @@ public class GraphStoredProcedures {
                             .collect(Collectors.toMap(StoredProcedureMeta::getName, k -> k));
         }
         this.metaReader = metaReader;
+        registerBuiltInProcedures();
+    }
+
+    private void registerBuiltInProcedures() {
+        // register system-built-in procedures
+        String schemaProcedure = META_PROCEDURE_PREFIX + "schema";
+        RelDataTypeFactory typeFactory = StoredProcedureMeta.typeFactory;
+        this.storedProcedureMetaMap.put(
+                schemaProcedure,
+                new StoredProcedureMeta(
+                        schemaProcedure,
+                        StoredProcedureMeta.Mode.SCHEMA,
+                        "",
+                        "",
+                        typeFactory.createStructType(
+                                ImmutableList.of(typeFactory.createSqlType(SqlTypeName.CHAR)),
+                                ImmutableList.of("schema")),
+                        ImmutableList.of(),
+                        ImmutableMap.of()));
+        String statsProcedure = META_PROCEDURE_PREFIX + "statistics";
+        this.storedProcedureMetaMap.put(
+                statsProcedure,
+                new StoredProcedureMeta(
+                        statsProcedure,
+                        StoredProcedureMeta.Mode.SCHEMA,
+                        "",
+                        "",
+                        typeFactory.createStructType(
+                                ImmutableList.of(typeFactory.createSqlType(SqlTypeName.CHAR)),
+                                ImmutableList.of("statistics")),
+                        ImmutableList.of(),
+                        ImmutableMap.of()));
     }
 
     public @Nullable StoredProcedureMeta getStoredProcedure(String procedureName) {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/StoredProcedureMeta.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/StoredProcedureMeta.java
@@ -293,14 +293,14 @@ public class StoredProcedureMeta {
                         (RexProcedureCall) summary.getLogicalPlan().getProcedureCall();
                 String metaProcedure = procedureCall.op.getName();
                 String metaInJson;
-                // call graph.procedure.meta.schema();
+                // call gs.procedure.meta.schema();
                 if (metaProcedure.endsWith("schema")) {
                     metaInJson = irMeta.getSchema().getSchemaSpec(SchemaSpec.Type.FLEX_IN_JSON);
                     ObjectMapper mapper = new ObjectMapper();
                     JsonNode rootNode = mapper.readTree(metaInJson);
                     metaInJson = mapper.writeValueAsString(rootNode.get("schema"));
                 } else if (metaProcedure.endsWith(
-                        "statistics")) { // call graph.procedure.meta.statistics();
+                        "statistics")) { // call gs.procedure.meta.statistics();
                     Preconditions.checkArgument(
                             irMeta instanceof IrMetaStats,
                             "cannot get statistics from ir meta, should be instance"

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/StoredProcedureMeta.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/procedure/StoredProcedureMeta.java
@@ -16,9 +16,22 @@
 
 package com.alibaba.graphscope.common.ir.meta.procedure;
 
+import com.alibaba.graphscope.common.client.type.ExecutionResponseListener;
 import com.alibaba.graphscope.common.config.Configs;
+import com.alibaba.graphscope.common.ir.meta.IrMeta;
+import com.alibaba.graphscope.common.ir.meta.IrMetaStats;
 import com.alibaba.graphscope.common.ir.meta.schema.GSDataTypeConvertor;
 import com.alibaba.graphscope.common.ir.meta.schema.GSDataTypeDesc;
+import com.alibaba.graphscope.common.ir.meta.schema.IrGraphStatistics;
+import com.alibaba.graphscope.common.ir.meta.schema.SchemaSpec;
+import com.alibaba.graphscope.common.ir.rex.RexProcedureCall;
+import com.alibaba.graphscope.common.ir.tools.GraphPlanExecutor;
+import com.alibaba.graphscope.common.ir.tools.GraphPlanner;
+import com.alibaba.graphscope.gaia.proto.Common;
+import com.alibaba.graphscope.gaia.proto.IrResult;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
@@ -34,8 +47,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class StoredProcedureMeta {
-    private static final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
-
+    public static final RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
     private final String name;
     private final RelDataType returnType;
     private final List<Parameter> parameters;
@@ -44,7 +56,7 @@ public class StoredProcedureMeta {
     private final String extension;
     private final Map<String, Object> options;
 
-    protected StoredProcedureMeta(
+    public StoredProcedureMeta(
             String name,
             Mode mode,
             String description,
@@ -107,6 +119,10 @@ public class StoredProcedureMeta {
                 + ", option="
                 + options
                 + '}';
+    }
+
+    public Mode getMode() {
+        return this.mode;
     }
 
     public static class Parameter {
@@ -265,10 +281,56 @@ public class StoredProcedureMeta {
         }
     }
 
-    public enum Mode {
+    public enum Mode implements GraphPlanExecutor {
         READ,
         WRITE,
-        SCHEMA
+        SCHEMA {
+            @Override
+            public void execute(
+                    GraphPlanner.Summary summary, IrMeta irMeta, ExecutionResponseListener listener)
+                    throws Exception {
+                RexProcedureCall procedureCall =
+                        (RexProcedureCall) summary.getLogicalPlan().getProcedureCall();
+                String metaProcedure = procedureCall.op.getName();
+                String metaInJson;
+                // call graph.procedure.meta.schema();
+                if (metaProcedure.endsWith("schema")) {
+                    metaInJson = irMeta.getSchema().getSchemaSpec(SchemaSpec.Type.FLEX_IN_JSON);
+                    ObjectMapper mapper = new ObjectMapper();
+                    JsonNode rootNode = mapper.readTree(metaInJson);
+                    metaInJson = mapper.writeValueAsString(rootNode.get("schema"));
+                } else if (metaProcedure.endsWith(
+                        "statistics")) { // call graph.procedure.meta.statistics();
+                    Preconditions.checkArgument(
+                            irMeta instanceof IrMetaStats,
+                            "cannot get statistics from ir meta, should be instance"
+                                    + " of %s, but is %s",
+                            IrMetaStats.class,
+                            irMeta.getClass());
+                    metaInJson =
+                            ((IrGraphStatistics) ((IrMetaStats) irMeta).getStatistics())
+                                    .getStatsJson();
+                } else {
+                    throw new IllegalArgumentException("invalid meta procedure: " + metaProcedure);
+                }
+                IrResult.Entry metaEntry =
+                        IrResult.Entry.newBuilder()
+                                .setElement(
+                                        IrResult.Element.newBuilder()
+                                                .setObject(
+                                                        Common.Value.newBuilder()
+                                                                .setStr(metaInJson)
+                                                                .build())
+                                                .build())
+                                .build();
+                listener.onNext(
+                        IrResult.Record.newBuilder()
+                                .addColumns(
+                                        IrResult.Column.newBuilder().setEntry(metaEntry).build())
+                                .build());
+                listener.onCompleted();
+            }
+        }
     }
 
     public static class Config {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/reader/HttpIrMetaReader.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/reader/HttpIrMetaReader.java
@@ -24,10 +24,7 @@ import com.alibaba.graphscope.common.ir.meta.GraphId;
 import com.alibaba.graphscope.common.ir.meta.IrMeta;
 import com.alibaba.graphscope.common.ir.meta.SnapshotId;
 import com.alibaba.graphscope.common.ir.meta.procedure.GraphStoredProcedures;
-import com.alibaba.graphscope.common.ir.meta.schema.FileFormatType;
-import com.alibaba.graphscope.common.ir.meta.schema.IrGraphSchema;
-import com.alibaba.graphscope.common.ir.meta.schema.IrGraphStatistics;
-import com.alibaba.graphscope.common.ir.meta.schema.SchemaInputStream;
+import com.alibaba.graphscope.common.ir.meta.schema.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -76,7 +73,7 @@ public class HttpIrMetaReader implements IrMetaReader {
                             new SchemaInputStream(
                                     new ByteArrayInputStream(
                                             metaInYaml.getBytes(StandardCharsets.UTF_8)),
-                                    FileFormatType.YAML)),
+                                    SchemaSpec.Type.FLEX_IN_YAML)),
                     new GraphStoredProcedures(
                             new ByteArrayInputStream(metaInYaml.getBytes(StandardCharsets.UTF_8)),
                             this));

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/reader/LocalIrMetaReader.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/reader/LocalIrMetaReader.java
@@ -21,10 +21,7 @@ import com.alibaba.graphscope.common.config.GraphConfig;
 import com.alibaba.graphscope.common.ir.meta.GraphId;
 import com.alibaba.graphscope.common.ir.meta.IrMeta;
 import com.alibaba.graphscope.common.ir.meta.procedure.GraphStoredProcedures;
-import com.alibaba.graphscope.common.ir.meta.schema.FileFormatType;
-import com.alibaba.graphscope.common.ir.meta.schema.IrGraphSchema;
-import com.alibaba.graphscope.common.ir.meta.schema.IrGraphStatistics;
-import com.alibaba.graphscope.common.ir.meta.schema.SchemaInputStream;
+import com.alibaba.graphscope.common.ir.meta.schema.*;
 import com.alibaba.graphscope.common.utils.FileUtils;
 
 import org.slf4j.Logger;
@@ -56,10 +53,15 @@ public class LocalIrMetaReader implements IrMetaReader {
         Path schemaPath =
                 (schemaURI.getScheme() == null) ? Path.of(schemaURI.getPath()) : Path.of(schemaURI);
         FileFormatType formatType = FileUtils.getFormatType(schemaUri);
+        // hack way to determine schema specification from the file format
+        SchemaSpec.Type schemaSpec =
+                formatType == FileFormatType.YAML
+                        ? SchemaSpec.Type.FLEX_IN_YAML
+                        : SchemaSpec.Type.IR_CORE_IN_JSON;
         IrGraphSchema graphSchema =
                 new IrGraphSchema(
                         new SchemaInputStream(
-                                new FileInputStream(schemaPath.toFile()), formatType));
+                                new FileInputStream(schemaPath.toFile()), schemaSpec));
         IrMeta irMeta =
                 (formatType == FileFormatType.YAML)
                         ? new IrMeta(

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/IrGraphSchema.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/IrGraphSchema.java
@@ -47,7 +47,7 @@ public class IrGraphSchema implements GraphSchema {
     public IrGraphSchema(GraphSchema graphSchema, boolean isColumnId) {
         this.graphSchema = graphSchema;
         this.isColumnId = isColumnId;
-        this.specManager = new SchemaSpecManager();
+        this.specManager = new SchemaSpecManager(this);
     }
 
     public boolean isColumnId() {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/IrGraphStatistics.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/IrGraphStatistics.java
@@ -17,6 +17,9 @@
 package com.alibaba.graphscope.common.ir.meta.schema;
 
 import com.alibaba.graphscope.groot.common.schema.api.GraphStatistics;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.google.common.base.Preconditions;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,16 +30,19 @@ import java.util.Optional;
  * Maintain Graph statistics meta for IR
  */
 public class IrGraphStatistics implements GraphStatistics {
+    private final String statsJson;
     private final GraphStatistics graphStatistics;
 
     public IrGraphStatistics(InputStream statisticsStream) throws IOException {
         String content = new String(statisticsStream.readAllBytes(), StandardCharsets.UTF_8);
         statisticsStream.close();
+        this.statsJson = content;
         this.graphStatistics = Utils.buildStatisticsFromJson(content);
     }
 
     public IrGraphStatistics(GraphStatistics statistics) {
         this.graphStatistics = statistics;
+        this.statsJson = null;
     }
 
     @Override
@@ -65,5 +71,15 @@ public class IrGraphStatistics implements GraphStatistics {
     @Override
     public String getVersion() {
         return this.graphStatistics.getVersion();
+    }
+
+    public String getStatsJson() throws Exception {
+        // todo: conversion from 'GraphStatistics' to json need to be implemented in groot
+        Preconditions.checkArgument(
+                statsJson != null, "conversion from 'GraphStatistics' to json is unsupported yet");
+        // print json in indent mode
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(SerializationFeature.INDENT_OUTPUT, false);
+        return mapper.writeValueAsString(mapper.readTree(statsJson));
     }
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpec.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpec.java
@@ -19,6 +19,13 @@
 package com.alibaba.graphscope.common.ir.meta.schema;
 
 import com.alibaba.graphscope.groot.common.schema.api.GraphSchema;
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.util.Map;
 
 public class SchemaSpec {
     private final Type type;
@@ -29,8 +36,19 @@ public class SchemaSpec {
         this.content = content;
     }
 
-    public GraphSchema convert() {
+    public GraphSchema convert() throws JacksonException {
         switch (type) {
+            case IR_CORE_IN_JSON:
+                return Utils.buildSchemaFromJson(content);
+            case FLEX_IN_YAML:
+                return Utils.buildSchemaFromYaml(content);
+            case FLEX_IN_JSON:
+            default:
+                ObjectMapper mapper = new ObjectMapper();
+                JsonNode rootNode = mapper.readTree(content);
+                Map rootMap = mapper.convertValue(rootNode, Map.class);
+                Yaml yaml = new Yaml();
+                return Utils.buildSchemaFromYaml(yaml.dump(rootMap));
         }
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpec.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpec.java
@@ -18,22 +18,33 @@
 
 package com.alibaba.graphscope.common.ir.meta.schema;
 
-import java.io.InputStream;
+import com.alibaba.graphscope.groot.common.schema.api.GraphSchema;
 
-public class SchemaInputStream {
-    private final InputStream inputStream;
-    private final SchemaSpec.Type type;
+public class SchemaSpec {
+    private final Type type;
+    private final String content;
 
-    public SchemaInputStream(InputStream inputStream, SchemaSpec.Type type) {
-        this.inputStream = inputStream;
+    public SchemaSpec(Type type, String content) {
         this.type = type;
+        this.content = content;
     }
 
-    public InputStream getInputStream() {
-        return inputStream;
+    public GraphSchema convert() {
+        switch (type) {
+        }
     }
 
-    public SchemaSpec.Type getType() {
+    public String getContent() {
+        return content;
+    }
+
+    public Type getType() {
         return type;
+    }
+
+    public enum Type {
+        IR_CORE_IN_JSON,
+        FLEX_IN_JSON,
+        FLEX_IN_YAML;
     }
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpecManager.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpecManager.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *  * Copyright 2020 Alibaba Group Holding Limited.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.alibaba.graphscope.common.ir.meta.schema;
+
+import com.alibaba.graphscope.groot.common.util.IrSchemaParser;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+
+public class SchemaSpecManager {
+    private final IrGraphSchema parent;
+    private final List<SchemaSpec> specifications;
+
+    public SchemaSpecManager(IrGraphSchema parent, SchemaSpec input) {
+        this.parent = parent;
+        this.specifications = Lists.newArrayList(input);
+    }
+
+    public SchemaSpec getSpec(SchemaSpec.Type type) {
+        // if not exist, try to register it
+        for (SchemaSpec spec : specifications) {
+            if (spec.getType() == type) {
+                return spec;
+            }
+        }
+        // create a new JsonSpecification with content converted from others
+
+    }
+
+    private SchemaSpec convert(SchemaSpec source, SchemaSpec.Type target) {
+        if (source.getType() == target) {
+            return source;
+        }
+        switch (target) {
+            case IR_CORE_IN_JSON:
+                return new SchemaSpec(
+                        target,
+                        IrSchemaParser.getInstance()
+                                .parse(parent.getGraphSchema(), parent.isColumnId()));
+            case FLEX_IN_JSON:
+                if (source.getType() == SchemaSpec.Type.FLEX_IN_YAML) {}
+
+                throw new UnsupportedOperationException(
+                        "cannot convert schema specification from ["
+                                + source.getType()
+                                + "]"
+                                + " to ["
+                                + target
+                                + "]");
+            case FLEX_IN_YAML:
+                if (source.getType() == SchemaSpec.Type.FLEX_IN_YAML) {}
+
+                throw new UnsupportedOperationException(
+                        "cannot convert schema specification from ["
+                                + source.getType()
+                                + "]"
+                                + " to ["
+                                + target
+                                + "]");
+        }
+    }
+}

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpecManager.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpecManager.java
@@ -54,14 +54,19 @@ public class SchemaSpecManager {
         }
         // if not exist, try to create a new JsonSpecification with content converted from others
         SchemaSpec newSpec;
+        List<SchemaSpec.Type> existing = Lists.newArrayList();
         for (SchemaSpec spec : specifications) {
             if ((newSpec = convert(spec, type)) != null) {
                 specifications.add(newSpec);
                 return newSpec;
             }
+            existing.add(spec.getType());
         }
         throw new IllegalArgumentException(
-                "spec type [" + type + "] cannot be converted from any existing spec types");
+                "spec type ["
+                        + type
+                        + "] cannot be converted from any existing spec types "
+                        + existing);
     }
 
     private @Nullable SchemaSpec convert(SchemaSpec source, SchemaSpec.Type target) {
@@ -82,6 +87,7 @@ public class SchemaSpecManager {
                         ObjectMapper mapper = new ObjectMapper();
                         return new SchemaSpec(target, mapper.writeValueAsString(rootMap));
                     }
+                    // todo: convert from JSON in IR_CORE to JSON in FLEX
                     return null;
                 case FLEX_IN_YAML:
                 default:
@@ -92,6 +98,7 @@ public class SchemaSpecManager {
                         Yaml yaml = new Yaml();
                         return new SchemaSpec(target, yaml.dump(rootMap));
                     }
+                    // todo: convert from JSON in IR_CORE to YAML in FlEX
                     return null;
             }
         } catch (Exception e) {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpecManager.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/schema/SchemaSpecManager.java
@@ -38,7 +38,7 @@ public class SchemaSpecManager {
 
     public SchemaSpecManager(IrGraphSchema parent) {
         this.parent = parent;
-        this.specifications = Lists.newArrayList();
+        this.specifications = Lists.newArrayList(convert(null, SchemaSpec.Type.IR_CORE_IN_JSON));
     }
 
     public SchemaSpecManager(IrGraphSchema parent, SchemaSpec input) {
@@ -69,9 +69,9 @@ public class SchemaSpecManager {
                         + existing);
     }
 
-    private @Nullable SchemaSpec convert(SchemaSpec source, SchemaSpec.Type target) {
+    private @Nullable SchemaSpec convert(@Nullable SchemaSpec source, SchemaSpec.Type target) {
         try {
-            if (source.getType() == target) {
+            if (source != null && source.getType() == target) {
                 return source;
             }
             switch (target) {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/rex/RexProcedureCall.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/rex/RexProcedureCall.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *  * Copyright 2020 Alibaba Group Holding Limited.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.alibaba.graphscope.common.ir.rex;
+
+import com.alibaba.graphscope.common.ir.meta.procedure.StoredProcedureMeta;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlOperator;
+
+import java.util.List;
+import java.util.Objects;
+
+public class RexProcedureCall extends RexCall {
+    private final StoredProcedureMeta procedureMeta;
+
+    public RexProcedureCall(
+            RelDataType type,
+            SqlOperator operator,
+            List<? extends RexNode> operands,
+            StoredProcedureMeta procedureMeta) {
+        super(type, operator, operands);
+        this.procedureMeta = Objects.requireNonNull(procedureMeta);
+    }
+
+    public StoredProcedureMeta getProcedureMeta() {
+        return procedureMeta;
+    }
+
+    public StoredProcedureMeta.Mode getMode() {
+        return this.procedureMeta.getMode();
+    }
+}

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/runtime/ffi/FfiPhysicalBuilder.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/runtime/ffi/FfiPhysicalBuilder.java
@@ -80,7 +80,7 @@ public class FfiPhysicalBuilder extends RegularPhysicalBuilder<Pointer> {
     }
 
     private static PlanPointer createDefaultPlanPointer(IrMeta irMeta) {
-        checkFfiResult(LIB.setSchema(irMeta.getSchema().schemaJson()));
+        checkFfiResult(LIB.setSchema(irMeta.getSchema().getSchemaSpec()));
         return new PlanPointer(LIB.initLogicalPlan());
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/runtime/ffi/FfiPhysicalBuilder.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/runtime/ffi/FfiPhysicalBuilder.java
@@ -20,6 +20,7 @@ import com.alibaba.graphscope.common.config.Configs;
 import com.alibaba.graphscope.common.config.FrontendConfig;
 import com.alibaba.graphscope.common.config.PegasusConfig;
 import com.alibaba.graphscope.common.ir.meta.IrMeta;
+import com.alibaba.graphscope.common.ir.meta.schema.SchemaSpec.Type;
 import com.alibaba.graphscope.common.ir.rel.*;
 import com.alibaba.graphscope.common.ir.rel.GraphLogicalAggregate;
 import com.alibaba.graphscope.common.ir.rel.GraphLogicalProject;
@@ -80,7 +81,7 @@ public class FfiPhysicalBuilder extends RegularPhysicalBuilder<Pointer> {
     }
 
     private static PlanPointer createDefaultPlanPointer(IrMeta irMeta) {
-        checkFfiResult(LIB.setSchema(irMeta.getSchema().getSchemaSpec()));
+        checkFfiResult(LIB.setSchema(irMeta.getSchema().getSchemaSpec(Type.IR_CORE_IN_JSON)));
         return new PlanPointer(LIB.initLogicalPlan());
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphBuilder.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphBuilder.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import com.alibaba.graphscope.common.config.Configs;
 import com.alibaba.graphscope.common.config.FrontendConfig;
 import com.alibaba.graphscope.common.exception.FrontendException;
+import com.alibaba.graphscope.common.ir.meta.procedure.StoredProcedureMeta;
 import com.alibaba.graphscope.common.ir.meta.schema.GraphOptSchema;
 import com.alibaba.graphscope.common.ir.meta.schema.IrGraphSchema;
 import com.alibaba.graphscope.common.ir.rel.*;
@@ -750,6 +751,15 @@ public class GraphBuilder extends RelBuilder {
     @Override
     public RexNode call(SqlOperator operator, RexNode... operands) {
         return call_(operator, ImmutableList.copyOf(operands));
+    }
+
+    public RexNode procedureCall(
+            SqlOperator operator,
+            Iterable<? extends RexNode> operands,
+            StoredProcedureMeta procedureMeta) {
+        RexCall call = (RexCall) call(operator, operands);
+        return new RexProcedureCall(
+                call.getType(), call.getOperator(), call.getOperands(), procedureMeta);
     }
 
     @Override

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanExecutor.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanExecutor.java
@@ -1,0 +1,28 @@
+/*
+ *
+ *  * Copyright 2020 Alibaba Group Holding Limited.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.alibaba.graphscope.common.ir.tools;
+
+import com.alibaba.graphscope.common.client.type.ExecutionResponseListener;
+import com.alibaba.graphscope.common.ir.meta.IrMeta;
+
+public interface GraphPlanExecutor {
+    default void execute(
+            GraphPlanner.Summary summary, IrMeta irMeta, ExecutionResponseListener listener)
+            throws Exception {}
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
To get schema, run `call graph.procedure.meta.schema();`, which returns the schema in [FLEX specification](https://app.swaggerhub.com/apis/GRAPHSCOPE/flex-api/1.0.0#/Graph/importSchemaById) in json string;
To get statistiscs, run `call graph.procedure.meta.statistics();`, which returns the statistics in [json string](https://github.com/alibaba/GraphScope/blob/main/interactive_engine/compiler/src/test/resources/statistics/modern_statistics.json);

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

