### PR TITLE
feat(interactive): Increase the reserved slots for small graphs

### DIFF
--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -192,8 +192,11 @@ void MutablePropertyFragment::Open(const std::string& work_dir,
     }
 
     // We will reserve the at least 4096 slots for each vertex label
+    auto max_vnum = schema_.get_max_vnum(v_label_name);
     size_t vertex_capacity =
-        std::max(schema_.get_max_vnum(v_label_name), (size_t) 4096);
+        std::max(max_vnum == Schema::DEFAULT_MAX_VNUM ? lf_indexers_[i].size()
+                                                      : max_vnum,
+                 (size_t) 4096);
     if (vertex_capacity >= lf_indexers_[i].size()) {
       lf_indexers_[i].reserve(vertex_capacity);
     }

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -191,12 +191,11 @@ void MutablePropertyFragment::Open(const std::string& work_dir,
           schema_.get_vertex_storage_strategies(v_label_name), true);
     }
 
+    // We will reserve the at least 4096 slots for each vertex label
     size_t vertex_capacity =
-        schema_.get_max_vnum(v_label_name);  // lf_indexers_[i].capacity();
-    if (build_empty_graph) {
+        std::max(schema_.get_max_vnum(v_label_name), (size_t) 4096);
+    if (vertex_capacity >= lf_indexers_[i].size()) {
       lf_indexers_[i].reserve(vertex_capacity);
-    } else {
-      vertex_capacity = lf_indexers_[i].capacity();
     }
     vertex_data_[i].resize(vertex_capacity);
     vertex_capacities[i] = vertex_capacity;

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -192,11 +192,7 @@ void MutablePropertyFragment::Open(const std::string& work_dir,
     }
 
     // We will reserve the at least 4096 slots for each vertex label
-    auto max_vnum = schema_.get_max_vnum(v_label_name);
-    size_t vertex_capacity =
-        std::max(max_vnum == Schema::DEFAULT_MAX_VNUM ? lf_indexers_[i].size()
-                                                      : max_vnum,
-                 (size_t) 4096);
+    size_t vertex_capacity = std::max(lf_indexers_[i].size(), (size_t) 4096);
     if (vertex_capacity >= lf_indexers_[i].size()) {
       lf_indexers_[i].reserve(vertex_capacity);
     }

--- a/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
+++ b/flex/storages/rt_mutable_graph/mutable_property_fragment.cc
@@ -192,7 +192,8 @@ void MutablePropertyFragment::Open(const std::string& work_dir,
     }
 
     // We will reserve the at least 4096 slots for each vertex label
-    size_t vertex_capacity = std::max(lf_indexers_[i].size(), (size_t) 4096);
+    size_t vertex_capacity =
+        std::max(lf_indexers_[i].capacity(), (size_t) 4096);
     if (vertex_capacity >= lf_indexers_[i].size()) {
       lf_indexers_[i].reserve(vertex_capacity);
     }

--- a/flex/storages/rt_mutable_graph/schema.h
+++ b/flex/storages/rt_mutable_graph/schema.h
@@ -67,7 +67,6 @@ class Schema {
   // An array containing all compatible versions of schema.
   static const std::vector<std::string> COMPATIBLE_VERSIONS;
   static constexpr const char* DEFAULT_SCHEMA_VERSION = "v0.0";
-  static constexpr const size_t DEFAULT_MAX_VNUM = (1ULL << 32);
 
   static bool IsBuiltinPlugin(const std::string& plugin_name);
 
@@ -85,7 +84,8 @@ class Schema {
       const std::vector<std::tuple<PropertyType, std::string, size_t>>&
           primary_key,
       const std::vector<StorageStrategy>& strategies = {},
-      size_t max_vnum = DEFAULT_MAX_VNUM, const std::string& description = "");
+      size_t max_vnum = static_cast<size_t>(1) << 32,
+      const std::string& description = "");
 
   void add_edge_label(const std::string& src_label,
                       const std::string& dst_label,

--- a/flex/storages/rt_mutable_graph/schema.h
+++ b/flex/storages/rt_mutable_graph/schema.h
@@ -67,6 +67,7 @@ class Schema {
   // An array containing all compatible versions of schema.
   static const std::vector<std::string> COMPATIBLE_VERSIONS;
   static constexpr const char* DEFAULT_SCHEMA_VERSION = "v0.0";
+  static constexpr const size_t DEFAULT_MAX_VNUM = (1ULL << 32);
 
   static bool IsBuiltinPlugin(const std::string& plugin_name);
 
@@ -84,8 +85,7 @@ class Schema {
       const std::vector<std::tuple<PropertyType, std::string, size_t>>&
           primary_key,
       const std::vector<StorageStrategy>& strategies = {},
-      size_t max_vnum = static_cast<size_t>(1) << 32,
-      const std::string& description = "");
+      size_t max_vnum = DEFAULT_MAX_VNUM, const std::string& description = "");
 
   void add_edge_label(const std::string& src_label,
                       const std::string& dst_label,


### PR DESCRIPTION
We currently allocate an additional 1/4 of the required space when opening a graph, resulting in a smaller reserved space for smaller graphs. To address this, we are increasing the minimum capacity for vertex storage to 4096.

Fix #4105 