### PR TITLE
fix(interactive): Download boost source files from archives.boost.io

### DIFF
--- a/python/graphscope/gsctl/scripts/install_deps.sh
+++ b/python/graphscope/gsctl/scripts/install_deps.sh
@@ -293,7 +293,7 @@ install_boost() {
   pushd "${tempdir}" || exit
   directory="boost_1_75_0"
   file="${directory}.tar.gz"
-  url="https://boostorg.jfrog.io/artifactory/main/release/1.75.0/source"
+  url="https://archives.boost.io/release/1.75.0/source"
   url=$(set_to_cn_url ${url})
   download_and_untar "${url}" "${file}" "${directory}"
   pushd ${directory} || exit


### PR DESCRIPTION
Download boost source files from archives.boost.io rather than unavailable jfrog.

CI failure: https://github.com/alibaba/GraphScope/actions/runs/12578855110/job/35058156761
Related Issue: https://github.com/boostorg/boost/issues/997