### PR TITLE
fix(interactive): fix the bug by passing empty STORE_COUNT setting in Groot charts

### DIFF
--- a/charts/graphscope-store/templates/frontend/statefulset.yaml
+++ b/charts/graphscope-store/templates/frontend/statefulset.yaml
@@ -97,6 +97,8 @@ spec:
           env:
             - name: ROLE
               value: "frontend"
+            - name: STORE_COUNT
+              value: "{{ .Values.store.replicaCount }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/graphscope-store/templates/store/statefulset-backup.yaml
+++ b/charts/graphscope-store/templates/store/statefulset-backup.yaml
@@ -101,6 +101,8 @@ spec:
           env:
             - name: ROLE
               value: "store"
+            - name: STORE_COUNT
+              value: "{{ .Values.store.replicaCount }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/charts/graphscope-store/templates/store/statefulset.yaml
+++ b/charts/graphscope-store/templates/store/statefulset.yaml
@@ -97,6 +97,8 @@ spec:
           env:
             - name: ROLE
               value: "store"
+            - name: STORE_COUNT
+              value: "{{ .Values.store.replicaCount }}"
             - name: POD_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The missing value for `STORE_COUNT` in configmap.yaml (https://github.com/alibaba/GraphScope/blob/main/charts/graphscope-store/templates/configmap.yaml#L126) caused the compiler to overlook multiple stores in the configuration. Consequently, the compiler might incorrectly assume the system is non-distributed, potentially omitting essential repartition operations (if worker_num is also set to 1) in the physical plan. This PR addresses the issue by properly setting the value of `STORE_COUNT`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #4402

