### PR TITLE
fix(interactive): Limit Maximum Hops in Path Expand

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/YamlConfigs.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/config/YamlConfigs.java
@@ -207,6 +207,9 @@ public class YamlConfigs extends Configs {
                 .put(
                         "query.execution.timeout.ms",
                         (Configs configs) -> configs.get("compiler.query_timeout"))
+                .put(
+                        "query.execution.max.iterations",
+                        (Configs configs) -> configs.get("compiler.query_max_iterations"))
                 .put("engine.type", (Configs configs) -> configs.get("compute_engine.type"))
                 .put(
                         "calcite.default.charset",

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/glogue/PrimitiveCountEstimator.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/glogue/PrimitiveCountEstimator.java
@@ -106,7 +106,7 @@ public class PrimitiveCountEstimator {
         int baseHop = Math.max(minHop, 1);
         double baseHopCount = Math.pow(edgeCount, baseHop) / Math.pow(dstVertexCount, baseHop - 1);
         for (int hop = baseHop, iters = 0;
-                hop <= maxHop && iters < QueryExecutionValidator.MAX_ITERATIONS;
+                hop <= maxHop && iters < QueryExecutionValidator.SYSTEM_MAX_ITERATIONS;
                 ++hop, ++iters) {
             sum += baseHopCount;
             baseHopCount *= (edgeCount / dstVertexCount);

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/glogue/PrimitiveCountEstimator.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/glogue/PrimitiveCountEstimator.java
@@ -89,7 +89,10 @@ public class PrimitiveCountEstimator {
         PathExpandRange range = edge.getElementDetails().getRange();
         if (range != null) {
             minHop = range.getOffset();
-            maxHop = range.getOffset() + range.getFetch() - 1;
+            maxHop =
+                    Math.min(
+                            com.alibaba.graphscope.common.ir.tools.Utils.PATH_EXPAND_MAX_HOPS,
+                            range.getOffset() + range.getFetch() - 1);
         }
         double sum = 0.0d;
         for (int hop = minHop; hop <= maxHop; ++hop) {

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphBuilder.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphBuilder.java
@@ -53,6 +53,7 @@ import org.apache.calcite.rel.AbstractRelNode;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.*;
+import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.type.*;
 import org.apache.calcite.rex.*;
 import org.apache.calcite.sql.SqlAggFunction;
@@ -181,11 +182,13 @@ public class GraphBuilder extends RelBuilder {
                         config.getAlias(),
                         getAliasNameWithId(
                                 config.getStartAlias(),
-                                (RelDataType type) ->
-                                        (type instanceof GraphSchemaType)
-                                                        && ((GraphSchemaType) type).getScanOpt()
-                                                                == GraphOpt.Source.EDGE
-                                                || type instanceof GraphPathType));
+                                (RelDataType type) -> {
+                                    if (input instanceof LogicalValues) return true;
+                                    return (type instanceof GraphSchemaType)
+                                                    && ((GraphSchemaType) type).getScanOpt()
+                                                            == GraphOpt.Source.EDGE
+                                            || type instanceof GraphPathType;
+                                }));
         replaceTop(getV);
         return this;
     }
@@ -225,10 +228,12 @@ public class GraphBuilder extends RelBuilder {
                         pxdConfig.getAlias(),
                         getAliasNameWithId(
                                 pxdConfig.getStartAlias(),
-                                (RelDataType type) ->
-                                        (type instanceof GraphSchemaType)
-                                                && ((GraphSchemaType) type).getScanOpt()
-                                                        == GraphOpt.Source.VERTEX));
+                                (RelDataType type) -> {
+                                    if (input instanceof LogicalValues) return true;
+                                    return (type instanceof GraphSchemaType)
+                                            && ((GraphSchemaType) type).getScanOpt()
+                                                    == GraphOpt.Source.VERTEX;
+                                }));
         replaceTop(pathExpand);
         return this;
     }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
@@ -71,6 +71,7 @@ public class GraphPlanner {
     private final GraphRelOptimizer optimizer;
     private final RexBuilder rexBuilder;
     private final LogicalPlanFactory logicalPlanFactory;
+    private final QueryExecutionValidator validator;
 
     public static final Function<Configs, RexBuilder> rexBuilderFactory =
             (Configs configs) -> new GraphRexBuilder(new GraphTypeFactoryImpl(configs));
@@ -83,6 +84,7 @@ public class GraphPlanner {
         this.optimizer = optimizer;
         this.logicalPlanFactory = logicalPlanFactory;
         this.rexBuilder = rexBuilderFactory.apply(graphConfig);
+        this.validator = new QueryExecutionValidator(graphConfig);
     }
 
     public PlannerInstance instance(String query, IrMeta irMeta) {
@@ -106,7 +108,7 @@ public class GraphPlanner {
                 GraphBuilder.create(
                         graphConfig, optCluster, new GraphOptSchema(optCluster, schema));
         LogicalPlan logicalPlan = logicalPlanFactory.create(graphBuilder, irMeta, query);
-        new QueryExecutionValidator().validate(logicalPlan, true);
+        this.validator.validate(logicalPlan, true);
         return new PlannerInstance(query, logicalPlan, graphBuilder, irMeta, queryLogger);
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/GraphPlanner.java
@@ -53,7 +53,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -103,8 +105,8 @@ public class GraphPlanner {
         GraphBuilder graphBuilder =
                 GraphBuilder.create(
                         graphConfig, optCluster, new GraphOptSchema(optCluster, schema));
-
         LogicalPlan logicalPlan = logicalPlanFactory.create(graphBuilder, irMeta, query);
+        new QueryExecutionValidator().validate(logicalPlan, true);
         return new PlannerInstance(query, logicalPlan, graphBuilder, irMeta, queryLogger);
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/QueryExecutionValidator.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/QueryExecutionValidator.java
@@ -53,12 +53,19 @@ public class QueryExecutionValidator {
                         throw new FrontendException(
                                 Code.LOGICAL_PLAN_BUILD_FAILED,
                                 "path expand with no upper bound exceeds the maximum allowed"
-                                    + " iterations "
+                                        + " iterations "
                                         + MAX_ITERATIONS);
                     }
                     return false;
                 }
-                hops += ((Number) ((RexLiteral) pxd.getFetch()).getValue()).intValue();
+                int lower =
+                        (pxd.getOffset() == null)
+                                ? 0
+                                : ((Number) ((RexLiteral) pxd.getOffset()).getValue()).intValue();
+                hops +=
+                        (lower
+                                + ((Number) ((RexLiteral) pxd.getFetch()).getValue()).intValue()
+                                - 1);
             } else if (top instanceof GraphLogicalSingleMatch) {
                 validate(
                         new LogicalPlan(((GraphLogicalSingleMatch) top).getSentence()),

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/QueryExecutionValidator.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/QueryExecutionValidator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.graphscope.common.ir.tools;
+
+import com.alibaba.graphscope.common.exception.FrontendException;
+import com.alibaba.graphscope.common.ir.meta.schema.CommonOptTable;
+import com.alibaba.graphscope.common.ir.rel.CommonTableScan;
+import com.alibaba.graphscope.common.ir.rel.graph.GraphLogicalExpand;
+import com.alibaba.graphscope.common.ir.rel.graph.GraphLogicalPathExpand;
+import com.alibaba.graphscope.common.ir.rel.graph.GraphPhysicalExpand;
+import com.alibaba.graphscope.common.ir.rel.graph.match.GraphLogicalMultiMatch;
+import com.alibaba.graphscope.common.ir.rel.graph.match.GraphLogicalSingleMatch;
+import com.alibaba.graphscope.proto.frontend.Code;
+import com.google.common.collect.Lists;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rex.RexLiteral;
+
+import java.util.List;
+
+public class QueryExecutionValidator {
+    public static int MAX_ITERATIONS = 15;
+
+    boolean validate(LogicalPlan plan, boolean throwsOnFail) {
+        if (plan.getRegularQuery() == null || plan.isReturnEmpty()) return true;
+        int hops = 0;
+        List<RelNode> queue = Lists.newArrayList(plan.getRegularQuery());
+        while (!queue.isEmpty()) {
+            RelNode top = queue.remove(0);
+            if (top instanceof GraphLogicalExpand) {
+                ++hops;
+            } else if (top instanceof GraphPhysicalExpand) {
+                ++hops;
+            } else if (top instanceof GraphLogicalPathExpand) {
+                GraphLogicalPathExpand pxd = (GraphLogicalPathExpand) top;
+                // null means no limit
+                if (pxd.getFetch() == null) {
+                    if (throwsOnFail) {
+                        throw new FrontendException(
+                                Code.LOGICAL_PLAN_BUILD_FAILED,
+                                "path expand with no upper bound exceeds the maximum allowed"
+                                    + " iterations "
+                                        + MAX_ITERATIONS);
+                    }
+                    return false;
+                }
+                hops += ((Number) ((RexLiteral) pxd.getFetch()).getValue()).intValue();
+            } else if (top instanceof GraphLogicalSingleMatch) {
+                validate(
+                        new LogicalPlan(((GraphLogicalSingleMatch) top).getSentence()),
+                        throwsOnFail);
+            } else if (top instanceof GraphLogicalMultiMatch) {
+                for (RelNode sentence : ((GraphLogicalMultiMatch) top).getSentences()) {
+                    validate(new LogicalPlan(sentence), throwsOnFail);
+                }
+            } else if (top instanceof CommonTableScan) {
+                CommonOptTable optTable = (CommonOptTable) top.getTable();
+                validate(new LogicalPlan(optTable.getCommon()), throwsOnFail);
+            }
+            queue.addAll(top.getInputs());
+        }
+        if (hops <= MAX_ITERATIONS) return true;
+        if (throwsOnFail) {
+            throw new FrontendException(
+                    Code.LOGICAL_PLAN_BUILD_FAILED,
+                    "query hops "
+                            + hops
+                            + " exceeds the maximum allowed iterations "
+                            + MAX_ITERATIONS);
+        }
+        return false;
+    }
+}

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/Utils.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/Utils.java
@@ -223,4 +223,6 @@ public class Utils {
             return sw.toString();
         }
     }
+
+    public static final int PATH_EXPAND_MAX_HOPS = 10;
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/Utils.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/tools/Utils.java
@@ -223,6 +223,4 @@ public class Utils {
             return sw.toString();
         }
     }
-
-    public static final int PATH_EXPAND_MAX_HOPS = 10;
 }

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/type/GraphTypeInference.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/type/GraphTypeInference.java
@@ -21,6 +21,7 @@ import com.alibaba.graphscope.common.ir.rel.type.AliasNameWithId;
 import com.alibaba.graphscope.common.ir.rel.type.TableConfig;
 import com.alibaba.graphscope.common.ir.tools.AliasInference;
 import com.alibaba.graphscope.common.ir.tools.GraphBuilder;
+import com.alibaba.graphscope.common.ir.tools.Utils;
 import com.alibaba.graphscope.common.ir.tools.config.GraphOpt;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -847,6 +848,9 @@ public class GraphTypeInference {
         }
 
         public GraphPathType inferPathType() {
+            if (this.maxHop > Utils.PATH_EXPAND_MAX_HOPS) {
+                return this.pxdType;
+            }
             recursive(startVType, new CompositePathType(Lists.newArrayList()), 0);
             List<GraphLabelType.Entry> expandTypes = Lists.newArrayList();
             List<GraphLabelType.Entry> getVTypes = Lists.newArrayList();

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/type/GraphTypeInference.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/type/GraphTypeInference.java
@@ -21,7 +21,7 @@ import com.alibaba.graphscope.common.ir.rel.type.AliasNameWithId;
 import com.alibaba.graphscope.common.ir.rel.type.TableConfig;
 import com.alibaba.graphscope.common.ir.tools.AliasInference;
 import com.alibaba.graphscope.common.ir.tools.GraphBuilder;
-import com.alibaba.graphscope.common.ir.tools.Utils;
+import com.alibaba.graphscope.common.ir.tools.QueryExecutionValidator;
 import com.alibaba.graphscope.common.ir.tools.config.GraphOpt;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -848,7 +848,7 @@ public class GraphTypeInference {
         }
 
         public GraphPathType inferPathType() {
-            if (this.maxHop > Utils.PATH_EXPAND_MAX_HOPS) {
+            if (this.maxHop > QueryExecutionValidator.MAX_ITERATIONS) {
                 return this.pxdType;
             }
             recursive(startVType, new CompositePathType(Lists.newArrayList()), 0);

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/type/GraphTypeInference.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/type/GraphTypeInference.java
@@ -848,7 +848,7 @@ public class GraphTypeInference {
         }
 
         public GraphPathType inferPathType() {
-            if (this.maxHop > QueryExecutionValidator.MAX_ITERATIONS) {
+            if (this.maxHop > QueryExecutionValidator.SYSTEM_MAX_ITERATIONS) {
                 return this.pxdType;
             }
             recursive(startVType, new CompositePathType(Lists.newArrayList()), 0);

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/type/GraphTypeInference.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/type/GraphTypeInference.java
@@ -21,6 +21,7 @@ import com.alibaba.graphscope.common.ir.rel.type.AliasNameWithId;
 import com.alibaba.graphscope.common.ir.rel.type.TableConfig;
 import com.alibaba.graphscope.common.ir.tools.AliasInference;
 import com.alibaba.graphscope.common.ir.tools.GraphBuilder;
+import com.alibaba.graphscope.common.ir.tools.LogicalPlan;
 import com.alibaba.graphscope.common.ir.tools.QueryExecutionValidator;
 import com.alibaba.graphscope.common.ir.tools.config.GraphOpt;
 import com.google.common.base.Preconditions;
@@ -59,6 +60,7 @@ public class GraphTypeInference {
      * @return
      */
     public RelNode inferTypes(RelNode top) {
+        if (new LogicalPlan(top).isReturnEmpty()) return top;
         return visitRels(ImmutableList.of(top)).get(0);
     }
 

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/suite/standard/IrGremlinQueryTest.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/gremlin/integration/suite/standard/IrGremlinQueryTest.java
@@ -1633,7 +1633,7 @@ public abstract class IrGremlinQueryTest extends AbstractGremlinProcessTest {
         @Override
         public Traversal<Vertex, Object> get_g_V_path_expand_until_age_gt_30_values_age() {
             return ((IrCustomizedTraversal)
-                            g.V().out("1..100", "knows")
+                            g.V().out("1..15", "knows") // system maximum hops is 15
                                     .with(
                                             "UNTIL",
                                             com.alibaba.graphscope.gremlin.integration.suite.utils

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/sdk/JNICompilePlanTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/sdk/JNICompilePlanTest.java
@@ -19,6 +19,7 @@
 package com.alibaba.graphscope.sdk;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -53,7 +54,11 @@ public class JNICompilePlanTest {
 
     @Test
     public void path_expand_max_hop_test() throws Exception {
-        String query = "MATCH (src)-[e:test6*1..1000000]->(dest) Return src, dest";
-        PlanUtils.compilePlan(configPath, query, schemaYaml, statsJson);
+        try {
+            String query = "MATCH (src)-[e:test6*1..1000000]->(dest) Return src, dest";
+            PlanUtils.compilePlan(configPath, query, schemaYaml, statsJson);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("exceeds the maximum allowed iterations"));
+        }
     }
 }

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/sdk/JNICompilePlanTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/sdk/JNICompilePlanTest.java
@@ -50,4 +50,10 @@ public class JNICompilePlanTest {
                         + " src.__entity_id__ AS sId, dest.__entity_id__ AS dId;";
         PlanUtils.compilePlan(configPath, query, schemaYaml, statsJson);
     }
+
+    @Test
+    public void path_expand_max_hop_test() throws Exception {
+        String query = "MATCH (src)-[e:test6*1..1000000]->(dest) Return src, dest";
+        PlanUtils.compilePlan(configPath, query, schemaYaml, statsJson);
+    }
 }

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/sdk/JNICompilePlanTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/sdk/JNICompilePlanTest.java
@@ -61,4 +61,15 @@ public class JNICompilePlanTest {
             Assert.assertTrue(e.getMessage().contains("exceeds the maximum allowed iterations"));
         }
     }
+
+    @Test
+    public void path_expand_invalid_hop_test() throws Exception {
+        try {
+            // the max hop will be set as unlimited if it is less than min hop
+            String query = "MATCH (src)-[e:test6*5..4]->(dest) Return src, dest";
+            PlanUtils.compilePlan(configPath, query, schemaYaml, statsJson);
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("exceeds the maximum allowed iterations"));
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

1. Limit the maximum hops in path expansion to prevent compilation errors and excessive consumption of computational resources during execution.
2. Handle invalid hops, i.e. `Match (a)-[e:4..3]-(b)`, which will throw exceptions containing `exceeds the maximum allowed iterations` at compiling phase.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

