### PR TITLE
fix(analytical): Fix Louvain algorithm's stop condition

### DIFF
--- a/analytical_engine/apps/pregel/louvain/louvain_app_base.h
+++ b/analytical_engine/apps/pregel/louvain/louvain_app_base.h
@@ -226,8 +226,7 @@ class LouvainAppBase
       // after one pass if already decided halt, that means the pass yield no
       // changes, so we halt computation.
       if (current_super_step <= 14 ||
-          std::fabs(actual_quality - ctx.prev_quality()) <
-              min_quality_improvement) {
+          (actual_quality - ctx.prev_quality()) <= min_quality_improvement) {
         // turn to sync community result
         ctx.compute_context().set_superstep(sync_result_step);
         syncCommunity(frag, ctx, messages);


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
When using Louvain algorithm, I found a question with its stop condition, the Louvain algotithm's quality may be 0, 0.85, 0.80, I want to stop the iterations at 0.80 as the quality has started to decrease, but the current stop condition can't do that.
Besides, the change is consistent with [NetworkX's implementation](https://github.com/networkx/networkx/blob/c34400f1ea5b9daa733b971f7f5ef7072fe410a9/networkx/algorithms/community/louvain.py#L216)

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

