### PR TITLE
fix(interactive): Allow implicit type conversion in `WithInExpr`

### DIFF
--- a/flex/engines/graph_db/runtime/utils/expr_impl.cc
+++ b/flex/engines/graph_db/runtime/utils/expr_impl.cc
@@ -564,9 +564,6 @@ static std::unique_ptr<ExprBase> build_expr(
           } else if (key->type() == RTAnyType::kI32Value) {
             return std::make_unique<WithInExpr<int32_t>>(ctx, std::move(key),
                                                          rhs.const_());
-          } else if (key->type() == RTAnyType::kF64Value) {
-            return std::make_unique<WithInExpr<double>>(ctx, std::move(key),
-                                                        rhs.const_());
           } else if (key->type() == RTAnyType::kStringValue) {
             return std::make_unique<WithInExpr<std::string>>(
                 ctx, std::move(key), rhs.const_());

--- a/flex/engines/graph_db/runtime/utils/expr_impl.cc
+++ b/flex/engines/graph_db/runtime/utils/expr_impl.cc
@@ -558,9 +558,15 @@ static std::unique_ptr<ExprBase> build_expr(
           if (key->type() == RTAnyType::kI64Value) {
             return std::make_unique<WithInExpr<int64_t>>(ctx, std::move(key),
                                                          rhs.const_());
+          } else if (key->type() == RTAnyType::kU64Value) {
+            return std::make_unique<WithInExpr<uint64_t>>(ctx, std::move(key),
+                                                          rhs.const_());
           } else if (key->type() == RTAnyType::kI32Value) {
             return std::make_unique<WithInExpr<int32_t>>(ctx, std::move(key),
                                                          rhs.const_());
+          } else if (key->type() == RTAnyType::kF64Value) {
+            return std::make_unique<WithInExpr<double>>(ctx, std::move(key),
+                                                        rhs.const_());
           } else if (key->type() == RTAnyType::kStringValue) {
             return std::make_unique<WithInExpr<std::string>>(
                 ctx, std::move(key), rhs.const_());

--- a/flex/engines/graph_db/runtime/utils/expr_impl.h
+++ b/flex/engines/graph_db/runtime/utils/expr_impl.h
@@ -192,8 +192,8 @@ class WithInExpr : public ExprBase {
       } else {
         // TODO(zhanglei,lexiao): We should support more types here, and if type
         // conversion fails, we should return an error.
-        LOG(ERROR) << "Could not convert array with type " << array.item_case()
-                   << " to int64_t array";
+        LOG(INFO) << "Could not convert array with type " << array.item_case()
+                  << " to int64_t array";
       }
     } else if constexpr (std::is_same_v<T, uint64_t>) {
       if (array.item_case() == common::Value::kI64Array) {
@@ -201,8 +201,8 @@ class WithInExpr : public ExprBase {
       } else if (array.item_case() == common::Value::kI32Array) {
         PARSER_COMMON_VALUE_ARRAY_TO_VECTOR(container_, array.i32_array());
       } else {
-        LOG(ERROR) << "Could not convert array with type " << array.item_case()
-                   << " to int64_t array";
+        LOG(INFO) << "Could not convert array with type " << array.item_case()
+                  << " to int64_t array";
       }
     } else if constexpr (std::is_same_v<T, int32_t>) {
       if (array.item_case() == common::Value::kI32Array) {
@@ -210,12 +210,9 @@ class WithInExpr : public ExprBase {
       } else if constexpr (std::is_same_v<T, int64_t>) {
         PARSER_COMMON_VALUE_ARRAY_TO_VECTOR(container_, array.i64_array());
       } else {
-        LOG(ERROR) << "Could not convert array with type " << array.item_case()
-                   << " to int32_t array";
+        LOG(INFO) << "Could not convert array with type " << array.item_case()
+                  << " to int32_t array";
       }
-    } else if constexpr (std::is_same_v<T, double>) {
-      assert(array.item_case() == common::Value::kF64Array);
-      PARSER_COMMON_VALUE_ARRAY_TO_VECTOR(container_, array.f64_array());
     } else if constexpr (std::is_same_v<T, std::string>) {
       assert(array.item_case() == common::Value::kStrArray);
       PARSER_COMMON_VALUE_ARRAY_TO_VECTOR(container_, array.str_array());

--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/integration/suite/graphAlgo/GraphAlgoQueries.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/cypher/integration/suite/graphAlgo/GraphAlgoQueries.java
@@ -247,4 +247,11 @@ public class GraphAlgoQueries {
         List<String> expected = Arrays.asList("Record<{id: 0}>");
         return new QueryContext(query, expected);
     }
+
+    // Test WithInExpression
+    public static QueryContext get_graph_algo_test15() {
+        String query = "MATCH(a)-[b:WorkOn]->(c) where elementId(a) in [0,1] return a.id;";
+        List<String> expected = Arrays.asList("Record<{id: 0}>", "Record<{id: 1}>");
+        return new QueryContext(query, expected);
+    }
 }

--- a/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/cypher/integration/graphAlgo/GraphAlgoTest.java
+++ b/interactive_engine/compiler/src/test/java/com/alibaba/graphscope/cypher/integration/graphAlgo/GraphAlgoTest.java
@@ -148,6 +148,13 @@ public class GraphAlgoTest {
         Assert.assertEquals(testQuery.getExpectedResult().toString(), result.list().toString());
     }
 
+    @Test
+    public void run_graph_query15_test() {
+        QueryContext testQuery = GraphAlgoQueries.get_graph_algo_test15();
+        Result result = session.run(testQuery.getQuery());
+        Assert.assertEquals(testQuery.getExpectedResult().toString(), result.list().toString());
+    }
+
     @AfterClass
     public static void afterClass() {
         if (session != null) {


### PR DESCRIPTION
As titled.

Fix #4513 