### PR TITLE
fix(analytical): Fix Louvain algorithm's implementation

### DIFF
--- a/analytical_engine/apps/pregel/louvain/louvain_app_base.h
+++ b/analytical_engine/apps/pregel/louvain/louvain_app_base.h
@@ -223,6 +223,7 @@ class LouvainAppBase
       auto actual_quality =
           ctx.compute_context().template get_aggregated_value<double>(
               actual_quality_aggregator);
+      assert(actual_quality <= 1.0);
       // after one pass if already decided halt, that means the pass yield no
       // changes, so we halt computation.
       if (current_super_step <= 14 ||

--- a/analytical_engine/apps/pregel/louvain/louvain_vertex.h
+++ b/analytical_engine/apps/pregel/louvain/louvain_vertex.h
@@ -68,7 +68,7 @@ class LouvainVertex : public PregelVertex<FRAG_T, VD_T, MD_T> {
 
   size_t edge_size() {
     if (!this->use_fake_edges()) {
-      return this->incoming_edges().Size() + this->outgoing_edges().Size();
+      return this->outgoing_edges().Size();
     } else {
       return this->fake_edges().size();
     }
@@ -88,11 +88,6 @@ class LouvainVertex : public PregelVertex<FRAG_T, VD_T, MD_T> {
 
   edata_t get_edge_value(const vid_t& dst_id) {
     if (!this->use_fake_edges()) {
-      for (auto& edge : this->incoming_edges()) {
-        if (this->fragment_->Vertex2Gid(edge.get_neighbor()) == dst_id) {
-          return static_cast<edata_t>(edge.get_data());
-        }
-      }
       for (auto& edge : this->outgoing_edges()) {
         if (this->fragment_->Vertex2Gid(edge.get_neighbor()) == dst_id) {
           return static_cast<edata_t>(edge.get_data());
@@ -117,12 +112,6 @@ class LouvainVertex : public PregelVertex<FRAG_T, VD_T, MD_T> {
   edata_t get_edge_values(const std::set<vid_t>& dst_ids) {
     edata_t ret = 0;
     if (!this->use_fake_edges()) {
-      for (auto& edge : this->incoming_edges()) {
-        auto gid = this->fragment_->Vertex2Gid(edge.get_neighbor());
-        if (dst_ids.find(gid) != dst_ids.end()) {
-          ret += static_cast<edata_t>(edge.get_data());
-        }
-      }
       for (auto& edge : this->outgoing_edges()) {
         auto gid = this->fragment_->Vertex2Gid(edge.get_neighbor());
         if (dst_ids.find(gid) != dst_ids.end()) {


### PR DESCRIPTION

## What do these changes do?

When I test Louvain with the [DBLP dataset](https://snap.stanford.edu/data/com-DBLP.html), I found the QUALITY is bigger than 1.0 (which is 1.13) in the first iteration, which is not correct, see [here](https://en.wikipedia.org/wiki/Louvain_method#:~:text=Modularity%20is%20a%20scale%20value,nodes%20of%20a%20given%20network.) QUALITY is in [-1, 1].
<img width="1028" alt="f1" src="https://github.com/user-attachments/assets/aa10112e-2168-49a3-b0bd-1cd83ea06646" />


Then I found the Louvain's implementation has some problems, as the Louvain  only supports undirected graph now, the current edge weight in each edge has calculated one more time as using both outgoing_edges() and incoming_edges(), fix it , we only need use outgoing_edges() in undirected graph.
