### PR TITLE
docs: Keep docs for latest 1 tags

### DIFF
--- a/docs/sphinx_ext.py
+++ b/docs/sphinx_ext.py
@@ -29,7 +29,7 @@ from sphinx.environment.adapters.toctree import TocTree
 from furo.navigation import get_navigation_tree
 
 # set maximum_recent_versions to 3 to avoid creating too many files, which may cause failure when uploading to cloudflare
-def resolve_git_tags(maximum_recent_versions=3): 
+def resolve_git_tags(maximum_recent_versions=2): 
     git = shutil.which("git")
     if git is None:
         return "latest", []

--- a/docs/sphinx_ext.py
+++ b/docs/sphinx_ext.py
@@ -28,8 +28,8 @@ from sphinx.environment.adapters.toctree import TocTree
 
 from furo.navigation import get_navigation_tree
 
-# set maximum_recent_versions to 3 to avoid creating too many files, which may cause failure when uploading to cloudflare
-def resolve_git_tags(maximum_recent_versions=2): 
+# set maximum_recent_versions to 1 to avoid creating too many files, which may cause failure when uploading to cloudflare
+def resolve_git_tags(maximum_recent_versions=1): 
     git = shutil.which("git")
     if git is None:
         return "latest", []


### PR DESCRIPTION
As titled.

```bash
git clone https://github.com/alibaba/GraphScope.git -b gh-pages --single-branch
cd docs
find v0.31.0 -type f | wc -l # 6078
find v0.30.0 -type f | wc -l  #5999
find v0.29.0 -type f | wc -l  # 5909
find latest -type f | wc -l # 6204
find ./reference -type f | wc -l # 4903
```
