### PR TITLE
refactor(interactive): Let transction returns commit result

### DIFF
--- a/docs/flex/interactive/development/dev_and_test.md
+++ b/docs/flex/interactive/development/dev_and_test.md
@@ -251,3 +251,14 @@ The mapping between status codes and HTTP codes is shown in the table below.
 | IO_ERROR(105)             | 500         |
 | QUERY_FAILED(106)         | 500         |
 | default                             | 500         |
+
+
+### Transactions
+
+In Interactive's execution engine, transactions such as `ReadTransaction`, `UpdateTransaction`, and `InsertTransaction` are employed to maintain data consistency and integrity throughout operations. Each transaction can either succeed or fail, and it is important to understand the transactional guarantees provided by Interactive:
+
+1. For every transaction, we first write the Write-Ahead Log (WAL) to persistent storage before applying it to the graph data. This ensures a reliable record of the transaction steps.
+
+2. If a transaction returns `false` during the `commit()` process, the error occurred prior to applying the WAL to the graph data. This type of failure could arise during the construction of the WAL or during its writing phase.
+
+3. It is important to note that errors can still occur when replaying the WAL to the graph database. Replaying might fail due to limitations in resources or due to unforeseen bugs. **However,** any errors encountered during this stage will be handled via exceptions or may result in process failure. Currently, there is no established mechanism to handle such failures. Future improvements should focus on implementing failover strategies, potentially allowing the GraphDB to continue replaying the WAL until it succeeds.

--- a/flex/engines/graph_db/database/compact_transaction.h
+++ b/flex/engines/graph_db/database/compact_transaction.h
@@ -33,7 +33,7 @@ class CompactTransaction {
 
   timestamp_t timestamp() const;
 
-  void Commit();
+  bool Commit();
 
   void Abort();
 

--- a/flex/engines/graph_db/database/graph_db_session.cc
+++ b/flex/engines/graph_db/database/graph_db_session.cc
@@ -58,8 +58,7 @@ UpdateTransaction GraphDBSession::GetUpdateTransaction() {
 }
 
 bool GraphDBSession::BatchUpdate(UpdateBatch& batch) {
-  GetUpdateTransaction().batch_commit(batch);
-  return true;
+  return GetUpdateTransaction().batch_commit(batch);
 }
 
 const MutablePropertyFragment& GraphDBSession::graph() const {

--- a/flex/engines/graph_db/database/insert_transaction.cc
+++ b/flex/engines/graph_db/database/insert_transaction.cc
@@ -144,26 +144,31 @@ bool InsertTransaction::AddEdge(label_t src_label, const Any& src,
   return true;
 }
 
-void InsertTransaction::Commit() {
+bool InsertTransaction::Commit() {
   if (timestamp_ == std::numeric_limits<timestamp_t>::max()) {
-    return;
+    return true;
   }
   if (arc_.GetSize() == sizeof(WalHeader)) {
     vm_.release_insert_timestamp(timestamp_);
     clear();
-    return;
+    return true;
   }
   auto* header = reinterpret_cast<WalHeader*>(arc_.GetBuffer());
   header->length = arc_.GetSize() - sizeof(WalHeader);
   header->type = 0;
   header->timestamp = timestamp_;
 
-  logger_.append(arc_.GetBuffer(), arc_.GetSize());
+  if (!logger_.append(arc_.GetBuffer(), arc_.GetSize())) {
+    LOG(ERROR) << "Failed to append wal log";
+    Abort();
+    return false;
+  }
   IngestWal(graph_, timestamp_, arc_.GetBuffer() + sizeof(WalHeader),
             header->length, alloc_);
 
   vm_.release_insert_timestamp(timestamp_);
   clear();
+  return true;
 }
 
 void InsertTransaction::Abort() {

--- a/flex/engines/graph_db/database/insert_transaction.h
+++ b/flex/engines/graph_db/database/insert_transaction.h
@@ -48,7 +48,7 @@ class InsertTransaction {
   bool AddEdge(label_t src_label, const Any& src, label_t dst_label,
                const Any& dst, label_t edge_label, const Any& prop);
 
-  void Commit();
+  bool Commit();
 
   void Abort();
 

--- a/flex/engines/graph_db/database/read_transaction.cc
+++ b/flex/engines/graph_db/database/read_transaction.cc
@@ -34,7 +34,10 @@ std::string ReadTransaction::run(
 
 timestamp_t ReadTransaction::timestamp() const { return timestamp_; }
 
-void ReadTransaction::Commit() { release(); }
+bool ReadTransaction::Commit() {
+  release();
+  return true;
+}
 
 void ReadTransaction::Abort() { release(); }
 

--- a/flex/engines/graph_db/database/read_transaction.h
+++ b/flex/engines/graph_db/database/read_transaction.h
@@ -320,7 +320,7 @@ class ReadTransaction {
 
   timestamp_t timestamp() const;
 
-  void Commit();
+  bool Commit();
 
   void Abort();
 

--- a/flex/engines/graph_db/database/single_edge_insert_transaction.cc
+++ b/flex/engines/graph_db/database/single_edge_insert_transaction.cc
@@ -109,15 +109,19 @@ timestamp_t SingleEdgeInsertTransaction::timestamp() const {
   return timestamp_;
 }
 
-void SingleEdgeInsertTransaction::Commit() {
+bool SingleEdgeInsertTransaction::Commit() {
   if (timestamp_ == std::numeric_limits<timestamp_t>::max()) {
-    return;
+    return false;
   }
   auto* header = reinterpret_cast<WalHeader*>(arc_.GetBuffer());
   header->length = arc_.GetSize() - sizeof(WalHeader);
   header->type = 0;
   header->timestamp = timestamp_;
-  logger_.append(arc_.GetBuffer(), arc_.GetSize());
+  if (!logger_.append(arc_.GetBuffer(), arc_.GetSize())) {
+    LOG(ERROR) << "Failed to append wal log";
+    Abort();
+    return false;
+  }
 
   grape::OutArchive arc;
   {
@@ -134,6 +138,7 @@ void SingleEdgeInsertTransaction::Commit() {
                     timestamp_, arc, alloc_);
   vm_.release_insert_timestamp(timestamp_);
   clear();
+  return true;
 }
 
 void SingleEdgeInsertTransaction::clear() {

--- a/flex/engines/graph_db/database/single_edge_insert_transaction.h
+++ b/flex/engines/graph_db/database/single_edge_insert_transaction.h
@@ -41,7 +41,7 @@ class SingleEdgeInsertTransaction {
 
   timestamp_t timestamp() const;
 
-  void Commit();
+  bool Commit();
 
  private:
   void clear();

--- a/flex/engines/graph_db/database/single_vertex_insert_transaction.h
+++ b/flex/engines/graph_db/database/single_vertex_insert_transaction.h
@@ -39,7 +39,7 @@ class SingleVertexInsertTransaction {
   bool AddEdge(label_t src_label, const Any& src, label_t dst_label,
                const Any& dst, label_t edge_label, const Any& prop);
 
-  void Commit();
+  bool Commit();
 
   void Abort();
 

--- a/flex/engines/graph_db/database/update_transaction.cc
+++ b/flex/engines/graph_db/database/update_transaction.cc
@@ -102,24 +102,29 @@ UpdateTransaction::~UpdateTransaction() { release(); }
 
 timestamp_t UpdateTransaction::timestamp() const { return timestamp_; }
 
-void UpdateTransaction::Commit() {
+bool UpdateTransaction::Commit() {
   if (timestamp_ == std::numeric_limits<timestamp_t>::max()) {
-    return;
+    return true;
   }
   if (op_num_ == 0) {
     release();
-    return;
+    return true;
   }
 
   auto* header = reinterpret_cast<WalHeader*>(arc_.GetBuffer());
   header->length = arc_.GetSize() - sizeof(WalHeader);
   header->type = 1;
   header->timestamp = timestamp_;
-  logger_.append(arc_.GetBuffer(), arc_.GetSize());
+  if (!logger_.append(arc_.GetBuffer(), arc_.GetSize())) {
+    LOG(ERROR) << "Failed to append wal log";
+    Abort();
+    return false;
+  }
 
   applyVerticesUpdates();
   applyEdgesUpdates();
   release();
+  return true;
 }
 
 void UpdateTransaction::Abort() { release(); }
@@ -729,9 +734,9 @@ void UpdateTransaction::release() {
   }
 }
 
-void UpdateTransaction::batch_commit(UpdateBatch& batch) {
+bool UpdateTransaction::batch_commit(UpdateBatch& batch) {
   if (timestamp_ == std::numeric_limits<timestamp_t>::max()) {
-    return;
+    return true;
   }
   const auto& updateVertices = batch.GetUpdateVertices();
   for (auto& [label, oid, props] : updateVertices) {
@@ -762,10 +767,15 @@ void UpdateTransaction::batch_commit(UpdateBatch& batch) {
     header->length = arc.GetSize() - sizeof(WalHeader);
     header->type = 1;
     header->timestamp = timestamp_;
-    logger_.append(arc.GetBuffer(), arc.GetSize());
+    if (!logger_.append(arc.GetBuffer(), arc.GetSize())) {
+      LOG(ERROR) << "Failed to append wal log";
+      Abort();
+      return false;
+    }
   }
 
   release();
+  return true;
 }
 
 void UpdateTransaction::applyVerticesUpdates() {

--- a/flex/engines/graph_db/database/update_transaction.h
+++ b/flex/engines/graph_db/database/update_transaction.h
@@ -52,7 +52,7 @@ class UpdateTransaction {
 
   const Schema& schema() const { return graph_.schema(); }
 
-  void Commit();
+  bool Commit();
 
   void Abort();
 
@@ -155,7 +155,7 @@ class UpdateTransaction {
 
  private:
   friend class GraphDBSession;
-  void batch_commit(UpdateBatch& batch);
+  bool batch_commit(UpdateBatch& batch);
 
   void set_edge_data_with_offset(bool dir, label_t label, vid_t v,
                                  label_t neighbor_label, vid_t nbr,

--- a/flex/engines/graph_db/database/wal.h
+++ b/flex/engines/graph_db/database/wal.h
@@ -58,7 +58,7 @@ class WalWriter {
 
   void close();
 
-  void append(const char* data, size_t length);
+  bool append(const char* data, size_t length);
 
  private:
   int fd_;

--- a/flex/engines/graph_db/runtime/common/graph_interface.h
+++ b/flex/engines/graph_db/runtime/common/graph_interface.h
@@ -402,7 +402,7 @@ class GraphInsertInterface {
     return txn_.AddEdge(src_label, src, dst_label, dst, edge_label, prop);
   }
 
-  inline void Commit() { txn_.Commit(); }
+  inline bool Commit() { return txn_.Commit(); }
 
   inline void Abort() { txn_.Abort(); }
 
@@ -472,7 +472,7 @@ class GraphUpdateInterface {
     return txn_.AddEdge(src_label, src, dst_label, dst, edge_label, prop);
   }
 
-  inline void Commit() { txn_.Commit(); }
+  inline bool Commit() { return txn_.Commit(); }
 
   inline void Abort() { txn_.Abort(); }
 


### PR DESCRIPTION
In Interactive's execution engine, transactions such as `ReadTransaction`, `UpdateTransaction`, and `InsertTransaction` are employed to maintain data consistency and integrity throughout operations. Each transaction can either succeed or fail, and it is important to understand the transactional guarantees provided by Interactive:

1. For every transaction, we first write the Write-Ahead Log (WAL) to persistent storage before applying it to the graph data. This ensures a reliable record of the transaction steps.

2. If a transaction returns `false` during the `commit()` process, the error occurred prior to applying the WAL to the graph data. This type of failure could arise during the construction of the WAL or during its writing phase.

3. It is important to note that errors can still occur when replaying the WAL to the graph database. Replaying might fail due to limitations in resources or due to unforeseen bugs. **However,** any errors encountered during this stage will be handled via exceptions or may result in process failure. Currently, there is no established mechanism to handle such failures. Future improvements should focus on implementing failover strategies, potentially allowing the GraphDB to continue replaying the WAL until it succeeds.
