### PR TITLE
feat(interactive): Support compiler fetching schema from `/v1/graph/{graph_id}`

### DIFF
--- a/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/reader/HttpIrMetaReader.java
+++ b/interactive_engine/compiler/src/main/java/com/alibaba/graphscope/common/ir/meta/reader/HttpIrMetaReader.java
@@ -144,10 +144,18 @@ public class HttpIrMetaReader implements IrMetaReader {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode rootNode = mapper.readTree(metaInJson);
         Map<String, Object> rootMap = mapper.convertValue(rootNode, Map.class);
-        Map metaMap = (Map) rootMap.get("graph");
-        GraphId graphId = new GraphId(metaMap.get("id"));
-        Yaml yaml = new Yaml();
-        return Pair.with(graphId, yaml.dump(metaMap));
+        if (rootMap.containsKey("graph")) {
+            // Parse the response if in the 'graph' field of the response
+            Map metaMap = (Map) rootMap.get("graph");
+            GraphId graphId = new GraphId(metaMap.get("id"));
+            Yaml yaml = new Yaml();
+            return Pair.with(graphId, yaml.dump(metaMap));
+        } else {
+            // Parser the response if the response is the root
+            GraphId graphId = new GraphId(rootMap.get("id"));
+            Yaml yaml = new Yaml();
+            return Pair.with(graphId, yaml.dump(rootMap));
+        }
     }
 
     private boolean getStaticEnabled(String metaInJson) throws IOException {


### PR DESCRIPTION
Previously, compiler get the schema info from the response of `GET /v1/service/status` where the schema info is in the field `graph` of response. However, we should support let compier get schema from the specific graph `GET /v1/graph/{graph_id]/schema`.