### PR TITLE
fix(interactive): Fix linkage for libflex_utils

### DIFF
--- a/flex/CMakeLists.txt
+++ b/flex/CMakeLists.txt
@@ -15,7 +15,7 @@ option(BUILD_DOC "Whether to build doc" OFF)
 option(BUILD_ODPS_FRAGMENT_LOADER "Whether to build odps fragment loader" OFF)
 option(USE_PTHASH "Whether to use pthash" OFF)
 option(OPTIMIZE_FOR_HOST "Whether to optimize on host" ON) # Whether to build optimized code on host
-option(USE_STATIC_ARROW "Whether to use static arrow" ON) # Whether to link arrow statically, default is ON
+option(USE_STATIC_ARROW "Whether to use static arrow" OFF) # Whether to link arrow statically, default is OFF
 option(BUILD_WITH_OTEL "Whether to build with opentelemetry-cpp" OFF) # Whether to build with opentelemetry-cpp, default is OFF
 
 #print options

--- a/flex/utils/CMakeLists.txt
+++ b/flex/utils/CMakeLists.txt
@@ -70,7 +70,7 @@ target_include_directories(flex_utils PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> 
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 # Link the static library of arrow, to save the trouble of linking the shared library of arrow
-target_link_libraries(flex_utils ${ARROW_LIB} ${YAML_CPP_LIBRARIES} ${Boost_LIBRARIES} ${GLOG_LIBRARIES})
+target_link_libraries(flex_utils ${Protobuf_LIBRARIES} ${ARROW_LIB} ${YAML_CPP_LIBRARIES} ${Boost_LIBRARIES} ${GLOG_LIBRARIES})
 install_flex_target(flex_utils)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/python/graphscope/gsctl/scripts/install_deps.sh
+++ b/python/graphscope/gsctl/scripts/install_deps.sh
@@ -888,7 +888,15 @@ install_interactive_dependencies() {
   fi
   # opentelemetry
   if [[ "${OS_PLATFORM}" != *"Darwin"* ]]; then
-    install_opentelemetry
+    # opentelemetry expect libprotoc >= 3.13.0, see https://github.com/open-telemetry/opentelemetry-cpp/discussions/2223
+    proto_version=$(protoc --version | awk '{print $2}')
+    major_version=$(echo ${proto_version} | cut -d'.' -f1)
+    minor_version=$(echo ${proto_version} | cut -d'.' -f2)
+    if [[ ${major_version} -lt 3 ]] || [[ ${major_version} -eq 3 && ${minor_version} -lt 13 ]]; then
+      warning "OpenTelemetry requires protoc >= 3.13, current version is ${proto_version}, please upgrade it."
+    else
+      install_opentelemetry
+    fi
   fi
 }
 


### PR DESCRIPTION
Link `PROTOBUF_libraries` for libflex_utils and by default use dynamic arrow libraries.

Fix #4416 
Fix #4430 