### PR TITLE
fix(interactive): Use static arrow when building interactive image

### DIFF
--- a/.github/workflows/flex-interactive.yml
+++ b/.github/workflows/flex-interactive.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
     paths:
+      - 'k8s/**'
       - 'flex/**'
       - 'coordinator/gscoordinator/flex/**'
       - 'python/graphscope/gsctl/**'
@@ -16,6 +17,7 @@ on:
     branches:
       - main
     paths:
+      - 'k8s/**'
       - 'flex/**'
       - 'coordinator/gscoordinator/flex/**'
       - 'python/graphscope/gsctl/**'

--- a/k8s/dockerfiles/flex-interactive.Dockerfile
+++ b/k8s/dockerfiles/flex-interactive.Dockerfile
@@ -27,7 +27,7 @@ COPY --chown=graphscope:graphscope . /home/graphscope/GraphScope
 
 # install flex
 RUN . ${HOME}/.cargo/env  && cd ${HOME}/GraphScope/flex && \
-    git submodule update --init && mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/opt/flex -DBUILD_DOC=OFF -DBUILD_TEST=OFF -DOPTIMIZE_FOR_HOST=${OPTIMIZE_FOR_HOST} && make -j ${PARALLEL} && make install && \
+    git submodule update --init && mkdir build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/opt/flex -DBUILD_DOC=OFF -DBUILD_TEST=OFF -DOPTIMIZE_FOR_HOST=${OPTIMIZE_FOR_HOST} -DUSE_STATIC_ARROW=ON && make -j ${PARALLEL} && make install && \
     cd ~/GraphScope/interactive_engine/ && mvn clean package -Pexperimental -DskipTests && \
     cd ~/GraphScope/interactive_engine/compiler && cp target/compiler-0.0.1-SNAPSHOT.jar /opt/flex/lib/ && \
     cp target/libs/*.jar /opt/flex/lib/ && \


### PR DESCRIPTION
In #4419, Interactive is changed to link to dynamic arrow lib but forgot to change the image building, where we need a static library for arrow.