### PR TITLE
feat(coordinator): Add config `coordinator.max_content_length`

### DIFF
--- a/coordinator/gscoordinator/coordinator.py
+++ b/coordinator/gscoordinator/coordinator.py
@@ -130,6 +130,7 @@ def start_http_service(config):
     initialize_client_wrapper(config)
     app = connexion.App(__name__, specification_dir="./flex/openapi/")
     app.app.json_encoder = JSONEncoder
+    app.app.config["MAX_CONTENT_LENGTH"] = config.coordinator.max_content_length
     app.add_api(
         "openapi.yaml",
         arguments={"title": "GraphScope FLEX HTTP SERVICE API"},

--- a/python/graphscope/config.py
+++ b/python/graphscope/config.py
@@ -263,6 +263,9 @@ class CoordinatorConfig:
     # It would try to find existing resources and connect to it.
     operator_mode: bool = False
 
+    # For http server, limit the max content length of request. Mainly for file upload.
+    max_content_length: int = 1024 * 1024 * 1024  # 1GB
+
 
 @dataclass
 class HostsLauncherConfig:


### PR DESCRIPTION
Add a config item to control the maximum content length that coordinator's http server could handle. By default it is set to 1GB.