### PR TITLE
fix(interactive): Reuse the graph schema preprocessing to create the default graph schema when the service starts

### DIFF
--- a/flex/engines/http_server/actor/admin_actor.act.cc
+++ b/flex/engines/http_server/actor/admin_actor.act.cc
@@ -104,80 +104,6 @@ std::string merge_graph_and_plugin_meta(
   return res.Empty() ? "{}" : gs::rapidjson_stringify(res, 2);
 }
 
-gs::Result<YAML::Node> preprocess_vertex_schema(YAML::Node root,
-                                                const std::string& type_name) {
-  // 1. To support open a empty graph, we should check if the x_csr_params is
-  // set for each vertex type, if not set, we set it to a rather small max_vnum,
-  // to avoid to much memory usage.
-  auto types = root[type_name];
-  for (auto type : types) {
-    if (!type["x_csr_params"]) {
-      type["x_csr_params"]["max_vertex_num"] = 8192;
-    }
-  }
-  return types;
-}
-
-gs::Result<YAML::Node> preprocess_vertex_edge_types(
-    YAML::Node root, const std::string& type_name) {
-  auto types = root[type_name];
-  int32_t cur_type_id = 0;
-  for (auto type : types) {
-    if (type["type_id"]) {
-      auto type_id = type["type_id"].as<int32_t>();
-      if (type_id != cur_type_id) {
-        return gs::Status(gs::StatusCode::INVALID_SCHEMA,
-                          "Invalid " + type_name +
-                              " type_id: " + std::to_string(type_id) +
-                              ", expect: " + std::to_string(cur_type_id));
-      }
-    } else {
-      type["type_id"] = cur_type_id;
-    }
-    cur_type_id++;
-    int32_t cur_prop_id = 0;
-    if (type["properties"]) {
-      for (auto prop : type["properties"]) {
-        if (prop["property_id"]) {
-          auto prop_id = prop["property_id"].as<int32_t>();
-          if (prop_id != cur_prop_id) {
-            return gs::Status(gs::StatusCode::INVALID_SCHEMA,
-                              "Invalid " + type_name + " property_id: " +
-                                  type["type_name"].as<std::string>() + " : " +
-                                  std::to_string(prop_id) +
-                                  ", expect: " + std::to_string(cur_prop_id));
-          }
-        } else {
-          prop["property_id"] = cur_prop_id;
-        }
-        cur_prop_id++;
-      }
-    }
-  }
-  return types;
-}
-
-// Preprocess the schema to be compatible with the current storage.
-// 1. check if any property_id or type_id is set for each type, If set, then all
-// vertex/edge types should all set.
-// 2. If property_id or type_id is not set, then set them according to the order
-gs::Result<YAML::Node> preprocess_graph_schema(YAML::Node&& node) {
-  if (node["schema"] && node["schema"]["vertex_types"]) {
-    // First check whether property_id or type_id is set in the schema
-    RETURN_IF_NOT_OK(
-        preprocess_vertex_edge_types(node["schema"], "vertex_types"));
-    RETURN_IF_NOT_OK(preprocess_vertex_schema(node["schema"], "vertex_types"));
-    if (node["schema"]["edge_types"]) {
-      // edge_type could be optional.
-      RETURN_IF_NOT_OK(
-          preprocess_vertex_edge_types(node["schema"], "edge_types"));
-    }
-    return node;
-  } else {
-    return gs::Status(gs::StatusCode::INVALID_SCHEMA, "Invalid graph schema: ");
-  }
-}
-
 void add_runnable_info(gs::PluginMeta& plugin_meta) {
   const auto& graph_db = gs::GraphDB::get();
   const auto& schema = graph_db.schema();
@@ -405,59 +331,18 @@ seastar::future<admin_query_result> admin_actor::run_create_graph(
     query_param&& query_param) {
   LOG(INFO) << "Creating Graph: " << query_param.content;
 
-  YAML::Node yaml;
-
-  try {
-    rapidjson::Document doc;
-    if (doc.Parse(query_param.content.c_str()).HasParseError()) {
-      throw std::runtime_error("Fail to parse json: " +
-                               std::to_string(doc.GetParseError()));
-    }
-    std::stringstream json_ss;
-    json_ss << query_param.content;
-    yaml = YAML::Load(json_ss);
-  } catch (std::exception& e) {
-    LOG(ERROR) << "Fail to parse json: " << e.what();
+  auto request = gs::CreateGraphMetaRequest::FromJson(query_param.content);
+  if (!request.ok()) {
+    LOG(ERROR) << "Fail to parse graph meta: "
+               << request.status().error_message();
     return seastar::make_ready_future<admin_query_result>(
-        gs::Result<seastar::sstring>(
-            gs::Status(gs::StatusCode::INVALID_SCHEMA,
-                       "Fail to parse json: " + std::string(e.what()))));
-  } catch (...) {
-    LOG(ERROR) << "Fail to parse json: " << query_param.content;
-    return seastar::make_ready_future<admin_query_result>(
-        gs::Result<seastar::sstring>(gs::Status(gs::StatusCode::INVALID_SCHEMA,
-                                                "Fail to parse json: ")));
+        gs::Result<seastar::sstring>(request.status()));
   }
-  // preprocess the schema yaml,
-  auto res_yaml = preprocess_graph_schema(std::move(yaml));
-  if (!res_yaml.ok()) {
-    return seastar::make_ready_future<admin_query_result>(
-        gs::Result<seastar::sstring>(res_yaml.status()));
-  }
-  auto& yaml_value = res_yaml.value();
-  // set default value
-  if (!yaml_value["store_type"]) {
-    yaml_value["store_type"] = "mutable_csr";
-  }
-
-  auto parse_schema_res = gs::Schema::LoadFromYamlNode(yaml_value);
-  if (!parse_schema_res.ok()) {
-    return seastar::make_ready_future<admin_query_result>(
-        gs::Result<seastar::sstring>(parse_schema_res.status()));
-  }
-
-  auto real_schema_json = gs::get_json_string_from_yaml(yaml_value);
-  if (!real_schema_json.ok()) {
-    return seastar::make_ready_future<admin_query_result>(
-        gs::Result<seastar::sstring>(real_schema_json.status()));
-  }
-
-  auto result = metadata_store_->CreateGraphMeta(
-      gs::CreateGraphMetaRequest::FromJson(real_schema_json.value()));
+  auto result = metadata_store_->CreateGraphMeta(request.value());
   // we also need to store a graph.yaml on disk, for other services to read.
   if (result.ok()) {
-    auto dump_res =
-        WorkDirManipulator::DumpGraphSchema(result.value(), res_yaml.value());
+    auto dump_res = WorkDirManipulator::DumpGraphSchema(
+        result.value(), request.value().ToString());
     if (!dump_res.ok()) {
       LOG(ERROR) << "Fail to dump graph schema: "
                  << dump_res.status().error_message();

--- a/flex/engines/http_server/graph_db_service.cc
+++ b/flex/engines/http_server/graph_db_service.cc
@@ -409,7 +409,13 @@ gs::GraphId GraphDBService::insert_default_graph_meta() {
     LOG(FATAL) << "Failed to get graph schema string: "
                << schema_str_res.status().error_message();
   }
-  auto request = gs::CreateGraphMetaRequest::FromJson(schema_str_res.value());
+  auto request_res =
+      gs::CreateGraphMetaRequest::FromJson(schema_str_res.value());
+  if (!request_res.ok()) {
+    LOG(FATAL) << "Failed to parse graph schema string: "
+               << request_res.status().error_message();
+  }
+  auto request = request_res.value();
   request.data_update_time = gs::GetCurrentTimeStamp();
 
   auto res = metadata_store_->CreateGraphMeta(request);

--- a/flex/engines/http_server/workdir_manipulator.cc
+++ b/flex/engines/http_server/workdir_manipulator.cc
@@ -149,6 +149,7 @@ gs::Result<bool> WorkDirManipulator::DumpGraphSchema(
       VLOG(10) << "Plugin is not enabled: " << plugin.name;
     }
   }
+  yaml_node["stored_procedures"] = procedures_node;
   auto dump_res = dump_graph_schema(yaml_node, graph_id);
   if (!dump_res.ok()) {
     return gs::Result<bool>(gs::Status(gs::StatusCode::PERMISSION_DENIED,

--- a/flex/engines/http_server/workdir_manipulator.cc
+++ b/flex/engines/http_server/workdir_manipulator.cc
@@ -40,6 +40,20 @@ void WorkDirManipulator::SetWorkspace(const std::string& path) {
 
 std::string WorkDirManipulator::GetWorkspace() { return workspace; }
 
+gs::Result<seastar::sstring> WorkDirManipulator::DumpGraphSchema(
+    const gs::GraphId& graph_id, const std::string& json_str) {
+  YAML::Node yaml_node;
+  try {
+    yaml_node = YAML::Load(json_str);
+
+  } catch (const std::exception& e) {
+    return gs::Result<seastar::sstring>(gs::Status(
+        gs::StatusCode::INVALID_SCHEMA,
+        "Fail to parse graph schema: " + json_str + ", error: " + e.what()));
+  }
+  return DumpGraphSchema(graph_id, yaml_node);
+}
+
 // GraphName can be specified in the config file or in the argument.
 gs::Result<seastar::sstring> WorkDirManipulator::DumpGraphSchema(
     const gs::GraphId& graph_id, const YAML::Node& yaml_config) {

--- a/flex/engines/http_server/workdir_manipulator.h
+++ b/flex/engines/http_server/workdir_manipulator.h
@@ -31,10 +31,10 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 
+#include <rapidjson/document.h>
 #include <yaml-cpp/yaml.h>
 #include <boost/process.hpp>
 #include <boost/property_tree/json_parser.hpp>
-#include <rapidjson/document.h>
 
 namespace server {
 
@@ -66,6 +66,9 @@ class WorkDirManipulator {
   static void SetWorkspace(const std::string& workspace_path);
 
   static std::string GetWorkspace();
+
+  static gs::Result<seastar::sstring> DumpGraphSchema(
+      const gs::GraphId& graph_id, const std::string& json_string);
 
   /**
    * @brief Create a graph with a given name and config.

--- a/flex/openapi/openapi_coordinator.yaml
+++ b/flex/openapi/openapi_coordinator.yaml
@@ -602,6 +602,7 @@ components:
             $ref: '#/components/schemas/GetEdgeType'
 
     GetGraphResponse:
+      additionalProperties: true
       required:
         - id
         - name

--- a/flex/openapi/openapi_interactive.yaml
+++ b/flex/openapi/openapi_interactive.yaml
@@ -1701,6 +1701,8 @@ components:
       x-body-name: get_graph_response
       type: object
       properties:
+        version:
+          type: string
         id: 
           type: string
         name:

--- a/flex/storages/metadata/graph_meta_store.cc
+++ b/flex/storages/metadata/graph_meta_store.cc
@@ -68,6 +68,7 @@ std::string Parameter::ToJson() const {
 
 void GraphMeta::ToJson(rapidjson::Value& json,
                        rapidjson::Document::AllocatorType& allocator) const {
+  json.AddMember("version", version, allocator);
   json.AddMember("id", id, allocator);
   json.AddMember("name", name, allocator);
   json.AddMember("description", description, allocator);
@@ -117,6 +118,11 @@ GraphMeta GraphMeta::FromJson(const std::string& json_str) {
 
 GraphMeta GraphMeta::FromJson(const rapidjson::Value& json) {
   GraphMeta meta;
+  if (json.HasMember("version")) {
+    meta.version = json["version"].GetString();
+  } else {
+    meta.version = "v0.1";
+  }
   if (json.HasMember("id")) {
     if (json["id"].IsInt()) {
       meta.id = json["id"].GetInt();
@@ -522,7 +528,11 @@ Result<CreateGraphMetaRequest> CreateGraphMetaRequest::FromJson(
                << real_json_str.value();
     return request;
   }
-
+  if (json.HasMember("version")) {
+    request.version = json["version"].GetString();
+  } else {
+    request.version = "v0.1";
+  }
   if (json.HasMember("name")) {
     request.name = json["name"].GetString();
   }
@@ -553,6 +563,7 @@ Result<CreateGraphMetaRequest> CreateGraphMetaRequest::FromJson(
 
 std::string CreateGraphMetaRequest::ToString() const {
   rapidjson::Document json(rapidjson::kObjectType);
+  json.AddMember("version", version, json.GetAllocator());
   json.AddMember("name", name, json.GetAllocator());
   json.AddMember("description", description, json.GetAllocator());
   {

--- a/flex/storages/metadata/graph_meta_store.h
+++ b/flex/storages/metadata/graph_meta_store.h
@@ -57,6 +57,7 @@ JobStatus parseFromString(const std::string& status_string);
 struct PluginMeta;
 struct GraphMeta {
   GraphId id;
+  std::string version;
   std::string name;
   std::string description;
   uint64_t creation_time;
@@ -128,6 +129,7 @@ struct JobMeta {
 
 ////////////////// CreateMetaRequest ///////////////////////
 struct CreateGraphMetaRequest {
+  std::string version;
   std::string name;
   std::string description;
   std::string schema;  // all in one string.

--- a/flex/storages/metadata/graph_meta_store.h
+++ b/flex/storages/metadata/graph_meta_store.h
@@ -136,7 +136,7 @@ struct CreateGraphMetaRequest {
 
   std::vector<PluginMeta> plugin_metas;
 
-  static CreateGraphMetaRequest FromJson(const std::string& json_str);
+  static Result<CreateGraphMetaRequest> FromJson(const std::string& json_str);
 
   std::string ToString() const;
 };

--- a/flex/utils/result.h
+++ b/flex/utils/result.h
@@ -122,25 +122,31 @@ struct is_gs_status_type<Status> : std::true_type {};
 // function, the function name, and the variable name.
 // reference:
 // https://github.com/boostorg/leaf/blob/develop/include/boost/leaf/error.hpp
-#define ASSIGN_AND_RETURN_IF_RESULT_NOT_OK(var, expr)                          \
-  auto&& FLEX_TMP_VAR = expr;                                                  \
-  static_assert(::gs::is_gs_result_type<                                       \
-                    typename std::decay<decltype(FLEX_TMP_VAR)>::type>::value, \
-                "The expression must return a Result type");                   \
-  if (!FLEX_TMP_VAR.ok()) {                                                    \
-    return FLEX_TMP_VAR;                                                       \
-  }                                                                            \
-  var = std::forward<decltype(FLEX_TMP_VAR)>(FLEX_TMP_VAR).move_value()
+#define ASSIGN_AND_RETURN_IF_RESULT_NOT_OK(var, expr)                      \
+  {                                                                        \
+    auto&& FLEX_TMP_VAR = expr;                                            \
+    static_assert(                                                         \
+        ::gs::is_gs_result_type<                                           \
+            typename std::decay<decltype(FLEX_TMP_VAR)>::type>::value,     \
+        "The expression must return a Result type");                       \
+    if (!FLEX_TMP_VAR.ok()) {                                              \
+      return FLEX_TMP_VAR;                                                 \
+    }                                                                      \
+    var = std::forward<decltype(FLEX_TMP_VAR)>(FLEX_TMP_VAR).move_value(); \
+  }
 
-#define ASSIGN_AND_RETURN_IF_STATUS_NOT_OK(var, expr)                          \
-  auto&& FLEX_TMP_VAR = expr;                                                  \
-  static_assert(::gs::is_gs_status_type<                                       \
-                    typename std::decay<decltype(FLEX_TMP_VAR)>::type>::value, \
-                "The expression must return a Status type");                   \
-  if (!FLEX_TMP_VAR.ok()) {                                                    \
-    return FLEX_TMP_VAR;                                                       \
-  }                                                                            \
-  var = std::forward<decltype(FLEX_TMP_VAR)>(FLEX_TMP_VAR)
+#define ASSIGN_AND_RETURN_IF_STATUS_NOT_OK(var, expr)                      \
+  {                                                                        \
+    auto&& FLEX_TMP_VAR = expr;                                            \
+    static_assert(                                                         \
+        ::gs::is_gs_status_type<                                           \
+            typename std::decay<decltype(FLEX_TMP_VAR)>::type>::value,     \
+        "The expression must return a Status type");                       \
+    if (!FLEX_TMP_VAR.ok()) {                                              \
+      return FLEX_TMP_VAR;                                                 \
+    }                                                                      \
+    var = std::forward<decltype(FLEX_TMP_VAR)>(FLEX_TMP_VAR).move_value(); \
+  }
 
 // A Marco automatically use a auto variable to store the return value of a
 // function, which returns result, and check the status of the result, if ok,

--- a/flex/utils/yaml_utils.cc
+++ b/flex/utils/yaml_utils.cc
@@ -15,11 +15,11 @@
  */
 
 #include "flex/utils/yaml_utils.h"
-#include <fstream>
-#include "service_utils.h"
 #include <rapidjson/document.h>
 #include <rapidjson/pointer.h>
 #include <rapidjson/prettywriter.h>
+#include <fstream>
+#include "service_utils.h"
 
 namespace gs {
 std::vector<std::string> get_yaml_files(const std::string& plugin_dir) {
@@ -122,7 +122,10 @@ Result<std::string> get_json_string_from_yaml(const YAML::Node& node) {
 Result<std::string> get_yaml_string_from_yaml_node(const YAML::Node& node) {
   try {
     YAML::Emitter emitter;
-    write_yaml_node_to_yaml_string(node, emitter);
+    auto status = write_yaml_node_to_yaml_string(node, emitter);
+    if (!status.ok()) {
+      return Result<std::string>(status);
+    }
     return std::string(emitter.c_str());
   } catch (const YAML::BadConversion& e) {
     return Result<std::string>(Status{StatusCode::IO_ERROR, e.what()});


### PR DESCRIPTION
- When starting the service from the default graph without specifying `property_id` and `type_id` in `graph.yaml`, we should be able  to generate them as needed. 
- We will also reuse the logic for creating the graph upon receiving a request. Additionally, we need to resolve the problem of using multiple `ASSIGN_AND_RETURN_IF_RESULT_NOT_OK` macros within a single code snippet.