### PR TITLE
refactor(interactive): Resolve the dependency problem between compiler and interactive SDK

### DIFF
--- a/flex/interactive/sdk/java/README.md
+++ b/flex/interactive/sdk/java/README.md
@@ -93,4 +93,25 @@ public class GettingStarted {
 
 For more a more detailed example, please refer to [Java SDK Example](https://github.com/alibaba/GraphScope/flex/interactive/sdk/examples/java/interactive-example/)
 
+### Advanced building
+
+In some cases, you may want to exclude the proto-generated gaia-related files from the jar. 
+To build the jar without the gaia-related files, you can use the following command:
+
+```bash
+mvn clean package -Pno-gaia-ir
+```
+
+To release the jar to a remote repository, you can use the following command:
+
+```bash
+mvn clean deploy -Psign-artifacts
+```
+
+To release the jar without the gaia-related files to a remote repository, you can use the following command:
+
+```bash
+mvn clean deploy -Psign-artifacts,no-gaia-ir
+```
+
 

--- a/flex/interactive/sdk/java/README.md
+++ b/flex/interactive/sdk/java/README.md
@@ -36,7 +36,6 @@ Add this dependency to your project's POM:
   <groupId>com.alibaba.graphscope</groupId>
   <artifactId>interactive</artifactId>
   <version>0.3</version>
-  <scope>compile</scope>
 </dependency>
 ```
 
@@ -95,11 +94,15 @@ For more a more detailed example, please refer to [Java SDK Example](https://git
 
 ### Advanced building
 
-In some cases, you may want to exclude the proto-generated gaia-related files from the jar. 
-To build the jar without the gaia-related files, you can use the following command:
+In some cases, you may want to exclude the proto-generated gaia-related files from the jar. You could use the jar with classifier `no-gaia-ir`.
 
-```bash
-mvn clean package -Pno-gaia-ir
+```xml
+<dependency>
+  <groupId>com.alibaba.graphscope</groupId>
+  <artifactId>interactive</artifactId>
+  <version>0.3</version>
+  <classifier>no-gaia-ir</classifier>
+</dependency>
 ```
 
 To release the jar to a remote repository, you can use the following command:
@@ -108,10 +111,5 @@ To release the jar to a remote repository, you can use the following command:
 mvn clean deploy -Psign-artifacts
 ```
 
-To release the jar without the gaia-related files to a remote repository, you can use the following command:
-
-```bash
-mvn clean deploy -Psign-artifacts,no-gaia-ir
-```
 
 

--- a/flex/interactive/sdk/java/pom.xml
+++ b/flex/interactive/sdk/java/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>interactive</artifactId>
     <packaging>jar</packaging>
     <name>interactive</name>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.4</version>
     <url>https://github.com/alibaba/GraphScope/tree/main/flex/interactive</url>
     <description>GraphScope Interactive Java SDK</description>
     <organization>
@@ -148,13 +148,18 @@
                 <version>3.3.0</version>
                 <executions>
                     <execution>
+                        <phase>package</phase>
                         <goals>
-                            <goal>test-jar</goal>
+                            <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>com/alibaba/graphscope/gaia/**</exclude>
+                            </excludes>
+                            <classifier>${no-gaia-ir-classifier}</classifier>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -377,27 +382,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>no-gaia-ir</id>  
-            <activation>  
-                <activeByDefault>false</activeByDefault>  
-            </activation>  
-            <build>  
-                <plugins>  
-                    <plugin>  
-                        <groupId>org.apache.maven.plugins</groupId>  
-                        <artifactId>maven-jar-plugin</artifactId>  
-                        <configuration>  
-                            <excludes>  
-                                <exclude>com/alibaba/graphscope/gaia/**</exclude>  
-                                <exlucde>
-                            </excludes>  
-                            <classifier>${no-gaia-ir-classifier}</classifier>
-                        </configuration>  
-                    </plugin>  
-                </plugins>  
-            </build>  
         </profile>
     </profiles>
 

--- a/flex/interactive/sdk/java/pom.xml
+++ b/flex/interactive/sdk/java/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>interactive</artifactId>
     <packaging>jar</packaging>
     <name>interactive</name>
-    <version>0.4</version>
+    <version>0.4-SNAPSHOT</version>
     <url>https://github.com/alibaba/GraphScope/tree/main/flex/interactive</url>
     <description>GraphScope Interactive Java SDK</description>
     <organization>

--- a/flex/interactive/sdk/java/pom.xml
+++ b/flex/interactive/sdk/java/pom.xml
@@ -378,6 +378,27 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>no-gaia-ir</id>  
+            <activation>  
+                <activeByDefault>false</activeByDefault>  
+            </activation>  
+            <build>  
+                <plugins>  
+                    <plugin>  
+                        <groupId>org.apache.maven.plugins</groupId>  
+                        <artifactId>maven-jar-plugin</artifactId>  
+                        <configuration>  
+                            <excludes>  
+                                <exclude>com/alibaba/graphscope/gaia/**</exclude>  
+                                <exlucde>
+                            </excludes>  
+                            <classifier>${no-gaia-ir-classifier}</classifier>
+                        </configuration>  
+                    </plugin>  
+                </plugins>  
+            </build>  
+        </profile>
     </profiles>
 
     <dependencies>
@@ -534,5 +555,6 @@
         <opentelemetry-bom.version>1.37.0</opentelemetry-bom.version>
         <javadoc.output.destDir>${project.build.directory}/javadoc</javadoc.output.destDir>
         <javadoc.output.destDir>reference</javadoc.output.destDir>
+        <no-gaia-ir-classifier>no-gaia-ir</no-gaia-ir-classifier>
     </properties>
 </project>

--- a/interactive_engine/compiler/pom.xml
+++ b/interactive_engine/compiler/pom.xml
@@ -165,6 +165,7 @@
         <dependency>
             <groupId>com.alibaba.graphscope</groupId>
             <artifactId>interactive</artifactId>
+            <classifier>${interactive.sdk.classifier}</classifier>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -254,6 +254,7 @@
     <neo4j.version>4.4.0</neo4j.version>
     <neo4j.driver.version>4.4.0</neo4j.driver.version>
     <interactive.sdk.version>0.4</interactive.sdk.version>
+    <interactive.sdk.classifier>no-gaia-ir</interactive.sdk.classifier>
   </properties>
 
   <dependencyManagement>
@@ -695,6 +696,7 @@
         <groupId>com.alibaba.graphscope</groupId>
         <artifactId>interactive</artifactId>
         <version>${interactive.sdk.version}</version>
+        <classifier>${interactive.sdk.classifier}</classifier>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -734,36 +736,6 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>${maven.deploy.version}</version>
         </plugin>
-        <!-- <plugin>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>${maven.shade.version}</version>
-          <executions>
-              <execution>
-                  <phase>package</phase>
-                  <goals>
-                      <goal>shade</goal>
-                  </goals>
-                  <configuration>
-                      <filters>
-                          <filter>
-                              <artifact>com.alibaba.graphscope:interactive</artifact>
-                              <excludes>
-                                  <exclude>com.alibaba.graphscope.gaia.proto.*</exclude>
-                              </excludes>
-                          </filter>
-                          <filter>
-                            <artifact>*:*</artifact>
-                            <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
-                            </excludes>
-                        </filter>
-                      </filters>
-                  </configuration>
-              </execution>
-          </executions>
-        </plugin> -->
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven.assembly.version}</version>

--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -253,7 +253,7 @@
 
     <neo4j.version>4.4.0</neo4j.version>
     <neo4j.driver.version>4.4.0</neo4j.driver.version>
-    <interactive.sdk.version>0.4</interactive.sdk.version>
+    <interactive.sdk.version>0.4.2</interactive.sdk.version>
     <interactive.sdk.classifier>no-gaia-ir</interactive.sdk.classifier>
   </properties>
 


### PR DESCRIPTION
The Interactive SDK and compiler both rely on gaia-ir-proto, including the protoc-generated classes. Previously, we used the maven-shade-plugin to shade the protoc files from the Interactive SDK, but this led to other build issues, as noted in PR #4255.

In this PR, we address the problem by adding an additional jar classifier, `no-gaia-ir`, which can be easily utilized by the compiler.