### PR TITLE
chore: migrate to correct logger interface

### DIFF
--- a/coordinator/gscoordinator/flex/core/alert/alert_manager.py
+++ b/coordinator/gscoordinator/flex/core/alert/alert_manager.py
@@ -62,14 +62,14 @@ class AlertManager(object):
                 with open(self._receiver_path, "rb") as f:
                     self._receivers = pickle.load(f)
         except Exception as e:
-            logger.warn("Failed to recover alert receiver: %s", str(e))
+            logger.warning("Failed to recover alert receiver: %s", str(e))
 
     def _pickle_receiver_impl(self):
         try:
             with open(self._receiver_path, "wb") as f:
                 pickle.dump(self._receivers, f)
         except Exception as e:
-            logger.warn("Failed to dump receiver: %s", str(e))
+            logger.warning("Failed to dump receiver: %s", str(e))
 
     def list_alert_rules(self) -> List[GetAlertRuleResponse]:
         rlt = []

--- a/coordinator/gscoordinator/flex/core/alert/alert_receiver.py
+++ b/coordinator/gscoordinator/flex/core/alert/alert_receiver.py
@@ -118,5 +118,5 @@ class DingTalkReceiver(object):
                 raise RuntimeError(str(rlt))
 
         except Exception as e:
-            logger.warn("Failed to send dingtalk: %s", str(e))
+            logger.warning("Failed to send dingtalk: %s", str(e))
             self._error_msg = str(e)

--- a/coordinator/gscoordinator/flex/core/alert/builtin_rules.py
+++ b/coordinator/gscoordinator/flex/core/alert/builtin_rules.py
@@ -80,7 +80,7 @@ class HighDiskUtilizationAlert(AlertRule):
                 # alert
                 self.alert(alert_message)
         except Exception as e:
-            logger.warn("Failed to get disk usage: %s", str(e))
+            logger.warning("Failed to get disk usage: %s", str(e))
 
 
 class GremlinServiceAvailableAlert(AlertRule):

--- a/coordinator/gscoordinator/flex/core/alert/message_collector.py
+++ b/coordinator/gscoordinator/flex/core/alert/message_collector.py
@@ -60,7 +60,7 @@ class OneDayAlertMessageCollector(object):
         try:
             self.dump_to_disk()
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Failed to dump alert message on date %s: %s",
                 str(self._date),
                 str(e),
@@ -74,7 +74,7 @@ class OneDayAlertMessageCollector(object):
                 with open(self._pickle_path, "rb") as f:
                     self._messages = pickle.load(f)  # noqa: B301
         except Exception as e:
-            logger.warn(
+            logger.warning(
                 "Failed to recover alert message from path %s: %s",
                 self._pickle_path,
                 str(e),
@@ -151,7 +151,7 @@ class AlertMessageCollector(object):
                         os.remove(file_path)
                         logger.info("Clean alert file: %s", str(file_path))
         except Exception as e:
-            logger.warn("Failed to clean the alert file: %s", str(e))
+            logger.warning("Failed to clean the alert file: %s", str(e))
 
     def is_message_belongs_to_certain_day(self, message, date):
         """

--- a/coordinator/gscoordinator/flex/core/client_wrapper.py
+++ b/coordinator/gscoordinator/flex/core/client_wrapper.py
@@ -79,7 +79,7 @@ class ClientWrapper(object):
             from gscoordinator.flex.core.insight import init_groot_client
             initializer = init_groot_client
         if initializer is None:
-            logger.warn(f"Client initializer of {SOLUTION} not found.")
+            logger.warning(f"Client initializer of {SOLUTION} not found.")
             return None
         return initializer(config)
 

--- a/coordinator/gscoordinator/flex/core/config.py
+++ b/coordinator/gscoordinator/flex/core/config.py
@@ -107,7 +107,7 @@ GROOT_PASSWORD = os.environ.get("GROOT_PASSWORD", "")
 try:
     GROOT_PASSWORD = base64.b64decode(GROOT_PASSWORD).decode('utf-8')
 except Exception as e:
-    logger.warn("Invalid base64-encoded string found, use original value: %s", str(e))
+    logger.warning("Invalid base64-encoded string found, use original value: %s", str(e))
 GROOT_FRONTEND_POD_SUFFIX = os.environ.get("GROOT_FRONTEND_POD_SUFFIX", "graphscope-store-frontend")
 GROOT_STORE_POD_SUFFIX = os.environ.get("GROOT_STORE_POD_SUFFIX", "graphscope-store-store")
 GROOT_COORDINATOR_POD_SUFFIX = os.environ.get("GROOT_COORDINATOR_POD_SUFFIX", "graphscope-store-coordinator")

--- a/coordinator/gscoordinator/flex/core/datasource.py
+++ b/coordinator/gscoordinator/flex/core/datasource.py
@@ -45,14 +45,14 @@ class DataSourceManager(object):
                 with open(self._pickle_path, "rb") as f:
                     self._datasource_mapping = pickle.load(f)
         except Exception as e:
-            logger.warn("Failed to recover data source mapping: %s", str(e))
+            logger.warning("Failed to recover data source mapping: %s", str(e))
 
     def dump_to_disk(self):
         try:
             with open(self._pickle_path, "wb") as f:
                 pickle.dump(self._datasource_mapping, f)
         except Exception as e:
-            logger.warn("Failed to dump data source mapping: %s", str(e))
+            logger.warning("Failed to dump data source mapping: %s", str(e))
 
     def get_edge_full_label(
         self,

--- a/coordinator/gscoordinator/flex/core/deployment.py
+++ b/coordinator/gscoordinator/flex/core/deployment.py
@@ -291,7 +291,7 @@ class KubeDeployment(Deployment):
                     {"host": name, "timestamp": t, "usage": round(memory)}
                 )
         except Exception as e:
-            logger.warn("Failed to fetch resource usage %s", str(e))
+            logger.warning("Failed to fetch resource usage %s", str(e))
 
     def _fetch_status_impl(self):
         try:
@@ -358,7 +358,7 @@ class KubeDeployment(Deployment):
                 sorted_status[key] = status[key]
             self._status["pods"] = sorted_status
         except Exception as e:
-            logger.warn("Failed to fetch deployment status %s", str(e))
+            logger.warning("Failed to fetch deployment status %s", str(e))
 
     def initialize_resource_usage(self):
         try:
@@ -379,7 +379,7 @@ class KubeDeployment(Deployment):
                 "memory_usage": queue.Queue(maxsize=720 * pod_num),
             }
         except Exception as e:
-            logger.warn("Failed to fetch resource usage %s", str(e))
+            logger.warning("Failed to fetch resource usage %s", str(e))
             return {"cpu_usage": [], "memory_usage": []}
 
     def get_resource_usage(self) -> dict:

--- a/coordinator/gscoordinator/flex/core/insight/graph.py
+++ b/coordinator/gscoordinator/flex/core/insight/graph.py
@@ -109,7 +109,7 @@ class GrootGraph(object):
             cypher_endpoint = test_cypher_endpoint(pod.status.pod_ip, GROOT_CYPHER_PORT)
             
         except Exception as e:
-            logger.warn(f"Failed to fetch frontend endpoints: {str(e)}")
+            logger.warning(f"Failed to fetch frontend endpoints: {str(e)}")
         else:
             if (
                 gremlin_endpoint != self._endpoints["gremlin_endpoint"]

--- a/coordinator/gscoordinator/flex/core/insight/groot.py
+++ b/coordinator/gscoordinator/flex/core/insight/groot.py
@@ -89,7 +89,7 @@ class GrootClient(object):
                     self._graph, JobStatus.from_dict(status)
                 )
         except Exception as e:
-            logger.warn("Failed to recover job status: %s", str(e))
+            logger.warning("Failed to recover job status: %s", str(e))
 
     def _pickle_job_status_impl(self):
         try:
@@ -100,7 +100,7 @@ class GrootClient(object):
             with open(self._job_status_pickle_path, "wb") as f:
                 pickle.dump(status, f)
         except Exception as e:
-            logger.warn("Pickle job status failed: %s", str(e))
+            logger.warning("Pickle job status failed: %s", str(e))
     
     def _restart_pod(self, pod_name, pod_ip, port):
         logger.info(f"Restart groot store pod {pod_name}, ip {pod_ip}")

--- a/coordinator/gscoordinator/flex/core/utils.py
+++ b/coordinator/gscoordinator/flex/core/utils.py
@@ -273,7 +273,7 @@ def get_public_ip() -> Union[str, None]:
         else:
             return None
     except requests.exceptions.RequestException as e:
-        logger.warn("Failed to get public ip: %s", str(e))
+        logger.warning("Failed to get public ip: %s", str(e))
         return None
 
 


### PR DESCRIPTION
## What do these changes do?
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Related issue number

