### PR TITLE
fix(interactive): Add error handling for expression parsing and support get global id for edge

### DIFF
--- a/flex/engines/graph_db/runtime/adhoc/expr.cc
+++ b/flex/engines/graph_db/runtime/adhoc/expr.cc
@@ -18,11 +18,16 @@
 namespace gs {
 
 namespace runtime {
+Expr::Expr() : expr_(nullptr) {}
 
-Expr::Expr(const ReadTransaction& txn, const Context& ctx,
-           const std::map<std::string, std::string>& params,
-           const common::Expression& expr, VarType var_type) {
-  expr_ = parse_expression(txn, ctx, params, expr, var_type);
+bl::result<Expr> Expr::MakeExpr(
+    const ReadTransaction& txn, const Context& ctx,
+    const std::map<std::string, std::string>& params,
+    const common::Expression& expr, VarType var_type) {
+  Expr expression;
+  BOOST_LEAF_ASSIGN(expression.expr_,
+                    parse_expression(txn, ctx, params, expr, var_type));
+  return expression;
 }
 
 RTAny Expr::eval_path(size_t idx) const {

--- a/flex/engines/graph_db/runtime/adhoc/expr.h
+++ b/flex/engines/graph_db/runtime/adhoc/expr.h
@@ -18,6 +18,7 @@
 #include "flex/engines/graph_db/database/read_transaction.h"
 
 #include "flex/engines/graph_db/runtime/adhoc/expr_impl.h"
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
 #include "flex/engines/graph_db/runtime/common/rt_any.h"
 
 namespace gs {
@@ -26,9 +27,11 @@ namespace runtime {
 
 class Expr {
  public:
-  Expr(const ReadTransaction& txn, const Context& ctx,
-       const std::map<std::string, std::string>& params,
-       const common::Expression& expr, VarType var_type);
+  Expr();
+  static bl::result<Expr> MakeExpr(
+      const ReadTransaction& txn, const Context& ctx,
+      const std::map<std::string, std::string>& params,
+      const common::Expression& expr, VarType var_type);
 
   RTAny eval_path(size_t idx) const;
   RTAny eval_vertex(label_t label, vid_t v, size_t idx) const;

--- a/flex/engines/graph_db/runtime/adhoc/expr_impl.h
+++ b/flex/engines/graph_db/runtime/adhoc/expr_impl.h
@@ -19,6 +19,7 @@
 #include "flex/proto_generated_gie/expr.pb.h"
 
 #include "flex/engines/graph_db/runtime/adhoc/var.h"
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
 #include "flex/engines/graph_db/runtime/common/rt_any.h"
 
 namespace gs {
@@ -171,8 +172,10 @@ class WithInExpr : public ExprBase {
 
 class VariableExpr : public ExprBase {
  public:
-  VariableExpr(const ReadTransaction& txn, const Context& ctx,
-               const common::Variable& pb, VarType var_type);
+  VariableExpr();
+  static bl::result<std::unique_ptr<VariableExpr>> MakeVariableExpr(
+      const ReadTransaction& txn, const Context& ctx,
+      const common::Variable& pb, VarType var_type);
 
   RTAny eval_path(size_t idx) const override;
   RTAny eval_vertex(label_t label, vid_t v, size_t idx) const override;
@@ -399,7 +402,7 @@ class MapExpr : public ExprBase {
   std::vector<std::unique_ptr<ExprBase>> value_exprs;
   mutable std::vector<std::vector<RTAny>> values;
 };
-std::unique_ptr<ExprBase> parse_expression(
+bl::result<std::unique_ptr<ExprBase>> parse_expression(
     const ReadTransaction& txn, const Context& ctx,
     const std::map<std::string, std::string>& params,
     const common::Expression& expr, VarType var_type);

--- a/flex/engines/graph_db/runtime/adhoc/operators/dedup.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/dedup.cc
@@ -35,7 +35,7 @@ bl::result<Context> eval_dedup(const algebra::Dedup& opr,
       tag = key.tag().id();
     }
     if (key.has_property()) {
-      Var var(txn, ctx, key, VarType::kPathVar);
+      BOOST_LEAF_AUTO(var, Var::MakeVar(txn, ctx, key, VarType::kPathVar));
       vars.emplace_back([var](size_t i) { return var.get(i); });
       flag = true;
     } else {

--- a/flex/engines/graph_db/runtime/adhoc/operators/edge_expand.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/edge_expand.cc
@@ -70,7 +70,8 @@ bl::result<Context> eval_edge_expand(
       eep.dir = dir;
       eep.alias = alias;
 
-      GeneralEdgePredicate pred(txn, ctx, params, query_params.predicate());
+      BOOST_LEAF_AUTO(pred, GeneralEdgePredicate::MakeGeneralEdgePredicate(
+                                txn, ctx, params, query_params.predicate()));
 
       return EdgeExpand::expand_edge(txn, std::move(ctx), eep, pred);
     } else {

--- a/flex/engines/graph_db/runtime/adhoc/operators/get_v.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/get_v.cc
@@ -60,7 +60,8 @@ bl::result<Context> eval_get_v(
     p.tables = parse_tables(query_params);
     p.alias = alias;
     if (query_params.has_predicate()) {
-      GeneralVertexPredicate pred(txn, ctx, params, query_params.predicate());
+      BOOST_LEAF_AUTO(pred, GeneralVertexPredicate::MakeGeneralVertexPredicate(
+                                txn, ctx, params, query_params.predicate()));
 
       if (opt == VOpt::kItself) {
         return GetV::get_vertex_from_vertices(txn, std::move(ctx), p, pred);

--- a/flex/engines/graph_db/runtime/adhoc/operators/order_by.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/order_by.cc
@@ -70,7 +70,7 @@ bl::result<Context> eval_order_by(const algebra::OrderBy& opr,
   int keys_num = opr.pairs_size();
   for (int i = 0; i < keys_num; ++i) {
     const algebra::OrderBy_OrderingPair& pair = opr.pairs(i);
-    Var v(txn, ctx, pair.key(), VarType::kPathVar);
+    BOOST_LEAF_AUTO(v, Var::MakeVar(txn, ctx, pair.key(), VarType::kPathVar));
     CHECK(pair.order() == algebra::OrderBy_OrderingPair_Order::
                               OrderBy_OrderingPair_Order_ASC ||
           pair.order() == algebra::OrderBy_OrderingPair_Order::

--- a/flex/engines/graph_db/runtime/adhoc/operators/project.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/project.cc
@@ -65,7 +65,8 @@ bl::result<Context> eval_project(
           continue;
         }
       }
-      Expr expr(txn, ctx, params, m.expr(), VarType::kPathVar);
+      BOOST_LEAF_AUTO(
+          expr, Expr::MakeExpr(txn, ctx, params, m.expr(), VarType::kPathVar));
       int alias = -1;
       if (m.has_alias()) {
         alias = m.alias().value();
@@ -86,7 +87,8 @@ bl::result<Context> eval_project(
         }
       }
 
-      Expr expr(txn, ctx, params, m.expr(), VarType::kPathVar);
+      BOOST_LEAF_AUTO(
+          expr, Expr::MakeExpr(txn, ctx, params, m.expr(), VarType::kPathVar));
       int alias = -1;
       if (m.has_alias()) {
         alias = m.alias().value();

--- a/flex/engines/graph_db/runtime/adhoc/operators/scan.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/scan.cc
@@ -269,8 +269,9 @@ bl::result<Context> eval_scan(
     if (!has_other_type_oid && scan_opr.has_idx_predicate()) {
       if (scan_opr.has_idx_predicate() && scan_opr_params.has_predicate()) {
         Context ctx;
-        auto expr = parse_expression(
-            txn, ctx, params, scan_opr_params.predicate(), VarType::kVertexVar);
+        BOOST_LEAF_AUTO(expr, parse_expression(txn, ctx, params,
+                                               scan_opr_params.predicate(),
+                                               VarType::kVertexVar));
         std::vector<Any> oids{};
         if (!parse_idx_predicate(scan_opr.idx_predicate(), params, oids,
                                  scan_oid)) {
@@ -309,8 +310,9 @@ bl::result<Context> eval_scan(
     } else if (scan_opr.has_idx_predicate()) {
       if (scan_opr.has_idx_predicate() && scan_opr_params.has_predicate()) {
         Context ctx;
-        auto expr = parse_expression(
-            txn, ctx, params, scan_opr_params.predicate(), VarType::kVertexVar);
+        BOOST_LEAF_AUTO(expr, parse_expression(txn, ctx, params,
+                                               scan_opr_params.predicate(),
+                                               VarType::kVertexVar));
         std::vector<Any> oids{};
         if (!parse_idx_predicate(scan_opr.idx_predicate(), params, oids,
                                  scan_oid)) {
@@ -336,8 +338,9 @@ bl::result<Context> eval_scan(
 
     if (scan_opr_params.has_predicate()) {
       Context ctx;
-      auto expr = parse_expression(
-          txn, ctx, params, scan_opr_params.predicate(), VarType::kVertexVar);
+      BOOST_LEAF_AUTO(
+          expr, parse_expression(txn, ctx, params, scan_opr_params.predicate(),
+                                 VarType::kVertexVar));
       if (expr->is_optional()) {
         return Scan::scan_vertex(
             txn, scan_params, [&expr](label_t label, vid_t vid) {

--- a/flex/engines/graph_db/runtime/adhoc/operators/select.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/select.cc
@@ -23,7 +23,8 @@ namespace runtime {
 bl::result<Context> eval_select(
     const algebra::Select& opr, const ReadTransaction& txn, Context&& ctx,
     const std::map<std::string, std::string>& params) {
-  Expr expr(txn, ctx, params, opr.predicate(), VarType::kPathVar);
+  BOOST_LEAF_AUTO(expr, Expr::MakeExpr(txn, ctx, params, opr.predicate(),
+                                       VarType::kPathVar));
   std::vector<size_t> offsets;
   size_t row_num = ctx.row_num();
   if (expr.is_optional()) {

--- a/flex/engines/graph_db/runtime/adhoc/predicates.h
+++ b/flex/engines/graph_db/runtime/adhoc/predicates.h
@@ -19,6 +19,7 @@
 #include "flex/engines/graph_db/runtime/adhoc/expr.h"
 #include "flex/engines/graph_db/runtime/adhoc/var.h"
 #include "flex/engines/graph_db/runtime/common/context.h"
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
 #include "flex/proto_generated_gie/expr.pb.h"
 
 namespace gs {
@@ -26,10 +27,15 @@ namespace gs {
 namespace runtime {
 
 struct GeneralPathPredicate {
-  GeneralPathPredicate(const ReadTransaction& txn, const Context& ctx,
-                       const std::map<std::string, std::string>& params,
-                       const common::Expression& expr)
-      : expr_(txn, ctx, params, expr, VarType::kPathVar) {}
+  GeneralPathPredicate(Expr&& expr) : expr_(std::move(expr)) {}
+  static bl::result<GeneralPathPredicate> MakeGeneralPathPredicate(
+      const ReadTransaction& txn, const Context& ctx,
+      const std::map<std::string, std::string>& params,
+      const common::Expression& expr) {
+    BOOST_LEAF_AUTO(expression,
+                    Expr::MakeExpr(txn, ctx, params, expr, VarType::kPathVar));
+    return GeneralPathPredicate(std::move(expression));
+  }
 
   bool operator()(size_t idx) const {
     auto val = expr_.eval_path(idx);
@@ -40,10 +46,15 @@ struct GeneralPathPredicate {
 };
 
 struct GeneralVertexPredicate {
-  GeneralVertexPredicate(const ReadTransaction& txn, const Context& ctx,
-                         const std::map<std::string, std::string>& params,
-                         const common::Expression& expr)
-      : expr_(txn, ctx, params, expr, VarType::kVertexVar) {}
+  GeneralVertexPredicate(Expr&& expr) : expr_(std::move(expr)) {}
+  static bl::result<GeneralVertexPredicate> MakeGeneralVertexPredicate(
+      const ReadTransaction& txn, const Context& ctx,
+      const std::map<std::string, std::string>& params,
+      const common::Expression& expr) {
+    BOOST_LEAF_AUTO(expression, Expr::MakeExpr(txn, ctx, params, expr,
+                                               VarType::kVertexVar));
+    return GeneralVertexPredicate(std::move(expression));
+  }
 
   bool operator()(label_t label, vid_t v, size_t path_idx) const {
     auto val = expr_.eval_vertex(label, v, path_idx);
@@ -54,10 +65,15 @@ struct GeneralVertexPredicate {
 };
 
 struct GeneralEdgePredicate {
-  GeneralEdgePredicate(const ReadTransaction& txn, const Context& ctx,
-                       const std::map<std::string, std::string>& params,
-                       const common::Expression& expr)
-      : expr_(txn, ctx, params, expr, VarType::kEdgeVar) {}
+  GeneralEdgePredicate(Expr&& expr) : expr_(std::move(expr)) {}
+  static bl::result<GeneralEdgePredicate> MakeGeneralEdgePredicate(
+      const ReadTransaction& txn, const Context& ctx,
+      const std::map<std::string, std::string>& params,
+      const common::Expression& expr) {
+    BOOST_LEAF_AUTO(expression,
+                    Expr::MakeExpr(txn, ctx, params, expr, VarType::kEdgeVar));
+    return GeneralEdgePredicate(std::move(expression));
+  }
 
   bool operator()(const LabelTriplet& label, vid_t src, vid_t dst,
                   const Any& edata, Direction dir, size_t path_idx) const {

--- a/flex/engines/graph_db/runtime/adhoc/var.cc
+++ b/flex/engines/graph_db/runtime/adhoc/var.cc
@@ -23,27 +23,28 @@ namespace gs {
 
 namespace runtime {
 
-Var::Var(const ReadTransaction& txn, const Context& ctx,
-         const common::Variable& pb, VarType var_type)
-    : getter_(nullptr) {
+Var::Var() : getter_(nullptr) {}
+bl::result<Var> Var::MakeVar(const ReadTransaction& txn, const Context& ctx,
+                             const common::Variable& pb, VarType var_type) {
+  Var var;
   int tag = -1;
-  type_ = RTAnyType::kUnknown;
+  var.type_ = RTAnyType::kUnknown;
   if (pb.has_node_type()) {
-    type_ = parse_from_ir_data_type(pb.node_type());
+    var.type_ = parse_from_ir_data_type(pb.node_type());
   }
   if (pb.has_tag()) {
     tag = pb.tag().id();
   }
 
-  if (type_ == RTAnyType::kUnknown) {
+  if (var.type_ == RTAnyType::kUnknown) {
     if (pb.has_tag()) {
       tag = pb.tag().id();
       CHECK(ctx.get(tag) != nullptr);
-      type_ = ctx.get(tag)->elem_type();
+      var.type_ = ctx.get(tag)->elem_type();
     } else if (pb.has_property() && pb.property().has_label()) {
-      type_ = RTAnyType::kI64Value;
+      var.type_ = RTAnyType::kI64Value;
     } else {
-      LOG(FATAL) << "not support";
+      RETURN_UNSUPPORTED_ERROR("not support for var: " + pb.DebugString());
     }
   }
 
@@ -53,117 +54,133 @@ Var::Var(const ReadTransaction& txn, const Context& ctx,
       if (pb.has_property()) {
         auto& pt = pb.property();
         if (pt.has_id()) {
-          getter_ = std::make_shared<VertexGIdPathAccessor>(ctx, tag);
+          var.getter_ = std::make_shared<VertexGIdPathAccessor>(ctx, tag);
         } else if (pt.has_key()) {
           if (pt.key().name() == "id") {
-            if (type_ == RTAnyType::kStringValue) {
-              getter_ =
+            if (var.type_ == RTAnyType::kStringValue) {
+              var.getter_ =
                   std::make_shared<VertexIdPathAccessor<std::string_view>>(
                       txn, ctx, tag);
-            } else if (type_ == RTAnyType::kI32Value) {
-              getter_ = std::make_shared<VertexIdPathAccessor<int32_t>>(
+            } else if (var.type_ == RTAnyType::kI32Value) {
+              var.getter_ = std::make_shared<VertexIdPathAccessor<int32_t>>(
                   txn, ctx, tag);
-            } else if (type_ == RTAnyType::kI64Value) {
-              getter_ = std::make_shared<VertexIdPathAccessor<int64_t>>(
+            } else if (var.type_ == RTAnyType::kI64Value) {
+              var.getter_ = std::make_shared<VertexIdPathAccessor<int64_t>>(
                   txn, ctx, tag);
             } else {
-              LOG(FATAL) << "not support for "
-                         << static_cast<int>(type_.type_enum_);
+              RETURN_UNSUPPORTED_ERROR(
+                  "not support for " +
+                  std::to_string(static_cast<int>(var.type_.type_enum_)));
             }
           } else {
-            getter_ = create_vertex_property_path_accessor(txn, ctx, tag, type_,
-                                                           pt.key().name());
+            var.getter_ = create_vertex_property_path_accessor(
+                txn, ctx, tag, var.type_, pt.key().name());
           }
         } else if (pt.has_label()) {
-          getter_ = create_vertex_label_path_accessor(ctx, tag);
+          var.getter_ = create_vertex_label_path_accessor(ctx, tag);
         } else {
-          LOG(FATAL) << "xxx, " << pt.item_case();
+          RETURN_UNSUPPORTED_ERROR("Supported property for vertex : " +
+                                   pt.DebugString());
         }
       } else {
-        getter_ = std::make_shared<VertexPathAccessor>(ctx, tag);
+        var.getter_ = std::make_shared<VertexPathAccessor>(ctx, tag);
       }
     } else if (ctx.get(tag)->column_type() == ContextColumnType::kValue ||
                ctx.get(tag)->column_type() ==
                    ContextColumnType::kOptionalValue) {
-      getter_ = create_context_value_accessor(ctx, tag, type_);
+      var.getter_ = create_context_value_accessor(ctx, tag, var.type_);
     } else if (ctx.get(tag)->column_type() == ContextColumnType::kEdge) {
       if (pb.has_property()) {
         auto& pt = pb.property();
         if (pt.has_key()) {
           auto name = pt.key().name();
-          getter_ =
-              create_edge_property_path_accessor(txn, name, ctx, tag, type_);
+          var.getter_ = create_edge_property_path_accessor(txn, name, ctx, tag,
+                                                           var.type_);
         } else if (pt.has_label()) {
-          getter_ = create_edge_label_path_accessor(ctx, tag);
+          var.getter_ = create_edge_label_path_accessor(ctx, tag);
+        } else if (pt.has_id()) {
+          var.getter_ = create_edge_global_id_path_accessor(ctx, tag);
         } else {
-          LOG(FATAL) << "not support...";
+          RETURN_UNSUPPORTED_ERROR("Supported property for edge: " +
+                                   pt.DebugString());
         }
       } else {
-        getter_ = std::make_shared<EdgeIdPathAccessor>(ctx, tag);
+        var.getter_ = std::make_shared<EdgeIdPathAccessor>(ctx, tag);
         // LOG(FATAL) << "not support for edge column - " << tag;
       }
     } else if (ctx.get(tag)->column_type() == ContextColumnType::kPath) {
       if (pb.has_property()) {
         auto& pt = pb.property();
         if (pt.has_len()) {
-          getter_ = std::make_shared<PathLenPathAccessor>(ctx, tag);
+          var.getter_ = std::make_shared<PathLenPathAccessor>(ctx, tag);
         } else {
-          LOG(FATAL) << "not support for path column - " << pt.DebugString();
+          RETURN_UNSUPPORTED_ERROR("Supported property for path: " +
+                                   pt.DebugString());
         }
       } else {
-        getter_ = std::make_shared<PathIdPathAccessor>(ctx, tag);
+        var.getter_ = std::make_shared<PathIdPathAccessor>(ctx, tag);
       }
     } else {
-      LOG(FATAL) << "not support for " << ctx.get(tag)->column_info();
+      RETURN_UNSUPPORTED_ERROR(
+          "not support for column type: " +
+          std::to_string(static_cast<int>(ctx.get(tag)->column_type())));
     }
   } else {
     if (var_type == VarType::kVertexVar) {
       if (pb.has_property()) {
         auto& pt = pb.property();
         if (pt.has_id()) {
-          getter_ = std::make_shared<VertexGIdVertexAccessor>();
+          var.getter_ = std::make_shared<VertexGIdVertexAccessor>();
         } else if (pt.has_key()) {
           if (pt.key().name() == "id") {
-            if (type_ == RTAnyType::kStringValue) {
-              getter_ =
+            if (var.type_ == RTAnyType::kStringValue) {
+              var.getter_ =
                   std::make_shared<VertexIdVertexAccessor<std::string_view>>(
                       txn);
-            } else if (type_ == RTAnyType::kI32Value) {
-              getter_ = std::make_shared<VertexIdVertexAccessor<int32_t>>(txn);
-            } else if (type_ == RTAnyType::kI64Value) {
-              getter_ = std::make_shared<VertexIdVertexAccessor<int64_t>>(txn);
+            } else if (var.type_ == RTAnyType::kI32Value) {
+              var.getter_ =
+                  std::make_shared<VertexIdVertexAccessor<int32_t>>(txn);
+            } else if (var.type_ == RTAnyType::kI64Value) {
+              var.getter_ =
+                  std::make_shared<VertexIdVertexAccessor<int64_t>>(txn);
             } else {
-              LOG(FATAL) << "not support for "
-                         << static_cast<int>(type_.type_enum_);
+              RETURN_UNSUPPORTED_ERROR(
+                  "not support for " +
+                  std::to_string(static_cast<int>(var.type_.type_enum_)));
             }
           } else {
-            getter_ = create_vertex_property_vertex_accessor(txn, type_,
-                                                             pt.key().name());
+            var.getter_ = create_vertex_property_vertex_accessor(
+                txn, var.type_, pt.key().name());
           }
         } else if (pt.has_label()) {
-          getter_ = std::make_shared<VertexLabelVertexAccessor>();
+          var.getter_ = std::make_shared<VertexLabelVertexAccessor>();
         } else {
-          LOG(FATAL) << "xxx, " << pt.item_case();
+          RETURN_UNSUPPORTED_ERROR("Supported property for vertex : " +
+                                   pt.DebugString());
         }
       } else {
-        LOG(FATAL) << "not support";
+        RETURN_UNSUPPORTED_ERROR("not support for vertex var with no property");
       }
     } else if (var_type == VarType::kEdgeVar) {
       if (pb.has_property()) {
         auto& pt = pb.property();
         if (pt.has_key()) {
           auto name = pt.key().name();
-          getter_ = create_edge_property_edge_accessor(txn, name, type_);
+          var.getter_ =
+              create_edge_property_edge_accessor(txn, name, var.type_);
         } else {
-          LOG(FATAL) << "not support";
+          RETURN_UNSUPPORTED_ERROR("Supported property for edge: " +
+                                   pt.DebugString());
         }
       } else {
-        LOG(FATAL) << "not support";
+        RETURN_UNSUPPORTED_ERROR("not support for edge var with no property");
       }
     } else {
-      LOG(FATAL) << "not support";
+      RETURN_UNSUPPORTED_ERROR("not support for var type: " +
+                               std::to_string(static_cast<int>(var_type)));
     }
   }
+  return var;
 }
 
 Var::~Var() {}

--- a/flex/engines/graph_db/runtime/adhoc/var.h
+++ b/flex/engines/graph_db/runtime/adhoc/var.h
@@ -20,6 +20,7 @@
 
 #include "flex/engines/graph_db/runtime/common/accessors.h"
 #include "flex/engines/graph_db/runtime/common/context.h"
+#include "flex/engines/graph_db/runtime/common/leaf_utils.h"
 
 #include "flex/proto_generated_gie/expr.pb.h"
 
@@ -45,8 +46,9 @@ class VarGetterBase {
 
 class Var {
  public:
-  Var(const ReadTransaction& txn, const Context& ctx,
-      const common::Variable& pb, VarType var_type);
+  static bl::result<Var> MakeVar(const ReadTransaction& txn, const Context& ctx,
+                                 const common::Variable& pb, VarType var_type);
+  Var();
   ~Var();
 
   RTAny get(size_t path_idx) const;

--- a/flex/engines/graph_db/runtime/common/accessors.cc
+++ b/flex/engines/graph_db/runtime/common/accessors.cc
@@ -175,6 +175,11 @@ std::shared_ptr<IAccessor> create_edge_label_path_accessor(const Context& ctx,
   return std::make_shared<EdgeLabelPathAccessor>(ctx, tag);
 }
 
+std::shared_ptr<IAccessor> create_edge_global_id_path_accessor(
+    const Context& ctx, int tag) {
+  return std::make_shared<EdgeGlobalIdPathAccessor>(ctx, tag);
+}
+
 std::shared_ptr<IAccessor> create_edge_property_edge_accessor(
     const ReadTransaction& txn, const std::string& prop_name, RTAnyType type) {
   bool multip_properties = txn.schema().has_multi_props_edge();

--- a/flex/engines/graph_db/runtime/common/accessors.h
+++ b/flex/engines/graph_db/runtime/common/accessors.h
@@ -398,6 +398,73 @@ class EdgeIdPathAccessor : public IAccessor {
   const IEdgeColumn& edge_col_;
 };
 
+// Access the global edge id of an edge in a path
+// Currently we have no unique id for a edge.
+// We construct the id from the edge's src, dst and label.
+class EdgeGlobalIdPathAccessor : public IAccessor {
+ public:
+  using elem_t = int64_t;  // edge global id
+  EdgeGlobalIdPathAccessor(const Context& ctx, int tag)
+      : edge_col_(*std::dynamic_pointer_cast<IEdgeColumn>(ctx.get(tag))) {}
+
+  static uint32_t generate_edge_label_id(label_t src_label_id,
+                                         label_t dst_label_id,
+                                         label_t edge_label_id) {
+    uint32_t unique_edge_label_id = src_label_id;
+    static constexpr int num_bits = sizeof(label_t) * 8;
+    unique_edge_label_id = unique_edge_label_id << num_bits;
+    unique_edge_label_id = unique_edge_label_id | dst_label_id;
+    unique_edge_label_id = unique_edge_label_id << num_bits;
+    unique_edge_label_id = unique_edge_label_id | edge_label_id;
+    return unique_edge_label_id;
+  }
+
+  static int64_t encode_unique_edge_id(uint32_t label_id, vid_t src,
+                                       vid_t dst) {
+    // We assume label_id is only used by 24 bits.
+    int64_t unique_edge_id = label_id;
+    unique_edge_id = unique_edge_id << 40;
+    // bitmask for top 40 bits set to 1
+    int64_t bitmask = 0xFFFFFFFFFF000000;
+    // 24 bit | 20 bit | 20 bit
+    if (bitmask & (int64_t) src || bitmask & (int64_t) dst) {
+      LOG(ERROR) << "src or dst is too large to be encoded in 20 bits: " << src
+                 << " " << dst;
+    }
+    unique_edge_id = unique_edge_id | (src << 20);
+    unique_edge_id = unique_edge_id | dst;
+    return unique_edge_id;
+  }
+
+  elem_t typed_eval_path(size_t idx) const {
+    const auto& e = edge_col_.get_edge(idx);
+    auto label_id = generate_edge_label_id(std::get<0>(e).src_label,
+                                           std::get<0>(e).dst_label,
+                                           std::get<0>(e).edge_label);
+    return encode_unique_edge_id(label_id, std::get<1>(e), std::get<2>(e));
+  }
+
+  RTAny eval_path(size_t idx) const override {
+    return RTAny::from_int64(typed_eval_path(idx));
+  }
+
+  bool is_optional() const override { return edge_col_.is_optional(); }
+
+  RTAny eval_path(size_t idx, int) const override {
+    if (!edge_col_.has_value(idx)) {
+      return RTAny(RTAnyType::kNull);
+    }
+    return RTAny::from_int64(typed_eval_path(idx));
+  }
+
+  std::shared_ptr<IContextColumnBuilder> builder() const override {
+    return edge_col_.builder();
+  }
+
+ private:
+  const IEdgeColumn& edge_col_;
+};
+
 template <typename T>
 class EdgePropertyPathAccessor : public IAccessor {
  public:
@@ -763,6 +830,9 @@ std::shared_ptr<IAccessor> create_edge_property_path_accessor(
 
 std::shared_ptr<IAccessor> create_edge_label_path_accessor(const Context& ctx,
                                                            int tag);
+
+std::shared_ptr<IAccessor> create_edge_global_id_path_accessor(
+    const Context& ctx, int tag);
 
 std::shared_ptr<IAccessor> create_edge_property_edge_accessor(
     const ReadTransaction& txn, const std::string& prop_name, RTAnyType type);

--- a/flex/engines/graph_db/runtime/common/leaf_utils.h
+++ b/flex/engines/graph_db/runtime/common/leaf_utils.h
@@ -21,16 +21,22 @@
 
 namespace bl = boost::leaf;
 
-#define RETURN_UNSUPPORTED_ERROR(msg) \
-  return ::boost::leaf::new_error(    \
-      ::gs::Status(::gs::StatusCode::UNSUPPORTED_OPERATION, msg))
+// Concatenate the current function name and line number to form the error
+// message
+#define PREPEND_LINE_INFO(msg)                             \
+  std::string(__FILE__) + ":" + std::to_string(__LINE__) + \
+      " func: " + std::string(__FUNCTION__) + ", " + msg
+
+#define RETURN_UNSUPPORTED_ERROR(msg)           \
+  return ::boost::leaf::new_error(::gs::Status( \
+      ::gs::StatusCode::UNSUPPORTED_OPERATION, PREPEND_LINE_INFO(msg)))
 
 #define RETURN_BAD_REQUEST_ERROR(msg) \
   return ::boost::leaf::new_error(    \
-      ::gs::Status(::gs::StatusCode::BAD_REQUEST, msg))
+      ::gs::Status(::gs::StatusCode::BAD_REQUEST, PREPEND_LINE_INFO(msg)))
 
 #define RETURN_NOT_IMPLEMENTED_ERROR(msg) \
   return ::boost::leaf::new_error(        \
-      ::gs::Status(::gs::StatusCode::UNIMPLEMENTED, msg))
+      ::gs::Status(::gs::StatusCode::UNIMPLEMENTED, PREPEND_LINE_INFO(msg)))
 
 #endif  // RUNTIME_COMMON_LEAF_UTILS_H_


### PR DESCRIPTION
- Wrap the errors may occurred when parsing the expression.
- Support getting the global id of edges.
- Add file,function and line info when returning errors.

Fix #4226 