### PR TITLE
refactor(interactive): Use netcat to check service readiness

### DIFF
--- a/charts/graphscope-store/templates/configmap.yaml
+++ b/charts/graphscope-store/templates/configmap.yaml
@@ -181,7 +181,12 @@ data:
       export GRPC_PORT=${GROOT_GRPC_PORT}
       export GREMLIN_PORT=${GROOT_GREMLIN_PORT}
       echo "${HOST} ${GRPC_PORT} ${GREMLIN_PORT}"
-      python3 -c 'import base64;import os;from gremlin_python.driver.client import Client;ip=os.getenv("HOST");gremlin_port=os.getenv("GREMLIN_PORT");graph_url=f"ws://{ip}:{gremlin_port}/gremlin";username=os.getenv("GROOT_USERNAME");password=base64.b64decode(os.getenv("GROOT_PASSWORD")).decode("utf-8");client = Client(graph_url, "g", username=username, password=password); ret = client.submit("g.V().limit(1)").all().result(); client.close();' && break
+      cmd="nc -zv ${HOST} ${GREMLIN_PORT}"
+      res=$(eval $cmd 2>&1)
+      if [[ $res == *succeeded* ]]; then
+        # Expected Output is <Connection to localhost (::1) 8182 port [tcp/*] succeeded!>
+        break
+      fi
       sleep 3
     done
 

--- a/coordinator/gscoordinator/utils.py
+++ b/coordinator/gscoordinator/utils.py
@@ -2088,7 +2088,7 @@ def check_argument(condition, message=None):
 
 def check_server_ready(endpoint, server="gremlin"):
     def _check_gremlin_task(endpoint):
-        import socket
+        from gremlin_python.driver.client import Client
 
         if "MY_POD_NAME" in os.environ:
             # inner kubernetes env
@@ -2099,14 +2099,16 @@ def check_server_ready(endpoint, server="gremlin"):
                 return True
 
         try:
-            # Check whether endpoint is reachable and connectable without gremlin client
-            host, port = endpoint.split(":")
-            with socket.create_connection((host, port), timeout=3):
-                logger.info("Checked connectivity to gremlin server.")
-                return True
-        except socket.error as e:
-            logger.error("Failed to connect to gremlin server: %s", str(e))
-            return False
+            client = Client(f"ws://{endpoint}/gremlin", "g")
+            # May throw
+            client.submit("g.V().limit(1)").all().result()
+            logger.info("Gremlin server is ready.")
+        finally:
+            try:
+                client.close()
+            except:  # noqa: E722
+                pass
+        return True
 
     def _check_cypher_task(endpoint):
         from neo4j import GraphDatabase

--- a/k8s/dockerfiles/coordinator.Dockerfile
+++ b/k8s/dockerfiles/coordinator.Dockerfile
@@ -36,7 +36,7 @@ FROM ubuntu:22.04 AS coordinator
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
-    apt-get install -y sudo python3-pip openmpi-bin curl tzdata && \
+    apt-get install -y sudo python3-pip openmpi-bin curl tzdata netcat && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/k8s/dockerfiles/graphscope-dev-wheel.Dockerfile
+++ b/k8s/dockerfiles/graphscope-dev-wheel.Dockerfile
@@ -51,6 +51,7 @@ RUN yum install -y sudo vim && \
     yum remove java-1.8.0-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-headless -y && \
     yum install java-11-openjdk-devel -y && \
     yum clean all -y --enablerepo='*' && \
+    yum install -y netcat && \ 
     rm -rf /var/cache/yum
 
 RUN mkdir -p /opt/graphscope /opt/vineyard && chown -R graphscope:graphscope /opt/graphscope /opt/vineyard


### PR DESCRIPTION
Previously we used a Gremlin query to check whether the Gremlin service is ready, which may reveal unexpected problems. It is better to use netcat to find out whether the endpoint is ready for serving.