### PR TITLE
fix(interactive): Incorporating the builtin procedure's metadata into the schema's plugin map

### DIFF
--- a/flex/engines/graph_db/database/graph_db.cc
+++ b/flex/engines/graph_db/database/graph_db.cc
@@ -428,9 +428,14 @@ void GraphDB::initApps(
   size_t valid_plugins = 0;
   for (auto& path_and_index : plugins) {
     auto path = path_and_index.second.first;
+    auto name = path_and_index.first;
     auto index = path_and_index.second.second;
-    if (registerApp(path, index)) {
-      ++valid_plugins;
+    if (!Schema::IsBuiltinPlugin(name)) {
+      if (registerApp(path, index)) {
+        ++valid_plugins;
+      }
+    } else {
+      valid_plugins++;
     }
   }
   LOG(INFO) << "Successfully registered stored procedures : " << valid_plugins

--- a/flex/engines/graph_db/database/graph_db_session.cc
+++ b/flex/engines/graph_db/database/graph_db_session.cc
@@ -214,6 +214,15 @@ double GraphDBSession::eval_duration() const {
 
 int64_t GraphDBSession::query_num() const { return query_num_.load(); }
 
+AppBase* GraphDBSession::GetApp(const std::string& app_name) {
+  auto& app_name_to_path_index = db_.schema().GetPlugins();
+  if (app_name_to_path_index.count(app_name) <= 0) {
+    LOG(ERROR) << "Query name is not registered: " << app_name;
+    return nullptr;
+  }
+  return GetApp(app_name_to_path_index.at(app_name).second);
+}
+
 #define likely(x) __builtin_expect(!!(x), 1)
 
 AppBase* GraphDBSession::GetApp(int type) {

--- a/flex/engines/graph_db/database/graph_db_session.h
+++ b/flex/engines/graph_db/database/graph_db_session.h
@@ -105,6 +105,8 @@ class GraphDBSession {
 
   AppBase* GetApp(int idx);
 
+  AppBase* GetApp(const std::string& name);
+
  private:
   Result<std::pair<uint8_t, std::string_view>>
   parse_query_type_from_cypher_json(const std::string_view& input);

--- a/flex/storages/rt_mutable_graph/schema.cc
+++ b/flex/storages/rt_mutable_graph/schema.cc
@@ -1321,6 +1321,19 @@ bool Schema::EmplacePlugins(
                  << ", name or library not found.";
     }
   }
+  // Emplace the built-in plugins
+  plugin_name_to_path_and_id_.emplace(
+      Schema::BUILTIN_COUNT_VERTICES_PLUGIN_NAME,
+      std::make_pair("", Schema::BUILTIN_COUNT_VERTICES_PLUGIN_ID));
+  plugin_name_to_path_and_id_.emplace(
+      Schema::BUILTIN_PAGERANK_PLUGIN_NAME,
+      std::make_pair("", Schema::BUILTIN_PAGERANK_PLUGIN_ID));
+  plugin_name_to_path_and_id_.emplace(
+      Schema::BUILTIN_K_DEGREE_NEIGHBORS_PLUGIN_NAME,
+      std::make_pair("", Schema::BUILTIN_K_DEGREE_NEIGHBORS_PLUGIN_ID));
+  plugin_name_to_path_and_id_.emplace(
+      Schema::BUILTIN_TVSP_PLUGIN_NAME,
+      std::make_pair("", Schema::BUILTIN_TVSP_PLUGIN_ID));
 
   LOG(INFO) << "Load " << plugin_name_to_path_and_id_.size() << " plugins";
   return true;


### PR DESCRIPTION
The meta info about builtin procedure should also be put in schema's fields.