### PR TITLE
fix(interactive): Add PVC support for Insight logs

### DIFF
--- a/charts/graphscope-store/templates/configmap.yaml
+++ b/charts/graphscope-store/templates/configmap.yaml
@@ -116,6 +116,7 @@ data:
 
     sudo chown -R graphscope:graphscope {{ .Values.storeDataPath }} || true
     sudo chown -R graphscope:graphscope /etc/groot || true
+    sudo chown -R graphscope:graphscope /var/log/graphscope || true
 
     [[ `hostname` =~ -([0-9]+)$ ]] || exit 1
     ordinal=${BASH_REMATCH[1]}

--- a/charts/graphscope-store/templates/coordinator/statefulset.yaml
+++ b/charts/graphscope-store/templates/coordinator/statefulset.yaml
@@ -150,6 +150,14 @@ spec:
         - name: meta
           emptyDir: {}
         {{- end }}
+        {{- if not .Values.logPersistence.enabled }}
+        - name: log
+          emptyDir: {}
+        {{- else if .Values.logPersistence.existingClaim }}
+        - name: log
+          persistentVolumeClaim:
+            claimName: {{ printf "%s" (tpl .Values.logPersistence.existingClaim .) }}
+        {{- end }}
   volumeClaimTemplates:
     {{- if and .Values.coordinator.persistence.enabled (not .Values.coordinator.persistence.existingClaim) }}
     - metadata:
@@ -173,6 +181,7 @@ spec:
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.coordinator.persistence.selector "context" $) | nindent 10 }}
         {{- end -}}
     {{- end }}
+    {{- if and .Values.logPersistence.enabled (not .Values.logPersistence.existingClaim) }}
     - metadata:
         name: log
         {{- if .Values.persistence.annotations }}
@@ -193,4 +202,5 @@ spec:
         {{- if .Values.logPersistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
         {{- end -}}
+    {{- end }}
 {{- end -}}

--- a/charts/graphscope-store/templates/coordinator/statefulset.yaml
+++ b/charts/graphscope-store/templates/coordinator/statefulset.yaml
@@ -135,20 +135,23 @@ spec:
             - name: config
               mountPath: /etc/groot/setup.sh
               subPath: setup.sh
+            - name: log
+              mountPath:  {{ .Values.logPersistence.mountPath }}
       volumes:
         - name: config
           configMap:
             name: {{ include "graphscope-store.configmapName" . }}
             defaultMode: 0755
-  {{- if and .Values.coordinator.persistence.enabled .Values.coordinator.persistence.existingClaim }}
+        {{- if and .Values.coordinator.persistence.enabled .Values.coordinator.persistence.existingClaim }}
         - name: meta
           persistentVolumeClaim:
             claimName: {{ printf "%s" (tpl .Values.coordinator.persistence.existingClaim .) }}
-  {{- else if not .Values.coordinator.persistence.enabled }}
+        {{- else if not .Values.coordinator.persistence.enabled }}
         - name: meta
           emptyDir: {}
-  {{- else if and .Values.coordinator.persistence.enabled (not .Values.coordinator.persistence.existingClaim) }}
+        {{- end }}
   volumeClaimTemplates:
+    {{- if and .Values.coordinator.persistence.enabled (not .Values.coordinator.persistence.existingClaim) }}
     - metadata:
         name: meta
         {{- if .Values.persistence.annotations }}
@@ -169,5 +172,25 @@ spec:
         {{- if .Values.coordinator.persistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.coordinator.persistence.selector "context" $) | nindent 10 }}
         {{- end -}}
-  {{- end }}
+    {{- end }}
+    - metadata:
+        name: log
+        {{- if .Values.persistence.annotations }}
+        annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.persistence.labels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.labels "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- range .Values.logPersistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.logPersistence.size | quote }}
+        {{ include "graphscope-store.storageClass" . | nindent 8 }}
+        {{- if .Values.logPersistence.selector }}
+        selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
+        {{- end -}}
 {{- end -}}

--- a/charts/graphscope-store/templates/frontend/statefulset.yaml
+++ b/charts/graphscope-store/templates/frontend/statefulset.yaml
@@ -144,7 +144,16 @@ spec:
           configMap:
             name: {{ include "graphscope-store.configmapName" . }}
             defaultMode: 0755
+        {{- if not .Values.logPersistence.enabled }}
+        - name: log
+          emptyDir: {}
+        {{- else if .Values.logPersistence.existingClaim }}
+        - name: log
+          persistentVolumeClaim:
+            claimName: {{ printf "%s" (tpl .Values.logPersistence.existingClaim .) }}
+        {{- end }}
   volumeClaimTemplates:
+    {{- if and .Values.logPersistence.enabled (not .Values.logPersistence.existingClaim) }}
     - metadata:
         name: log
         {{- if .Values.persistence.annotations }}
@@ -165,4 +174,5 @@ spec:
         {{- if .Values.logPersistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
         {{- end -}}
+    {{- end }}
 {{- end }}

--- a/charts/graphscope-store/templates/frontend/statefulset.yaml
+++ b/charts/graphscope-store/templates/frontend/statefulset.yaml
@@ -137,9 +137,32 @@ spec:
             - name: config
               mountPath: /etc/groot/setup.sh
               subPath: setup.sh
+            - name: log
+              mountPath: {{ .Values.logPersistence.mountPath }}
       volumes:
         - name: config
           configMap:
             name: {{ include "graphscope-store.configmapName" . }}
             defaultMode: 0755
+  volumeClaimTemplates:
+    - metadata:
+        name: log
+        {{- if .Values.persistence.annotations }}
+        annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.persistence.labels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.labels "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- range .Values.logPersistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.logPersistence.size | quote }}
+        {{ include "graphscope-store.storageClass" . | nindent 8 }}
+        {{- if .Values.logPersistence.selector }}
+        selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
+        {{- end -}}
 {{- end }}

--- a/charts/graphscope-store/templates/onepod/statefulset.yaml
+++ b/charts/graphscope-store/templates/onepod/statefulset.yaml
@@ -137,6 +137,8 @@ spec:
             - name: config
               mountPath: /etc/groot/setup.sh
               subPath: setup.sh
+            - name: log
+              mountPath: {{ .Values.logPersistence.mountPath }}
             {{- if .Values.store.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.store.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -148,15 +150,16 @@ spec:
         {{- if .Values.store.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.store.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-  {{- if and .Values.store.persistence.enabled .Values.store.persistence.existingClaim }}
+        {{- if and .Values.store.persistence.enabled .Values.store.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ printf "%s" (tpl .Values.store.persistence.existingClaim .) }}
-  {{- else if not .Values.store.persistence.enabled }}
+        {{- else if not .Values.store.persistence.enabled }}
         - name: data
           emptyDir: {}
-  {{- else if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
+        {{- end }}
   volumeClaimTemplates:
+    {{- if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
     - metadata:
         name: data
         {{- if .Values.persistence.annotations }}
@@ -177,5 +180,25 @@ spec:
         {{- if .Values.store.persistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.store.persistence.selector "context" $) | nindent 10 }}
         {{- end -}}
-  {{- end }}
+    {{- end }}
+    - metadata:
+        name: log
+        {{- if .Values.persistence.annotations }}
+        annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.persistence.labels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.labels "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- range .Values.logPersistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.logPersistence.size | quote }}
+        {{ include "graphscope-store.storageClass" . | nindent 8 }}
+        {{- if .Values.logPersistence.selector }}
+        selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
+        {{- end -}}
 {{- end }}

--- a/charts/graphscope-store/templates/onepod/statefulset.yaml
+++ b/charts/graphscope-store/templates/onepod/statefulset.yaml
@@ -158,6 +158,14 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if not .Values.logPersistence.enabled }}
+        - name: log
+          emptyDir: {}
+        {{- else if .Values.logPersistence.existingClaim }}
+        - name: log
+          persistentVolumeClaim:
+            claimName: {{ printf "%s" (tpl .Values.logPersistence.existingClaim .) }}
+        {{- end }}
   volumeClaimTemplates:
     {{- if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
     - metadata:
@@ -181,6 +189,7 @@ spec:
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.store.persistence.selector "context" $) | nindent 10 }}
         {{- end -}}
     {{- end }}
+    {{- if and .Values.logPersistence.enabled (not .Values.logPersistence.existingClaim) }}
     - metadata:
         name: log
         {{- if .Values.persistence.annotations }}
@@ -201,4 +210,5 @@ spec:
         {{- if .Values.logPersistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
         {{- end -}}
+    {{- end }}
 {{- end }}

--- a/charts/graphscope-store/templates/store/statefulset-backup.yaml
+++ b/charts/graphscope-store/templates/store/statefulset-backup.yaml
@@ -164,6 +164,14 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if not .Values.logPersistence.enabled }}
+        - name: log
+          emptyDir: {}
+        {{- else if .Values.logPersistence.existingClaim }}
+        - name: log
+          persistentVolumeClaim:
+            claimName: {{ printf "%s" (tpl .Values.logPersistence.existingClaim .) }}
+        {{- end }}
   volumeClaimTemplates:
     {{- if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
     - metadata:
@@ -187,6 +195,7 @@ spec:
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.store.persistence.selector "context" $) | nindent 10 }}
         {{- end -}}
     {{- end }}
+    {{- if and .Values.logPersistence.enabled (not .Values.logPersistence.existingClaim) }}
     - metadata:
         name: log
         {{- if .Values.persistence.annotations }}
@@ -207,5 +216,6 @@ spec:
         {{- if .Values.logPersistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
         {{- end -}}
+    {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/graphscope-store/templates/store/statefulset-backup.yaml
+++ b/charts/graphscope-store/templates/store/statefulset-backup.yaml
@@ -143,6 +143,8 @@ spec:
             - name: config
               mountPath: /etc/groot/setup.sh
               subPath: setup.sh
+            - name: log
+              mountPath: {{ .Values.logPersistence.mountPath }}
             {{- if .Values.store.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.store.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -154,15 +156,16 @@ spec:
         {{- if .Values.store.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.store.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-  {{- if and .Values.store.persistence.enabled .Values.store.persistence.existingClaim }}
+        {{- if and .Values.store.persistence.enabled .Values.store.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ printf "%s" (tpl .Values.store.persistence.existingClaim .) }}
-  {{- else if not .Values.store.persistence.enabled }}
+        {{- else if not .Values.store.persistence.enabled }}
         - name: data
           emptyDir: {}
-  {{- else if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
+        {{- end }}
   volumeClaimTemplates:
+    {{- if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
     - metadata:
         name: data
         {{- if .Values.persistence.annotations }}
@@ -183,6 +186,26 @@ spec:
         {{- if .Values.store.persistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.store.persistence.selector "context" $) | nindent 10 }}
         {{- end -}}
-  {{- end }}
+    {{- end }}
+    - metadata:
+        name: log
+        {{- if .Values.persistence.annotations }}
+        annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.persistence.labels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.labels "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- range .Values.logPersistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.logPersistence.size | quote }}
+        {{ include "graphscope-store.storageClass" . | nindent 8 }}
+        {{- if .Values.logPersistence.selector }}
+        selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
+        {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/graphscope-store/templates/store/statefulset.yaml
+++ b/charts/graphscope-store/templates/store/statefulset.yaml
@@ -160,6 +160,14 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- if not .Values.logPersistence.enabled }}
+        - name: log
+          emptyDir: {}
+        {{- else if .Values.logPersistence.existingClaim }}
+        - name: log
+          persistentVolumeClaim:
+            claimName: {{ printf "%s" (tpl .Values.logPersistence.existingClaim .) }}
+        {{- end }}
   volumeClaimTemplates:
     {{- if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
     - metadata:
@@ -183,6 +191,7 @@ spec:
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.store.persistence.selector "context" $) | nindent 10 }}
         {{- end -}}
     {{- end }}
+    {{- if and .Values.logPersistence.enabled (not .Values.logPersistence.existingClaim) }}
     - metadata:
         name: log
         {{- if .Values.persistence.annotations }}
@@ -203,4 +212,5 @@ spec:
         {{- if .Values.logPersistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
         {{- end -}}
+    {{- end }}
 {{- end -}}

--- a/charts/graphscope-store/templates/store/statefulset.yaml
+++ b/charts/graphscope-store/templates/store/statefulset.yaml
@@ -139,6 +139,8 @@ spec:
             - name: config
               mountPath: /etc/groot/setup.sh
               subPath: setup.sh
+            - name: log
+              mountPath: {{ .Values.logPersistence.mountPath }}
             {{- if .Values.store.extraVolumeMounts }}
             {{- include "common.tplvalues.render" (dict "value" .Values.store.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -150,15 +152,16 @@ spec:
         {{- if .Values.store.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.store.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-  {{- if and .Values.store.persistence.enabled .Values.store.persistence.existingClaim }}
+        {{- if and .Values.store.persistence.enabled .Values.store.persistence.existingClaim }}
         - name: data
           persistentVolumeClaim:
             claimName: {{ printf "%s" (tpl .Values.store.persistence.existingClaim .) }}
-  {{- else if not .Values.store.persistence.enabled }}
+        {{- else if not .Values.store.persistence.enabled }}
         - name: data
           emptyDir: {}
-  {{- else if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
+        {{- end }}
   volumeClaimTemplates:
+    {{- if and .Values.store.persistence.enabled (not .Values.store.persistence.existingClaim) }}
     - metadata:
         name: data
         {{- if .Values.persistence.annotations }}
@@ -179,5 +182,25 @@ spec:
         {{- if .Values.store.persistence.selector }}
         selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.store.persistence.selector "context" $) | nindent 10 }}
         {{- end -}}
-  {{- end }}
+    {{- end }}
+    - metadata:
+        name: log
+        {{- if .Values.persistence.annotations }}
+        annotations: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.annotations "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.persistence.labels }}
+        labels: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.labels "context" $) | nindent 10 }}
+        {{- end }}
+      spec:
+        accessModes:
+          {{- range .Values.logPersistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.logPersistence.size | quote }}
+        {{ include "graphscope-store.storageClass" . | nindent 8 }}
+        {{- if .Values.logPersistence.selector }}
+        selector: {{- include "graphscope-store.tplvalues.render" (dict "value" .Values.logPersistence.selector "context" $) | nindent 10 }}
+        {{- end -}}
 {{- end -}}

--- a/charts/graphscope-store/values.yaml
+++ b/charts/graphscope-store/values.yaml
@@ -599,7 +599,7 @@ graphPlannerCboGlogueSize: 3
 ##
 logPersistence:
   ## Enable persistence using Persistent Volume Claims. If false, use emptyDir
-  enabled: true
+  enabled: false
   ## Existing PVC to hold the log data. If not provided, a new PVC will be created.
   existingClaim: ""
   ## Persistent Volume storage class

--- a/charts/graphscope-store/values.yaml
+++ b/charts/graphscope-store/values.yaml
@@ -595,6 +595,27 @@ queryExecutionTimeoutMs: 600000
 graphPlannerJoinMinPatternSize: 5
 graphPlannerCboGlogueSize: 3
 
+## Log Persistence parameters
+##
+logPersistence:
+  ## Enable persistence using Persistent Volume Claims
+  enabled: false
+  ## If true, use a Persistent Volume Claim, If false, use emptyDir
+  existingClaim: ""
+  ## Persistent Volume storage class
+  storageClass: ""
+  ## Persistent Volume access modes
+  accessModes:
+  - ReadWriteOnce
+  ## Persistent Volume size
+  size: 2Gi
+  ## Persistent Volume annotations
+  annotations: {}
+  ## Persistent Volume labels
+  selector: {}
+  ## mountPath for the Persistent Volume
+  mountPath: "/var/log/graphscope"
+
 ## Key-value pair separated by ;
 ## For example extraConfig="k1=v1;k2=v2"
 extraConfig: ""

--- a/charts/graphscope-store/values.yaml
+++ b/charts/graphscope-store/values.yaml
@@ -598,9 +598,9 @@ graphPlannerCboGlogueSize: 3
 ## Log Persistence parameters
 ##
 logPersistence:
-  ## Enable persistence using Persistent Volume Claims
-  enabled: false
-  ## If true, use a Persistent Volume Claim, If false, use emptyDir
+  ## Enable persistence using Persistent Volume Claims. If false, use emptyDir
+  enabled: true
+  ## Existing PVC to hold the log data. If not provided, a new PVC will be created.
   existingClaim: ""
   ## Persistent Volume storage class
   storageClass: ""
@@ -608,7 +608,7 @@ logPersistence:
   accessModes:
   - ReadWriteOnce
   ## Persistent Volume size
-  size: 2Gi
+  size: 1Gi
   ## Persistent Volume annotations
   annotations: {}
   ## Persistent Volume labels


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This pull request introduces PVCs for the coordinator, frontend, and stores components within Insight.

For instance, we can get log PVCs as follows:
![image](https://github.com/user-attachments/assets/fcb63fcf-47ce-424a-a955-c168fa0d2c37)


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #4307 

