### PR TITLE
fix(interactive): Refactor EdgeColumn Implementation

### DIFF
--- a/flex/engines/graph_db/runtime/adhoc/operators/procedure_call.cc
+++ b/flex/engines/graph_db/runtime/adhoc/operators/procedure_call.cc
@@ -143,12 +143,11 @@ RTAny edge_to_rt_any(const results::Edge& edge) {
                              std::get<2>(edge_triplet_tuple)};
   if (properties.size() == 0) {
     return RTAny::from_edge(
-        std::tuple{label_triplet, src_vid, dst_vid, Any(), Direction::kOut});
+        {label_triplet, src_vid, dst_vid, Any(), Direction::kOut});
   } else if (properties.size() == 1) {
     LOG(FATAL) << "Not implemented.";
-    return RTAny::from_edge(std::tuple{label_triplet, src_vid, dst_vid,
-                                       property_to_any(properties[0]),
-                                       Direction::kOut});
+    return RTAny::from_edge({label_triplet, src_vid, dst_vid,
+                             property_to_any(properties[0]), Direction::kOut});
   } else {
     std::vector<Any> props;
     for (auto& prop : properties) {
@@ -157,7 +156,7 @@ RTAny edge_to_rt_any(const results::Edge& edge) {
     Any any;
     any.set_record(props);
     return RTAny::from_edge(
-        std::tuple{label_triplet, src_vid, dst_vid, any, Direction::kOut});
+        {label_triplet, src_vid, dst_vid, any, Direction::kOut});
   }
 }  // namespace runtime
 

--- a/flex/engines/graph_db/runtime/common/columns/edge_columns.cc
+++ b/flex/engines/graph_db/runtime/common/columns/edge_columns.cc
@@ -29,7 +29,7 @@ std::shared_ptr<IContextColumn> SDSLEdgeColumn::dup() const {
   builder.reserve(edges_.size());
   for (size_t i = 0; i < edges_.size(); ++i) {
     auto e = get_edge(i);
-    builder.push_back_opt(std::get<1>(e), std::get<2>(e), std::get<3>(e));
+    builder.push_back_opt(e.src_, e.dst_, e.prop_);
   }
   return builder.finish();
 }
@@ -58,7 +58,41 @@ std::shared_ptr<IContextColumn> SDSLEdgeColumn::shuffle(
       size_t off = offsets[idx];
       const auto& e = edges_[off];
       builder.push_back_endpoints(e.first, e.second);
-      ret_props.set_any(idx, prop_col_->get(off));
+      ret_props.set_any(idx, prop_col_.get(), off);
+    }
+  }
+
+  return builder.finish();
+}
+
+std::shared_ptr<IContextColumn> SDSLEdgeColumn::optional_shuffle(
+    const std::vector<size_t>& offsets) const {
+  CHECK(prop_type_ != PropertyType::kRecordView);
+  OptionalSDSLEdgeColumnBuilder builder(dir_, label_, prop_type_);
+  size_t new_row_num = offsets.size();
+  builder.reserve(new_row_num);
+
+  if (prop_type_ == PropertyType::kEmpty) {
+    for (auto off : offsets) {
+      if (off == std::numeric_limits<size_t>::max()) {
+        builder.push_back_null();
+      } else {
+        const auto& e = edges_[off];
+        builder.push_back_endpoints(e.first, e.second);
+      }
+    }
+  } else {
+    auto& ret_props = *builder.prop_col_;
+    ret_props.resize(new_row_num);
+    for (size_t idx = 0; idx < new_row_num; ++idx) {
+      size_t off = offsets[idx];
+      if (off == std::numeric_limits<size_t>::max()) {
+        builder.push_back_null();
+      } else {
+        const auto& e = edges_[off];
+        builder.push_back_endpoints(e.first, e.second);
+        ret_props.set_any(idx, prop_col_.get(), off);
+      }
     }
   }
 
@@ -70,7 +104,7 @@ std::shared_ptr<IContextColumn> SDSLEdgeColumnBuilder::finish() {
       std::make_shared<SDSLEdgeColumn>(dir_, label_, prop_type_, sub_types_);
   ret->edges_.swap(edges_);
   // shrink to fit
-  prop_col_->resize(edges_.size());
+  prop_col_->resize(ret->edges_.size());
   ret->prop_col_ = prop_col_;
   return ret;
 }
@@ -80,8 +114,7 @@ std::shared_ptr<IContextColumn> BDSLEdgeColumn::dup() const {
   builder.reserve(size());
   for (size_t i = 0; i < size(); ++i) {
     auto e = get_edge(i);
-    builder.push_back_opt(std::get<1>(e), std::get<2>(e), std::get<3>(e),
-                          std::get<4>(e));
+    builder.push_back_opt(e.src_, e.dst_, e.prop_, e.dir_);
   }
   return builder.finish();
 }
@@ -98,7 +131,30 @@ std::shared_ptr<IContextColumn> BDSLEdgeColumn::shuffle(
     size_t off = offsets[idx];
     const auto& e = edges_[off];
     builder.push_back_endpoints(std::get<0>(e), std::get<1>(e), std::get<2>(e));
-    ret_props.set_any(idx, prop_col_->get(off));
+    ret_props.set_any(idx, prop_col_.get(), off);
+  }
+
+  return builder.finish();
+}
+
+std::shared_ptr<IContextColumn> BDSLEdgeColumn::optional_shuffle(
+    const std::vector<size_t>& offsets) const {
+  OptionalBDSLEdgeColumnBuilder builder(label_, prop_type_);
+  size_t new_row_num = offsets.size();
+  builder.reserve(new_row_num);
+
+  auto& ret_props = *builder.prop_col_;
+  ret_props.resize(new_row_num);
+  for (size_t idx = 0; idx < new_row_num; ++idx) {
+    size_t off = offsets[idx];
+    if (off == std::numeric_limits<size_t>::max()) {
+      builder.push_back_null();
+    } else {
+      const auto& e = edges_[off];
+      builder.push_back_endpoints(std::get<0>(e), std::get<1>(e),
+                                  std::get<2>(e));
+      ret_props.set_any(idx, prop_col_.get(), off);
+    }
   }
 
   return builder.finish();
@@ -106,6 +162,7 @@ std::shared_ptr<IContextColumn> BDSLEdgeColumn::shuffle(
 
 std::shared_ptr<IContextColumn> BDSLEdgeColumnBuilder::finish() {
   auto ret = std::make_shared<BDSLEdgeColumn>(label_, prop_type_);
+  prop_col_->resize(edges_.size());
   ret->edges_.swap(edges_);
   ret->prop_col_ = prop_col_;
   return ret;
@@ -189,8 +246,7 @@ std::shared_ptr<IContextColumn> OptionalBDSLEdgeColumn::shuffle(
   for (size_t idx = 0; idx < new_row_num; ++idx) {
     size_t off = offsets[idx];
     const auto& e = get_edge(off);
-    builder.push_back_opt(std::get<1>(e), std::get<2>(e), std::get<3>(e),
-                          std::get<4>(e));
+    builder.push_back_opt(e.src_, e.dst_, e.prop_, e.dir_);
   }
   return builder.finish();
 }
@@ -199,8 +255,24 @@ std::shared_ptr<IContextColumn> OptionalBDSLEdgeColumn::dup() const {
   builder.reserve(edges_.size());
   for (size_t i = 0; i < edges_.size(); ++i) {
     auto e = get_edge(i);
-    builder.push_back_opt(std::get<1>(e), std::get<2>(e), std::get<3>(e),
-                          std::get<4>(e));
+    builder.push_back_opt(e.src_, e.dst_, e.prop_, e.dir_);
+  }
+  return builder.finish();
+}
+
+std::shared_ptr<IContextColumn> OptionalBDSLEdgeColumn::optional_shuffle(
+    const std::vector<size_t>& offsets) const {
+  OptionalBDSLEdgeColumnBuilder builder(label_, prop_type_);
+  size_t new_row_num = offsets.size();
+  builder.reserve(new_row_num);
+  for (size_t idx = 0; idx < new_row_num; ++idx) {
+    size_t off = offsets[idx];
+    if (off == std::numeric_limits<size_t>::max()) {
+      builder.push_back_null();
+      continue;
+    }
+    const auto& e = get_edge(off);
+    builder.push_back_opt(e.src_, e.dst_, e.prop_, e.dir_);
   }
   return builder.finish();
 }
@@ -209,6 +281,8 @@ std::shared_ptr<IContextColumn> OptionalBDSLEdgeColumnBuilder::finish() {
   auto ret = std::make_shared<OptionalBDSLEdgeColumn>(label_, prop_type_);
   ret->edges_.swap(edges_);
   ret->prop_col_ = prop_col_;
+  // shrink to fit
+  ret->prop_col_->resize(ret->edges_.size());
   return ret;
 }
 
@@ -220,7 +294,7 @@ std::shared_ptr<IContextColumn> OptionalSDSLEdgeColumn::shuffle(
   for (size_t idx = 0; idx < new_row_num; ++idx) {
     size_t off = offsets[idx];
     const auto& e = get_edge(off);
-    builder.push_back_opt(std::get<1>(e), std::get<2>(e), std::get<3>(e));
+    builder.push_back_opt(e.src_, e.dst_, e.prop_);
   }
   return builder.finish();
 }
@@ -230,7 +304,7 @@ std::shared_ptr<IContextColumn> OptionalSDSLEdgeColumn::dup() const {
   builder.reserve(edges_.size());
   for (size_t i = 0; i < edges_.size(); ++i) {
     auto e = get_edge(i);
-    builder.push_back_opt(std::get<1>(e), std::get<2>(e), std::get<3>(e));
+    builder.push_back_opt(e.src_, e.dst_, e.prop_);
   }
   return builder.finish();
 }
@@ -239,6 +313,8 @@ std::shared_ptr<IContextColumn> OptionalSDSLEdgeColumnBuilder::finish() {
   auto ret = std::make_shared<OptionalSDSLEdgeColumn>(dir_, label_, prop_type_);
   ret->edges_.swap(edges_);
   ret->prop_col_ = prop_col_;
+  // shrink to fit
+  ret->prop_col_->resize(ret->edges_.size());
   return ret;
 }
 

--- a/flex/engines/graph_db/runtime/common/columns/edge_columns.h
+++ b/flex/engines/graph_db/runtime/common/columns/edge_columns.h
@@ -79,7 +79,8 @@ static inline void set_edge_data(EdgePropVecBase* col, size_t idx,
     dynamic_cast<EdgePropVec<Date>*>(col)->set(idx,
                                                Date(edge_data.value.i64_val));
   } else {
-    // LOG(FATAL) << "not support for " << edge_data.type;
+    LOG(FATAL) << "not support for "
+               << static_cast<int>(edge_data.type.type_enum_);
   }
 }
 

--- a/flex/engines/graph_db/runtime/common/columns/edge_columns.h
+++ b/flex/engines/graph_db/runtime/common/columns/edge_columns.h
@@ -499,9 +499,7 @@ class OptionalBDSLEdgeColumn : public IEdgeColumn {
            std::get<1>(edges_[idx]) != std::numeric_limits<vid_t>::max();
   }
 
-  std::vector<LabelTriplet> get_labels() const override {
-    return {label_};
-  }
+  std::vector<LabelTriplet> get_labels() const override { return {label_}; }
 
   EdgeColumnType edge_column_type() const override {
     return EdgeColumnType::kBDSL;

--- a/flex/engines/graph_db/runtime/common/columns/edge_columns.h
+++ b/flex/engines/graph_db/runtime/common/columns/edge_columns.h
@@ -703,8 +703,7 @@ class SDSLEdgeColumnBuilder : public IContextColumnBuilder {
         label_(label),
         prop_type_(prop_type),
         prop_col_(EdgePropVecBase::make_edge_prop_vec(prop_type)),
-        sub_types_(sub_types),
-        cap_(0) {}
+        sub_types_(sub_types) {}
   ~SDSLEdgeColumnBuilder() = default;
 
   void reserve(size_t size) override { edges_.reserve(size); }
@@ -733,7 +732,6 @@ class SDSLEdgeColumnBuilder : public IContextColumnBuilder {
   PropertyType prop_type_;
   std::shared_ptr<EdgePropVecBase> prop_col_;
   std::vector<PropertyType> sub_types_;
-  size_t cap_;
 };
 
 template <typename T>

--- a/flex/engines/graph_db/runtime/common/columns/i_context_column.h
+++ b/flex/engines/graph_db/runtime/common/columns/i_context_column.h
@@ -192,6 +192,12 @@ class IContextColumn {
     return nullptr;
   }
 
+  virtual std::shared_ptr<IContextColumn> optional_shuffle(
+      const std::vector<size_t>& offsets) const {
+    LOG(FATAL) << "not implemented for " << this->column_info();
+    return nullptr;
+  }
+
   virtual std::shared_ptr<IContextColumn> union_col(
       std::shared_ptr<IContextColumn> other) const {
     LOG(FATAL) << "not implemented for " << this->column_info();
@@ -214,6 +220,20 @@ class IContextColumn {
 
   virtual void generate_dedup_offset(std::vector<size_t>& offsets) const {
     LOG(FATAL) << "not implemented for " << this->column_info();
+  }
+
+  virtual std::pair<std::shared_ptr<IContextColumn>,
+                    std::vector<std::vector<size_t>>>
+  generate_aggregate_offset() const {
+    LOG(INFO) << "not implemented for " << this->column_info();
+    std::shared_ptr<IContextColumn> col(nullptr);
+    return std::make_pair(col, std::vector<std::vector<size_t>>());
+  }
+
+  virtual bool order_by_limit(bool asc, size_t limit,
+                              std::vector<size_t>& offsets) const {
+    LOG(INFO) << "order by limit not implemented for " << this->column_info();
+    return false;
   }
 };
 

--- a/flex/engines/graph_db/runtime/common/columns/value_columns.h
+++ b/flex/engines/graph_db/runtime/common/columns/value_columns.h
@@ -19,6 +19,7 @@
 #include "flex/engines/graph_db/runtime/common/columns/i_context_column.h"
 #include "flex/engines/graph_db/runtime/common/rt_any.h"
 
+#include <string_view>
 #include <vector>
 
 namespace gs {

--- a/flex/engines/graph_db/runtime/common/operators/get_v.h
+++ b/flex/engines/graph_db/runtime/common/operators/get_v.h
@@ -113,7 +113,7 @@ class GetV {
       if (opt == VOpt::kStart) {
         input_edge_list.foreach_edge(
             [&](size_t index, const LabelTriplet& label, vid_t src, vid_t dst,
-                const Any& edata, Direction dir) {
+                const EdgeData& edata, Direction dir) {
               if (pred(label.src_label, src, index)) {
                 builder.push_back_opt(src);
                 shuffle_offset.push_back(index);
@@ -122,7 +122,7 @@ class GetV {
       } else if (opt == VOpt::kEnd) {
         input_edge_list.foreach_edge(
             [&](size_t index, const LabelTriplet& label, vid_t src, vid_t dst,
-                const Any& edata, Direction dir) {
+                const EdgeData& edata, Direction dir) {
               if (pred(label.dst_label, dst, index)) {
                 builder.push_back_opt(dst);
                 shuffle_offset.push_back(index);
@@ -159,7 +159,7 @@ class GetV {
         if (opt == VOpt::kStart) {
           input_edge_list.foreach_edge([&](size_t index,
                                            const LabelTriplet& label, vid_t src,
-                                           vid_t dst, const Any& edata,
+                                           vid_t dst, const EdgeData& edata,
                                            Direction dir) {
             if (std::find(labels.begin(), labels.end(), label.src_label) !=
                 labels.end()) {
@@ -170,7 +170,7 @@ class GetV {
         } else if (opt == VOpt::kEnd) {
           input_edge_list.foreach_edge([&](size_t index,
                                            const LabelTriplet& label, vid_t src,
-                                           vid_t dst, const Any& edata,
+                                           vid_t dst, const EdgeData& edata,
                                            Direction dir) {
             if (std::find(labels.begin(), labels.end(), label.dst_label) !=
                 labels.end()) {
@@ -196,7 +196,7 @@ class GetV {
           CHECK(params.opt == VOpt::kOther);
           input_edge_list.foreach_edge([&](size_t index,
                                            const LabelTriplet& label, vid_t src,
-                                           vid_t dst, const Any& edata,
+                                           vid_t dst, const EdgeData& edata,
                                            Direction dir) {
             if (dir == Direction::kOut) {
               builder.push_back_vertex(std::make_pair(label.dst_label, dst));
@@ -212,7 +212,7 @@ class GetV {
           SLVertexColumnBuilder builder(type.src_label);
           input_edge_list.foreach_edge(
               [&](size_t index, const LabelTriplet& label, vid_t src, vid_t dst,
-                  const Any& edata, Direction dir) {
+                  const EdgeData& edata, Direction dir) {
                 if (dir == Direction::kOut) {
                   builder.push_back_opt(dst);
                   shuffle_offset.push_back(index);
@@ -237,7 +237,7 @@ class GetV {
           SLVertexColumnBuilder builder(labels[0]);
           input_edge_list.foreach_edge(
               [&](size_t index, const LabelTriplet& label, vid_t src, vid_t dst,
-                  const Any& edata, Direction dir) {
+                  const EdgeData& edata, Direction dir) {
                 if (dir == Direction::kOut) {
                   if (label.dst_label == labels[0]) {
                     builder.push_back_opt(dst);
@@ -257,7 +257,7 @@ class GetV {
           MLVertexColumnBuilder builder;
           input_edge_list.foreach_edge([&](size_t index,
                                            const LabelTriplet& label, vid_t src,
-                                           vid_t dst, const Any& edata,
+                                           vid_t dst, const EdgeData& edata,
                                            Direction dir) {
             if (dir == Direction::kOut) {
               if (std::find(labels.begin(), labels.end(), label.dst_label) !=
@@ -286,7 +286,7 @@ class GetV {
         CHECK(params.opt == VOpt::kOther);
         input_edge_list.foreach_edge(
             [&](size_t index, const LabelTriplet& label, vid_t src, vid_t dst,
-                const Any& edata, Direction dir) {
+                const EdgeData& edata, Direction dir) {
               if (dir == Direction::kOut) {
                 builder.push_back_vertex(std::make_pair(label.dst_label, dst));
               } else {
@@ -303,7 +303,7 @@ class GetV {
           SLVertexColumnBuilder builder(vlabel);
           input_edge_list.foreach_edge(
               [&](size_t index, const LabelTriplet& label, vid_t src, vid_t dst,
-                  const Any& edata, Direction dir) {
+                  const EdgeData& edata, Direction dir) {
                 if (dir == Direction::kOut) {
                   if (label.dst_label == vlabel) {
                     builder.push_back_opt(dst);
@@ -327,7 +327,7 @@ class GetV {
           MLVertexColumnBuilder builder;
           input_edge_list.foreach_edge([&](size_t index,
                                            const LabelTriplet& label, vid_t src,
-                                           vid_t dst, const Any& edata,
+                                           vid_t dst, const EdgeData& edata,
                                            Direction dir) {
             if (dir == Direction::kOut) {
               if (labels[label.dst_label]) {

--- a/flex/engines/graph_db/runtime/common/rt_any.cc
+++ b/flex/engines/graph_db/runtime/common/rt_any.cc
@@ -48,6 +48,9 @@ const RTAnyType RTAnyType::kNull = RTAnyType(RTAnyType::RTAnyTypeImpl::kNull);
 const RTAnyType RTAnyType::kTuple = RTAnyType(RTAnyType::RTAnyTypeImpl::kTuple);
 const RTAnyType RTAnyType::kList = RTAnyType(RTAnyType::RTAnyTypeImpl::kList);
 const RTAnyType RTAnyType::kMap = RTAnyType(RTAnyType::RTAnyTypeImpl::kMap);
+const RTAnyType RTAnyType::kEmpty = RTAnyType(RTAnyType::RTAnyTypeImpl::kEmpty);
+const RTAnyType RTAnyType::kRecordView =
+    RTAnyType(RTAnyType::RTAnyTypeImpl::kRecordView);
 RTAny List::get(size_t idx) const { return impl_->get(idx); }
 RTAnyType parse_from_ir_data_type(const ::common::IrDataType& dt) {
   switch (dt.type_case()) {
@@ -70,6 +73,8 @@ RTAnyType parse_from_ir_data_type(const ::common::IrDataType& dt) {
       return RTAnyType::kDate32;
     case ::common::DataType::DOUBLE:
       return RTAnyType::kF64Value;
+    case ::common::DataType::NONE:
+      return RTAnyType::kUnknown;
     default:
       LOG(FATAL) << "unrecoginized data type - " << ddt;
       break;
@@ -95,6 +100,27 @@ RTAnyType parse_from_ir_data_type(const ::common::IrDataType& dt) {
 
   // LOG(FATAL) << "unknown";
   return RTAnyType::kUnknown;
+}
+
+PropertyType rt_type_to_property_type(RTAnyType type) {
+  switch (type.type_enum_) {
+  case RTAnyType::RTAnyTypeImpl::kEmpty:
+    return PropertyType::kEmpty;
+  case RTAnyType::RTAnyTypeImpl::kI64Value:
+    return PropertyType::kInt64;
+  case RTAnyType::RTAnyTypeImpl::kI32Value:
+    return PropertyType::kInt32;
+  case RTAnyType::RTAnyTypeImpl::kF64Value:
+    return PropertyType::kDouble;
+  case RTAnyType::RTAnyTypeImpl::kBoolValue:
+    return PropertyType::kBool;
+  case RTAnyType::RTAnyTypeImpl::kStringValue:
+    return PropertyType::kString;
+  case RTAnyType::RTAnyTypeImpl::kDate32:
+    return PropertyType::kDate;
+  default:
+    LOG(FATAL) << "not support for " << static_cast<int>(type.type_enum_);
+  }
 }
 
 RTAny::RTAny() : type_(RTAnyType::kUnknown), value_() {}
@@ -124,6 +150,32 @@ RTAny::RTAny(const Any& val) {
   } else {
     LOG(FATAL) << "Any value: " << val.to_string()
                << ", type = " << val.type.type_enum;
+  }
+}
+
+RTAny::RTAny(const EdgeData& val) {
+  if (val.type == RTAnyType::kI64Value) {
+    type_ = RTAnyType::kI64Value;
+    value_.i64_val = val.value.i64_val;
+  } else if (val.type == RTAnyType::kStringValue) {
+    type_ = RTAnyType::kStringValue;
+    value_.str_val =
+        std::string_view(val.value.str_val.data(), val.value.str_val.size());
+  } else if (val.type == RTAnyType::kI32Value) {
+    type_ = RTAnyType::kI32Value;
+    value_.i32_val = val.value.i32_val;
+  } else if (val.type == RTAnyType::kF64Value) {
+    type_ = RTAnyType::kF64Value;
+    value_.f64_val = val.value.f64_val;
+  } else if (val.type == RTAnyType::kBoolValue) {
+    type_ = RTAnyType::kBoolValue;
+    value_.b_val = val.value.b_val;
+  } else if (val.type == RTAnyType::kDate32) {
+    type_ = RTAnyType::kDate32;
+    value_.i64_val = val.value.i64_val;
+  } else {
+    LOG(FATAL) << "Any value: " << val.to_string()
+               << ", type = " << static_cast<int>(val.type.type_enum_);
   }
 }
 
@@ -202,8 +254,7 @@ RTAny RTAny::from_vertex(const std::pair<label_t, vid_t>& v) {
   return ret;
 }
 
-RTAny RTAny::from_edge(
-    const std::tuple<LabelTriplet, vid_t, vid_t, Any, Direction>& v) {
+RTAny RTAny::from_edge(const EdgeRecord& v) {
   RTAny ret;
   ret.type_ = RTAnyType::kEdge;
   ret.value_.edge = v;
@@ -343,8 +394,7 @@ const std::pair<label_t, vid_t>& RTAny::as_vertex() const {
   CHECK(type_ == RTAnyType::kVertex);
   return value_.vertex;
 }
-const std::tuple<LabelTriplet, vid_t, vid_t, Any, Direction>& RTAny::as_edge()
-    const {
+const EdgeRecord& RTAny::as_edge() const {
   CHECK(type_ == RTAnyType::kEdge);
   return value_.edge;
 }
@@ -618,6 +668,23 @@ void sink_vertex(const gs::ReadTransaction& txn,
   }
 }
 
+static void sink_edge_data(const EdgeData& any, common::Value* value) {
+  if (any.type == RTAnyType::kI64Value) {
+    value->set_i64(any.value.i64_val);
+  } else if (any.type == RTAnyType::kStringValue) {
+    value->set_str(any.value.str_val.data(), any.value.str_val.size());
+  } else if (any.type == RTAnyType::kI32Value) {
+    value->set_i32(any.value.i32_val);
+  } else if (any.type == RTAnyType::kF64Value) {
+    value->set_f64(any.value.f64_val);
+  } else if (any.type == RTAnyType::kBoolValue) {
+    value->set_boolean(any.value.b_val);
+  } else {
+    LOG(FATAL) << "Any value: " << any.to_string()
+               << ", type = " << static_cast<int>(any.type.type_enum_);
+  }
+}
+
 void RTAny::sink(const gs::ReadTransaction& txn, int id,
                  results::Column* col) const {
   col->mutable_name_or_id()->set_id(id);
@@ -677,9 +744,9 @@ void RTAny::sink(const gs::ReadTransaction& txn, int id,
     if (prop_names.size() == 1) {
       auto props = e->add_properties();
       props->mutable_key()->set_name(prop_names[0]);
-      sink_any(prop, e->mutable_properties(0)->mutable_value());
+      sink_edge_data(prop, e->mutable_properties(0)->mutable_value());
     } else if (prop_names.size() > 1) {
-      auto rv = prop.AsRecordView();
+      auto rv = prop.as<RecordView>();
       if (rv.size() != prop_names.size()) {
         LOG(ERROR) << "record view size not match with prop names";
       }
@@ -803,6 +870,27 @@ std::string RTAny::to_string() const {
   }
 }
 
+std::shared_ptr<EdgePropVecBase> EdgePropVecBase::make_edge_prop_vec(
+    PropertyType type) {
+  if (type == PropertyType::Int64()) {
+    return std::make_shared<EdgePropVec<int64_t>>();
+  } else if (type == PropertyType::StringView()) {
+    return std::make_shared<EdgePropVec<std::string_view>>();
+  } else if (type == PropertyType::Date()) {
+    return std::make_shared<EdgePropVec<Date>>();
+  } else if (type == PropertyType::Int32()) {
+    return std::make_shared<EdgePropVec<int32_t>>();
+  } else if (type == PropertyType::Double()) {
+    return std::make_shared<EdgePropVec<double>>();
+  } else if (type == PropertyType::Bool()) {
+    return std::make_shared<EdgePropVec<bool>>();
+  } else if (type == PropertyType::Empty()) {
+    return std::make_shared<EdgePropVec<grape::EmptyType>>();
+  } else {
+    LOG(FATAL) << "not support for " << type;
+    return nullptr;
+  }
+}
 }  // namespace runtime
 
 }  // namespace gs

--- a/flex/engines/graph_db/runtime/common/types.h
+++ b/flex/engines/graph_db/runtime/common/types.h
@@ -56,6 +56,7 @@ enum class JoinKind {
 };
 
 struct LabelTriplet {
+  LabelTriplet() = default;
   LabelTriplet(label_t src, label_t dst, label_t edge)
       : src_label(src), dst_label(dst), edge_label(edge) {}
 


### PR DESCRIPTION
Use In-memory EdgePropVector to store edge properties for EdgeColumn. Speed up EdgeColumn scanning.

Fix #4392 

Co-Authored-By: liulx20 liulexiao.llx@alibaba-inc.com