### PR TITLE
fix(analytical): Fix WCC's wrong result

### DIFF
--- a/analytical_engine/apps/property/wcc_property.h
+++ b/analytical_engine/apps/property/wcc_property.h
@@ -140,6 +140,21 @@ class WCCProperty : public PropertyAppBase<FRAG_T, WCCPropertyContext<FRAG_T>> {
       }
     }
 
+    for (label_id_t i = 0; i < v_label_num; ++i) {
+      auto iv = frag.InnerVertices(i);
+      bool ok = false;
+      for (auto v : iv) {
+        if (ctx.next_modified[i][v]) {
+          messages.ForceContinue();
+          ok = true;
+          break;
+        }
+      }
+      if (ok) {
+        break;
+      }
+    }
+
     ctx.curr_modified.swap(ctx.next_modified);
   }
 


### PR DESCRIPTION
## What do these changes do?
When run this WCC algorithm with only one worker, the algorithm will only compute one iteration, so as to cause wrong result.
Fix by add ForceContinue() in PEval() when needed.



