### PR TITLE
fix(interactive): Fix a bug in insight runtime when eval empty string

### DIFF
--- a/interactive_engine/executor/common/dyn_type/tests/object.rs
+++ b/interactive_engine/executor/common/dyn_type/tests/object.rs
@@ -17,7 +17,7 @@
 mod tests {
     use std::cmp::Ordering;
 
-    use dyn_type::{object, BorrowObject, Object, Primitives};
+    use dyn_type::{object, BorrowObject, Object, OwnedOrRef, Primitives};
 
     #[test]
     fn test_as_primitive() {
@@ -139,7 +139,7 @@ mod tests {
     fn test_owned_or_ref() {
         let a = object!(8_u128);
         let left = 0u128;
-        let right = a.get().unwrap();
+        let right: OwnedOrRef<'_, u128> = a.get().unwrap();
         assert_eq!(left.partial_cmp(&*right), Some(Ordering::Less));
         assert_eq!(right.partial_cmp(&left), Some(Ordering::Greater));
         assert_eq!(*&*right, 8_u128);

--- a/interactive_engine/executor/engine/pegasus/pegasus/tests/iteration_test.rs
+++ b/interactive_engine/executor/engine/pegasus/pegasus/tests/iteration_test.rs
@@ -337,7 +337,7 @@ fn iterate_x_map_reduce_unfold_x_test() {
         .unwrap();
     println!("i2 = {}", i2);
     assert_eq!(count, 1000);
-    assert_eq!(sum, (1..i2).rev().take(1000).sum());
+    assert_eq!(sum, (1..i2).rev().take(1000).sum::<u32>());
 }
 
 #[test]

--- a/interactive_engine/executor/ir/graph_proxy/src/utils/expr/eval.rs
+++ b/interactive_engine/executor/ir/graph_proxy/src/utils/expr/eval.rs
@@ -21,6 +21,7 @@ use std::panic;
 
 use dyn_type::arith::{BitOperand, Exp};
 use dyn_type::object;
+use dyn_type::object::RawType;
 use dyn_type::{BorrowObject, Object};
 use ir_common::error::{ParsePbError, ParsePbResult};
 use ir_common::expr_parse::to_suffix_expr;
@@ -330,7 +331,9 @@ pub(crate) fn apply_logical<'a>(
         if b_opt.is_some() {
             let b = b_opt.unwrap();
             // process null values
-            if a.eq(&Object::None) || b.eq(&Object::None) {
+            // "a.eq(&Object::None)" has a potential bug, that if a is empty string "", it will be treated as None.
+            // Fix it by using raw_type() == RawType::None
+            if a.raw_type() == RawType::None || b.raw_type() == RawType::None {
                 match logical {
                     And => {
                         if (a != Object::None && !a.eval_bool::<(), NoneContext>(None)?)
@@ -713,7 +716,7 @@ impl TryFrom<common_pb::ExprOpr> for Operand {
                     Ok(Self::VarMap(vec))
                 }
                 Map(key_vals) => Operand::try_from(key_vals),
-                _ => Err(ParsePbError::ParseError("invalid operators for an Operand".to_string())),
+                _ => Err(ParsePbError::ParseError(format!("invalid operators for an Operand {:?}", item))),
             }
         } else {
             Err(ParsePbError::from("empty value provided"))

--- a/interactive_engine/executor/ir/graph_proxy/src/utils/expr/eval.rs
+++ b/interactive_engine/executor/ir/graph_proxy/src/utils/expr/eval.rs
@@ -1619,4 +1619,17 @@ mod tests {
             assert_eq!(eval.eval::<_, Vertices>(Some(&ctxt)).unwrap(), expected);
         }
     }
+
+    #[test]
+    fn test_eval_empty_string() {
+        let map1: HashMap<NameOrId, Object> =
+            vec![(NameOrId::from("emptyProp".to_string()), Object::String("".to_string()))]
+                .into_iter()
+                .collect();
+
+        let ctxt = Vertices { vec: vec![Vertex::new(1, Some(9.into()), DynDetails::new(map1))] };
+        let case = "@0.emptyProp == \"\""; // true
+        let eval = Evaluator::try_from(str_to_expr_pb(case.to_string()).unwrap()).unwrap();
+        assert_eq!(eval.eval::<_, Vertices>(Some(&ctxt)).unwrap(), object!(true));
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

As titled, this bug occurs because an Object with an empty string is incorrectly treated as NULL, leading `NULL==NULL` to evaluate as false. However, the comparison `""==""` should be true. This PR addresses and fixes the issue.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#4581 

