### PR TITLE
fix(interactive): Fix Interactive CI

### DIFF
--- a/flex/interactive/sdk/generate_sdk.sh
+++ b/flex/interactive/sdk/generate_sdk.sh
@@ -30,7 +30,7 @@ DEVELOPER_NAME="GraphScope Team"
 LICENSE_NAME="Apache-2.0"
 LICENSE_URL="https://www.apache.org/licenses/LICENSE-2.0.html"
 LOG_LEVEL="error"
-
+export OPENAPI_GENERATOR_VERSION=7.2.0
 
 #get current bash scrip's directory
 CUR_DIR=$(cd `dirname $0`; pwd)
@@ -129,7 +129,6 @@ function install_generator() {
     curl https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/bin/utils/openapi-generator-cli.sh > ~/bin/openapitools/openapi-generator-cli
     chmod u+x ~/bin/openapitools/openapi-generator-cli
     export PATH=$PATH:~/bin/openapitools/
-    export OPENAPI_GENERATOR_VERSION=7.2.0
   fi
   # on ubuntu apt-get jq on mac brew install jq
 

--- a/flex/interactive/sdk/python/gs_interactive/tests/conftest.py
+++ b/flex/interactive/sdk/python/gs_interactive/tests/conftest.py
@@ -477,5 +477,5 @@ def update_procedure(sess: Session, graph_id: str, proc_id: str, desc: str):
 def start_service_on_graph(interactive_session, graph_id: str):
     resp = interactive_session.start_service(StartServiceRequest(graph_id=graph_id))
     assert resp.is_ok()
-    # wait one second to let compiler get the new graph
-    time.sleep(1)
+    # wait three second to let compiler get the new graph
+    time.sleep(3)

--- a/flex/interactive/sdk/python/gs_interactive/tests/test_driver.py
+++ b/flex/interactive/sdk/python/gs_interactive/tests/test_driver.py
@@ -31,7 +31,7 @@ from gs_interactive.models import CreateEdgeType
 from gs_interactive.models import CreateGraphRequest
 from gs_interactive.models import CreateGraphSchemaRequest
 from gs_interactive.models import CreateProcedureRequest
-from gs_interactive.models import BasePropertyMeta
+from gs_interactive.models import CreatePropertyMeta
 from gs_interactive.models import CreateVertexType
 from gs_interactive.models import EdgeMapping
 from gs_interactive.models import EdgeMappingTypeTriplet
@@ -172,19 +172,19 @@ class TestDriver(unittest.TestCase):
             type_name="person",
             primary_keys=["id"],
             properties=[
-                BasePropertyMeta(
+                CreatePropertyMeta(
                     property_name="id",
                     property_type=GSDataType(
                         PrimitiveType(primitive_type="DT_SIGNED_INT64")
                     ),
                 ),
-                BasePropertyMeta(
+                CreatePropertyMeta(
                     property_name="name",
                     property_type=GSDataType(
                         StringType(string=StringTypeString(LongText(long_text="")))
                     ),
                 ),
-                BasePropertyMeta(
+                CreatePropertyMeta(
                     property_name="age",
                     property_type=GSDataType(
                         PrimitiveType(primitive_type="DT_SIGNED_INT32")
@@ -196,7 +196,7 @@ class TestDriver(unittest.TestCase):
         create_knows_edge = CreateEdgeType(
             type_name="knows",
             properties=[
-                BasePropertyMeta(
+                CreatePropertyMeta(
                     property_name="weight",
                     property_type=GSDataType(PrimitiveType(primitive_type="DT_DOUBLE")),
                 )

--- a/flex/interactive/sdk/python/gs_interactive/tests/test_driver.py
+++ b/flex/interactive/sdk/python/gs_interactive/tests/test_driver.py
@@ -31,7 +31,7 @@ from gs_interactive.models import CreateEdgeType
 from gs_interactive.models import CreateGraphRequest
 from gs_interactive.models import CreateGraphSchemaRequest
 from gs_interactive.models import CreateProcedureRequest
-from gs_interactive.models import CreatePropertyMeta
+from gs_interactive.models import BasePropertyMeta
 from gs_interactive.models import CreateVertexType
 from gs_interactive.models import EdgeMapping
 from gs_interactive.models import EdgeMappingTypeTriplet
@@ -172,19 +172,19 @@ class TestDriver(unittest.TestCase):
             type_name="person",
             primary_keys=["id"],
             properties=[
-                CreatePropertyMeta(
+                BasePropertyMeta(
                     property_name="id",
                     property_type=GSDataType(
                         PrimitiveType(primitive_type="DT_SIGNED_INT64")
                     ),
                 ),
-                CreatePropertyMeta(
+                BasePropertyMeta(
                     property_name="name",
                     property_type=GSDataType(
                         StringType(string=StringTypeString(LongText(long_text="")))
                     ),
                 ),
-                CreatePropertyMeta(
+                BasePropertyMeta(
                     property_name="age",
                     property_type=GSDataType(
                         PrimitiveType(primitive_type="DT_SIGNED_INT32")
@@ -196,7 +196,7 @@ class TestDriver(unittest.TestCase):
         create_knows_edge = CreateEdgeType(
             type_name="knows",
             properties=[
-                CreatePropertyMeta(
+                BasePropertyMeta(
                     property_name="weight",
                     property_type=GSDataType(PrimitiveType(primitive_type="DT_DOUBLE")),
                 )

--- a/flex/interactive/sdk/python/gs_interactive/tests/test_robustness.py
+++ b/flex/interactive/sdk/python/gs_interactive/tests/test_robustness.py
@@ -290,6 +290,3 @@ def test_custom_pk_name(
     records = result.fetch(1)
     assert len(records) == 1 and records[0]["$f0"] == 2
     start_service_on_graph(interactive_session, "1")
-    sleep(
-        3
-    )  # sleep for a while to make sure the compiler has updated to the new schema


### PR DESCRIPTION
Use a fixed `openapi-generator` version to make codegen repeatable.

Related CI failure: https://github.com/alibaba/GraphScope/actions/runs/11948608684/job/33307061458