### PR TITLE
fix(interactive): Add Unit Tests for Graph Optimizer in Concurrent Scenario

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/GraphServer.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/GraphServer.java
@@ -159,6 +159,9 @@ public class GraphServer {
         if (!FrontendConfig.GREMLIN_SERVER_DISABLED.get(configs) && this.gremlinServer != null) {
             this.gremlinServer.close();
         }
+        if (this.optimizer != null) {
+            this.optimizer.close();
+        }
     }
 
     public static void main(String[] args) throws Exception {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/planner/GraphRelOptimizer.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/planner/GraphRelOptimizer.java
@@ -44,13 +44,14 @@ import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import java.io.Closeable;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Optimize graph relational tree which consists of match and other relational operators
  */
-public class GraphRelOptimizer {
+public class GraphRelOptimizer implements Closeable {
     private final PlannerConfig config;
     private final RelBuilderFactory relBuilderFactory;
     private final GlogueHolder glogueHolder;
@@ -95,6 +96,13 @@ public class GraphRelOptimizer {
                     new GraphMetadataHandlerProvider(getMatchPlanner(), gq, this.config));
         }
         return null;
+    }
+
+    @Override
+    public void close() {
+        if (this.plannerGroupManager != null) {
+            this.plannerGroupManager.close();
+        }
     }
 
     public static class MatchOptimizer extends GraphShuttle {

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ConcurrentProcessRunner.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ConcurrentProcessRunner.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *  * Copyright 2020 Alibaba Group Holding Limited.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.alibaba.graphscope.common;
+
+import org.apache.tinkerpop.gremlin.process.GremlinProcessRunner;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerScheduler;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A JUnit runner that runs tests concurrently, the default thread pool size is 4.
+ */
+public class ConcurrentProcessRunner extends GremlinProcessRunner {
+    private final ExecutorService executorService;
+
+    public ConcurrentProcessRunner(Class<?> klass) throws InitializationError {
+        super(klass);
+        this.executorService = Executors.newFixedThreadPool(4);
+        RunnerScheduler scheduler =
+                new RunnerScheduler() {
+                    @Override
+                    public void schedule(Runnable childStatement) {
+                        executorService.submit(childStatement);
+                    }
+
+                    @Override
+                    public void finished() {
+                        try {
+                            executorService.shutdown();
+                            executorService.awaitTermination(120, TimeUnit.SECONDS);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                };
+        setScheduler(scheduler);
+    }
+}

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/planner/cbo/BITest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/planner/cbo/BITest.java
@@ -27,6 +27,7 @@ import com.alibaba.graphscope.common.ir.tools.GraphBuilder;
 import com.google.common.collect.ImmutableMap;
 
 import org.apache.calcite.rel.RelNode;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,6 +55,13 @@ public class BITest {
                         "schema/ldbc_schema_exp_hierarchy.json",
                         "statistics/ldbc30_hierarchy_statistics.json",
                         optimizer.getGlogueHolder());
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (optimizer != null) {
+            optimizer.close();
+        }
     }
 
     @Test

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/planner/cbo/ConcurrentBITest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/planner/cbo/ConcurrentBITest.java
@@ -1,0 +1,27 @@
+/*
+ *
+ *  * Copyright 2020 Alibaba Group Holding Limited.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.alibaba.graphscope.common.ir.planner.cbo;
+
+import com.alibaba.graphscope.common.ConcurrentProcessRunner;
+
+import org.junit.runner.RunWith;
+
+// run BI Tests in parallel, to check thread-safety of the CBO optimization
+@RunWith(ConcurrentProcessRunner.class)
+public class ConcurrentBITest extends BITest {}

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/planner/cbo/ConcurrentBITest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/common/ir/planner/cbo/ConcurrentBITest.java
@@ -23,5 +23,6 @@ import com.alibaba.graphscope.common.ConcurrentProcessRunner;
 import org.junit.runner.RunWith;
 
 // run BI Tests in parallel, to check thread-safety of the CBO optimization
+// ConcurrentProcessRunner is a custom runner that runs tests in parallel
 @RunWith(ConcurrentProcessRunner.class)
 public class ConcurrentBITest extends BITest {}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. Add `close()` interface in GraphOptimizer to shutdown `CleanScheduler` (used to clean memory occupation by CBO optimizer periodically) when compiler service stops.
2. Add `ConcurrentBITest` to run BI Tests in parallel, to verify the optimizer's functionality in concurrent cases.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

