### PR TITLE
fix(interactive): Fix the conflict of error proto for compiler

### DIFF
--- a/interactive_engine/pom.xml
+++ b/interactive_engine/pom.xml
@@ -253,7 +253,7 @@
 
     <neo4j.version>4.4.0</neo4j.version>
     <neo4j.driver.version>4.4.0</neo4j.driver.version>
-    <interactive.sdk.version>0.4.2</interactive.sdk.version>
+    <interactive.sdk.version>0.4.3</interactive.sdk.version>
     <interactive.sdk.classifier>no-gaia-ir</interactive.sdk.classifier>
   </properties>
 


### PR DESCRIPTION
update interactive-no-gaia-ir to 0.4.3. The 0.4.2 version seems to contains the generated java files for insight.proto