### PR TITLE
fix(interactive): bump up rustup toolchain version to 1.81.0 to avoid compilation failure

### DIFF
--- a/.github/workflows/gss.yml
+++ b/.github/workflows/gss.yml
@@ -79,6 +79,8 @@ jobs:
         . ${HOME}/.graphscope_env
         export SCCACHE_DIR=~/.cache/sccache
         export RUSTC_WRAPPER=/usr/local/bin/sccache
+        rustup toolchain install 1.81.0
+        rustup default 1.81.0
         cd ${GITHUB_WORKSPACE}/interactive_engine
         mvn clean install -P groot -Drust.compile.mode=debug -DskipTests --quiet
         mvn clean install -Pgroot-data-load --quiet

--- a/.github/workflows/k8s-ci.yml
+++ b/.github/workflows/k8s-ci.yml
@@ -282,6 +282,12 @@ jobs:
           ~/.cache/sccache
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.81.0
+        override: true
+
     - name: Build Artifact
       run: |
         . ${HOME}/.graphscope_env
@@ -639,6 +645,12 @@ jobs:
             ~/.cargo/git/db/
             ~/.cache/sccache
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.81.0
+          override: true
 
       - name: Build GIE Experimental Artifacts
         run: |

--- a/k8s/dockerfiles/graphscope-store.Dockerfile
+++ b/k8s/dockerfiles/graphscope-store.Dockerfile
@@ -14,7 +14,7 @@ COPY --chown=graphscope:graphscope . /home/graphscope/graphscope
 COPY --chown=graphscope:graphscope ./interactive_engine/assembly/src/conf/maven.settings.xml /home/graphscope/.m2/settings.xml
 
 USER graphscope
-RUN rustup toolchain install 1.76.0 && rustup default 1.76.0
+RUN rustup toolchain install 1.81.0 && rustup default 1.81.0
 
 RUN cd /home/graphscope/graphscope \
     && . ~/.graphscope_env \

--- a/k8s/dockerfiles/interactive.Dockerfile
+++ b/k8s/dockerfiles/interactive.Dockerfile
@@ -18,7 +18,7 @@ RUN cd /home/graphscope/GraphScope/ && \
     else \
         mkdir /home/graphscope/install; \
         . /home/graphscope/.graphscope_env; \
-        rustup toolchain install 1.76.0 && rustup default 1.76.0; \
+        rustup toolchain install 1.81.0 && rustup default 1.81.0; \
         make interactive-install BUILD_TYPE="$profile" INSTALL_PREFIX=/home/graphscope/install; \
     fi
 

--- a/k8s/internal/Makefile
+++ b/k8s/internal/Makefile
@@ -110,7 +110,7 @@ graphscope-manylinux2014-py3-nodocker:
 	sudo sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
 	sudo yum install java-11-openjdk-devel -y && \
 	sudo yum remove java-1.8.0-openjdk-devel java-1.8.0-openjdk java-1.8.0-openjdk-headless -y && \
-	rustup toolchain install 1.76.0 && rustup default 1.76.0 && \
+	rustup toolchain install 1.81.0 && rustup default 1.81.0 && \
 	cd $(WORKING_DIR)/../.. && \
 		if [[ "${PLATFORM}" == "aarch64" ]]; then \
 			export AUDITWHEEL_PLAT=manylinux2014_${PLATFORM}; \

--- a/python/graphscope/gsctl/scripts/install_deps.sh
+++ b/python/graphscope/gsctl/scripts/install_deps.sh
@@ -882,8 +882,8 @@ install_interactive_dependencies() {
   if ! command -v rustup &>/dev/null; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     source $HOME/.cargo/env
-    rustup install 1.76.0
-    rustup default 1.76.0
+    rustup install 1.81.0
+    rustup default 1.81.0
     rustc --version
   fi
   # opentelemetry


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #4372 

