### PR TITLE
docs: Fix document generation

### DIFF
--- a/flex/interactive/sdk/python/.openapi-generator-ignore
+++ b/flex/interactive/sdk/python/.openapi-generator-ignore
@@ -30,3 +30,4 @@ gs_interactive/models/long_text.py
 requirements.txt
 test-requirements.txt
 test/
+setup.cfg


### PR DESCRIPTION
Resolve the documentation deployment issue at https://github.com/alibaba/GraphScope/actions/runs/11247023257/job/31269817278. When using `openapi-generator-cli` to generate documentation, do not override the setup.cfg.