### PR TITLE
fix(interactive): Support Http Gremlin Service

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/HttpContext.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/HttpContext.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *  * Copyright 2020 Alibaba Group Holding Limited.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.alibaba.graphscope.gremlin.plugin.processor;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.*;
+
+import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.driver.message.ResponseMessage;
+import org.apache.tinkerpop.gremlin.driver.message.ResponseStatusCode;
+import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer;
+import org.apache.tinkerpop.gremlin.driver.ser.SerializationException;
+import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
+import org.apache.tinkerpop.gremlin.server.Context;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.handler.HttpHandlerUtils;
+import org.javatuples.Pair;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Maintain the gremlin execution context for http request.
+ */
+public class HttpContext extends Context {
+    private final Pair<String, MessageTextSerializer<?>> serializer;
+    private final boolean keepAlive;
+    private final AtomicReference<Boolean> headerSent;
+
+    public HttpContext(
+            RequestMessage requestMessage,
+            ChannelHandlerContext ctx,
+            Settings settings,
+            GraphManager graphManager,
+            GremlinExecutor gremlinExecutor,
+            ScheduledExecutorService scheduledExecutorService,
+            Pair<String, MessageTextSerializer<?>> serializer,
+            boolean keepAlive) {
+        super(
+                requestMessage,
+                ctx,
+                settings,
+                graphManager,
+                gremlinExecutor,
+                scheduledExecutorService);
+        this.serializer = Objects.requireNonNull(serializer);
+        this.keepAlive = keepAlive;
+        this.headerSent = new AtomicReference<>(false);
+    }
+
+    /**
+     * serialize the response message to http response and write to http channel.
+     * @param responseMessage
+     */
+    @Override
+    public void writeAndFlush(final ResponseMessage responseMessage) {
+        try {
+            // send header once
+            if (!headerSent.compareAndSet(false, true)) {
+                FullHttpResponse chunkedResponse =
+                        new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+                chunkedResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, serializer.getValue0());
+                chunkedResponse
+                        .headers()
+                        .set(HttpHeaderNames.TRANSFER_ENCODING, HttpHeaderValues.CHUNKED);
+                this.getChannelHandlerContext().writeAndFlush(chunkedResponse);
+            }
+            ByteBuf byteBuf =
+                    Unpooled.wrappedBuffer(
+                            serializer
+                                    .getValue1()
+                                    .serializeResponseAsString(responseMessage)
+                                    .getBytes(StandardCharsets.UTF_8));
+            FullHttpResponse response =
+                    new DefaultFullHttpResponse(
+                            HttpVersion.HTTP_1_1, HttpResponseStatus.OK, byteBuf);
+            ChannelFuture channelFuture = this.getChannelHandlerContext().writeAndFlush(response);
+            ResponseStatusCode statusCode = responseMessage.getStatus().getCode();
+            if (!keepAlive && statusCode.isFinalResponse()) {
+                channelFuture.addListener(ChannelFutureListener.CLOSE);
+            }
+        } catch (SerializationException e) {
+            HttpHandlerUtils.sendError(
+                    this.getChannelHandlerContext(),
+                    HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                    e.getMessage(),
+                    keepAlive);
+        }
+    }
+}

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/service/IrHttpGremlinHandler.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/service/IrHttpGremlinHandler.java
@@ -1,0 +1,217 @@
+/*
+ *
+ *  * Copyright 2020 Alibaba Group Holding Limited.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.alibaba.graphscope.gremlin.service;
+
+import com.alibaba.graphscope.gremlin.Utils;
+import com.alibaba.graphscope.gremlin.plugin.processor.HttpContext;
+import com.alibaba.graphscope.gremlin.plugin.processor.IrOpLoader;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.*;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
+import org.apache.tinkerpop.gremlin.driver.message.RequestMessage;
+import org.apache.tinkerpop.gremlin.driver.ser.MessageTextSerializer;
+import org.apache.tinkerpop.gremlin.groovy.engine.GremlinExecutor;
+import org.apache.tinkerpop.gremlin.server.GraphManager;
+import org.apache.tinkerpop.gremlin.server.OpProcessor;
+import org.apache.tinkerpop.gremlin.server.Settings;
+import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
+import org.apache.tinkerpop.gremlin.server.handler.HttpHandlerUtils;
+import org.javatuples.Pair;
+import org.javatuples.Quartet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class IrHttpGremlinHandler extends HttpGremlinEndpointHandler {
+    private static final Logger logger = LoggerFactory.getLogger(HttpGremlinEndpointHandler.class);
+    private final Map<String, MessageSerializer<?>> serializers;
+    private final GremlinExecutor gremlinExecutor;
+    private final GraphManager graphManager;
+    private final Settings settings;
+    private final Pattern pattern;
+
+    public IrHttpGremlinHandler(
+            final Map<String, MessageSerializer<?>> serializers,
+            final GremlinExecutor gremlinExecutor,
+            final GraphManager graphManager,
+            final Settings settings) {
+        super(serializers, gremlinExecutor, graphManager, settings);
+        this.serializers =
+                Utils.getFieldValue(HttpGremlinEndpointHandler.class, this, "serializers");
+        this.gremlinExecutor =
+                Utils.getFieldValue(HttpGremlinEndpointHandler.class, this, "gremlinExecutor");
+        this.graphManager =
+                Utils.getFieldValue(HttpGremlinEndpointHandler.class, this, "graphManager");
+        this.settings = Utils.getFieldValue(HttpGremlinEndpointHandler.class, this, "settings");
+        this.pattern = Pattern.compile("(.*);q=(.*)");
+    }
+
+    /**
+     * Convert {@code FullHttpRequest} to {@code RequestMessage}, and process the request by {@code IrStandardOpProcessor}
+     * @param ctx
+     * @param msg
+     */
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+        if (msg instanceof FullHttpRequest) {
+            FullHttpRequest req = (FullHttpRequest) msg;
+            boolean keepAlive = HttpUtil.isKeepAlive(req);
+            try {
+                if ("/favicon.ico".equals(req.uri())) {
+                    HttpHandlerUtils.sendError(
+                            ctx,
+                            HttpResponseStatus.NOT_FOUND,
+                            "Gremlin Server doesn't have a favicon.ico",
+                            keepAlive);
+                    return;
+                }
+
+                if (HttpUtil.is100ContinueExpected(req)) {
+                    ctx.write(
+                            new DefaultFullHttpResponse(
+                                    HttpVersion.HTTP_1_1, HttpResponseStatus.CONTINUE));
+                }
+
+                if (req.method() != HttpMethod.GET && req.method() != HttpMethod.POST) {
+                    HttpHandlerUtils.sendError(
+                            ctx,
+                            HttpResponseStatus.METHOD_NOT_ALLOWED,
+                            HttpResponseStatus.METHOD_NOT_ALLOWED.toString(),
+                            keepAlive);
+                    return;
+                }
+
+                RequestMessage requestMessage;
+                try {
+                    requestMessage = createRequestMessage(req);
+                } catch (Exception e) {
+                    HttpHandlerUtils.sendError(
+                            ctx, HttpResponseStatus.BAD_REQUEST, e.getMessage(), keepAlive);
+                    return;
+                }
+
+                String acceptString =
+                        Optional.ofNullable(req.headers().get("Accept")).orElse("application/json");
+                Pair<String, MessageTextSerializer<?>> serializer =
+                        this.chooseSerializer(acceptString);
+                if (null == serializer) {
+                    HttpHandlerUtils.sendError(
+                            ctx,
+                            HttpResponseStatus.BAD_REQUEST,
+                            String.format(
+                                    "no serializer for requested Accept header: %s", acceptString),
+                            keepAlive);
+                    return;
+                }
+
+                HttpContext context =
+                        new HttpContext(
+                                requestMessage,
+                                ctx,
+                                this.settings,
+                                this.graphManager,
+                                this.gremlinExecutor,
+                                this.gremlinExecutor.getScheduledExecutorService(),
+                                serializer,
+                                keepAlive);
+
+                OpProcessor opProcessor = IrOpLoader.getProcessor("").get();
+                opProcessor.select(context).accept(context);
+            } catch (Exception e) {
+                Throwable t = ExceptionUtils.getRootCause(e);
+                if (t instanceof TooLongFrameException) {
+                    HttpHandlerUtils.sendError(
+                            ctx,
+                            HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
+                            t.getMessage() + " - increase the maxContentLength",
+                            false);
+                } else {
+                    String message = (t != null) ? t.getMessage() : e.getMessage();
+                    HttpHandlerUtils.sendError(
+                            ctx, HttpResponseStatus.INTERNAL_SERVER_ERROR, message, keepAlive);
+                }
+            } finally {
+                if (req.refCnt() > 0) {
+                    boolean fullyRelease = req.release();
+                    if (!fullyRelease) {
+                        logger.warn(
+                                "http request message was not fully released, may cause a"
+                                        + " memory leak");
+                    }
+                }
+            }
+        }
+    }
+
+    private Pair<String, MessageTextSerializer<?>> chooseSerializer(final String acceptString) {
+        List<Pair<String, Double>> ordered =
+                Stream.of(acceptString.split(","))
+                        .map(
+                                (mediaType) -> {
+                                    Matcher matcher = pattern.matcher(mediaType);
+                                    return matcher.matches()
+                                            ? Pair.with(
+                                                    matcher.group(1),
+                                                    Double.parseDouble(matcher.group(2)))
+                                            : Pair.with(mediaType, 1.0);
+                                })
+                        .sorted(
+                                (o1, o2) -> {
+                                    return ((String) o2.getValue0())
+                                            .compareTo((String) o1.getValue0());
+                                })
+                        .collect(Collectors.toList());
+        Iterator var3 = ordered.iterator();
+
+        String accept;
+        do {
+            if (!var3.hasNext()) {
+                return null;
+            }
+
+            Pair<String, Double> p = (Pair) var3.next();
+            accept = p.getValue0().equals("*/*") ? "application/json" : p.getValue0();
+        } while (!this.serializers.containsKey(accept));
+
+        return Pair.with(accept, (MessageTextSerializer) this.serializers.get(accept));
+    }
+
+    private RequestMessage createRequestMessage(FullHttpRequest httpRequest) {
+        Quartet<String, Map<String, Object>, String, Map<String, String>> req =
+                HttpHandlerUtils.getRequestArguments(httpRequest);
+        return RequestMessage.build("eval")
+                .addArg("gremlin", req.getValue0())
+                .addArg("bindings", req.getValue1())
+                .addArg("language", req.getValue2())
+                .addArg("aliases", req.getValue3())
+                .create();
+    }
+}

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/service/IrWsAndHttpChannelizer.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/service/IrWsAndHttpChannelizer.java
@@ -20,22 +20,22 @@ import com.alibaba.graphscope.gremlin.Utils;
 
 import org.apache.tinkerpop.gremlin.server.AbstractChannelizer;
 import org.apache.tinkerpop.gremlin.server.channel.WsAndHttpChannelizer;
-import org.apache.tinkerpop.gremlin.server.handler.HttpGremlinEndpointHandler;
 import org.apache.tinkerpop.gremlin.server.handler.OpSelectorHandler;
 import org.apache.tinkerpop.gremlin.server.handler.WsAndHttpChannelizerHandler;
 import org.apache.tinkerpop.gremlin.server.util.ServerGremlinExecutor;
 
 // config the channelizer in conf/gremlin-server.yaml to set the IrOpSelectorHandler as the default
 public class IrWsAndHttpChannelizer extends WsAndHttpChannelizer {
-    private WsAndHttpChannelizerHandler handler;
 
     @Override
     public void init(ServerGremlinExecutor serverGremlinExecutor) {
         super.init(serverGremlinExecutor);
-        this.handler = new WsAndHttpChannelizerHandler();
-        this.handler.init(
+        WsAndHttpChannelizerHandler handler =
+                Utils.getFieldValue(WsAndHttpChannelizer.class, this, "handler");
+        // reset http handler for gremlin request
+        handler.init(
                 serverGremlinExecutor,
-                new HttpGremlinEndpointHandler(
+                new IrHttpGremlinHandler(
                         this.serializers, this.gremlinExecutor, this.graphManager, this.settings));
         OpSelectorHandler irOpSelectorHandler =
                 new IrOpSelectorHandler(

--- a/interactive_engine/compiler/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtils.java
+++ b/interactive_engine/compiler/src/main/java/org/apache/tinkerpop/gremlin/server/handler/HttpHandlerUtils.java
@@ -1,0 +1,52 @@
+/*
+ *
+ *  * Copyright 2020 Alibaba Group Holding Limited.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.apache.tinkerpop.gremlin.server.handler;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import org.javatuples.Quartet;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class HttpHandlerUtils {
+    public static final Quartet<String, Map<String, Object>, String, Map<String, String>>
+            getRequestArguments(final FullHttpRequest request) {
+        return HttpHandlerUtil.getRequestArguments(request);
+    }
+
+    public static final void sendError(
+            final ChannelHandlerContext ctx,
+            final HttpResponseStatus status,
+            final String message,
+            final boolean keepAlive) {
+        sendError(ctx, status, message, Optional.empty(), keepAlive);
+    }
+
+    public static final void sendError(
+            final ChannelHandlerContext ctx,
+            final HttpResponseStatus status,
+            final String message,
+            final Optional<Throwable> t,
+            final boolean keepAlive) {
+        HttpHandlerUtil.sendError(ctx, status, message, t, keepAlive);
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. Support sending Gremlin queries via HTTP requests. Clients can submit queries using curl as shown below:

```
curl -X POST \
    -H "Connection: close" \
    -H "Content-Type: application/json" \
    -d '{"gremlin": "g.V().limit(2)"}' \
    http://localhost:8182/gremlin
```

The response will be in JSON format like:

```
{"requestId":"bb66ad80-336d-4541-8bd3-de0a40451436","status":{"message":"","code":200,"attributes":{"@type":"g:Map","@value":[]}},"result":{"data":{"@type":"g:List","@value":[{"@type":"g:Vertex","@value":{"id":{"@type":"g:Int64","@value":1},"label":"person"}},{"@type":"g:Vertex","@value":{"id":{"@type":"g:Int64","@value":2},"label":"person"}}]},"meta":{"@type":"g:Map","@value":[]}}}
```

If error occurs, the error message with the error code will be returned in json format like:

```
{"requestId":"1882cbfd-a0b4-419d-924e-2ca3a63e209a","status":{"message":"ErrorCode: GREMLIN_INVALID_RESULT\nMessage: getKeyName fail code is TableNotExistError, msg is entity label_id 2 is not found\nEC: 03-0108\nQueryId: 9132153615669087179\n","code":500,"attributes":{"@type":"g:Map","@value":[]}},"result":{"data":null,"meta":{"@type":"g:Map","@value":[]}}}
```

2. The HTTP API also supports streaming results using HTTP Chunked Transfer Encoding. You can use curl or other SDKs to check the streamed results.

3.  If the Gremlin service requires authentication, the request must include the Authorization header, as shown below:

```
curl -X POST \
    -H "Authorization: Basic YWRtaW46YWRtaW4=" \
    -H "Connection: close" \
    -H "Content-Type: application/json" \
    -d '{"gremlin": "g.V().limit(5)"}' \
    http://localhost:8182/gremlin
```

The expected format for the Authorization header is:

```
Authorization: Basic <Base64(user:password)>
```

In this example, `YWRtaW46YWRtaW4=` is the Base64 encoding of `admin:admin`.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

