### PR TITLE
feat(interactive): Expose a http api for readiness probe

### DIFF
--- a/docs/flex/interactive/configuration.md
+++ b/docs/flex/interactive/configuration.md
@@ -114,7 +114,7 @@ In this following table, we use the `.` notation to represent the hierarchy with
 | --------           | --------  | -------- |-----------  |
 | log_level     |  INFO   | The level of database log, INFO/WARNING/ERROR/FATAL | 0.0.1 |
 | verbose_level     |  0   | The verbose level of database log, should be a int | 0.0.3 |
-| compute_engine.thread_num_per_worker | 1 | The number of threads will be used to process the queries. Increase the number can benefit the query throughput | 0.0.1 |
+| compute_engine.thread_num_per_worker | 4 | The number of threads will be used to process the queries. Increase the number can benefit the query throughput | 0.0.1 |
 | compute_engine.wal_uri    | file://{GRAPH_DATA_DIR}/wal | The location where Interactive will store and access WALs. `GRAPH_DATA_DIR` is a placeholder that will be populated by Interactive. | 0.5 |
 | compiler.planner.is_on | true | Determines if query optimization is enabled for compiling Cypher queries  | 0.0.1 |
 | compiler.planner.opt | RBO | Specifies the optimizer to be used for query optimization. Currently, only the Rule-Based Optimizer (RBO) is supported | 0.0.1 |

--- a/flex/engines/http_server/actor/admin_actor.act.cc
+++ b/flex/engines/http_server/actor/admin_actor.act.cc
@@ -1125,6 +1125,17 @@ seastar::future<admin_query_result> admin_actor::stop_service(
   });
 }
 
+seastar::future<admin_query_result> admin_actor::service_ready(
+    query_param&& query_param) {
+  auto& graph_db_service = GraphDBService::get();
+  return graph_db_service.is_actors_running()
+             ? seastar::make_ready_future<admin_query_result>(
+                   gs::Result<seastar::sstring>("true"))
+             : seastar::make_exception_future<admin_query_result>(
+                   gs::Status(gs::StatusCode::SERVICE_UNAVAILABLE,
+                              "Service is not ready"));
+}
+
 // get service status
 seastar::future<admin_query_result> admin_actor::service_status(
     query_param&& query_param) {

--- a/flex/engines/http_server/actor/admin_actor.act.h
+++ b/flex/engines/http_server/actor/admin_actor.act.h
@@ -52,6 +52,8 @@ class ANNOTATION(actor:impl) admin_actor : public hiactor::actor {
 
   seastar::future<admin_query_result> ANNOTATION(actor:method) service_status(query_param&& param);
 
+  seastar::future<admin_query_result> ANNOTATION(actor:method) service_status(query_param&& param);
+
   seastar::future<admin_query_result> ANNOTATION(actor:method) get_procedure_by_procedure_name(procedure_query_param&& param);
 
   seastar::future<admin_query_result> ANNOTATION(actor:method) get_procedures_by_graph_name(query_param&& param);

--- a/flex/engines/http_server/actor/admin_actor.act.h
+++ b/flex/engines/http_server/actor/admin_actor.act.h
@@ -52,7 +52,7 @@ class ANNOTATION(actor:impl) admin_actor : public hiactor::actor {
 
   seastar::future<admin_query_result> ANNOTATION(actor:method) service_status(query_param&& param);
 
-  seastar::future<admin_query_result> ANNOTATION(actor:method) service_status(query_param&& param);
+  seastar::future<admin_query_result> ANNOTATION(actor:method) service_ready(query_param&& param);
 
   seastar::future<admin_query_result> ANNOTATION(actor:method) get_procedure_by_procedure_name(procedure_query_param&& param);
 

--- a/flex/engines/http_server/handler/admin_http_handler.cc
+++ b/flex/engines/http_server/handler/admin_http_handler.cc
@@ -511,7 +511,6 @@ class admin_http_service_handler_impl : public seastar::httpd::handler_base {
     } else {
       // v1/service/ready or v1/service/status
       if (path.find("ready") != seastar::sstring::npos) {
-        LOG(INFO) << "GET with action: ready";
         return admin_actor_refs_[dst_executor]
             .service_ready(query_param{std::move(req->content)})
             .then_wrapped(
@@ -521,7 +520,6 @@ class admin_http_service_handler_impl : public seastar::httpd::handler_base {
                                                   std::move(fut));
                 });
       } else {
-        LOG(INFO) << "GET with action: status";
         return admin_actor_refs_[dst_executor]
             .service_status(query_param{std::move(req->content)})
             .then_wrapped(

--- a/flex/engines/http_server/handler/admin_http_handler.cc
+++ b/flex/engines/http_server/handler/admin_http_handler.cc
@@ -509,12 +509,28 @@ class admin_http_service_handler_impl : public seastar::httpd::handler_base {
             std::move(rep), std::string("Unsupported action: ") + action);
       }
     } else {
-      return admin_actor_refs_[dst_executor]
-          .service_status(query_param{std::move(req->content)})
-          .then_wrapped([rep = std::move(rep)](
-                            seastar::future<admin_query_result>&& fut) mutable {
-            return return_reply_with_result(std::move(rep), std::move(fut));
-          });
+      // v1/service/ready or v1/service/status
+      if (path.find("ready") != seastar::sstring::npos) {
+        LOG(INFO) << "GET with action: ready";
+        return admin_actor_refs_[dst_executor]
+            .service_ready(query_param{std::move(req->content)})
+            .then_wrapped(
+                [rep = std::move(rep)](
+                    seastar::future<admin_query_result>&& fut) mutable {
+                  return return_reply_with_result(std::move(rep),
+                                                  std::move(fut));
+                });
+      } else {
+        LOG(INFO) << "GET with action: status";
+        return admin_actor_refs_[dst_executor]
+            .service_status(query_param{std::move(req->content)})
+            .then_wrapped(
+                [rep = std::move(rep)](
+                    seastar::future<admin_query_result>&& fut) mutable {
+                  return return_reply_with_result(std::move(rep),
+                                                  std::move(fut));
+                });
+      }
     }
   }
 
@@ -828,6 +844,12 @@ seastar::future<> admin_http_handler::set_routes() {
 
       r.add(seastar::httpd::operation_type::GET,
             seastar::httpd::url("/v1/service/status"),
+            new admin_http_service_handler_impl(interactive_admin_group_id,
+                                                shard_admin_concurrency,
+                                                exclusive_shard_id_));
+
+      r.add(seastar::httpd::operation_type::GET,
+            seastar::httpd::url("/v1/service/ready"),
             new admin_http_service_handler_impl(interactive_admin_group_id,
                                                 shard_admin_concurrency,
                                                 exclusive_shard_id_));

--- a/flex/tests/hqps/interactive_config_test_cbo.yaml
+++ b/flex/tests/hqps/interactive_config_test_cbo.yaml
@@ -4,7 +4,7 @@ compute_engine:
   type: hiactor
   workers:
     - localhost:10000
-  thread_num_per_worker: 1
+  thread_num_per_worker: 4
   store:
     type: cpp-mcsr
 compiler:

--- a/k8s/dockerfiles/interactive-entrypoint.sh
+++ b/k8s/dockerfiles/interactive-entrypoint.sh
@@ -60,9 +60,6 @@ function prepare_workspace() {
     cp ${DEFAULT_INTERACTIVE_CONFIG_FILE} $engine_config_path
     #make sure the line which start with default_graph is changed to default_graph: ${DEFAULT_GRAPH_NAME}
     sed -i "s/default_graph:.*/default_graph: ${DEFAULT_GRAPH_NAME}/" $engine_config_path
-    # By default, we occupy the all available cpus
-    cpus=$(grep -c ^processor /proc/cpuinfo)
-    sed -i "s/thread_num_per_worker:.*/thread_num_per_worker: ${cpus}/" $engine_config_path
     echo "Using default graph: ${DEFAULT_GRAPH_NAME} to start the service"
     
     # copy the builtin graph

--- a/k8s/dockerfiles/interactive-entrypoint.sh
+++ b/k8s/dockerfiles/interactive-entrypoint.sh
@@ -50,8 +50,10 @@ function prepare_workspace() {
         mkdir -p ${workspace}
         mkdir -p ${workspace}/conf/
     else 
-        echo "Workspace ${workspace} already exists"
-        return 0
+        if [ -f "${workspace}/conf/interactive_config.yaml" ]; then
+            echo "Workspace ${workspace} already exists"
+            return 0
+        fi
     fi
     # prepare interactive_config.yaml
     engine_config_path="${workspace}/conf/interactive_config.yaml"


### PR DESCRIPTION
Interactive lacks a probing method to denote whether the service could successfully process queries; we introduce `/v1/service/ready`.

Also, we modify the `interactive-entrypoint.sh` to support initializing a workspace from an empty folder.